### PR TITLE
fix pooling2x2s2_max_neon stride bug

### DIFF
--- a/src/layer/arm/pooling_2x2.h
+++ b/src/layer/arm/pooling_2x2.h
@@ -23,7 +23,9 @@ static void pooling2x2s2_max_neon(const Mat& bottom_blob, Mat& top_blob)
 
     int outw = top_blob.w;
     int outh = top_blob.h;
-
+    
+    const int tailstep = w - 2*outw + w;
+    
     #pragma omp parallel for
     for (int q=0; q<inch; q++)
     {
@@ -103,8 +105,8 @@ static void pooling2x2s2_max_neon(const Mat& bottom_blob, Mat& top_blob)
                 outptr++;
             }
 
-            r0 += w;
-            r1 += w;
+            r0 += tailstep;
+            r1 += tailstep;
         }
     }
 }


### PR DESCRIPTION
图像width为奇数时，stride为2时，出错