### PR TITLE
fix the bug of innerproduce layer with int8 implement

### DIFF
--- a/src/layer/innerproduct.cpp
+++ b/src/layer/innerproduct.cpp
@@ -138,6 +138,7 @@ int InnerProduct::forward(const Mat& bottom_blob, Mat& top_blob, const Option& o
         for (int p=0; p<num_output; p++)
         {
             int sum = 0;
+            int* out = top_blob;
 
             // channels
             for (int q=0; q<channels; q++)
@@ -151,7 +152,7 @@ int InnerProduct::forward(const Mat& bottom_blob, Mat& top_blob, const Option& o
                 }
             }
 
-            top_blob[p] = sum;
+            out[p] = sum;
         }
 
         // dequantize, reverse scale inplace

--- a/src/layer/x86/convolution_1x1.h
+++ b/src/layer/x86/convolution_1x1.h
@@ -14,8 +14,6 @@
 
 static void conv1x1s1_sse(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Mat& _bias, const Option& opt)
 {
-    int w = bottom_blob.w;
-    int h = bottom_blob.h;
     int inch = bottom_blob.c;
 
     int outw = top_blob.w;


### PR DESCRIPTION
Innerproduce layer with int8 implement,the type of top_blob should be integer.The result of and the mobilenet_v1 is correct(using the cute cat.jpg).

Float32:

```
282 = 0.290811
277 = 0.150142
278 = 0.136092
263 = 0.088919
281 = 0.030729
```

Int8:

```
282 = 0.418365
278 = 0.136934
277 = 0.135897
287 = 0.043163
281 = 0.042881
```