### PR TITLE
print benchmark information for every layer, especially for CONVOLUTION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(NCNN_OPENMP "openmp support" ON)
 option(NCNN_STDIO "load model from external file" ON)
 option(NCNN_STRING "plain and verbose string" ON)
 option(NCNN_OPENCV "minimal opencv structure emulation" OFF)
+option(NCNN_BENCHMARK "print benchmark information for every layer" OFF)
 
 if(NCNN_OPENMP)
     find_package(OpenMP)

--- a/build.sh
+++ b/build.sh
@@ -39,3 +39,14 @@ cmake -DCMAKE_TOOLCHAIN_FILE=../iossimxc.toolchain.cmake ..
 make
 make install
 popd
+
+##### MacOS
+mkdir -p build-mac
+pushd build-mac
+cmake   -DNCNN_OPENMP=OFF \
+        -DNCNN_OPENCV=ON \
+        -DNCNN_BENCHMARK=ON \
+        ..
+make -j 8
+make install
+popd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(ncnn_SRCS
     net.cpp
     opencv.cpp
     paramdict.cpp
+    benchmark.cpp
 )
 
 macro(ncnn_add_layer class)
@@ -154,6 +155,7 @@ install(FILES
     net.h
     opencv.h
     paramdict.h
+    benchmark.h
     ${CMAKE_CURRENT_BINARY_DIR}/layer_type_enum.h
     ${CMAKE_CURRENT_BINARY_DIR}/platform.h
     DESTINATION include

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -16,6 +16,33 @@
 #include <stdio.h>
 #include "layer/convolution.h"
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <stdint.h> // portable: uint64_t   MSVC: __int64 
+
+int gettimeofday(struct timeval * tp, struct timezone * tzp)
+{
+    // Note: some broken versions only have 8 trailing zero's, the correct epoch has 9 trailing zero's
+    // This magic number is the number of 100 nanosecond intervals since January 1, 1601 (UTC)
+    // until 00:00:00 January 1, 1970 
+    static const uint64_t EPOCH = ((uint64_t) 116444736000000000ULL);
+
+    SYSTEMTIME  system_time;
+    FILETIME    file_time;
+    uint64_t    time;
+
+    GetSystemTime( &system_time );
+    SystemTimeToFileTime( &system_time, &file_time );
+    time =  ((uint64_t)file_time.dwLowDateTime )      ;
+    time += ((uint64_t)file_time.dwHighDateTime) << 32;
+
+    tp->tv_sec  = (long) ((time - EPOCH) / 10000000L);
+    tp->tv_usec = (long) (system_time.wMilliseconds * 1000);
+    return 0;
+}
+#endif // _WIN32
+
 namespace ncnn {
 
 void benchmark(const ncnn::Layer* layer, struct timeval start, struct timeval end)

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -1,0 +1,42 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "benchmark.h"
+
+namespace ncnn {
+
+void benchmark(const ncnn::Layer* layer, clock_t begin, clock_t end)
+{
+    fprintf(stderr, "%-24s %-24s %8.2lfms", layer->type.c_str(), layer->name.c_str(), (end - begin) * 1.0 / CLOCKS_PER_SEC * 1000);
+    fprintf(stderr, "    |");
+    fprintf(stderr, "\n");
+}
+
+void benchmark(const Layer* layer, const Mat& bottom_blob, Mat& top_blob, clock_t begin, clock_t end)
+{
+    fprintf(stderr, "%-24s %-24s %8.2lfms", layer->type.c_str(), layer->name.c_str(), (end - begin) * 1.0 / CLOCKS_PER_SEC * 1000);
+    fprintf(stderr, "    |    feature_map: %4d x %-4d    inch: %4d    outch: %4d", bottom_blob.w, bottom_blob.h, bottom_blob.c, top_blob.c);
+    if (layer->type == "Convolution")
+    {
+        fprintf(stderr, "     kernel: %1d x %1d     stride: %1d x %1d", 
+        ((Convolution*)layer)->kernel_h, 
+        ((Convolution*)layer)->kernel_w,
+        ((Convolution*)layer)->stride_h,
+        ((Convolution*)layer)->stride_w
+        );
+    }
+    fprintf(stderr, "\n");
+}
+
+}

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -13,19 +13,31 @@
 // specific language governing permissions and limitations under the License.
 
 #include "benchmark.h"
+#include <stdio.h>
+#include "layer/convolution.h"
 
 namespace ncnn {
 
-void benchmark(const ncnn::Layer* layer, clock_t begin, clock_t end)
+void benchmark(const ncnn::Layer* layer, struct timeval start, struct timeval end)
 {
-    fprintf(stderr, "%-24s %-24s %8.2lfms", layer->type.c_str(), layer->name.c_str(), (end - begin) * 1.0 / CLOCKS_PER_SEC * 1000);
+    fprintf(stderr, 
+            "%-24s %-24s %8.2lfms", 
+            layer->type.c_str(), 
+            layer->name.c_str(), 
+            ((end.tv_sec * 1000.0 + end.tv_usec / 1000.0) - (start.tv_sec * 1000.0 + start.tv_usec / 1000.0))
+            );
     fprintf(stderr, "    |");
     fprintf(stderr, "\n");
 }
 
-void benchmark(const Layer* layer, const Mat& bottom_blob, Mat& top_blob, clock_t begin, clock_t end)
+void benchmark(const Layer* layer, const Mat& bottom_blob, Mat& top_blob, struct timeval start, struct timeval end)
 {
-    fprintf(stderr, "%-24s %-24s %8.2lfms", layer->type.c_str(), layer->name.c_str(), (end - begin) * 1.0 / CLOCKS_PER_SEC * 1000);
+    fprintf(stderr, 
+            "%-24s %-24s %8.2lfms", 
+            layer->type.c_str(), 
+            layer->name.c_str(), 
+            ((end.tv_sec * 1000.0 + end.tv_usec / 1000.0) - (start.tv_sec * 1000.0 + start.tv_usec / 1000.0))
+            );
     fprintf(stderr, "    |    feature_map: %4d x %-4d    inch: %4d    outch: %4d", bottom_blob.w, bottom_blob.h, bottom_blob.c, top_blob.c);
     if (layer->type == "Convolution")
     {

--- a/src/benchmark.h
+++ b/src/benchmark.h
@@ -12,12 +12,20 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-#ifndef NCNN_PLATFORM_H
-#define NCNN_PLATFORM_H
+#ifndef NCNN_BENCHMARK_H
+#define NCNN_BENCHMARK_H
 
-#cmakedefine01 NCNN_STDIO
-#cmakedefine01 NCNN_STRING
-#cmakedefine01 NCNN_OPENCV
-#cmakedefine01 NCNN_BENCHMARK
+#include <stdio.h>
+#include <time.h>
+#include "mat.h"
+#include "layer.h"
+#include "layer/convolution.h"
 
-#endif // NCNN_PLATFORM_H
+namespace ncnn {
+
+void benchmark(const ncnn::Layer* layer, clock_t begin, clock_t end);
+void benchmark(const ncnn::Layer* layer, const ncnn::Mat& bottom_blob, ncnn::Mat& top_blob, clock_t begin, clock_t end);
+
+}
+
+#endif // NCNN_BENCHMARK_H

--- a/src/benchmark.h
+++ b/src/benchmark.h
@@ -21,7 +21,7 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
-#include <stdint.h> // portable: uint64_t   MSVC: __int64 
+#include <stdint.h> // portable: uint64_t   MSVC: __int64
 
 typedef struct timeval 
 {
@@ -29,26 +29,7 @@ typedef struct timeval
     long tv_usec;
 } timeval;
 
-int gettimeofday(struct timeval * tp, struct timezone * tzp)
-{
-    // Note: some broken versions only have 8 trailing zero's, the correct epoch has 9 trailing zero's
-    // This magic number is the number of 100 nanosecond intervals since January 1, 1601 (UTC)
-    // until 00:00:00 January 1, 1970 
-    static const uint64_t EPOCH = ((uint64_t) 116444736000000000ULL);
-
-    SYSTEMTIME  system_time;
-    FILETIME    file_time;
-    uint64_t    time;
-
-    GetSystemTime( &system_time );
-    SystemTimeToFileTime( &system_time, &file_time );
-    time =  ((uint64_t)file_time.dwLowDateTime )      ;
-    time += ((uint64_t)file_time.dwHighDateTime) << 32;
-
-    tp->tv_sec  = (long) ((time - EPOCH) / 10000000L);
-    tp->tv_usec = (long) (system_time.wMilliseconds * 1000);
-    return 0;
-}
+int gettimeofday(struct timeval * tp, struct timezone * tzp);
 #elif defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
 #include <sys/time.h>
 #endif // _WIN32

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -24,6 +24,11 @@
 #include <omp.h>
 #endif // _OPENMP
 
+#if NCNN_BENCHMARK
+#include <time.h>
+#include "benchmark.h"
+#endif // NCNN_BENCHMARK
+
 namespace ncnn {
 
 Net::Net()
@@ -642,7 +647,14 @@ int Net::forward_layer(int layer_index, std::vector<Mat>& blob_mats, bool lightm
         if (lightmode && layer->support_inplace)
         {
             Mat& bottom_top_blob = bottom_blob;
+#if NCNN_BENCHMARK
+            clock_t begin = clock();
             int ret = layer->forward_inplace(bottom_top_blob);
+            clock_t end = clock();
+            benchmark(layer, bottom_top_blob, bottom_top_blob, begin, end);
+#else
+            int ret = layer->forward_inplace(bottom_top_blob);
+#endif // NCNN_BENCHMARK
             if (ret != 0)
                 return ret;
 
@@ -652,7 +664,15 @@ int Net::forward_layer(int layer_index, std::vector<Mat>& blob_mats, bool lightm
         else
         {
             Mat top_blob;
+#if NCNN_BENCHMARK
+            clock_t begin = clock();
             int ret = layer->forward(bottom_blob, top_blob);
+            clock_t end = clock();
+            benchmark(layer, bottom_blob, top_blob, begin, end);
+#else
+            int ret = layer->forward(bottom_blob, top_blob);
+#endif // NCNN_BENCHMARK
+            
             if (ret != 0)
                 return ret;
 
@@ -695,7 +715,14 @@ int Net::forward_layer(int layer_index, std::vector<Mat>& blob_mats, bool lightm
         if (lightmode && layer->support_inplace)
         {
             std::vector<Mat>& bottom_top_blobs = bottom_blobs;
+#if NCNN_BENCHMARK
+            clock_t begin = clock();
             int ret = layer->forward_inplace(bottom_top_blobs);
+            clock_t end = clock();
+            benchmark(layer, begin, end);
+#else
+            int ret = layer->forward_inplace(bottom_top_blobs);
+#endif // NCNN_BENCHMARK
             if (ret != 0)
                 return ret;
 
@@ -711,7 +738,15 @@ int Net::forward_layer(int layer_index, std::vector<Mat>& blob_mats, bool lightm
         {
             std::vector<Mat> top_blobs;
             top_blobs.resize(layer->tops.size());
+#if NCNN_BENCHMARK
+            clock_t begin = clock();
             int ret = layer->forward(bottom_blobs, top_blobs);
+            clock_t end = clock();
+            benchmark(layer, begin, end);
+#else
+            int ret = layer->forward(bottom_blobs, top_blobs);
+#endif // NCNN_BENCHMARK
+            
             if (ret != 0)
                 return ret;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -25,7 +25,6 @@
 #endif // _OPENMP
 
 #if NCNN_BENCHMARK
-#include <time.h>
 #include "benchmark.h"
 #endif // NCNN_BENCHMARK
 
@@ -648,10 +647,11 @@ int Net::forward_layer(int layer_index, std::vector<Mat>& blob_mats, bool lightm
         {
             Mat& bottom_top_blob = bottom_blob;
 #if NCNN_BENCHMARK
-            clock_t begin = clock();
+            struct timeval start, end;
+            gettimeofday(&start, NULL);
             int ret = layer->forward_inplace(bottom_top_blob);
-            clock_t end = clock();
-            benchmark(layer, bottom_top_blob, bottom_top_blob, begin, end);
+            gettimeofday(&end, NULL);
+            benchmark(layer, bottom_top_blob, bottom_top_blob, start, end);
 #else
             int ret = layer->forward_inplace(bottom_top_blob);
 #endif // NCNN_BENCHMARK
@@ -665,10 +665,11 @@ int Net::forward_layer(int layer_index, std::vector<Mat>& blob_mats, bool lightm
         {
             Mat top_blob;
 #if NCNN_BENCHMARK
-            clock_t begin = clock();
+            struct timeval start, end;
+            gettimeofday(&start, NULL);
             int ret = layer->forward(bottom_blob, top_blob);
-            clock_t end = clock();
-            benchmark(layer, bottom_blob, top_blob, begin, end);
+            gettimeofday(&end, NULL);
+            benchmark(layer, bottom_blob, top_blob, start, end);
 #else
             int ret = layer->forward(bottom_blob, top_blob);
 #endif // NCNN_BENCHMARK
@@ -716,10 +717,11 @@ int Net::forward_layer(int layer_index, std::vector<Mat>& blob_mats, bool lightm
         {
             std::vector<Mat>& bottom_top_blobs = bottom_blobs;
 #if NCNN_BENCHMARK
-            clock_t begin = clock();
+            struct timeval start, end;
+            gettimeofday(&start, NULL);
             int ret = layer->forward_inplace(bottom_top_blobs);
-            clock_t end = clock();
-            benchmark(layer, begin, end);
+            gettimeofday(&end, NULL);
+            benchmark(layer, start, end);
 #else
             int ret = layer->forward_inplace(bottom_top_blobs);
 #endif // NCNN_BENCHMARK
@@ -739,10 +741,11 @@ int Net::forward_layer(int layer_index, std::vector<Mat>& blob_mats, bool lightm
             std::vector<Mat> top_blobs;
             top_blobs.resize(layer->tops.size());
 #if NCNN_BENCHMARK
-            clock_t begin = clock();
+            struct timeval start, end;
+            gettimeofday(&start, NULL);
             int ret = layer->forward(bottom_blobs, top_blobs);
-            clock_t end = clock();
-            benchmark(layer, begin, end);
+            gettimeofday(&end, NULL);
+            benchmark(layer, start, end);
 #else
             int ret = layer->forward(bottom_blobs, top_blobs);
 #endif // NCNN_BENCHMARK


### PR DESCRIPTION
## Aim
Generally, Deep-Learning engineers usually pay more attention to network training, but neglect the performance of network inferencing, especially on mobile-platform.

These codes aim to help the engineers profile the performance and then shoot the bottleneck of the performance of their network. According to the profile result, they can adjust the network structure to make a trade-off between network accuracy and network speed on ncnn.

## Usage
Compile the ncnn with *_-DNCNN_BENCHMARK=ON_(OFF for default)*, for example, on armv7a & Mac
```shell
##### android armv7
mkdir -p build-android-armv7
pushd build-android-armv7
cmake   -DCMAKE_TOOLCHAIN_FILE=../android.toolchain.cmake \
        -DANDROID_ABI="armeabi-v7a with NEON" \
        -DANDROID_NATIVE_API_LEVEL=android-9 \
        -DANDROID_NDK=/Users/air/Documents/GitHub/android-ndk-r15c \
        -DANDROID_FORCE_ARM_BUILD=OFF \
        -DANDROID_STL_FORCE_FEATURES=OFF \
        -DNCNN_OPENMP=OFF \
        -DANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-4.9 \
        -DNCNN_BENCHMARK=ON \
        ..
make -j 8
make install
popd
adb push build-android-armv7/bin/squeezenet /data/local/tmp

##### MacOS
mkdir -p build-mac
pushd build-mac
cmake   -DNCNN_OPENMP=OFF \
        -DNCNN_OPENCV=ON \
        -DNCNN_BENCHMARK=ON \
        ..
make -j 8
make install
popd 
```

## Result
A benchmark example of squeezenet.
Platform: Google NEXUS P5
Input: 3 x 224 x 224
```shell
Convolution              conv1                       15.05ms    |    feature_map:  224 x 224     inch:    3    outch:   64     kernel: 3 x 3     stride: 2 x 2
ReLU                     relu_conv1                   1.80ms    |    feature_map:  111 x 111     inch:   64    outch:   64
Pooling                  pool1                        3.13ms    |    feature_map:  111 x 111     inch:   64    outch:   64
Convolution              fire2/squeeze1x1             1.39ms    |    feature_map:   55 x 55      inch:   64    outch:   16     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire2/relu_squeeze1x1        0.05ms    |    feature_map:   55 x 55      inch:   16    outch:   16
Split                    splitncnn_0                  0.00ms    |
Convolution              fire2/expand1x1              1.94ms    |    feature_map:   55 x 55      inch:   16    outch:   64     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire2/relu_expand1x1         0.18ms    |    feature_map:   55 x 55      inch:   64    outch:   64
Convolution              fire2/expand3x3             13.30ms    |    feature_map:   55 x 55      inch:   16    outch:   64     kernel: 3 x 3     stride: 1 x 1
ReLU                     fire2/relu_expand3x3         0.28ms    |    feature_map:   55 x 55      inch:   64    outch:   64
Concat                   fire2/concat                 2.31ms    |
Convolution              fire3/squeeze1x1             2.72ms    |    feature_map:   55 x 55      inch:  128    outch:   16     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire3/relu_squeeze1x1        0.06ms    |    feature_map:   55 x 55      inch:   16    outch:   16
Split                    splitncnn_1                  0.00ms    |
Convolution              fire3/expand1x1              1.94ms    |    feature_map:   55 x 55      inch:   16    outch:   64     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire3/relu_expand1x1         0.29ms    |    feature_map:   55 x 55      inch:   64    outch:   64
Convolution              fire3/expand3x3             12.87ms    |    feature_map:   55 x 55      inch:   16    outch:   64     kernel: 3 x 3     stride: 1 x 1
ReLU                     fire3/relu_expand3x3         0.30ms    |    feature_map:   55 x 55      inch:   64    outch:   64
Concat                   fire3/concat                 2.24ms    |
Pooling                  pool3                        1.64ms    |    feature_map:   55 x 55      inch:  128    outch:  128
Convolution              fire4/squeeze1x1             1.38ms    |    feature_map:   27 x 27      inch:  128    outch:   32     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire4/relu_squeeze1x1        0.02ms    |    feature_map:   27 x 27      inch:   32    outch:   32
Split                    splitncnn_2                  0.00ms    |
Convolution              fire4/expand1x1              1.60ms    |    feature_map:   27 x 27      inch:   32    outch:  128     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire4/relu_expand1x1         0.07ms    |    feature_map:   27 x 27      inch:  128    outch:  128
Convolution              fire4/expand3x3              9.40ms    |    feature_map:   27 x 27      inch:   32    outch:  128     kernel: 3 x 3     stride: 1 x 1
ReLU                     fire4/relu_expand3x3         0.11ms    |    feature_map:   27 x 27      inch:  128    outch:  128
Concat                   fire4/concat                 1.09ms    |
Convolution              fire5/squeeze1x1             2.65ms    |    feature_map:   27 x 27      inch:  256    outch:   32     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire5/relu_squeeze1x1        0.02ms    |    feature_map:   27 x 27      inch:   32    outch:   32
Split                    splitncnn_3                  0.00ms    |
Convolution              fire5/expand1x1              1.63ms    |    feature_map:   27 x 27      inch:   32    outch:  128     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire5/relu_expand1x1         0.07ms    |    feature_map:   27 x 27      inch:  128    outch:  128
Convolution              fire5/expand3x3              9.39ms    |    feature_map:   27 x 27      inch:   32    outch:  128     kernel: 3 x 3     stride: 1 x 1
ReLU                     fire5/relu_expand3x3         0.11ms    |    feature_map:   27 x 27      inch:  128    outch:  128
Concat                   fire5/concat                 1.16ms    |
Pooling                  pool5                        0.68ms    |    feature_map:   27 x 27      inch:  256    outch:  256
Convolution              fire6/squeeze1x1             0.70ms    |    feature_map:   13 x 13      inch:  256    outch:   48     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire6/relu_squeeze1x1        0.01ms    |    feature_map:   13 x 13      inch:   48    outch:   48
Split                    splitncnn_4                  0.00ms    |
Convolution              fire6/expand1x1              0.66ms    |    feature_map:   13 x 13      inch:   48    outch:  192     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire6/relu_expand1x1         0.02ms    |    feature_map:   13 x 13      inch:  192    outch:  192
Convolution              fire6/expand3x3              6.39ms    |    feature_map:   13 x 13      inch:   48    outch:  192     kernel: 3 x 3     stride: 1 x 1
ReLU                     fire6/relu_expand3x3         0.02ms    |    feature_map:   13 x 13      inch:  192    outch:  192
Concat                   fire6/concat                 0.39ms    |
Convolution              fire7/squeeze1x1             0.96ms    |    feature_map:   13 x 13      inch:  384    outch:   48     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire7/relu_squeeze1x1        0.01ms    |    feature_map:   13 x 13      inch:   48    outch:   48
Split                    splitncnn_5                  0.00ms    |
Convolution              fire7/expand1x1              0.69ms    |    feature_map:   13 x 13      inch:   48    outch:  192     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire7/relu_expand1x1         0.03ms    |    feature_map:   13 x 13      inch:  192    outch:  192
Convolution              fire7/expand3x3              6.27ms    |    feature_map:   13 x 13      inch:   48    outch:  192     kernel: 3 x 3     stride: 1 x 1
ReLU                     fire7/relu_expand3x3         0.02ms    |    feature_map:   13 x 13      inch:  192    outch:  192
Concat                   fire7/concat                 0.38ms    |
Convolution              fire8/squeeze1x1             1.24ms    |    feature_map:   13 x 13      inch:  384    outch:   64     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire8/relu_squeeze1x1        0.01ms    |    feature_map:   13 x 13      inch:   64    outch:   64
Split                    splitncnn_6                  0.00ms    |
Convolution              fire8/expand1x1              1.12ms    |    feature_map:   13 x 13      inch:   64    outch:  256     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire8/relu_expand1x1         0.03ms    |    feature_map:   13 x 13      inch:  256    outch:  256
Convolution              fire8/expand3x3             10.17ms    |    feature_map:   13 x 13      inch:   64    outch:  256     kernel: 3 x 3     stride: 1 x 1
ReLU                     fire8/relu_expand3x3         0.03ms    |    feature_map:   13 x 13      inch:  256    outch:  256
Concat                   fire8/concat                 0.51ms    |
Convolution              fire9/squeeze1x1             1.69ms    |    feature_map:   13 x 13      inch:  512    outch:   64     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire9/relu_squeeze1x1        0.01ms    |    feature_map:   13 x 13      inch:   64    outch:   64
Split                    splitncnn_7                  0.00ms    |
Convolution              fire9/expand1x1              1.07ms    |    feature_map:   13 x 13      inch:   64    outch:  256     kernel: 1 x 1     stride: 1 x 1
ReLU                     fire9/relu_expand1x1         0.03ms    |    feature_map:   13 x 13      inch:  256    outch:  256
Convolution              fire9/expand3x3             10.07ms    |    feature_map:   13 x 13      inch:   64    outch:  256     kernel: 3 x 3     stride: 1 x 1
ReLU                     fire9/relu_expand3x3         0.03ms    |    feature_map:   13 x 13      inch:  256    outch:  256
Concat                   fire9/concat                 0.54ms    |
Dropout                  drop9                        0.00ms    |    feature_map:   13 x 13      inch:  512    outch:  512
Convolution              conv10                      35.71ms    |    feature_map:   13 x 13      inch:  512    outch: 1000     kernel: 1 x 1     stride: 1 x 1
ReLU                     relu_conv10                  0.32ms    |    feature_map:   15 x 15      inch: 1000    outch: 1000
Pooling                  pool10                       0.43ms    |    feature_map:   15 x 15      inch: 1000    outch: 1000
Softmax                  prob                         0.12ms    |    feature_map:    1 x 1       inch: 1000    outch: 1000
```