### PR TITLE
fix warning:delete called on non-final 'PoolAllocator/UnlockedPoolAll…

### DIFF
--- a/src/allocator.h
+++ b/src/allocator.h
@@ -121,6 +121,7 @@ private:
 class Allocator
 {
 public:
+    virtual ~Allocator() = 0;
     virtual void* fastMalloc(size_t size) = 0;
     virtual void fastFree(void* ptr) = 0;
 };


### PR DESCRIPTION
…ocator' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]