### PR TITLE
modified tools/CMakeLists.txt, add ${PROTOBUF_INCLUDE_DIR}

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,6 +4,8 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/../src)
 
 find_package(Protobuf REQUIRED)
 
+include_directories(${PROTOBUF_INCLUDE_DIR})
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 protobuf_generate_cpp(CAFFE_PROTO_SRCS CAFFE_PROTO_HDRS caffe.proto)
 


### PR DESCRIPTION
modified tools/CMakeLists.txt，added a line:

include_directories(${PROTOBUF_INCLUDE_DIR})

otherwise, there is a error when compiling tools: 'google/protobuf/io/coded_stream.h' file not found