### PR TITLE
fix bug : undefined reference to 'typeinfo for ncnn::Allocator'

### DIFF
--- a/src/allocator.h
+++ b/src/allocator.h
@@ -121,7 +121,7 @@ private:
 class Allocator
 {
 public:
-    virtual ~Allocator();
+    virtual ~Allocator() = 0;
     virtual void* fastMalloc(size_t size) = 0;
     virtual void fastFree(void* ptr) = 0;
 };


### PR DESCRIPTION
由于ncnn编译的时候是 '-fno-rtti'的,'使用了-fno-rtti'是不会生成typeinfo,导致自己代码实现了Allocator的子类会出现链接时会出现undefined reference to 'typeinfo for ncnn::Allocator'的问题。
qwq