### PR TITLE
Fix error: building-ncnn_arm_lib depends on the opencv 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ option(NCNN_OPENCV "minimal opencv structure emulation" OFF)
 option(NCNN_BENCHMARK "print benchmark information for every layer" OFF)
 option(NCNN_PIXEL "convert and resize from/to image pixel" ON)
 option(NCNN_PIXEL_ROTATE "rotate image pixel orientation" OFF)
-option(NCNN_PIXEL_ROTATE "rotate image pixel orientation" OFF)
 option(NCNN_BUILD_ARM_EXAMPLE "notice:arm_example depends on the arm_opencv,If you want to build arm_example,you should be ready to arm_opencv in your host machine " OFF)
 
 if(NCNN_OPENMP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ option(NCNN_OPENCV "minimal opencv structure emulation" OFF)
 option(NCNN_BENCHMARK "print benchmark information for every layer" OFF)
 option(NCNN_PIXEL "convert and resize from/to image pixel" ON)
 option(NCNN_PIXEL_ROTATE "rotate image pixel orientation" OFF)
+option(NCNN_PIXEL_ROTATE "rotate image pixel orientation" OFF)
+option(NCNN_BUILD_ARM_EXAMPLE "notice:arm_example depends on the arm_opencv,If you want to build arm_example,you should be ready to arm_opencv in your host machine " OFF)
 
 if(NCNN_OPENMP)
     find_package(OpenMP)
@@ -65,8 +67,12 @@ elseif(IOS)
 endif()
 
 ##############################################
+if(NCNN_BUILD_ARM_EXAMPLE)
+add_subdirectory(examples)
+else()
+#add_subdirectory(examples)
+endif()
 
-# add_subdirectory(examples)
 # add_subdirectory(benchmark)
 add_subdirectory(src)
 if(NOT ANDROID AND NOT IOS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,11 +67,12 @@ elseif(IOS)
 endif()
 
 ##############################################
-if(NCNN_BUILD_ARM_EXAMPLE)
-add_subdirectory(examples)
-else()
+if(NCNN_BUILD_ARM_EXAMPLE STREQUAL "OFF")
 #add_subdirectory(examples)
+else()
+add_subdirectory(examples)
 endif()
+
 
 # add_subdirectory(benchmark)
 add_subdirectory(src)


### PR DESCRIPTION
Related Erro Info:
 CMake Error at examples/CMakeLists.txt:4 (find_package):
  By not providing "FindOpenCV.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "OpenCV", but
  CMake did not find one.

  Could not find a package configuration file provided by "OpenCV" with any
  of the following names:

    OpenCVConfig.cmake
    opencv-config.cmake

  Add the installation prefix of "OpenCV" to CMAKE_PREFIX_PATH or set
  "OpenCV_DIR" to a directory containing one of the above files.  If "OpenCV"
  provides a separate development package or SDK, be sure it has been
  installed.
