### PR TITLE
fix the model load error after converting model by ncnn2mem  

### DIFF
--- a/examples/mobilenetv2ssdlite.cpp
+++ b/examples/mobilenetv2ssdlite.cpp
@@ -20,8 +20,6 @@
 
 #include "net.h"
 
-class Noop : public ncnn::Layer {};
-DEFINE_LAYER_CREATOR(Noop)
 
 struct Object
 {
@@ -33,8 +31,6 @@ struct Object
 static int detect_mobilenetv2(const cv::Mat& bgr, std::vector<Object>& objects)
 {
     ncnn::Net mobilenetv2;
-
-    mobilenetv2.register_custom_layer("Silence", Noop_layer_creator);
 
     // original pretrained model from https://github.com/chuanqi305/MobileNetv2-SSDLite
     // https://github.com/chuanqi305/MobileNetv2-SSDLite/blob/master/ssdlite/voc/deploy.prototxt

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,6 +147,7 @@ ncnn_add_layer(Dequantize)
 ncnn_add_layer(Yolov3DetectionOutput)
 ncnn_add_layer(PSROIPooling)
 ncnn_add_layer(ROIAlign OFF)
+ncnn_add_layer(Silence)
 
 add_library(ncnn STATIC ${ncnn_SRCS})
 

--- a/src/layer/silence.cpp
+++ b/src/layer/silence.cpp
@@ -1,0 +1,6 @@
+
+#include "silence.h"
+
+namespace ncnn {
+    DEFINE_LAYER_CREATOR(Silence)
+}

--- a/src/layer/silence.h
+++ b/src/layer/silence.h
@@ -1,0 +1,16 @@
+
+#ifndef NCNN_SILENCE_H
+#define NCNN_SILENCE_H
+
+
+#include "layer.h"
+namespace ncnn {
+
+    class Silence : public Layer
+    {
+
+    };
+
+}
+
+#endif //NCNN_SILENCE_H


### PR DESCRIPTION
if implement silence layer outside, the model load error without any warring. And make the silence layer integrate with ncnn library, it can fix this problem.