### PR TITLE
add load_param_mem(), which load plain text params from memory buf. 

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -48,6 +48,7 @@ public:
     // return 0 if success
     int load_param(FILE* fp);
     int load_param(const char* protopath);
+    int load_param_mem(const char* mem);
 #endif // NCNN_STRING
     // load network structure from binary param file
     // return 0 if success

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -171,6 +171,92 @@ int ParamDict::load_param(FILE* fp)
 
     return 0;
 }
+
+#define mem_sscanf(ptr, format, ...)  ({int _b=0; int _n = sscanf(ptr, format "%n", __VA_ARGS__, &_b); ptr+=_b;_b>0?_n:0;}) 
+
+int ParamDict::load_param_mem(const char*& mem){
+    clear();
+
+//     0=100 1=1.250000 -23303=5,0.1,0.2,0.4,0.8,1.0
+
+    // parse each key=value pair
+    int id = 0;
+    while (mem_sscanf(mem, "%d=", &id) == 1)
+    {
+        bool is_array = id <= -23300;
+        if (is_array)
+        {
+            id = -id - 23300;
+        }
+
+        if (is_array)
+        {
+            int len = 0;
+            int nscan = mem_sscanf(mem, "%d", &len);
+            if (nscan != 1)
+            {
+                fprintf(stderr, "ParamDict read array length fail\n");
+                return -1;
+            }
+
+            params[id].v.create(len);
+
+            for (int j = 0; j < len; j++)
+            {
+                char vstr[16];
+                nscan = mem_sscanf(mem, ",%15[^,\n ]", vstr);
+                if (nscan != 1)
+                {
+                    fprintf(stderr, "ParamDict read array element fail\n");
+                    return -1;
+                }
+
+                bool is_float = vstr_is_float(vstr);
+
+                if (is_float)
+                {
+                    float* ptr = params[id].v;
+                    nscan = sscanf(vstr, "%f", &ptr[j]);
+                }
+                else
+                {
+                    int* ptr = params[id].v;
+                    nscan = sscanf(vstr, "%d", &ptr[j]);
+                }
+                if (nscan != 1)
+                {
+                    fprintf(stderr, "ParamDict parse array element fail\n");
+                    return -1;
+                }
+            }
+        }
+        else
+        {
+            char vstr[16];
+            int nscan = mem_sscanf(mem, "%15s", vstr);
+            if (nscan != 1)
+            {
+                fprintf(stderr, "ParamDict read value fail\n");
+                return -1;
+            }
+
+            bool is_float = vstr_is_float(vstr);
+
+            if (is_float)
+                nscan = sscanf(vstr, "%f", &params[id].f);
+            else
+                nscan = sscanf(vstr, "%d", &params[id].i);
+            if (nscan != 1)
+            {
+                fprintf(stderr, "ParamDict parse value fail\n");
+                return -1;
+            }
+        }
+
+        params[id].loaded = 1;
+    }
+    return 0;
+}
 #endif // NCNN_STRING
 
 int ParamDict::load_param_bin(FILE* fp)

--- a/src/paramdict.h
+++ b/src/paramdict.h
@@ -58,6 +58,7 @@ protected:
 #if NCNN_STDIO
 #if NCNN_STRING
     int load_param(FILE* fp);
+    int load_param_mem(const char*& mem);
 #endif // NCNN_STRING
     int load_param_bin(FILE* fp);
 #endif // NCNN_STDIO


### PR DESCRIPTION
虽然有load_param(const unsigned char*& mem)，从内存加载 bin格式的params，但是bin格式，只能通过layer index 指定输入输出，不同模型的layer index 不一样，但通过plain text 格式的params，则可以定义特定的输入输出名字。
虽然有 fmemopen()函数可以将一块内存映射位FILE*,就可以套用load_param(FILE* fp)， 但是fmemopen函数只能在Android6.0+上使用。
所