### PR TITLE
fix warning:有虚函数的基类PoolAllocator需要virtual 析构函数

### DIFF
--- a/src/allocator.h
+++ b/src/allocator.h
@@ -121,6 +121,7 @@ private:
 class Allocator
 {
 public:
+    virtual ~Allocator() = 0;
     virtual void* fastMalloc(size_t size) = 0;
     virtual void fastFree(void* ptr) = 0;
 };


### PR DESCRIPTION
fix warning:delete called on non-final 'PoolAllocator/UnlockedPoolAllocator' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]