### PR TITLE
Make debug easy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,12 @@ if(WIN32)
 else()
     add_definitions(-Wall -Wextra -Wno-unused-function)
 
-    add_definitions(-fPIC)
-    add_definitions(-Ofast)
+    if(CMAKE_BUILD_TYPE MATCHES "(Release|RELEASE|release)")
+        add_definitions(-fPIC)
+        add_definitions(-Ofast)
 
-    add_definitions(-ffast-math)
+        add_definitions(-ffast-math)
+    endif()
     # add_definitions(-march=native)
 
     # add_definitions(-flto)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 2.8.10)
 
 # set(CMAKE_BUILD_TYPE debug)
 # set(CMAKE_BUILD_TYPE relwithdebinfo)
-set(CMAKE_BUILD_TYPE release)
+set(CMAKE_BUILD_TYPE release CACHE STRING "Release")
 
 option(NCNN_OPENMP "openmp support" ON)
 option(NCNN_STDIO "load model from external file" ON)


### PR DESCRIPTION
Advice two updates to make debug more easy:

1. If the `CMAKE_BUILD_TYPE` is set somewhere, don't overwrite it.
2. If the `CMAKE_BUILD_TYPE` is `Debug`, switch off the optimization options.