### PR TITLE
fix: increase min cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,9 @@ set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation 
 endif()
 message(STATUS "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}")
 
-cmake_minimum_required(VERSION 2.8.10)
+# This is the minimum cmake version supporting the modern cmake OpenMP module below
+# modern cmake requires 3.0 anyway and android cmake requires 3.6
+cmake_minimum_required(VERSION 3.1.3)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE release CACHE STRING "Choose the type of build" FORCE)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src)
 
 add_executable(ncnn2mem ncnn2mem.cpp)
 
-target_link_libraries(ncnn2mem ncnn)
+target_link_libraries(ncnn2mem PRIVATE ncnn)
 
 if(COVERAGE)
     target_link_libraries(ncnn2mem PRIVATE --coverage)


### PR DESCRIPTION
Side note:
* Ubuntu 16.04 comes with cmake 3.5
* Ubuntu 14.04 comes with cmake 2.8 but can easily be upgraded to cmake 3.5:

sudo apt-get remove cmake
sudo apt-get update
sudo apt-get install cmake3

ref: https://packages.ubuntu.com/trusty/cmake3
