### PR TITLE
fix openmp not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,10 @@ option(NCNN_OPENCV "minimal opencv structure emulation" OFF)
 
 if(NCNN_OPENMP)
     find_package(OpenMP)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    if(OpenMP_CXX_FOUND OR OPENMP_FOUND)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    endif()
 endif()
 
 add_definitions(-Wall -Wextra)


### PR DESCRIPTION
in my mac, I tried to compiler ncnn.

cmake error
```
-- Could NOT find OpenMP_C (missing: OpenMP_C_FLAGS OpenMP_C_LIB_NAMES) (found version "1.0")
-- Could NOT find OpenMP_CXX (missing: OpenMP_CXX_FLAGS OpenMP_CXX_LIB_NAMES) (found version "1.0")
```

make error
```
[  1%] Building CXX object src/CMakeFiles/ncnn.dir/blob.cpp.o
clang: error: no such file or directory: 'NOTFOUND'
make[2]: *** [src/CMakeFiles/ncnn.dir/blob.cpp.o] Error 1
make[1]: *** [src/CMakeFiles/ncnn.dir/all] Error 2
make: *** [all] Error 2
```

I think `find_package` could not found OpenMP, and so all OpenMP variables were being set to NOTFOUND

I change code as pr, now I build successfully.