### PR TITLE
wing fix vs std::min std::max compile problem

### DIFF
--- a/src/mat_pixel.cpp
+++ b/src/mat_pixel.cpp
@@ -133,7 +133,7 @@ static void to_rgb(const Mat& m, unsigned char* rgb)
 
     int size = m.w * m.h;
 
-#define SATURATE_CAST_UCHAR(X) (unsigned char)std::min(std::max((int)(X), 0), 255);
+#define SATURATE_CAST_UCHAR(X) (unsigned char)::std::min(::std::max((int)(X), 0), 255);
 
     int remain = size;
 
@@ -239,7 +239,7 @@ static void to_gray(const Mat& m, unsigned char* gray)
 
     int size = m.w * m.h;
 
-#define SATURATE_CAST_UCHAR(X) (unsigned char)std::min(std::max((int)(X), 0), 255);
+#define SATURATE_CAST_UCHAR(X) (unsigned char)::std::min(::std::max((int)(X), 0), 255);
 
     int remain = size;
 
@@ -384,7 +384,7 @@ static void to_rgba(const Mat& m, unsigned char* rgba)
 
     int size = m.w * m.h;
 
-#define SATURATE_CAST_UCHAR(X) (unsigned char)std::min(std::max((int)(X), 0), 255);
+#define SATURATE_CAST_UCHAR(X) (unsigned char)::std::min(::std::max((int)(X), 0), 255);
 
     int remain = size;
 
@@ -517,7 +517,7 @@ static void to_bgr2rgb(const Mat& m, unsigned char* rgb)
 
     int size = m.w * m.h;
 
-#define SATURATE_CAST_UCHAR(X) (unsigned char)std::min(std::max((int)(X), 0), 255);
+#define SATURATE_CAST_UCHAR(X) (unsigned char)::std::min(::std::max((int)(X), 0), 255);
 
     int remain = size;
 
@@ -1149,7 +1149,7 @@ void resize_bilinear_c3(const unsigned char* src, int srcw, int srch, unsigned c
     int sx;
     int sy;
 
-#define SATURATE_CAST_SHORT(X) (short)std::min(std::max((int)(X + (X >= 0.f ? 0.5f : -0.5f)), SHRT_MIN), SHRT_MAX);
+#define SATURATE_CAST_SHORT(X) (short)::std::min(::std::max((int)(X + (X >= 0.f ? 0.5f : -0.5f)), SHRT_MIN), SHRT_MAX);
 
     for (int dx = 0; dx < w; dx++)
     {
@@ -1433,7 +1433,7 @@ void resize_bilinear_c1(const unsigned char* src, int srcw, int srch, unsigned c
     int sx;
     int sy;
 
-#define SATURATE_CAST_SHORT(X) (short)std::min(std::max((int)(X + (X >= 0.f ? 0.5f : -0.5f)), SHRT_MIN), SHRT_MAX);
+#define SATURATE_CAST_SHORT(X) (short)::std::min(::std::max((int)(X + (X >= 0.f ? 0.5f : -0.5f)), SHRT_MIN), SHRT_MAX);
 
     for (int dx = 0; dx < w; dx++)
     {
@@ -1674,7 +1674,7 @@ void resize_bilinear_c4(const unsigned char* src, int srcw, int srch, unsigned c
     int sx;
     int sy;
 
-#define SATURATE_CAST_SHORT(X) (short)std::min(std::max((int)(X + (X >= 0.f ? 0.5f : -0.5f)), SHRT_MIN), SHRT_MAX);
+#define SATURATE_CAST_SHORT(X) (short)::std::min(::std::max((int)(X + (X >= 0.f ? 0.5f : -0.5f)), SHRT_MIN), SHRT_MAX);
 
     for (int dx = 0; dx < w; dx++)
     {


### PR DESCRIPTION
VS complier can not recognize std::min std::max in a macro, so force to use global namespace to fix it. 