### PR TITLE
Add the epsilon parameter to the BatchNorm layer. (fix #303)

### DIFF
--- a/src/layer/batchnorm.cpp
+++ b/src/layer/batchnorm.cpp
@@ -60,7 +60,7 @@ int BatchNorm::load_model(const ModelBin& mb)
 
     for (int i=0; i<channels; i++)
     {
-        float sqrt_var = sqrt(var_data[i]) + eps;
+        float sqrt_var = sqrt(var_data[i] + eps);
         a_data[i] = bias_data[i] - slope_data[i] * mean_data[i] / sqrt_var;
         b_data[i] = slope_data[i] / sqrt_var;
     }

--- a/src/layer/batchnorm.cpp
+++ b/src/layer/batchnorm.cpp
@@ -28,6 +28,7 @@ BatchNorm::BatchNorm()
 int BatchNorm::load_param(const ParamDict& pd)
 {
     channels = pd.get(0, 0);
+    eps = pd.get(1, 0.f);
 
     return 0;
 }
@@ -59,7 +60,7 @@ int BatchNorm::load_model(const ModelBin& mb)
 
     for (int i=0; i<channels; i++)
     {
-        float sqrt_var = sqrt(var_data[i]);
+        float sqrt_var = sqrt(var_data[i]) + eps;
         a_data[i] = bias_data[i] - slope_data[i] * mean_data[i] / sqrt_var;
         b_data[i] = slope_data[i] / sqrt_var;
     }

--- a/src/layer/batchnorm.h
+++ b/src/layer/batchnorm.h
@@ -33,6 +33,7 @@ public:
 public:
     // param
     int channels;
+    float eps;
 
     // model
     Mat slope_data;


### PR DESCRIPTION
Liking the layers MVN and InstanceNorm, add the epsilon to the BatchNorm layer as a parameter to avoid the possible zero-division error.

* Making the default value of the `eps` to be `0.f` is to compatible with the old version.