### PR TITLE
no memcpy for small size copy_cut_border/copy_make_boder

### DIFF
--- a/src/mat.cpp
+++ b/src/mat.cpp
@@ -348,8 +348,18 @@ static void copy_make_border_image(const Mat& src, Mat& dst, int top, int left, 
             {
                 outptr[x] = v;
             }
-            memcpy(outptr + left, ptr, src.w * sizeof(float));
-            x += src.w;
+            if (src.w < 12)
+            {
+                for (; x < (left + src.w); x++)
+                {
+                    outptr[x] = ptr[x - left];
+                }
+            }
+            else
+            {
+                memcpy(outptr + left, ptr, src.w * sizeof(float));
+                x += src.w;
+            }
             for (; x < w; x++)
             {
                 outptr[x] = v;
@@ -379,8 +389,18 @@ static void copy_make_border_image(const Mat& src, Mat& dst, int top, int left, 
             {
                 outptr[x] = ptr[0];
             }
-            memcpy(outptr + left, ptr, src.w * sizeof(float));
-            x += src.w;
+            if(src.w < 12)
+            {
+                for (; x < (left + src.w); x++)
+                {
+                    outptr[x] = ptr[x - left];
+                }
+            }
+            else
+            {
+                memcpy(outptr + left, ptr, src.w * sizeof(float));
+                x += src.w;
+            }
             for (; x < w; x++)
             {
                 outptr[x] = ptr[src.w - 1];
@@ -395,8 +415,18 @@ static void copy_make_border_image(const Mat& src, Mat& dst, int top, int left, 
             {
                 outptr[x] = ptr[0];
             }
-            memcpy(outptr + left, ptr, src.w * sizeof(float));
-            x += src.w;
+            if(src.w < 12)
+            {
+                for (; x < (left + src.w); x++)
+                {
+                    outptr[x] = ptr[x - left];
+                }
+            }
+            else
+            {
+                memcpy(outptr + left, ptr, src.w * sizeof(float));
+                x += src.w;
+            }
             for (; x < w; x++)
             {
                 outptr[x] = ptr[src.w - 1];
@@ -413,8 +443,18 @@ static void copy_make_border_image(const Mat& src, Mat& dst, int top, int left, 
             {
                 outptr[x] = ptr[0];
             }
-            memcpy(outptr + left, ptr, src.w * sizeof(float));
-            x += src.w;
+            if(src.w < 12)
+            {
+                for (; x < (left + src.w); x++)
+                {
+                    outptr[x] = ptr[x - left];
+                }
+            }
+            else
+            {
+                memcpy(outptr + left, ptr, src.w * sizeof(float));
+                x += src.w;
+            }
             for (; x < w; x++)
             {
                 outptr[x] = ptr[src.w - 1];
@@ -473,7 +513,17 @@ static void copy_cut_border_image(const Mat& src, Mat& dst, int top, int left)
 
     for (int y = 0; y < h; y++)
     {
-        memcpy(outptr, ptr, w*sizeof(float));
+        if(w < 12)
+        {
+            for (int x = 0; x < w; x++)
+            {
+                outptr[x] = ptr[x];
+            }
+        }
+        else
+        {
+            memcpy(outptr, ptr, w*sizeof(float));
+        }
         outptr += w;
         ptr += src.w;
     }


### PR DESCRIPTION
在 https://github.com/Tencent/ncnn/pull/179 测试中memcpy对于<12 float 速度其实不如循环赋值.

在这修改 w >= 12 时才使用memcpy

下面android下测试结果(偶数行为memcpy版本)，在各种尺寸下速度>=循环版本

修改前后对比：
```
54.87ms   3*5*5
59.10ms   3*5*5
85.98ms   3*10*10
105.67ms   3*10*10
163.70ms   3*14*14
146.67ms   3*14*14
285.31ms   3*20*20
244.93ms   3*20*20
166.06ms   3*50*50
100.58ms   3*50*50
4857.01ms   3*250*250
3977.70ms   3*250*250
4362.71ms   3*500*500
3603.80ms   3*500*500
8728.20ms   3*1000*1000
7056.97ms   3*1000*1000
```

```
46.77ms   3*5*5
45.04ms   3*5*5
89.29ms   3*10*10
77.09ms   3*10*10
158.40ms   3*14*14
140.36ms   3*14*14
282.85ms   3*20*20
246.16ms   3*20*20
162.42ms   3*50*50
90.89ms   3*50*50
5107.91ms   3*250*250
3988.80ms   3*250*250
4439.87ms   3*500*500
3619.10ms   3*500*500
8824.09ms   3*1000*1000
7196.70ms   3*1000*1000
```
<12 float 速度保持不变，>=12: 平均快  10%~30%