### PR TITLE
mxnet convertor : softmax activation

### DIFF
--- a/tools/mxnet/mxnet2ncnn.cpp
+++ b/tools/mxnet/mxnet2ncnn.cpp
@@ -791,6 +791,10 @@ int main(int argc, char** argv)
         {
             fprintf(pp, "%-16s", "Softmax");
         }
+        else if (n.op == "SoftmaxActivation")
+        {
+            fprintf(pp, "%-16s", "Softmax");
+        }
         else
         {
             fprintf(stderr, "%s not supported yet!\n", n.op.c_str());


### PR DESCRIPTION
mxnet has softmaxoutput and also a softmax activation, softmaxoutput is often used for training while softmax activation is often used for predicting