### PR TITLE
Remove the destructor definition from the lstm layer.

### DIFF
--- a/src/layer/lstm.cpp
+++ b/src/layer/lstm.cpp
@@ -25,10 +25,6 @@ LSTM::LSTM()
     support_inplace = false;
 }
 
-LSTM::~LSTM()
-{
-}
-
 int LSTM::load_param(const ParamDict& pd)
 {
     num_output = pd.get(0, 0);


### PR DESCRIPTION
The destructor of the layer `LSTM` is not declared in its header so there's a compiling error (from gcc)

         error: definition of implicitly-declared ‘virtual ncnn::LSTM::~LSTM()’

I think it's unnecessary to define the destructor of the `LSTM`, so advice to remove it out.