### PR TITLE
fix unaryop bug

### DIFF
--- a/src/layer/unaryop.cpp
+++ b/src/layer/unaryop.cpp
@@ -41,7 +41,7 @@ static int unary_op(const Mat& a, Mat& b)
     int w = a.w;
     int h = a.h;
     int channels = a.c;
-    int size = w * h * channels;
+    int size = a.total();
 
     if (a.dims == 3)
     {
@@ -62,30 +62,13 @@ static int unary_op(const Mat& a, Mat& b)
             return -100;
     }
 
-    if (channels > 1)
-    {
-        #pragma omp parallel for
-        for (int i=0; i<channels; i++)
-        {
-            const float* ptr = a.channel(i);
-            float* outptr = b.channel(i);
+    const float* ptr = a;
+    float* outptr = b;
 
-            for (int j=0; j<w*h; j++)
-            {
-                outptr[j] = op(ptr[j]);
-            }
-        }
-    }
-    else
+    #pragma omp parallel for
+    for (int i=0; i<size; i++)
     {
-        const float* ptr = a;
-        float* outptr = b;
-
-        #pragma omp parallel for
-        for (int i=0; i<size; i++)
-        {
-            outptr[i] = op(ptr[i]);
-        }
+        outptr[i] = op(ptr[i]);
     }
 
     return 0;

--- a/src/layer/unaryop.cpp
+++ b/src/layer/unaryop.cpp
@@ -62,13 +62,30 @@ static int unary_op(const Mat& a, Mat& b)
             return -100;
     }
 
-    const float* ptr = a;
-    float* outptr = b;
-
-    #pragma omp parallel for
-    for (int i=0; i<size; i++)
+    if (channels > 1)
     {
-        outptr[i] = op(ptr[i]);
+        #pragma omp parallel for
+        for (int i=0; i<channels; i++)
+        {
+            const float* ptr = a.channel(i);
+            float* outptr = b.channel(i);
+
+            for (int j=0; j<w*h; j++)
+            {
+                outptr[j] = op(ptr[j]);
+            }
+        }
+    }
+    else
+    {
+        const float* ptr = a;
+        float* outptr = b;
+
+        #pragma omp parallel for
+        for (int i=0; i<size; i++)
+        {
+            outptr[i] = op(ptr[i]);
+        }
     }
 
     return 0;


### PR DESCRIPTION
- incorrect memory access when matrix is multi-channel

Signed-off-by: wangshunli <shunli0521.hi@163.com>