### PR TITLE
Add epsilon on variance of batch normalization layer.

### DIFF
--- a/src/layer/batchnorm.cpp
+++ b/src/layer/batchnorm.cpp
@@ -151,9 +151,10 @@ int BatchNorm::load_model(const unsigned char*& mem)
     const float* bias_data_ptr = bias_data;
     float* a_data_ptr = a_data;
     float* b_data_ptr = b_data;
+    const int eps = 0.001;
     for (int i=0; i<channels; i++)
     {
-        float sqrt_var = sqrt(var_data_ptr[i]);
+        float sqrt_var = sqrt(var_data_ptr[i] + eps);
         a_data_ptr[i] = bias_data_ptr[i] - slope_data_ptr[i] * mean_data_ptr[i] / sqrt_var;
         b_data_ptr[i] = slope_data_ptr[i] / sqrt_var;
     }


### PR DESCRIPTION
caffe (https://github.com/BVLC/caffe/blob/master/src/caffe/layers/batch_norm_layer.cpp#L150) and Tensorflow (https://github.com/tensorflow/tensorflow/blob/754048a0453a04a761e112ae5d99c149eb9910dd/tensorflow/core/kernels/batch_norm_op.h#L117) add epsilon value to variance.