### PR TITLE
add the armv7a conv3x3s1 implement without overflow

### DIFF
--- a/src/layer/arm/convolution_1x1_int8.h
+++ b/src/layer/arm/convolution_1x1_int8.h
@@ -3400,7 +3400,7 @@ static void conv1x1s1_int8_neon(const Mat &bottom_blob, Mat &top_blob, const Mat
 /*
  * Convolution 1x1 quantized with int8,unroll 8 x 4
  */
-static void conv1x1s1_neon_s8(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
+static void conv1x1s1_int8_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
 {
     int inch = bottom_blob.c;
 
@@ -3640,6 +3640,179 @@ static void conv1x1s1_neon_s8(const Mat& bottom_blob, Mat& top_blob, const Mat& 
                       "12"(r7)
                     : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q10", "q11", "q13", "q14", "q15"
                 );
+            }
+
+            if (remain >= 4)
+            {
+                remain -= 4;
+
+                asm volatile(
+                    "0:                            \n"
+                    //ld r0-r7
+                    "pld        [%5, #64]          \n"
+                    "vld1.s8    {d0}, [%5 :64]     \n"  //r0
+
+                    "pld        [%6, #64]          \n"
+                    "vld1.s8    {d1}, [%6 :64]     \n"  //r1
+
+                    "pld        [%7, #64]          \n"
+                    "vld1.s8    {d2}, [%7 :64]     \n"  //r2
+
+                    "pld        [%8, #64]          \n"
+                    "vld1.s8    {d3}, [%8 :64]     \n"  //r3
+
+                    "pld        [%9, #64]          \n"
+                    "vld1.s8    {d4}, [%9 :64]     \n"  //r4
+
+                    "pld        [%10, #64]         \n"
+                    "vld1.s8    {d5}, [%10 :64]    \n"  //r5
+
+                    "pld        [%11, #64]         \n"
+                    "vld1.s8    {d6}, [%11 :64]    \n"  //r6
+
+                    "pld        [%12, #64]         \n"
+                    "vld1.s8    {d7}, [%12 :64]    \n"  //r7
+
+                    "add        %5, #4             \n"
+                    "add        %6, #4             \n"
+                    "add        %7, #4             \n"
+                    "add        %8, #4             \n"
+                    "add        %9, #4             \n"
+                    "add        %10, #4            \n"
+                    "add        %11, #4            \n"
+                    "add        %12, #4            \n"
+                    //###########################################
+                    //load inch kernel_0 k0-k7
+                    "vdup.s8    d8, d18[0]          \n"
+                    "vdup.s8    d9, d18[1]          \n"
+                    "vdup.s8    d10, d18[2]         \n"
+                    "vdup.s8    d11, d18[3]         \n"
+                    "vdup.s8    d12, d18[4]         \n"
+                    "vdup.s8    d13, d18[5]         \n"
+                    "vdup.s8    d14, d18[6]         \n"
+                    "vdup.s8    d15, d18[7]         \n"
+
+                    //mla
+                    "vmull.s8   q8, d0, d8          \n"
+                    "vmlal.s8   q8, d1, d9          \n"
+                    "vmlal.s8   q8, d2, d10         \n"
+                    "vmlal.s8   q8, d3, d11         \n"
+                    "vmlal.s8   q8, d4, d12         \n"
+                    "vmlal.s8   q8, d5, d13         \n"
+                    "vmlal.s8   q8, d6, d14         \n"
+                    "vmlal.s8   q8, d7, d15         \n"
+
+                    //outptr0_s32
+                    "pld        [%1, #128]          \n"
+                    "vld1.32    {d20-d21}, [%1:128] \n" //outptr0_s32
+                    "vaddw.s16   q10, q10, d16      \n"
+                    "vst1.32    {d20-d21}, [%1:128]!\n"
+                    //###########################################
+                    //load inch kernel_1 k0-k7
+                    "vdup.s8    d8, d19[0]          \n"
+                    "vdup.s8    d9, d19[1]          \n"
+                    "vdup.s8    d10, d19[2]         \n"
+                    "vdup.s8    d11, d19[3]         \n"
+                    "vdup.s8    d12, d19[4]         \n"
+                    "vdup.s8    d13, d19[5]         \n"
+                    "vdup.s8    d14, d19[6]         \n"
+                    "vdup.s8    d15, d19[7]         \n"
+
+                    //mla
+                    "vmull.s8   q8, d0, d8          \n"
+                    "vmlal.s8   q8, d1, d9          \n"
+                    "vmlal.s8   q8, d2, d10         \n"
+                    "vmlal.s8   q8, d3, d11         \n"
+                    "vmlal.s8   q8, d4, d12         \n"
+                    "vmlal.s8   q8, d5, d13         \n"
+                    "vmlal.s8   q8, d6, d14         \n"
+                    "vmlal.s8   q8, d7, d15         \n"
+
+                    //outptr1_s32
+                    "pld        [%2, #128]          \n"
+                    "vld1.32    {d20-d21}, [%2:128] \n" //outptr1_s32
+                    "vaddw.s16   q10, q10, d16      \n"
+                    "vst1.32    {d20-d21}, [%2:128]!\n"
+                    //############################################
+                    //load inch kernel_2 k0-k7
+                    "vdup.s8    d8, d24[0]          \n"
+                    "vdup.s8    d9, d24[1]          \n"
+                    "vdup.s8    d10, d24[2]         \n"
+                    "vdup.s8    d11, d24[3]         \n"
+                    "vdup.s8    d12, d24[4]         \n"
+                    "vdup.s8    d13, d24[5]         \n"
+                    "vdup.s8    d14, d24[6]         \n"
+                    "vdup.s8    d15, d24[7]         \n"
+
+                    //mla
+                    "vmull.s8   q8, d0, d8          \n"
+                    "vmlal.s8   q8, d1, d9          \n"
+                    "vmlal.s8   q8, d2, d10         \n"
+                    "vmlal.s8   q8, d3, d11         \n"
+                    "vmlal.s8   q8, d4, d12         \n"
+                    "vmlal.s8   q8, d5, d13         \n"
+                    "vmlal.s8   q8, d6, d14         \n"
+                    "vmlal.s8   q8, d7, d15         \n"
+
+                    //outptr2_s32
+                    "pld        [%3, #256]          \n"
+                    "vld1.32    {d20-d21}, [%3:128] \n" //outptr2_s32
+                    "vaddw.s16   q10, q10, d16      \n"
+                    "vst1.32    {d20-d21}, [%3:128]!\n"
+                    //#############################################
+                    //load inch kernel_3 k0-k7
+                    "vdup.s8    d8, d25[0]          \n"
+                    "vdup.s8    d9, d25[1]          \n"
+                    "vdup.s8    d10, d25[2]         \n"
+                    "vdup.s8    d11, d25[3]         \n"
+                    "vdup.s8    d12, d25[4]         \n"
+                    "vdup.s8    d13, d25[5]         \n"
+                    "vdup.s8    d14, d25[6]         \n"
+                    "vdup.s8    d15, d25[7]         \n"
+
+                    //mla
+                    "vmull.s8   q8, d0, d8          \n"
+                    "vmlal.s8   q8, d1, d9          \n"
+                    "vmlal.s8   q8, d2, d10         \n"
+                    "vmlal.s8   q8, d3, d11         \n"
+                    "vmlal.s8   q8, d4, d12         \n"
+                    "vmlal.s8   q8, d5, d13         \n"
+                    "vmlal.s8   q8, d6, d14         \n"
+                    "vmlal.s8   q8, d7, d15         \n"
+
+                    //outptr3_s32
+                    "pld        [%4, #256]          \n"
+                    "vld1.32    {d20-d21}, [%4:128] \n" //outptr3_s32
+                    "vaddw.s16   q10, q10, d16      \n"
+                    "vst1.32    {d20-d21}, [%4:128]!\n"
+                    : "=r"(nn),          // %0
+                      "=r"(outptr0),     // %1
+                      "=r"(outptr1),     // %2
+                      "=r"(outptr2),     // %3
+                      "=r"(outptr3),     // %4
+                      "=r"(r0),          // %5
+                      "=r"(r1),          // %6
+                      "=r"(r2),          // %7
+                      "=r"(r3),          // %8
+                      "=r"(r4),          // %9
+                      "=r"(r5),          // %10
+                      "=r"(r6),          // %11
+                      "=r"(r7)           // %12
+                    : "0"(nn),
+                      "1"(outptr0),
+                      "2"(outptr1),
+                      "3"(outptr2),
+                      "4"(outptr3),
+                      "5"(r0),
+                      "6"(r1),
+                      "7"(r2),
+                      "8"(r3),
+                      "9"(r4),
+                      "10"(r5),
+                      "11"(r6),
+                      "12"(r7)
+                    : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q10", "q11"
+                );                
             }
 
             for (; remain>0; remain--)
@@ -3981,754 +4154,6 @@ static void conv1x1s1_neon_s8(const Mat& bottom_blob, Mat& top_blob, const Mat& 
             }
         }
     }
-}
-
-static void conv1x1s1_neon_s8_left4(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
-{
-    int inch = bottom_blob.c;
-
-    int outw = top_blob.w;
-    int outh = top_blob.h;
-    int outch = top_blob.c;
-
-    const signed char* kernel = _kernel;
-
-    int nn_outch = outch >> 2;
-    int remain_outch_start = nn_outch << 2;
-
-    #pragma omp parallel for num_threads(opt.num_threads)
-    for (int pp=0; pp<nn_outch; pp++)
-    {
-        int p = pp * 4;
-
-        Mat out0 = top_blob.channel(p);
-        Mat out1 = top_blob.channel(p+1);
-        Mat out2 = top_blob.channel(p+2);
-        Mat out3 = top_blob.channel(p+3);
-
-        out0.fill(0);
-        out1.fill(0);
-        out2.fill(0);
-        out3.fill(0);
-
-        int q = 0;
-
-        for (; q+7<inch; q+=8)
-        {
-            int* outptr0 = out0;
-            int* outptr1 = out1;
-            int* outptr2 = out2;
-            int* outptr3 = out3;
-
-            const signed char* r0 = bottom_blob.channel(q);
-            const signed char* r1 = bottom_blob.channel(q+1);
-            const signed char* r2 = bottom_blob.channel(q+2);
-            const signed char* r3 = bottom_blob.channel(q+3);
-            const signed char* r4 = bottom_blob.channel(q+4);
-            const signed char* r5 = bottom_blob.channel(q+5);
-            const signed char* r6 = bottom_blob.channel(q+6);
-            const signed char* r7 = bottom_blob.channel(q+7);
-
-            const signed char* kernel0 = (const signed char*)kernel + p*inch + q;
-            const signed char* kernel1 = (const signed char*)kernel + (p+1)*inch + q;
-            const signed char* kernel2 = (const signed char*)kernel + (p+2)*inch + q;
-            const signed char* kernel3 = (const signed char*)kernel + (p+3)*inch + q;
-
-            int size = outw * outh;
-
-            int nn = size >> 3;
-
-            asm volatile(
-                "vld1.s8    d18, [%0]   \n"
-                "vld1.s8    d19, [%1]   \n"
-                "vld1.s8    d24, [%2]   \n"
-                "vld1.s8    d25, [%3]   \n"
-                : "=r"(kernel0), // %0
-                  "=r"(kernel1), // %1
-                  "=r"(kernel2), // %2
-                  "=r"(kernel3)  // %3
-                : "0"(kernel0),
-                  "1"(kernel1),
-                  "2"(kernel2),
-                  "3"(kernel3)
-                :
-            );
-
-            if (nn > 0)
-            {
-                asm volatile(
-                    "0:                            \n"
-                    //ld r0-r7
-                    "pld        [%5, #64]          \n"
-                    "vld1.s8    {d0}, [%5 :64]!    \n"  //r0
-
-                    "pld        [%6, #64]          \n"
-                    "vld1.s8    {d1}, [%6 :64]!    \n"  //r1
-
-                    "pld        [%7, #64]          \n"
-                    "vld1.s8    {d2}, [%7 :64]!    \n"  //r2
-
-                    "pld        [%8, #64]          \n"
-                    "vld1.s8    {d3}, [%8 :64]!    \n"  //r3
-
-                    "pld        [%9, #64]          \n"
-                    "vld1.s8    {d4}, [%9 :64]!    \n"  //r4
-
-                    "pld        [%10, #64]         \n"
-                    "vld1.s8    {d5}, [%10 :64]!   \n"  //r5
-
-                    "pld        [%11, #64]         \n"
-                    "vld1.s8    {d6}, [%11 :64]!   \n"  //r6
-
-                    "pld        [%12, #64]         \n"
-                    "vld1.s8    {d7}, [%12 :64]!   \n"  //r7
-                    //###########################################
-                    //load inch kernel_0 k0-k7
-                    "vdup.s8    d8, d18[0]          \n"
-                    "vdup.s8    d9, d18[1]          \n"
-                    "vdup.s8    d10, d18[2]         \n"
-                    "vdup.s8    d11, d18[3]         \n"
-                    "vdup.s8    d12, d18[4]         \n"
-                    "vdup.s8    d13, d18[5]         \n"
-                    "vdup.s8    d14, d18[6]         \n"
-                    "vdup.s8    d15, d18[7]         \n"
-
-                    //mla
-                    "vmull.s8   q8, d0, d8          \n"
-                    "vmlal.s8   q8, d1, d9          \n"
-                    "vmlal.s8   q8, d2, d10         \n"
-                    "vmlal.s8   q8, d3, d11         \n"
-                    "vmlal.s8   q8, d4, d12         \n"
-                    "vmlal.s8   q8, d5, d13         \n"
-                    "vmlal.s8   q8, d6, d14         \n"
-                    "vmlal.s8   q8, d7, d15         \n"
-
-                    //outptr0_s32
-                    "pld        [%1, #256]          \n"
-                    "vld1.32    {d20-d23}, [%1:128] \n" //outptr0_s32
-                    "vaddw.s16   q10, q10, d16      \n"
-                    "vaddw.s16   q11, q11, d17      \n"
-                    "vst1.32    {d20-d23}, [%1:128]!\n"
-                    //###########################################
-                    //load inch kernel_1 k0-k7
-                    "vdup.s8    d8, d19[0]          \n"
-                    "vdup.s8    d9, d19[1]          \n"
-                    "vdup.s8    d10, d19[2]         \n"
-                    "vdup.s8    d11, d19[3]         \n"
-                    "vdup.s8    d12, d19[4]         \n"
-                    "vdup.s8    d13, d19[5]         \n"
-                    "vdup.s8    d14, d19[6]         \n"
-                    "vdup.s8    d15, d19[7]         \n"
-
-                    //mla
-                    "vmull.s8   q8, d0, d8          \n"
-                    "vmlal.s8   q8, d1, d9          \n"
-                    "vmlal.s8   q8, d2, d10         \n"
-                    "vmlal.s8   q8, d3, d11         \n"
-                    "vmlal.s8   q8, d4, d12         \n"
-                    "vmlal.s8   q8, d5, d13         \n"
-                    "vmlal.s8   q8, d6, d14         \n"
-                    "vmlal.s8   q8, d7, d15         \n"
-
-                    //outptr1_s32
-                    "pld        [%2, #256]          \n"
-                    "vld1.32    {d20-d23}, [%2:128] \n" //outptr1_s32
-                    "vaddw.s16   q10, q10, d16      \n"
-                    "vaddw.s16   q11, q11, d17      \n"
-                    "vst1.32    {d20-d23}, [%2:128]!\n"
-                    //############################################
-                    //load inch kernel_2 k0-k7
-                    "vdup.s8    d8, d24[0]          \n"
-                    "vdup.s8    d9, d24[1]          \n"
-                    "vdup.s8    d10, d24[2]         \n"
-                    "vdup.s8    d11, d24[3]         \n"
-                    "vdup.s8    d12, d24[4]         \n"
-                    "vdup.s8    d13, d24[5]         \n"
-                    "vdup.s8    d14, d24[6]         \n"
-                    "vdup.s8    d15, d24[7]         \n"
-
-                    //mla
-                    "vmull.s8   q8, d0, d8          \n"
-                    "vmlal.s8   q8, d1, d9          \n"
-                    "vmlal.s8   q8, d2, d10         \n"
-                    "vmlal.s8   q8, d3, d11         \n"
-                    "vmlal.s8   q8, d4, d12         \n"
-                    "vmlal.s8   q8, d5, d13         \n"
-                    "vmlal.s8   q8, d6, d14         \n"
-                    "vmlal.s8   q8, d7, d15         \n"
-
-                    //outptr2_s32
-                    "pld        [%3, #256]          \n"
-                    "vld1.32    {d20-d23}, [%3:128] \n" //outptr2_s32
-                    "vaddw.s16   q10, q10, d16      \n"
-                    "vaddw.s16   q11, q11, d17      \n"
-                    "vst1.32    {d20-d23}, [%3:128]!\n"
-                    //#############################################
-                    //load inch kernel_3 k0-k7
-                    "vdup.s8    d8, d25[0]          \n"
-                    "vdup.s8    d9, d25[1]          \n"
-                    "vdup.s8    d10, d25[2]         \n"
-                    "vdup.s8    d11, d25[3]         \n"
-                    "vdup.s8    d12, d25[4]         \n"
-                    "vdup.s8    d13, d25[5]         \n"
-                    "vdup.s8    d14, d25[6]         \n"
-                    "vdup.s8    d15, d25[7]         \n"
-
-                    //mla
-                    "vmull.s8   q8, d0, d8          \n"
-                    "vmlal.s8   q8, d1, d9          \n"
-                    "vmlal.s8   q8, d2, d10         \n"
-                    "vmlal.s8   q8, d3, d11         \n"
-                    "vmlal.s8   q8, d4, d12         \n"
-                    "vmlal.s8   q8, d5, d13         \n"
-                    "vmlal.s8   q8, d6, d14         \n"
-                    "vmlal.s8   q8, d7, d15         \n"
-
-                    //outptr3_s32
-                    "pld        [%4, #256]          \n"
-                    "vld1.32    {d20-d23}, [%4:128] \n" //outptr3_s32
-                    "vaddw.s16   q10, q10, d16      \n"
-                    "vaddw.s16   q11, q11, d17      \n"
-                    "vst1.32    {d20-d23}, [%4:128]!\n"
-
-                    //next
-                    "subs       %0, #1              \n"
-                    "bne        0b                  \n"
-                    : "=r"(nn),          // %0
-                      "=r"(outptr0),     // %1
-                      "=r"(outptr1),     // %2
-                      "=r"(outptr2),     // %3
-                      "=r"(outptr3),     // %4
-                      "=r"(r0),          // %5
-                      "=r"(r1),          // %6
-                      "=r"(r2),          // %7
-                      "=r"(r3),          // %8
-                      "=r"(r4),          // %9
-                      "=r"(r5),          // %10
-                      "=r"(r6),          // %11
-                      "=r"(r7)           // %12
-                    : "0"(nn),
-                      "1"(outptr0),
-                      "2"(outptr1),
-                      "3"(outptr2),
-                      "4"(outptr3),
-                      "5"(r0),
-                      "6"(r1),
-                      "7"(r2),
-                      "8"(r3),
-                      "9"(r4),
-                      "10"(r5),
-                      "11"(r6),
-                      "12"(r7)
-                    : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q10", "q11"
-                );
-            }
-
-            asm volatile(
-                    "0:                            \n"
-                    //ld r0-r7
-                    "pld        [%5, #64]          \n"
-                    "vld1.s8    {d0}, [%5 :64]     \n"  //r0
-
-                    "pld        [%6, #64]          \n"
-                    "vld1.s8    {d1}, [%6 :64]     \n"  //r1
-
-                    "pld        [%7, #64]          \n"
-                    "vld1.s8    {d2}, [%7 :64]     \n"  //r2
-
-                    "pld        [%8, #64]          \n"
-                    "vld1.s8    {d3}, [%8 :64]     \n"  //r3
-
-                    "pld        [%9, #64]          \n"
-                    "vld1.s8    {d4}, [%9 :64]     \n"  //r4
-
-                    "pld        [%10, #64]         \n"
-                    "vld1.s8    {d5}, [%10 :64]    \n"  //r5
-
-                    "pld        [%11, #64]         \n"
-                    "vld1.s8    {d6}, [%11 :64]    \n"  //r6
-
-                    "pld        [%12, #64]         \n"
-                    "vld1.s8    {d7}, [%12 :64]    \n"  //r7
-
-                    "add        %5, #4             \n"
-                    "add        %6, #4             \n"
-                    "add        %7, #4             \n"
-                    "add        %8, #4             \n"
-                    "add        %9, #4             \n"
-                    "add        %10, #4            \n"
-                    "add        %11, #4            \n"
-                    "add        %12, #4            \n"
-                    //###########################################
-                    //load inch kernel_0 k0-k7
-                    "vdup.s8    d8, d18[0]          \n"
-                    "vdup.s8    d9, d18[1]          \n"
-                    "vdup.s8    d10, d18[2]         \n"
-                    "vdup.s8    d11, d18[3]         \n"
-                    "vdup.s8    d12, d18[4]         \n"
-                    "vdup.s8    d13, d18[5]         \n"
-                    "vdup.s8    d14, d18[6]         \n"
-                    "vdup.s8    d15, d18[7]         \n"
-
-                    //mla
-                    "vmull.s8   q8, d0, d8          \n"
-                    "vmlal.s8   q8, d1, d9          \n"
-                    "vmlal.s8   q8, d2, d10         \n"
-                    "vmlal.s8   q8, d3, d11         \n"
-                    "vmlal.s8   q8, d4, d12         \n"
-                    "vmlal.s8   q8, d5, d13         \n"
-                    "vmlal.s8   q8, d6, d14         \n"
-                    "vmlal.s8   q8, d7, d15         \n"
-
-                    //outptr0_s32
-                    "pld        [%1, #128]          \n"
-                    "vld1.32    {d20-d21}, [%1:128] \n" //outptr0_s32
-                    "vaddw.s16   q10, q10, d16      \n"
-                    "vst1.32    {d20-d21}, [%1:128]!\n"
-                    //###########################################
-                    //load inch kernel_1 k0-k7
-                    "vdup.s8    d8, d19[0]          \n"
-                    "vdup.s8    d9, d19[1]          \n"
-                    "vdup.s8    d10, d19[2]         \n"
-                    "vdup.s8    d11, d19[3]         \n"
-                    "vdup.s8    d12, d19[4]         \n"
-                    "vdup.s8    d13, d19[5]         \n"
-                    "vdup.s8    d14, d19[6]         \n"
-                    "vdup.s8    d15, d19[7]         \n"
-
-                    //mla
-                    "vmull.s8   q8, d0, d8          \n"
-                    "vmlal.s8   q8, d1, d9          \n"
-                    "vmlal.s8   q8, d2, d10         \n"
-                    "vmlal.s8   q8, d3, d11         \n"
-                    "vmlal.s8   q8, d4, d12         \n"
-                    "vmlal.s8   q8, d5, d13         \n"
-                    "vmlal.s8   q8, d6, d14         \n"
-                    "vmlal.s8   q8, d7, d15         \n"
-
-                    //outptr1_s32
-                    "pld        [%2, #128]          \n"
-                    "vld1.32    {d20-d21}, [%2:128] \n" //outptr1_s32
-                    "vaddw.s16   q10, q10, d16      \n"
-                    "vst1.32    {d20-d21}, [%2:128]!\n"
-                    //############################################
-                    //load inch kernel_2 k0-k7
-                    "vdup.s8    d8, d24[0]          \n"
-                    "vdup.s8    d9, d24[1]          \n"
-                    "vdup.s8    d10, d24[2]         \n"
-                    "vdup.s8    d11, d24[3]         \n"
-                    "vdup.s8    d12, d24[4]         \n"
-                    "vdup.s8    d13, d24[5]         \n"
-                    "vdup.s8    d14, d24[6]         \n"
-                    "vdup.s8    d15, d24[7]         \n"
-
-                    //mla
-                    "vmull.s8   q8, d0, d8          \n"
-                    "vmlal.s8   q8, d1, d9          \n"
-                    "vmlal.s8   q8, d2, d10         \n"
-                    "vmlal.s8   q8, d3, d11         \n"
-                    "vmlal.s8   q8, d4, d12         \n"
-                    "vmlal.s8   q8, d5, d13         \n"
-                    "vmlal.s8   q8, d6, d14         \n"
-                    "vmlal.s8   q8, d7, d15         \n"
-
-                    //outptr2_s32
-                    "pld        [%3, #256]          \n"
-                    "vld1.32    {d20-d21}, [%3:128] \n" //outptr2_s32
-                    "vaddw.s16   q10, q10, d16      \n"
-                    "vst1.32    {d20-d21}, [%3:128]!\n"
-                    //#############################################
-                    //load inch kernel_3 k0-k7
-                    "vdup.s8    d8, d25[0]          \n"
-                    "vdup.s8    d9, d25[1]          \n"
-                    "vdup.s8    d10, d25[2]         \n"
-                    "vdup.s8    d11, d25[3]         \n"
-                    "vdup.s8    d12, d25[4]         \n"
-                    "vdup.s8    d13, d25[5]         \n"
-                    "vdup.s8    d14, d25[6]         \n"
-                    "vdup.s8    d15, d25[7]         \n"
-
-                    //mla
-                    "vmull.s8   q8, d0, d8          \n"
-                    "vmlal.s8   q8, d1, d9          \n"
-                    "vmlal.s8   q8, d2, d10         \n"
-                    "vmlal.s8   q8, d3, d11         \n"
-                    "vmlal.s8   q8, d4, d12         \n"
-                    "vmlal.s8   q8, d5, d13         \n"
-                    "vmlal.s8   q8, d6, d14         \n"
-                    "vmlal.s8   q8, d7, d15         \n"
-
-                    //outptr3_s32
-                    "pld        [%4, #256]          \n"
-                    "vld1.32    {d20-d21}, [%4:128] \n" //outptr3_s32
-                    "vaddw.s16   q10, q10, d16      \n"
-                    "vst1.32    {d20-d21}, [%4:128]!\n"
-                    : "=r"(nn),          // %0
-                      "=r"(outptr0),     // %1
-                      "=r"(outptr1),     // %2
-                      "=r"(outptr2),     // %3
-                      "=r"(outptr3),     // %4
-                      "=r"(r0),          // %5
-                      "=r"(r1),          // %6
-                      "=r"(r2),          // %7
-                      "=r"(r3),          // %8
-                      "=r"(r4),          // %9
-                      "=r"(r5),          // %10
-                      "=r"(r6),          // %11
-                      "=r"(r7)           // %12
-                    : "0"(nn),
-                      "1"(outptr0),
-                      "2"(outptr1),
-                      "3"(outptr2),
-                      "4"(outptr3),
-                      "5"(r0),
-                      "6"(r1),
-                      "7"(r2),
-                      "8"(r3),
-                      "9"(r4),
-                      "10"(r5),
-                      "11"(r6),
-                      "12"(r7)
-                    : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q10", "q11"
-                );
-
-        }
-
-        for (; q<inch; q++)
-        {
-            int* outptr0 = out0;
-            int* outptr1 = out1;
-            int* outptr2 = out2;
-            int* outptr3 = out3;
-
-            const signed char* img0_s8 = bottom_blob.channel(q);
-
-            const signed char* kernel0 = (const signed char*)kernel + p*inch + q;
-            const signed char* kernel1 = (const signed char*)kernel + (p+1)*inch + q;
-            const signed char* kernel2 = (const signed char*)kernel + (p+2)*inch + q;
-            const signed char* kernel3 = (const signed char*)kernel + (p+3)*inch + q;
-
-            const signed char k0 = kernel0[0];
-            const signed char k1 = kernel1[0];
-            const signed char k2 = kernel2[0];
-            const signed char k3 = kernel3[0];
-
-            const signed char* r0 = img0_s8;
-
-            int size = outw * outh;
-
-            int nn = size >> 3;
-            int remain = size & 7;
-
-            int8x8_t _k0 = vdup_n_s8(k0);
-            int8x8_t _k1 = vdup_n_s8(k1);
-            int8x8_t _k2 = vdup_n_s8(k2);
-            int8x8_t _k3 = vdup_n_s8(k3);
-
-            if (nn > 0)
-            {
-                asm volatile(
-                    "0:                             \n"
-                    //load r0
-                    "pld        [%5, #64]           \n"
-                    "vld1.s8    {d8}, [%5 :64]!     \n"
-
-                    //mla
-                    "vmull.s8   q5, d8, %12         \n"
-                    //outptr0_s32
-                    "pld        [%1, #256]          \n"
-                    "vld1.32    {d12-d15}, [%1]     \n"
-                    "vaddw.s16   q6, q6, d10        \n"
-                    "vaddw.s16   q7, q7, d11        \n"
-                    "vst1.32    {d12-d15}, [%1]!    \n"
-
-                    //mla
-                    "vmull.s8   q5, d8, %13         \n"
-                    //outptr1_s32
-                    "pld        [%2, #256]          \n"
-                    "vld1.32    {d12-d15}, [%2]     \n"
-                    "vaddw.s16   q6, q6, d10        \n"
-                    "vaddw.s16   q7, q7, d11        \n"
-                    "vst1.32    {d12-d15}, [%2]!    \n"
-
-                    //mla
-                    "vmull.s8   q5, d8, %14         \n"
-                    //outptr0_s32
-                    "pld        [%3, #256]          \n"
-                    "vld1.32    {d12-d15}, [%3]     \n"
-                    "vaddw.s16   q6, q6, d10        \n"
-                    "vaddw.s16   q7, q7, d11        \n"
-                    "vst1.32    {d12-d15}, [%3]!    \n"
-
-                    //mla
-                    "vmull.s8   q5, d8, %15         \n"
-                    //outptr0_s32
-                    "pld        [%4, #256]          \n"
-                    "vld1.32    {d12-d15}, [%4]     \n"
-                    "vaddw.s16   q6, q6, d10        \n"
-                    "vaddw.s16   q7, q7, d11        \n"
-                    "vst1.32    {d12-d15}, [%4]!    \n"
-
-                    "subs       %0, #1              \n"
-                    "bne        0b                  \n"
-                    : "=r"(nn),             // %0
-                      "=r"(outptr0),        // %1
-                      "=r"(outptr1),        // %2
-                      "=r"(outptr2),        // %3
-                      "=r"(outptr3),        // %4
-                      "=r"(r0)              // %5
-                    : "0"(nn),
-                      "1"(outptr0),
-                      "2"(outptr1),
-                      "3"(outptr2),
-                      "4"(outptr3),
-                      "5"(r0),
-                      "w"(_k0),             // %12
-                      "w"(_k1),             // %13
-                      "w"(_k2),             // %14
-                      "w"(_k3)              // %15
-                    : "cc", "memory", "q4", "q5", "q6", "q7", "q8", "q9"
-                );
-            }
-
-            for (; remain>0; remain--)
-            {
-                // TODO neon optimize
-                int sum0 = (int)*r0 * k0;
-                int sum1 = (int)*r0 * k1;
-                int sum2 = (int)*r0 * k2;
-                int sum3 = (int)*r0 * k3;
-
-                *outptr0 += sum0;
-                *outptr1 += sum1;
-                *outptr2 += sum2;
-                *outptr3 += sum3;
-
-                r0++;
-                outptr0++;
-                outptr1++;
-                outptr2++;
-                outptr3++;
-            }
-        }
-    }
-
-    #pragma omp parallel for num_threads(opt.num_threads)
-    for (int p=remain_outch_start; p<outch; p++)
-    {
-        Mat out0 = top_blob.channel(p);
-
-        out0.fill(0);
-
-        int q = 0;
-
-        for (; q+7<inch; q+=8)
-        {
-            int* outptr0 = out0;
-
-            const signed char* r0 = bottom_blob.channel(q);
-            const signed char* r1 = bottom_blob.channel(q+1);
-            const signed char* r2 = bottom_blob.channel(q+2);
-            const signed char* r3 = bottom_blob.channel(q+3);
-            const signed char* r4 = bottom_blob.channel(q+4);
-            const signed char* r5 = bottom_blob.channel(q+5);
-            const signed char* r6 = bottom_blob.channel(q+6);
-            const signed char* r7 = bottom_blob.channel(q+7);
-
-            const signed char* kernel0 = (const signed char*)kernel + p*inch + q;
-
-            int size = outw * outh;
-
-            int nn = size >> 3;
-            int remain = size & 7;
-
-            if (nn > 0)
-            {
-                //load inch kernel_0 k0-k7
-                asm volatile(
-                    "vld1.s8    d18, [%0]   \n"
-                    : "=r"(kernel0) // %0
-                    : "0" (kernel0)
-                    :
-                );
-
-                asm volatile(
-                    "0:                            \n"
-                    //ld r0-r7
-                    "pld        [%2, #64]          \n"
-                    "vld1.s8    {d0}, [%2 :64]!    \n"  //r0
-                    "pld        [%3, #64]          \n"
-                    "vld1.s8    {d1}, [%3 :64]!    \n"  //r1
-                    "pld        [%4, #64]          \n"
-                    "vld1.s8    {d2}, [%4 :64]!    \n"  //r2
-                    "pld        [%5, #64]          \n"
-                    "vld1.s8    {d3}, [%5 :64]!    \n"  //r3
-                    "pld        [%6, #64]          \n"
-                    "vld1.s8    {d4}, [%6 :64]!    \n"  //r4
-                    "pld        [%7, #64]          \n"
-                    "vld1.s8    {d5}, [%7 :64]!    \n"  //r5
-                    "pld        [%8, #64]          \n"
-                    "vld1.s8    {d6}, [%8 :64]!    \n"  //r6
-                    "pld        [%9, #64]          \n"
-                    "vld1.s8    {d7}, [%9 :64]!    \n"  //r7
-
-                    //load inch kernel_0 k0-k7
-                    "vdup.s8    d8, d18[0]          \n"
-                    "vdup.s8    d9, d18[1]          \n"
-                    "vdup.s8    d10, d18[2]         \n"
-                    "vdup.s8    d11, d18[3]         \n"
-                    "vdup.s8    d12, d18[4]         \n"
-                    "vdup.s8    d13, d18[5]         \n"
-                    "vdup.s8    d14, d18[6]         \n"
-                    "vdup.s8    d15, d18[7]         \n"
-
-                    //mla
-                    "vmull.s8   q8, d0, d8          \n"
-                    "vmlal.s8   q8, d1, d9          \n"
-                    "vmlal.s8   q8, d2, d10         \n"
-                    "vmlal.s8   q8, d3, d11         \n"
-                    "vmlal.s8   q8, d4, d12         \n"
-                    "vmlal.s8   q8, d5, d13         \n"
-                    "vmlal.s8   q8, d6, d14         \n"
-                    "vmlal.s8   q8, d7, d15         \n"
-
-                    //outptr0_s32
-                    "pld        [%1, #256]          \n"
-                    "vld1.32    {d20-d23}, [%1]     \n" //outptr0_s32
-                    "vaddw.s16   q10, q10, d16      \n"
-                    "vaddw.s16   q11, q11, d17      \n"
-                    "vst1.32    {d20-d23}, [%1]!    \n"
-
-                    //next
-                    "subs       %0, #1              \n"
-                    "bne        0b                  \n"
-                    : "=r"(nn),          // %0
-                      "=r"(outptr0),     // %1
-                      "=r"(r0),          // %2
-                      "=r"(r1),          // %3
-                      "=r"(r2),          // %4
-                      "=r"(r3),          // %5
-                      "=r"(r4),          // %6
-                      "=r"(r5),          // %7
-                      "=r"(r6),          // %8
-                      "=r"(r7)           // %9
-                    : "0"(nn),
-                      "1"(outptr0),
-                      "2"(r0),
-                      "3"(r1),
-                      "4"(r2),
-                      "5"(r3),
-                      "6"(r4),
-                      "7"(r5),
-                      "8"(r6),
-                      "9"(r7)
-                    : "cc", "memory", "q0", "q1", "q2", "q3", "q8", "q10", "q11", "q12", "q13"
-                );
-            }
-
-            for (; remain>0; remain--)
-            {
-                //ToDo Neon
-                int sum0 = (int)*r0 * kernel0[0] + *r1 * kernel0[1] + *r2 * kernel0[2] + *r3 * kernel0[3] + *r4 * kernel0[4] + *r5 * kernel0[5] + *r6 * kernel0[6] + *r7 * kernel0[7];
-
-                *outptr0 += sum0;
-
-                r0++;
-                r1++;
-                r2++;
-                r3++;
-                r4++;
-                r5++;
-                r6++;
-                r7++;
-                outptr0++;
-            }
-        }
-
-        for (; q<inch; q++)
-        {
-            int* outptr0 = out0;
-
-            const signed char* img0_s8 = bottom_blob.channel(q);
-            const signed char* r0 = img0_s8;
-
-            const signed char* kernel0 = (const signed char*)kernel + p*inch + q;
-            const signed char k0 = kernel0[0];
-
-            int size = outw * outh;
-
-            int nn = size >> 3;
-            int remain = size & 7;
-
-            int8x8_t _k0 = vdup_n_s8(k0);
-
-            if (nn > 0)
-            {
-                asm volatile(
-                    "0:                             \n"
-                    //load r0
-                    "pld        [%2, #64]           \n"
-                    "vld1.s8    {d8}, [%2 :64]!     \n"
-
-                    //mla
-                    "vmull.s8   q5, d8, %6          \n"
-                    //outptr0_s32
-                    "pld        [%1, #256]          \n"
-                    "vld1.32    {d12-d15}, [%1]     \n"
-                    "vaddw.s16   q6, q6, d10        \n"
-                    "vaddw.s16   q7, q7, d11        \n"
-                    "vst1.32    {d12-d15}, [%1]!    \n"
-
-                    "subs       %0, #1              \n"
-                    "bne        0b                  \n"
-                    : "=r"(nn),             // %0
-                      "=r"(outptr0),        // %1
-                      "=r"(r0)              // %2
-                    : "0"(nn),
-                      "1"(outptr0),
-                      "2"(r0),
-                      "w"(_k0)              // %6
-                    : "cc", "memory", "q4", "q5", "q7", "q8", "q9"
-                );
-            }
-
-            for (; remain>0; remain--)
-            {
-                int sum0 = (int)*r0 * k0;
-
-                *outptr0 += sum0;
-
-                r0++;
-                outptr0++;
-            }
-        }
-    }
-}
-
-static void conv1x1s1_int8_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
-{
-    int size = top_blob.h * top_blob.w;
-    int remain = size & 7;
-
-    typedef void (*conv_func_int8)(const Mat&, Mat&, const Mat&, const Option&);
-
-    conv_func_int8 conv_func_table[8] =
-    {
-        conv1x1s1_neon_s8,          //0
-        conv1x1s1_neon_s8,          //1
-        conv1x1s1_neon_s8,          //2
-        conv1x1s1_neon_s8,          //3
-        conv1x1s1_neon_s8_left4,    //4
-        conv1x1s1_neon_s8,          //5
-        conv1x1s1_neon_s8,          //6
-        conv1x1s1_neon_s8,          //7
-    };
-
-    conv_func_int8 conv = conv_func_table[remain];
-
-    conv(bottom_blob, top_blob, _kernel, opt);
-
-    return;
 }
 
 static void conv1x1s1_sgemm_int8_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Option& opt)

--- a/src/layer/arm/convolution_3x3_int8.h
+++ b/src/layer/arm/convolution_3x3_int8.h
@@ -4152,7 +4152,6 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
                 {
                 asm volatile(
                     "vld1.s8    {d0-d1}, [%5]       \n"// d0(k0 - k7) d1(k8 ...)
-                    "add        %5, #9              \n"
                     "vmovl.s8   q1, d1              \n"// d2(k8 ...)
                     "vmovl.s8   q0, d0              \n"// d0(k0 - k3) d1(k4 - k7)
                     "0:                             \n"
@@ -4173,7 +4172,7 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
                     "vmovl.s8   q2, d4              \n"// q2(a00 a02 ... a014)
                     "vmovl.s8   q4, d8              \n"// q4(a02 a04 ... a016)
 
-                    "vmovl.s8   q6, d11             \n"// q6(a10 a12 ... a114)
+                    "vmovl.s8   q6, d11             \n"// q6(a11 a13 ... a115)
                     "vmovl.s8   q5, d10             \n"// q5(a10 a12 ... a114)
                     "vmovl.s8   q7, d14             \n"// q7(a12 a14 ... a116)
 
@@ -4195,12 +4194,12 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
                     "vmlal.s16  q13, d14, d1[1]     \n"// k5
                     "vmlal.s16  q14, d15, d1[1]     \n"
 
-                    "vmlal.s16  q11, d12, d1[2]     \n"// k6
-                    "vmlal.s16  q12, d13, d1[2]     \n"
-                    "vmlal.s16  q13, d14, d1[3]     \n"// k7 
-                    "vmlal.s16  q14, d15, d1[3]     \n"
-                    "vmlal.s16  q11, d16, d2[0]     \n"// k8 
-                    "vmlal.s16  q12, d17, d2[0]     \n"
+                    "vmlal.s16  q11, d16, d1[2]     \n"// k6
+                    "vmlal.s16  q12, d17, d1[2]     \n"
+                    "vmlal.s16  q13, d18, d1[3]     \n"// k7 
+                    "vmlal.s16  q14, d19, d1[3]     \n"
+                    "vmlal.s16  q11, d20, d2[0]     \n"// k8 
+                    "vmlal.s16  q12, d21, d2[0]     \n"
 
                     "vadd.s32   q11, q11, q13       \n"
                     "vadd.s32   q12, q12, q14       \n"

--- a/src/layer/arm/convolution_3x3_int8.h
+++ b/src/layer/arm/convolution_3x3_int8.h
@@ -1347,7 +1347,7 @@ static void conv3x3s2_int8_neon(const Mat& bottom_blob, Mat& top_blob, const Mat
     }   
 }
 #else // __aarch64__
-static void conv3x3s1_neon_s8(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
+static void conv3x3s1_int8_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
 {
     int w = bottom_blob.w;
     int inch = bottom_blob.c;
@@ -2086,1936 +2086,7 @@ static void conv3x3s1_neon_s8(const Mat& bottom_blob, Mat& top_blob, const Mat& 
     }
 }
 
-static void conv3x3s1_neon_s8_left4(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
-{
-    int w = bottom_blob.w;
-    int inch = bottom_blob.c;
-
-    int outw = top_blob.w;
-    int outh = top_blob.h;
-    int outch = top_blob.c;
-
-    const float* kernel = _kernel;
-
-    int nn_outch = outch >> 1;
-    int remain_outch_start = nn_outch << 1; 
-
-    #pragma omp parallel for num_threads(opt.num_threads)
-    for (int pp=0; pp < nn_outch; pp++)
-    {
-        int p = pp * 2;
-
-        Mat out0 = top_blob.channel(p);
-        Mat out1 = top_blob.channel(p+1);
-
-        out0.fill(0);
-        out1.fill(0);
-
-        const signed char* kernel0 = (const signed char *)kernel + p * inch * 9;
-        const signed char* kernel1 = (const signed char *)kernel + (p + 1) * inch * 9;
-        
-        for (int q=0; q<inch; q++)
-        {
-            int* outptr0 = out0;
-            int* outptr1 = out1;
-            int* outptr0n = outptr0 + outw;
-            int* outptr1n = outptr1 + outw;
-        
-            const signed char* img0 = bottom_blob.channel(q);
-
-            const signed char* r0 = img0;
-            const signed char* r1 = img0 + w;
-            const signed char* r2 = img0 + w*2;
-            const signed char* r3 = img0 + w*3;
-
-            int i = 0;
-            for (; i+1 < outh; i+=2)
-            {
-                int nn = outw >> 3;
-
-                asm volatile(
-                    "vld1.8    {d26-d27}, [%0]    \n"  // k00 k01 k02 k03 k04 k05 k06 k07 k08
-                    "vld1.8    {d28-d29}, [%1]    \n"  // k10 k11 k12 k13 k14 k15 k16 k17 k18
-                    : "=r"(kernel0), // %0
-                      "=r"(kernel1)  // %1
-                    : "0"(kernel0),
-                      "1"(kernel1)
-                    : "cc", "memory"
-                );
-
-                if (nn > 0)
-                {
-                    asm volatile(
-                        "0:                             \n"
-                        "pld        [%5, #128]          \n"
-                        "vld1.32    {d0-d1}, [%5]       \n"// r0
-                        "add        %5, #8              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%6, #128]          \n"
-                        "vld1.32    {d6-d7}, [%6]       \n"// r1
-                        "add        %6, #8              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%7, #128]          \n"
-                        "vld1.32    {d10-d11}, [%7]     \n"// r2
-                        "add        %7, #8              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%8, #128]          \n"
-                        "vld1.32    {d14-d15}, [%8]     \n"// r3
-                        "add        %8, #8              \n"
-                        "vext.8     d16, d14, d15, #1   \n"
-                        "vext.8     d17, d14, d15, #2   \n"
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d21}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%1]!    \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d6, d1          \n"// k0
-                        "vmlal.s8   q2, d8, d30         \n"// k1
-                        "vmlal.s8   q2, d9, d31         \n"// k2
-
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k3
-                        "vmlal.s8   q2, d12, d30        \n"// k4
-                        "vmlal.s8   q2, d13, d31        \n"// k5
-
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d14, d1         \n"// k6
-                        "vmlal.s8   q2, d16, d30        \n"// k7
-                        "vmlal.s8   q2, d17, d31        \n"// k8
-
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d18-d21}, [%2]     \n"// sum0n
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%2]!    \n"
-                        
-                        "vdup.s8     d1, d28[0]         \n"
-                        "vdup.s8    d30, d28[1]         \n"
-                        "vdup.s8    d31, d28[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0n
-                        "vmlal.s8   q2, d2, d30         \n"// k1n
-                        "vmlal.s8   q2, d3, d31         \n"// k2n
-
-                        "vdup.s8     d1, d28[3]         \n"
-                        "vdup.s8    d30, d28[4]         \n"
-                        "vdup.s8    d31, d28[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3n
-                        "vmlal.s8   q2, d8, d30         \n"// k4n
-                        "vmlal.s8   q2, d9, d31         \n"// k5n
-
-                        "vdup.s8     d1, d28[6]         \n"
-                        "vdup.s8    d30, d28[7]         \n"
-                        "vdup.s8    d31, d29[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6n
-                        "vmlal.s8   q2, d12, d30        \n"// k7n
-                        "vmlal.s8   q2, d13, d31        \n"// k8n
-
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d18-d21}, [%3]     \n"// sum1
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%3]!    \n"
-                        
-                        "vdup.s8     d1, d28[0]         \n"
-                        "vdup.s8    d30, d28[1]         \n"
-                        "vdup.s8    d31, d28[2]         \n"
-                        "vmull.s8   q2, d6, d1          \n"// k0n
-                        "vmlal.s8   q2, d8, d30         \n"// k1n
-                        "vmlal.s8   q2, d9, d31         \n"// k2n
-
-                        "vdup.s8     d1, d28[3]         \n"
-                        "vdup.s8    d30, d28[4]         \n"
-                        "vdup.s8    d31, d28[5]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k3n
-                        "vmlal.s8   q2, d12, d30        \n"// k4n
-                        "vmlal.s8   q2, d13, d31        \n"// k5n
-
-                        "vdup.s8     d1, d28[6]         \n"
-                        "vdup.s8    d30, d28[7]         \n"
-                        "vdup.s8    d31, d29[0]         \n"
-                        "vmlal.s8   q2, d14, d1         \n"// k6n
-                        "vmlal.s8   q2, d16, d30        \n"// k7n
-                        "vmlal.s8   q2, d17, d31        \n"// k8n
-
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d18-d21}, [%4]     \n"// sum1n
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%4]!    \n"
-
-                        "subs       %0, #1              \n"
-                        "bne        0b                  \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),        // %1
-                          "=r"(outptr0n),       // %2
-                          "=r"(outptr1),        // %3
-                          "=r"(outptr1n),       // %4
-                          "=r"(r0),             // %5
-                          "=r"(r1),             // %6
-                          "=r"(r2),             // %7
-                          "=r"(r3)              // %8
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(outptr0n),
-                          "3"(outptr1),
-                          "4"(outptr1n),
-                          "5"(r0),
-                          "6"(r1),
-                          "7"(r2),
-                          "8"(r3)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q15"
-                    );
-                }
-
-                asm volatile(
-                    "pld        [%5, #128]          \n"
-                    "vld1.32    {d0-d1}, [%5]       \n"// r0
-                    "add        %5, #4              \n"
-                    "vext.8     d2, d0, d1, #1      \n"
-                    "vext.8     d3, d0, d1, #2      \n"
-                    
-                    "vdup.s8     d1, d26[0]         \n"
-                    "vdup.s8    d30, d26[1]         \n"
-                    "vdup.s8    d31, d26[2]         \n"
-                    "vmull.s8   q2, d0, d1          \n"// k0
-                    "vmlal.s8   q2, d2, d30         \n"// k1
-                    "vmlal.s8   q2, d3, d31         \n"// k2
-                    
-                    "pld        [%6, #128]          \n"
-                    "vld1.32    {d6-d7}, [%6]       \n"// r1
-                    "add        %6, #4              \n"
-                    "vext.8     d8, d6, d7, #1      \n"
-                    "vext.8     d9, d6, d7, #2      \n"
-                    
-                    "vdup.s8     d1, d26[3]         \n"
-                    "vdup.s8    d30, d26[4]         \n"
-                    "vdup.s8    d31, d26[5]         \n"
-                    "vmlal.s8   q2, d6, d1          \n"// k3
-                    "vmlal.s8   q2, d8, d30         \n"// k4
-                    "vmlal.s8   q2, d9, d31         \n"// k5
-
-                    "pld        [%7, #128]          \n"
-                    "vld1.32    {d10-d11}, [%7]     \n"// r2
-                    "add        %7, #4              \n"
-                    "vext.8     d12, d10, d11, #1   \n"
-                    "vext.8     d13, d10, d11, #2   \n"
-                    
-                    "vdup.s8     d1, d26[6]         \n"
-                    "vdup.s8    d30, d26[7]         \n"
-                    "vdup.s8    d31, d27[0]         \n"
-                    "vmlal.s8   q2, d10, d1         \n"// k6
-                    "vmlal.s8   q2, d12, d30        \n"// k7
-                    "vmlal.s8   q2, d13, d31        \n"// k8
-                    
-                    "pld        [%8, #128]          \n"
-                    "vld1.32    {d14-d15}, [%8]     \n"// r3
-                    "add        %8, #4              \n"
-                    "vext.8     d16, d14, d15, #1   \n"
-                    "vext.8     d17, d14, d15, #2   \n"
-                    
-                    "pld        [%1, #128]          \n"
-                    "vld1.32    {d18-d19}, [%1]     \n"// sum0
-                    "vaddw.s16   q9, q9, d4         \n"
-                    "vst1.32    {d18-d19}, [%1]!    \n"
-                    
-                    "vdup.s8     d1, d26[0]         \n"
-                    "vdup.s8    d30, d26[1]         \n"
-                    "vdup.s8    d31, d26[2]         \n"
-                    "vmull.s8   q2, d6, d1          \n"// k0
-                    "vmlal.s8   q2, d8, d30         \n"// k1
-                    "vmlal.s8   q2, d9, d31         \n"// k2
-
-                    "vdup.s8     d1, d26[3]         \n"
-                    "vdup.s8    d30, d26[4]         \n"
-                    "vdup.s8    d31, d26[5]         \n"
-                    "vmlal.s8   q2, d10, d1         \n"// k3
-                    "vmlal.s8   q2, d12, d30        \n"// k4
-                    "vmlal.s8   q2, d13, d31        \n"// k5
-
-                    "vdup.s8     d1, d26[6]         \n"
-                    "vdup.s8    d30, d26[7]         \n"
-                    "vdup.s8    d31, d27[0]         \n"
-                    "vmlal.s8   q2, d14, d1         \n"// k6
-                    "vmlal.s8   q2, d16, d30        \n"// k7
-                    "vmlal.s8   q2, d17, d31        \n"// k8
-
-                    "pld        [%2, #128]          \n"
-                    "vld1.32    {d18-d19}, [%2]     \n"// sum0n
-                    "vaddw.s16   q9, q9, d4         \n"
-                    "vst1.32    {d18-d19}, [%2]!    \n"
-
-                    "vdup.s8     d1, d28[0]         \n"
-                    "vdup.s8    d30, d28[1]         \n"
-                    "vdup.s8    d31, d28[2]         \n"
-                    "vmull.s8   q2, d0, d1          \n"// k0n
-                    "vmlal.s8   q2, d2, d30         \n"// k1n
-                    "vmlal.s8   q2, d3, d31         \n"// k2n
-
-                    "vdup.s8     d1, d28[3]         \n"
-                    "vdup.s8    d30, d28[4]         \n"
-                    "vdup.s8    d31, d28[5]         \n"
-                    "vmlal.s8   q2, d6, d1          \n"// k3n
-                    "vmlal.s8   q2, d8, d30         \n"// k4n
-                    "vmlal.s8   q2, d9, d31         \n"// k5n
-
-                    "vdup.s8     d1, d28[6]         \n"
-                    "vdup.s8    d30, d28[7]         \n"
-                    "vdup.s8    d31, d29[0]         \n"
-                    "vmlal.s8   q2, d10, d1         \n"// k6n
-                    "vmlal.s8   q2, d12, d30        \n"// k7n
-                    "vmlal.s8   q2, d13, d31        \n"// k8n
-
-                    "pld        [%3, #128]          \n"
-                    "vld1.32    {d18-d19}, [%3]     \n"// sum1
-                    "vaddw.s16   q9, q9, d4         \n"
-                    "vst1.32    {d18-d19}, [%3]!    \n"
-                    
-                    "vdup.s8     d1, d28[0]         \n"
-                    "vdup.s8    d30, d28[1]         \n"
-                    "vdup.s8    d31, d28[2]         \n"
-                    "vmull.s8   q2, d6, d1          \n"// k0n
-                    "vmlal.s8   q2, d8, d30         \n"// k1n
-                    "vmlal.s8   q2, d9, d31         \n"// k2n
-
-                    "vdup.s8     d1, d28[3]         \n"
-                    "vdup.s8    d30, d28[4]         \n"
-                    "vdup.s8    d31, d28[5]         \n"
-                    "vmlal.s8   q2, d10, d1         \n"// k3n
-                    "vmlal.s8   q2, d12, d30        \n"// k4n
-                    "vmlal.s8   q2, d13, d31        \n"// k5n
-
-                    "vdup.s8     d1, d28[6]         \n"
-                    "vdup.s8    d30, d28[7]         \n"
-                    "vdup.s8    d31, d29[0]         \n"
-                    "vmlal.s8   q2, d14, d1         \n"// k6n
-                    "vmlal.s8   q2, d16, d30        \n"// k7n
-                    "vmlal.s8   q2, d17, d31        \n"// k8n
-
-                    "pld        [%4, #128]          \n"
-                    "vld1.32    {d18-d19}, [%4]     \n"// sum1n
-                    "vaddw.s16   q9, q9, d4         \n"
-                    "vst1.32    {d18-d19}, [%4]!    \n"
-                    : "=r"(nn),             // %0
-                      "=r"(outptr0),        // %1
-                      "=r"(outptr0n),       // %2
-                      "=r"(outptr1),        // %3
-                      "=r"(outptr1n),       // %4
-                      "=r"(r0),             // %5
-                      "=r"(r1),             // %6
-                      "=r"(r2),             // %7
-                      "=r"(r3)              // %8
-                    : "0"(nn),
-                      "1"(outptr0),
-                      "2"(outptr0n),
-                      "3"(outptr1),
-                      "4"(outptr1n),
-                      "5"(r0),
-                      "6"(r1),
-                      "7"(r2),
-                      "8"(r3)
-                    : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q15"
-                );
-
-                r0 += 2 + w;
-                r1 += 2 + w;
-                r2 += 2 + w;
-                r3 += 2 + w;
-
-                outptr0 += outw;
-                outptr1 += outw;
-                outptr0n += outw;
-                outptr1n += outw;
-            }
-
-            for (; i < outh; i++)
-            {
-                int nn = outw >> 3;
-
-                asm volatile(
-                    "vld1.8    {d26-d27}, [%0]    \n"
-                    "vld1.8    {d28-d29}, [%1]    \n"
-                    : "=r"(kernel0), // %0
-                      "=r"(kernel1)  // %1
-                    : "0"(kernel0),
-                      "1"(kernel1)
-                    : "cc", "memory"
-                );
-
-                if (nn > 0)
-                {
-                    asm volatile(
-                        "0:                             \n"
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d0-d1}, [%3]       \n"// r0
-                        "add        %3, #8              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d6-d7}, [%4]       \n"// r1
-                        "add        %4, #8              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%5, #128]          \n"
-                        "vld1.32    {d10-d11}, [%5]     \n"// r2
-                        "add        %5, #8              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d21}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%1]!    \n"
-                        
-                        "vdup.s8     d1, d28[0]         \n"
-                        "vdup.s8     d7, d28[1]         \n"
-                        "vdup.s8    d11, d28[2]         \n" 
-                        "vmull.s8   q2, d0, d1          \n"// k0n
-                        "vmlal.s8   q2, d2, d7          \n"// k1n
-                        "vmlal.s8   q2, d3, d11         \n"// k2n
-
-                        "vdup.s8     d1, d28[3]         \n"
-                        "vdup.s8     d7, d28[4]         \n"
-                        "vdup.s8    d11, d28[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3n
-                        "vmlal.s8   q2, d8, d7          \n"// k4n
-                        "vmlal.s8   q2, d9, d11         \n"// k5n
-
-                        "vdup.s8     d1, d28[6]         \n"
-                        "vdup.s8     d7, d28[7]         \n"
-                        "vdup.s8    d11, d29[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6n
-                        "vmlal.s8   q2, d12, d7         \n"// k7n
-                        "vmlal.s8   q2, d13, d11        \n"// k8n
-
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d18-d21}, [%2]     \n"// sum1
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%2]!    \n"
-
-                        "subs       %0, #1              \n"
-                        "bne        0b                  \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),        // %1
-                          "=r"(outptr1),        // %2
-                          "=r"(r0),             // %3
-                          "=r"(r1),             // %4
-                          "=r"(r2)              // %5
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(outptr1),
-                          "3"(r0),
-                          "4"(r1),
-                          "5"(r2)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-                }
-
-                asm volatile(
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d0-d1}, [%3]       \n"// r0
-                        "add        %3, #4              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d6-d7}, [%4]       \n"// r1
-                        "add        %4, #4              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%5, #128]          \n"
-                        "vld1.32    {d10-d11}, [%5]     \n"// r2
-                        "add        %5, #4              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d19}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vst1.32    {d18-d19}, [%1]!    \n"
-                        
-                        "vdup.s8     d1, d28[0]         \n"
-                        "vdup.s8     d7, d28[1]         \n"
-                        "vdup.s8    d11, d28[2]         \n" 
-                        "vmull.s8   q2, d0, d1          \n"// k0n
-                        "vmlal.s8   q2, d2, d7          \n"// k1n
-                        "vmlal.s8   q2, d3, d11         \n"// k2n
-
-                        "vdup.s8     d1, d28[3]         \n"
-                        "vdup.s8     d7, d28[4]         \n"
-                        "vdup.s8    d11, d28[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3n
-                        "vmlal.s8   q2, d8, d7          \n"// k4n
-                        "vmlal.s8   q2, d9, d11         \n"// k5n
-
-                        "vdup.s8     d1, d28[6]         \n"
-                        "vdup.s8     d7, d28[7]         \n"
-                        "vdup.s8    d11, d29[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6n
-                        "vmlal.s8   q2, d12, d7         \n"// k7n
-                        "vmlal.s8   q2, d13, d11        \n"// k8n
-
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d18-d19}, [%2]     \n"// sum1
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vst1.32    {d18-d19}, [%2]!    \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),        // %1
-                          "=r"(outptr1),        // %2
-                          "=r"(r0),             // %3
-                          "=r"(r1),             // %4
-                          "=r"(r2)              // %5
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(outptr1),
-                          "3"(r0),
-                          "4"(r1),
-                          "5"(r2)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-
-                r0 += 2;
-                r1 += 2;
-                r2 += 2;
-            }
-
-            kernel0 += 9;
-            kernel1 += 9;
-        }
-    }
-
-    #pragma omp parallel for num_threads(opt.num_threads)
-    for (int p=remain_outch_start; p<outch; p++)
-    {
-        Mat out0 = top_blob.channel(p);
-
-        out0.fill(0);
-
-        const signed char* kernel0 = (const signed char *)kernel + p * inch * 9;
-
-        for (int q=0; q<inch; q++)
-        {                   
-            int* outptr0 = out0;
-            int* outptr0n = outptr0 + outw;
-        
-            const signed char* img0 = bottom_blob.channel(q);
-
-            const signed char* r0 = img0;
-            const signed char* r1 = img0 + w;
-            const signed char* r2 = img0 + w*2;
-            const signed char* r3 = img0 + w*3;
-
-            int i = 0;
-
-            for (; i+1 < outh; i+=2)
-            {
-                int nn = outw >> 3;
-
-                asm volatile(
-                    "vld1.8    {d26-d27}, [%0]    \n"
-                    : "=r"(kernel0) // %0
-                    : "0"(kernel0)
-                    : "cc", "memory"
-                );
-                
-                if (nn > 0)
-                {
-                    asm volatile(
-                        "0:                             \n"
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d0-d1}, [%3]       \n"// r0
-                        "add        %3, #8              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d6-d7}, [%4]       \n"// r1
-                        "add        %4, #8              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%5, #128]          \n"
-                        "vld1.32    {d10-d11}, [%5]     \n"// r2
-                        "add        %5, #8              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%6, #128]          \n"
-                        "vld1.32    {d14-d15}, [%6]     \n"// r3
-                        "add        %6, #8              \n"
-                        "vext.8     d16, d14, d15, #1   \n"
-                        "vext.8     d17, d14, d15, #2   \n"
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d21}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%1]!    \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d6, d1          \n"// k0
-                        "vmlal.s8   q2, d8, d30         \n"// k1
-                        "vmlal.s8   q2, d9, d31         \n"// k2
-
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k3
-                        "vmlal.s8   q2, d12, d30        \n"// k4
-                        "vmlal.s8   q2, d13, d31        \n"// k5
-
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d14, d1         \n"// k6
-                        "vmlal.s8   q2, d16, d30        \n"// k7
-                        "vmlal.s8   q2, d17, d31        \n"// k8
-
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d18-d21}, [%2]     \n"// sum0n
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%2]!    \n"
-
-                        "subs       %0, #1              \n"
-                        "bne        0b                  \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),        // %1
-                          "=r"(outptr0n),       // %2
-                          "=r"(r0),             // %3
-                          "=r"(r1),             // %4
-                          "=r"(r2),             // %5
-                          "=r"(r3)              // %6
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(outptr0n),
-                          "3"(r0),
-                          "4"(r1),
-                          "5"(r2),
-                          "6"(r3)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-                }
-
-                asm volatile(
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d0-d1}, [%3]       \n"// r0
-                        "add        %3, #4              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d6-d7}, [%4]       \n"// r1
-                        "add        %4, #4              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%5, #128]          \n"
-                        "vld1.32    {d10-d11}, [%5]     \n"// r2
-                        "add        %5, #4              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%6, #128]          \n"
-                        "vld1.32    {d14-d15}, [%6]     \n"// r3
-                        "add        %6, #4              \n"
-                        "vext.8     d16, d14, d15, #1   \n"
-                        "vext.8     d17, d14, d15, #2   \n"
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d19}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vst1.32    {d18-d19}, [%1]!    \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d6, d1          \n"// k0
-                        "vmlal.s8   q2, d8, d30         \n"// k1
-                        "vmlal.s8   q2, d9, d31         \n"// k2
-
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k3
-                        "vmlal.s8   q2, d12, d30        \n"// k4
-                        "vmlal.s8   q2, d13, d31        \n"// k5
-
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d14, d1         \n"// k6
-                        "vmlal.s8   q2, d16, d30        \n"// k7
-                        "vmlal.s8   q2, d17, d31        \n"// k8
-
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d18-d19}, [%2]     \n"// sum0n
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vst1.32    {d18-d19}, [%2]!    \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),        // %1
-                          "=r"(outptr0n),       // %2
-                          "=r"(r0),             // %3
-                          "=r"(r1),             // %4
-                          "=r"(r2),             // %5
-                          "=r"(r3)              // %6
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(outptr0n),
-                          "3"(r0),
-                          "4"(r1),
-                          "5"(r2),
-                          "6"(r3)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-
-                r0 += 2 + w;
-                r1 += 2 + w;
-                r2 += 2 + w;
-                r3 += 2 + w;
-
-                outptr0 += outw;
-                outptr0n += outw;
-            }
-
-            for (; i < outh; i++)
-            {
-                int nn = outw >> 3;
-
-                asm volatile(
-                    "vld1.8    {d26-d27}, [%0]    \n"
-                    : "=r"(kernel0) // %0
-                    : "0"(kernel0)
-                    : "cc", "memory"
-                );
-
-                if (nn > 0)
-                {
-                    asm volatile(
-                        "0:                             \n"
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d0-d1}, [%2]       \n"// r0
-                        "add        %2, #8              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d6-d7}, [%3]       \n"// r1
-                        "add        %3, #8              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d10-d11}, [%4]     \n"// r2
-                        "add        %4, #8              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d21}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%1]!    \n"
-
-                        "subs       %0, #1              \n"
-                        "bne        0b                  \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),        // %1
-                          "=r"(r0),             // %2
-                          "=r"(r1),             // %3
-                          "=r"(r2)              // %4
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(r0),
-                          "3"(r1),
-                          "4"(r2)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-                }
-
-                asm volatile(
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d0-d1}, [%2]       \n"// r0
-                        "add        %2, #4              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d6-d7}, [%3]       \n"// r1
-                        "add        %3, #4              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d10-d11}, [%4]     \n"// r2
-                        "add        %4, #4              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d19}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vst1.32    {d18-d19}, [%1]!    \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),        // %1
-                          "=r"(r0),             // %2
-                          "=r"(r1),             // %3
-                          "=r"(r2)              // %4
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(r0),
-                          "3"(r1),
-                          "4"(r2)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-
-                r0 += 2;
-                r1 += 2;
-                r2 += 2;
-            }           
-            kernel0 += 9;
-        }       
-    }
-}
-
-static void conv3x3s1_neon_s8_left6(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
-{
-    int w = bottom_blob.w;
-    int inch = bottom_blob.c;
-
-    int outw = top_blob.w;
-    int outh = top_blob.h;
-    int outch = top_blob.c;
-
-    const float* kernel = _kernel;
-
-    int nn_outch = outch >> 1;
-    int remain_outch_start = nn_outch << 1; 
-
-    #pragma omp parallel for num_threads(opt.num_threads)
-    for (int pp=0; pp < nn_outch; pp++)
-    {
-        int p = pp * 2;
-
-        Mat out0 = top_blob.channel(p);
-        Mat out1 = top_blob.channel(p+1);
-
-        out0.fill(0);
-        out1.fill(0);
-
-        const signed char* kernel0 = (const signed char *)kernel + p * inch * 9;
-        const signed char* kernel1 = (const signed char *)kernel + (p + 1) * inch * 9;
-        
-        for (int q=0; q<inch; q++)
-        {
-            int* outptr0 = out0;
-            int* outptr1 = out1;
-            int* outptr0n = outptr0 + outw;
-            int* outptr1n = outptr1 + outw;
-        
-            const signed char* img0 = bottom_blob.channel(q);
-
-            const signed char* r0 = img0;
-            const signed char* r1 = img0 + w;
-            const signed char* r2 = img0 + w*2;
-            const signed char* r3 = img0 + w*3;
-
-            int i = 0;
-            for (; i+1 < outh; i+=2)
-            {
-                int nn = outw >> 3;
-
-                asm volatile(
-                    "vld1.8    {d26-d27}, [%0]    \n"  // k00 k01 k02 k03 k04 k05 k06 k07 k08
-                    "vld1.8    {d28-d29}, [%1]    \n"  // k10 k11 k12 k13 k14 k15 k16 k17 k18
-                    : "=r"(kernel0), // %0
-                      "=r"(kernel1)  // %1
-                    : "0"(kernel0),
-                      "1"(kernel1)
-                    : "cc", "memory"
-                );
-
-                if (nn > 0)
-                {
-                    asm volatile(
-                        "0:                             \n"
-                        "pld        [%5, #128]          \n"
-                        "vld1.32    {d0-d1}, [%5]       \n"// r0
-                        "add        %5, #8              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%6, #128]          \n"
-                        "vld1.32    {d6-d7}, [%6]       \n"// r1
-                        "add        %6, #8              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%7, #128]          \n"
-                        "vld1.32    {d10-d11}, [%7]     \n"// r2
-                        "add        %7, #8              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%8, #128]          \n"
-                        "vld1.32    {d14-d15}, [%8]     \n"// r3
-                        "add        %8, #8              \n"
-                        "vext.8     d16, d14, d15, #1   \n"
-                        "vext.8     d17, d14, d15, #2   \n"
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d21}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%1]!    \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d6, d1          \n"// k0
-                        "vmlal.s8   q2, d8, d30         \n"// k1
-                        "vmlal.s8   q2, d9, d31         \n"// k2
-
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k3
-                        "vmlal.s8   q2, d12, d30        \n"// k4
-                        "vmlal.s8   q2, d13, d31        \n"// k5
-
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d14, d1         \n"// k6
-                        "vmlal.s8   q2, d16, d30        \n"// k7
-                        "vmlal.s8   q2, d17, d31        \n"// k8
-
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d18-d21}, [%2]     \n"// sum0n
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%2]!    \n"
-                        
-                        "vdup.s8     d1, d28[0]         \n"
-                        "vdup.s8    d30, d28[1]         \n"
-                        "vdup.s8    d31, d28[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0n
-                        "vmlal.s8   q2, d2, d30         \n"// k1n
-                        "vmlal.s8   q2, d3, d31         \n"// k2n
-
-                        "vdup.s8     d1, d28[3]         \n"
-                        "vdup.s8    d30, d28[4]         \n"
-                        "vdup.s8    d31, d28[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3n
-                        "vmlal.s8   q2, d8, d30         \n"// k4n
-                        "vmlal.s8   q2, d9, d31         \n"// k5n
-
-                        "vdup.s8     d1, d28[6]         \n"
-                        "vdup.s8    d30, d28[7]         \n"
-                        "vdup.s8    d31, d29[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6n
-                        "vmlal.s8   q2, d12, d30        \n"// k7n
-                        "vmlal.s8   q2, d13, d31        \n"// k8n
-
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d18-d21}, [%3]     \n"// sum1
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%3]!    \n"
-                        
-                        "vdup.s8     d1, d28[0]         \n"
-                        "vdup.s8    d30, d28[1]         \n"
-                        "vdup.s8    d31, d28[2]         \n"
-                        "vmull.s8   q2, d6, d1          \n"// k0n
-                        "vmlal.s8   q2, d8, d30         \n"// k1n
-                        "vmlal.s8   q2, d9, d31         \n"// k2n
-
-                        "vdup.s8     d1, d28[3]         \n"
-                        "vdup.s8    d30, d28[4]         \n"
-                        "vdup.s8    d31, d28[5]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k3n
-                        "vmlal.s8   q2, d12, d30        \n"// k4n
-                        "vmlal.s8   q2, d13, d31        \n"// k5n
-
-                        "vdup.s8     d1, d28[6]         \n"
-                        "vdup.s8    d30, d28[7]         \n"
-                        "vdup.s8    d31, d29[0]         \n"
-                        "vmlal.s8   q2, d14, d1         \n"// k6n
-                        "vmlal.s8   q2, d16, d30        \n"// k7n
-                        "vmlal.s8   q2, d17, d31        \n"// k8n
-
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d18-d21}, [%4]     \n"// sum1n
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%4]!    \n"
-
-                        "subs       %0, #1              \n"
-                        "bne        0b                  \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),        // %1
-                          "=r"(outptr0n),       // %2
-                          "=r"(outptr1),        // %3
-                          "=r"(outptr1n),       // %4
-                          "=r"(r0),             // %5
-                          "=r"(r1),             // %6
-                          "=r"(r2),             // %7
-                          "=r"(r3)              // %8
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(outptr0n),
-                          "3"(outptr1),
-                          "4"(outptr1n),
-                          "5"(r0),
-                          "6"(r1),
-                          "7"(r2),
-                          "8"(r3)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q15"
-                    );
-                }
-
-                asm volatile(
-                    "pld        [%5, #128]          \n"
-                    "vld1.32    {d0-d1}, [%5]       \n"// r0
-                    "add        %5, #6              \n"
-                    "vext.8     d2, d0, d1, #1      \n"
-                    "vext.8     d3, d0, d1, #2      \n"
-                    
-                    "vdup.s8     d1, d26[0]         \n"
-                    "vdup.s8    d30, d26[1]         \n"
-                    "vdup.s8    d31, d26[2]         \n"
-                    "vmull.s8   q2, d0, d1          \n"// k0
-                    "vmlal.s8   q2, d2, d30         \n"// k1
-                    "vmlal.s8   q2, d3, d31         \n"// k2
-                    
-                    "pld        [%6, #128]          \n"
-                    "vld1.32    {d6-d7}, [%6]       \n"// r1
-                    "add        %6, #6              \n"
-                    "vext.8     d8, d6, d7, #1      \n"
-                    "vext.8     d9, d6, d7, #2      \n"
-                    
-                    "vdup.s8     d1, d26[3]         \n"
-                    "vdup.s8    d30, d26[4]         \n"
-                    "vdup.s8    d31, d26[5]         \n"
-                    "vmlal.s8   q2, d6, d1          \n"// k3
-                    "vmlal.s8   q2, d8, d30         \n"// k4
-                    "vmlal.s8   q2, d9, d31         \n"// k5
-
-                    "pld        [%7, #128]          \n"
-                    "vld1.32    {d10-d11}, [%7]     \n"// r2
-                    "add        %7, #6              \n"
-                    "vext.8     d12, d10, d11, #1   \n"
-                    "vext.8     d13, d10, d11, #2   \n"
-                    
-                    "vdup.s8     d1, d26[6]         \n"
-                    "vdup.s8    d30, d26[7]         \n"
-                    "vdup.s8    d31, d27[0]         \n"
-                    "vmlal.s8   q2, d10, d1         \n"// k6
-                    "vmlal.s8   q2, d12, d30        \n"// k7
-                    "vmlal.s8   q2, d13, d31        \n"// k8
-                    
-                    "pld        [%8, #128]          \n"
-                    "vld1.32    {d14-d15}, [%8]     \n"// r3
-                    "add        %8, #6              \n"
-                    "vext.8     d16, d14, d15, #1   \n"
-                    "vext.8     d17, d14, d15, #2   \n"
-                    
-                    "pld        [%1, #128]          \n"
-                    "vld1.32    {d18-d20}, [%1]     \n"// sum0
-                    "vaddw.s16   q9,  q9, d4        \n"
-                    "vaddw.s16  q10, q10, d5        \n"
-                    "vst1.32    {d18-d20}, [%1]!    \n"
-                    
-                    "vdup.s8     d1, d26[0]         \n"
-                    "vdup.s8    d30, d26[1]         \n"
-                    "vdup.s8    d31, d26[2]         \n"
-                    "vmull.s8   q2, d6, d1          \n"// k0
-                    "vmlal.s8   q2, d8, d30         \n"// k1
-                    "vmlal.s8   q2, d9, d31         \n"// k2
-
-                    "vdup.s8     d1, d26[3]         \n"
-                    "vdup.s8    d30, d26[4]         \n"
-                    "vdup.s8    d31, d26[5]         \n"
-                    "vmlal.s8   q2, d10, d1         \n"// k3
-                    "vmlal.s8   q2, d12, d30        \n"// k4
-                    "vmlal.s8   q2, d13, d31        \n"// k5
-
-                    "vdup.s8     d1, d26[6]         \n"
-                    "vdup.s8    d30, d26[7]         \n"
-                    "vdup.s8    d31, d27[0]         \n" 
-                    "vmlal.s8   q2, d14, d1         \n"// k6
-                    "vmlal.s8   q2, d16, d30        \n"// k7
-                    "vmlal.s8   q2, d17, d31        \n"// k8
-
-                    "pld        [%2, #128]          \n"
-                    "vld1.32    {d18-d20}, [%2]     \n"// sum0n
-                    "vaddw.s16   q9,  q9, d4        \n"
-                    "vaddw.s16  q10, q10, d5        \n"
-                    "vst1.32    {d18-d20}, [%2]!    \n"
-                    
-                    "vdup.s8     d1, d28[0]         \n"
-                    "vdup.s8    d30, d28[1]         \n"
-                    "vdup.s8    d31, d28[2]         \n"
-                    "vmull.s8   q2, d0, d1          \n"// k0n
-                    "vmlal.s8   q2, d2, d30         \n"// k1n
-                    "vmlal.s8   q2, d3, d31         \n"// k2n
-
-                    "vdup.s8     d1, d28[3]         \n"
-                    "vdup.s8    d30, d28[4]         \n"
-                    "vdup.s8    d31, d28[5]         \n"
-                    "vmlal.s8   q2, d6, d1          \n"// k3n
-                    "vmlal.s8   q2, d8, d30         \n"// k4n
-                    "vmlal.s8   q2, d9, d31         \n"// k5n
-
-                    "vdup.s8     d1, d28[6]         \n"
-                    "vdup.s8    d30, d28[7]         \n"
-                    "vdup.s8    d31, d29[0]         \n"
-                    "vmlal.s8   q2, d10, d1         \n"// k6n
-                    "vmlal.s8   q2, d12, d30        \n"// k7n
-                    "vmlal.s8   q2, d13, d31        \n"// k8n
-
-                    "pld        [%3, #128]          \n"
-                    "vld1.32    {d18-d20}, [%3]     \n"// sum1
-                    "vaddw.s16   q9,  q9, d4        \n"
-                    "vaddw.s16  q10, q10, d5        \n"
-                    "vst1.32    {d18-d20}, [%3]!    \n"
-                    
-                    "vdup.s8     d1, d28[0]         \n"
-                    "vdup.s8    d30, d28[1]         \n"
-                    "vdup.s8    d31, d28[2]         \n"
-                    "vmull.s8   q2, d6, d1          \n"// k0n
-                    "vmlal.s8   q2, d8, d30         \n"// k1n
-                    "vmlal.s8   q2, d9, d31         \n"// k2n
-
-                    "vdup.s8     d1, d28[3]         \n"
-                    "vdup.s8    d30, d28[4]         \n"
-                    "vdup.s8    d31, d28[5]         \n"
-                    "vmlal.s8   q2, d10, d1         \n"// k3n
-                    "vmlal.s8   q2, d12, d30        \n"// k4n
-                    "vmlal.s8   q2, d13, d31        \n"// k5n
-
-                    "vdup.s8     d1, d28[6]         \n"
-                    "vdup.s8    d30, d28[7]         \n"
-                    "vdup.s8    d31, d29[0]         \n"
-                    "vmlal.s8   q2, d14, d1         \n"// k6n
-                    "vmlal.s8   q2, d16, d30        \n"// k7n
-                    "vmlal.s8   q2, d17, d31        \n"// k8n
-
-                    "pld        [%4, #128]          \n"
-                    "vld1.32    {d18-d20}, [%4]     \n"// sum1n
-                    "vaddw.s16   q9,  q9, d4        \n"
-                    "vaddw.s16  q10, q10, d5        \n"
-                    "vst1.32    {d18-d20}, [%4]!    \n"
-                    : "=r"(nn),             // %0
-                      "=r"(outptr0),        // %1
-                      "=r"(outptr0n),       // %2
-                      "=r"(outptr1),        // %3
-                      "=r"(outptr1n),       // %4
-                      "=r"(r0),             // %5
-                      "=r"(r1),             // %6
-                      "=r"(r2),             // %7
-                      "=r"(r3)              // %8
-                    : "0"(nn),
-                      "1"(outptr0),
-                      "2"(outptr0n),
-                      "3"(outptr1),
-                      "4"(outptr1n),
-                      "5"(r0),
-                      "6"(r1),
-                      "7"(r2),
-                      "8"(r3)
-                    : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q15"
-                );
-
-                r0 += 2 + w;
-                r1 += 2 + w;
-                r2 += 2 + w;
-                r3 += 2 + w;
-
-                outptr0 += outw;
-                outptr1 += outw;
-                outptr0n += outw;
-                outptr1n += outw;
-            }
-
-            for (; i < outh; i++)
-            {
-                int nn = outw >> 3;
-
-                asm volatile(
-                    "vld1.8    {d26-d27}, [%0]    \n"
-                    "vld1.8    {d28-d29}, [%1]    \n"
-                    : "=r"(kernel0), // %0
-                      "=r"(kernel1)  // %1
-                    : "0"(kernel0),
-                      "1"(kernel1)
-                    : "cc", "memory"
-                );
-
-                if (nn > 0)
-                {
-                    asm volatile(
-                        "0:                             \n"
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d0-d1}, [%3]       \n"// r0
-                        "add        %3, #8              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d6-d7}, [%4]       \n"// r1
-                        "add        %4, #8              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%5, #128]          \n"
-                        "vld1.32    {d10-d11}, [%5]     \n"// r2
-                        "add        %5, #8              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d21}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%1]!    \n"
-                        
-                        "vdup.s8     d1, d28[0]         \n"
-                        "vdup.s8     d7, d28[1]         \n"
-                        "vdup.s8    d11, d28[2]         \n" 
-                        "vmull.s8   q2, d0, d1          \n"// k0n
-                        "vmlal.s8   q2, d2, d7          \n"// k1n
-                        "vmlal.s8   q2, d3, d11         \n"// k2n
-
-                        "vdup.s8     d1, d28[3]         \n"
-                        "vdup.s8     d7, d28[4]         \n"
-                        "vdup.s8    d11, d28[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3n
-                        "vmlal.s8   q2, d8, d7          \n"// k4n
-                        "vmlal.s8   q2, d9, d11         \n"// k5n
-
-                        "vdup.s8     d1, d28[6]         \n"
-                        "vdup.s8     d7, d28[7]         \n"
-                        "vdup.s8    d11, d29[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6n
-                        "vmlal.s8   q2, d12, d7         \n"// k7n
-                        "vmlal.s8   q2, d13, d11        \n"// k8n
-
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d18-d21}, [%2]     \n"// sum1
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%2]!    \n"
-
-                        "subs       %0, #1              \n"
-                        "bne        0b                  \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),        // %1
-                          "=r"(outptr1),        // %2
-                          "=r"(r0),             // %3
-                          "=r"(r1),             // %4
-                          "=r"(r2)              // %5
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(outptr1),
-                          "3"(r0),
-                          "4"(r1),
-                          "5"(r2)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-                }
-
-                asm volatile(
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d0-d1}, [%3]       \n"// r0
-                        "add        %3, #6              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d6-d7}, [%4]       \n"// r1
-                        "add        %4, #6              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%5, #128]          \n"
-                        "vld1.32    {d10-d11}, [%5]     \n"// r2
-                        "add        %5, #6              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d20}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d20}, [%1]!    \n"
-                        
-                        "vdup.s8     d1, d28[0]         \n"
-                        "vdup.s8     d7, d28[1]         \n"
-                        "vdup.s8    d11, d28[2]         \n" 
-                        "vmull.s8   q2, d0, d1          \n"// k0n
-                        "vmlal.s8   q2, d2, d7          \n"// k1n
-                        "vmlal.s8   q2, d3, d11         \n"// k2n
-
-                        "vdup.s8     d1, d28[3]         \n"
-                        "vdup.s8     d7, d28[4]         \n"
-                        "vdup.s8    d11, d28[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3n
-                        "vmlal.s8   q2, d8, d7          \n"// k4n
-                        "vmlal.s8   q2, d9, d11         \n"// k5n
-
-                        "vdup.s8     d1, d28[6]         \n"
-                        "vdup.s8     d7, d28[7]         \n"
-                        "vdup.s8    d11, d29[0]         \n" 
-                        "vmlal.s8   q2, d10, d1         \n"// k6n
-                        "vmlal.s8   q2, d12, d7         \n"// k7n
-                        "vmlal.s8   q2, d13, d11        \n"// k8n
-
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d18-d20}, [%2]     \n"// sum1
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d20}, [%2]!    \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),        // %1
-                          "=r"(outptr1),        // %2
-                          "=r"(r0),             // %3
-                          "=r"(r1),             // %4
-                          "=r"(r2)              // %5
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(outptr1),
-                          "3"(r0),
-                          "4"(r1),
-                          "5"(r2)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-
-                r0 += 2;
-                r1 += 2;
-                r2 += 2;
-            }
-
-            kernel0 += 9;
-            kernel1 += 9;
-        }
-    }
-
-    #pragma omp parallel for num_threads(opt.num_threads)
-    for (int p=remain_outch_start; p<outch; p++)
-    {
-        Mat out0 = top_blob.channel(p);
-
-        out0.fill(0);
-
-        const signed char* kernel0 = (const signed char *)kernel + p * inch * 9;
-
-        for (int q=0; q<inch; q++)
-        {                   
-            int* outptr0 = out0;
-            int* outptr0n = outptr0 + outw;
-        
-            const signed char* img0 = bottom_blob.channel(q);
-
-            const signed char* r0 = img0;
-            const signed char* r1 = img0 + w;
-            const signed char* r2 = img0 + w * 2;
-            const signed char* r3 = img0 + w * 3;
-
-            int i = 0;
-
-            for (; i+1 < outh; i+=2)
-            {
-                int nn = outw >> 3;
-
-                asm volatile(
-                    "vld1.8    {d26-d27}, [%0]    \n"
-                    : "=r"(kernel0) // %0
-                    : "0"(kernel0)
-                    : "cc", "memory"
-                );
-
-                if (nn > 0)
-                {
-                    asm volatile(
-                        "0:                             \n"
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d0-d1}, [%3]       \n"// r0
-                        "add        %3, #8              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d6-d7}, [%4]       \n"// r1
-                        "add        %4, #8              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%5, #128]          \n"
-                        "vld1.32    {d10-d11}, [%5]     \n"// r2
-                        "add        %5, #8              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%6, #128]          \n"
-                        "vld1.32    {d14-d15}, [%6]     \n"// r3
-                        "add        %6, #8              \n"
-                        "vext.8     d16, d14, d15, #1   \n"
-                        "vext.8     d17, d14, d15, #2   \n"
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d21}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%1]!    \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d6, d1          \n"// k0
-                        "vmlal.s8   q2, d8, d30         \n"// k1
-                        "vmlal.s8   q2, d9, d31         \n"// k2
-
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k3
-                        "vmlal.s8   q2, d12, d30        \n"// k4
-                        "vmlal.s8   q2, d13, d31        \n"// k5
-
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d14, d1         \n"// k6
-                        "vmlal.s8   q2, d16, d30        \n"// k7
-                        "vmlal.s8   q2, d17, d31        \n"// k8
-
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d18-d21}, [%2]     \n"// sum0n
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%2]!    \n"
-
-                        "subs       %0, #1              \n"
-                        "bne        0b                  \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),    // %1
-                          "=r"(outptr0n),   // %2
-                          "=r"(r0),             // %3
-                          "=r"(r1),             // %4
-                          "=r"(r2),             // %5
-                          "=r"(r3)              // %6
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(outptr0n),
-                          "3"(r0),
-                          "4"(r1),
-                          "5"(r2),
-                          "6"(r3)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-                }
-
-                asm volatile(
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d0-d1}, [%3]       \n"// r0
-                        "add        %3, #6              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d6-d7}, [%4]       \n"// r1
-                        "add        %4, #6              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%5, #128]          \n"
-                        "vld1.32    {d10-d11}, [%5]     \n"// r2
-                        "add        %5, #6              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%6, #128]          \n"
-                        "vld1.32    {d14-d15}, [%6]     \n"// r3
-                        "add        %6, #6              \n"
-                        "vext.8     d16, d14, d15, #1   \n"
-                        "vext.8     d17, d14, d15, #2   \n"
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d20}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d20}, [%1]!    \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d6, d1          \n"// k0
-                        "vmlal.s8   q2, d8, d30         \n"// k1
-                        "vmlal.s8   q2, d9, d31         \n"// k2
-
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k3
-                        "vmlal.s8   q2, d12, d30        \n"// k4
-                        "vmlal.s8   q2, d13, d31        \n"// k5
-
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d14, d1         \n"// k6
-                        "vmlal.s8   q2, d16, d30        \n"// k7
-                        "vmlal.s8   q2, d17, d31        \n"// k8
-
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d18-d20}, [%2]     \n"// sum0n
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d20}, [%2]!    \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),        // %1
-                          "=r"(outptr0n),       // %2
-                          "=r"(r0),             // %3
-                          "=r"(r1),             // %4
-                          "=r"(r2),             // %5
-                          "=r"(r3)              // %6
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(outptr0n),
-                          "3"(r0),
-                          "4"(r1),
-                          "5"(r2),
-                          "6"(r3)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-
-                r0 += 2 + w;
-                r1 += 2 + w;
-                r2 += 2 + w;
-                r3 += 2 + w;
-
-                outptr0 += outw;
-                outptr0n += outw;
-            }
-
-            for (; i < outh; i++)
-            {
-                int nn = outw >> 3;
-
-                asm volatile(
-                    "vld1.8    {d26-d27}, [%0]    \n"
-                    : "=r"(kernel0) // %0
-                    : "0"(kernel0)
-                    : "cc", "memory"
-                );
-
-                if (nn > 0)
-                {
-                    asm volatile(
-                        "0:                             \n"
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d0-d1}, [%2]       \n"// r0
-                        "add        %2, #8              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d6-d7}, [%3]       \n"// r1
-                        "add        %3, #8              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d10-d11}, [%4]     \n"// r2
-                        "add        %4, #8              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d21}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d21}, [%1]!    \n"
-
-                        "subs       %0, #1              \n"
-                        "bne        0b                  \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),    // %1
-                          "=r"(r0),             // %2
-                          "=r"(r1),             // %3
-                          "=r"(r2)              // %4
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(r0),
-                          "3"(r1),
-                          "4"(r2)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-                }
-
-                asm volatile(
-                        "pld        [%2, #128]          \n"
-                        "vld1.32    {d0-d1}, [%2]       \n"// r0
-                        "add        %2, #6              \n"
-                        "vext.8     d2, d0, d1, #1      \n"
-                        "vext.8     d3, d0, d1, #2      \n"
-                        
-                        "vdup.s8     d1, d26[0]         \n"
-                        "vdup.s8    d30, d26[1]         \n"
-                        "vdup.s8    d31, d26[2]         \n"
-                        "vmull.s8   q2, d0, d1          \n"// k0
-                        "vmlal.s8   q2, d2, d30         \n"// k1
-                        "vmlal.s8   q2, d3, d31         \n"// k2
-                        
-                        "pld        [%3, #128]          \n"
-                        "vld1.32    {d6-d7}, [%3]       \n"// r1
-                        "add        %3, #6              \n"
-                        "vext.8     d8, d6, d7, #1      \n"
-                        "vext.8     d9, d6, d7, #2      \n"
-                        
-                        "vdup.s8     d1, d26[3]         \n"
-                        "vdup.s8    d30, d26[4]         \n"
-                        "vdup.s8    d31, d26[5]         \n"
-                        "vmlal.s8   q2, d6, d1          \n"// k3
-                        "vmlal.s8   q2, d8, d30         \n"// k4
-                        "vmlal.s8   q2, d9, d31         \n"// k5
-
-                        "pld        [%4, #128]          \n"
-                        "vld1.32    {d10-d11}, [%4]     \n"// r2
-                        "add        %4, #6              \n"
-                        "vext.8     d12, d10, d11, #1   \n"
-                        "vext.8     d13, d10, d11, #2   \n"
-                        
-                        "vdup.s8     d1, d26[6]         \n"
-                        "vdup.s8    d30, d26[7]         \n"
-                        "vdup.s8    d31, d27[0]         \n"
-                        "vmlal.s8   q2, d10, d1         \n"// k6
-                        "vmlal.s8   q2, d12, d30        \n"// k7
-                        "vmlal.s8   q2, d13, d31        \n"// k8
-                        
-                        "pld        [%1, #128]          \n"
-                        "vld1.32    {d18-d20}, [%1]     \n"// sum0
-                        "vaddw.s16   q9,  q9, d4        \n"
-                        "vaddw.s16  q10, q10, d5        \n"
-                        "vst1.32    {d18-d20}, [%1]!    \n"
-                        : "=r"(nn),             // %0
-                          "=r"(outptr0),        // %1
-                          "=r"(r0),             // %2
-                          "=r"(r1),             // %3
-                          "=r"(r2)              // %4
-                        : "0"(nn),
-                          "1"(outptr0),
-                          "2"(r0),
-                          "3"(r1),
-                          "4"(r2)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-
-                r0 += 2;
-                r1 += 2;
-                r2 += 2;
-            }
-            kernel0 += 9;
-        }       
-    }
-}
-
-static void conv3x3s2_neon_s8(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
+static void conv3x3s2_int8_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
 {
     int w = bottom_blob.w;
     int inch = bottom_blob.c;
@@ -4429,7 +2500,7 @@ static void conv3x3s2_neon_s8(const Mat& bottom_blob, Mat& top_blob, const Mat& 
 
                         "sub        %2, #8              \n"
                         "sub        %3, #8              \n"
-                        "sub        %4, #8              \n"	                        
+                        "sub        %4, #8              \n"                         
                         
                         "vdup.s8    d26, d22[6]         \n"
                         "vdup.s8    d27, d22[7]         \n"
@@ -4488,36 +2559,9 @@ static void conv3x3s2_neon_s8(const Mat& bottom_blob, Mat& top_blob, const Mat& 
     }   
 }
 
-static void conv3x3s1_int8_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
-{
-    int outw = top_blob.w;
-    int remain = outw & 7;
-
-    typedef void (*conv_func_int8)(const Mat&, Mat&, const Mat&, const Option&);
-
-    conv_func_int8 conv_func_table[8] =
-    {
-        conv3x3s1_neon_s8,          //0
-        conv3x3s1_neon_s8,          //1
-        conv3x3s1_neon_s8,          //2
-        conv3x3s1_neon_s8,          //3
-        conv3x3s1_neon_s8_left4,    //4
-        conv3x3s1_neon_s8,          //5
-        conv3x3s1_neon_s8_left6,    //6
-        conv3x3s1_neon_s8,          //7
-    };   
-
-    conv_func_int8 conv = conv_func_table[remain];
-
-    conv(bottom_blob, top_blob, _kernel, opt);
-
-    return;
-}
-
 static void conv3x3s1_packed_int8_neon(const Mat &bottom_blob, Mat &top_blob, const Mat &_kernel, const Option& opt)
 {
     int w = bottom_blob.w;
-    //int h = bottom_blob.h;
     int inch = bottom_blob.c;
 
     int outw = top_blob.w;
@@ -4556,862 +2600,8 @@ static void conv3x3s1_packed_int8_neon(const Mat &bottom_blob, Mat &top_blob, co
             const signed char *r0 = img0;
             const signed char *r1 = img0 + w;
             const signed char *r2 = img0 + w * 2;
-            const signed char *r3 = img0 + w * 3;
 
-            int i = 0;
-
-            for (; i+1 < outh; i+=2)
-            {
-#if __ARM_NEON
-                int nn = outw >> 3;
-                int remain = outw & 7;
-#else
-                int remain = outw;
-#endif // __ARM_NEON
-
-#if __ARM_NEON
-                if (nn > 0)
-                {
-                asm volatile(
-                    "0:                         \n"
-//                     "pld        [%9, #256]      \n"
-                    "vld1.s8    {d0-d3}, [%9]!  \n"// d0=k00 k01  d1=k02 k10  d2=k11 k12  d3=k20 k21
-
-                    "pld        [%5, #128]      \n"
-                    "vld1.s8    {d4-d5}, [%5]   \n"// d4=r00 d5=r00n
-                    "add        %5, #8          \n"
-
-                    "vdup.s8    d8, d0[0]       \n"
-                    "vdup.s8    d9, d0[1]       \n"
-
-                    "pld        [%6, #128]      \n"
-                    "vld1.s8    {d6-d7}, [%6]   \n"// d6=r10 d7=r10n
-                    "add        %6, #8          \n"
-
-                    "vdup.s8    d10, d0[2]      \n"
-                    "vdup.s8    d11, d0[3]      \n"
-
-                    "vmull.s8   q8, d4, d8      \n"
-                    "vmull.s8   q9, d4, d9      \n"
-
-                    "vdup.s8    d12, d0[4]      \n"
-                    "vdup.s8    d13, d0[5]      \n"
-
-                    "vmull.s8   q10, d4, d10    \n"
-                    "vmull.s8   q11, d4, d11    \n"
-
-                    "vdup.s8    d14, d0[6]      \n"
-                    "vdup.s8    d15, d0[7]      \n"
-
-                    "vmull.s8   q12, d6, d8     \n"
-                    "vmull.s8   q13, d6, d9     \n"
-
-                    "vext.s8    q2, q2, q2, #1  \n"// d4=r01
-
-                    "vmull.s8   q14, d6, d10    \n"
-                    "vmull.s8   q15, d6, d11    \n"
-
-                    "vext.s8    q3, q3, q3, #1  \n"// d6=r11
-
-                    "vmlal.s8   q8, d4, d12     \n"
-                    "vmlal.s8   q9, d4, d13     \n"
-
-                    "vdup.s8    d8, d1[0]       \n"
-                    "vdup.s8    d9, d1[1]       \n"
-
-                    "vmlal.s8   q10, d4, d14    \n"
-                    "vmlal.s8   q11, d4, d15    \n"
-
-                    "vdup.s8    d10, d1[2]      \n"
-                    "vdup.s8    d11, d1[3]      \n"
-
-                    "vmlal.s8   q12, d6, d12    \n"
-                    "vmlal.s8   q13, d6, d13    \n"
-
-                    "vext.s8    q2, q2, q2, #1  \n"// d4=r02
-
-                    "vmlal.s8   q14, d6, d14    \n"
-                    "vmlal.s8   q15, d6, d15    \n"
-
-                    "vext.s8    q3, q3, q3, #1  \n"// d6=r12
-
-                    "vmlal.s8   q8, d4, d8      \n"
-                    "vmlal.s8   q9, d4, d9      \n"
-
-                    "vdup.s8    d12, d1[4]      \n"
-                    "vdup.s8    d13, d1[5]      \n"
-
-                    "vmlal.s8   q10, d4, d10    \n"
-                    "vmlal.s8   q11, d4, d11    \n"
-
-                    "vdup.s8    d14, d1[6]      \n"
-                    "vdup.s8    d15, d1[7]      \n"
-
-                    "vmlal.s8   q12, d6, d8     \n"
-                    "vmlal.s8   q13, d6, d9     \n"
-
-                    "pld        [%7, #128]      \n"
-                    "vld1.s8    {d4-d5}, [%7]   \n"// d4=r20 d5=r20n
-                    "add        %7, #8          \n"
-
-                    "vmlal.s8   q14, d6, d10    \n"
-                    "vmlal.s8   q15, d6, d11    \n"
-
-                    ///
-                    "vext.s8    q3, q3, q3, #14 \n"// d6=r10
-
-                    "vmlal.s8   q8, d6, d12     \n"
-                    "vmlal.s8   q9, d6, d13     \n"
-
-                    "vdup.s8    d8, d2[0]       \n"
-                    "vdup.s8    d9, d2[1]       \n"
-
-                    "vmlal.s8   q10, d6, d14    \n"
-                    "vmlal.s8   q11, d6, d15    \n"
-
-                    "vdup.s8    d10, d2[2]      \n"
-                    "vdup.s8    d11, d2[3]      \n"
-
-                    "vmlal.s8   q12, d4, d12    \n"
-                    "vmlal.s8   q13, d4, d13    \n"
-
-                    "vext.s8    q3, q3, q3, #1  \n"// d6=r11
-
-                    "vmlal.s8   q14, d4, d14    \n"
-                    "vmlal.s8   q15, d4, d15    \n"
-
-                    "vext.s8    q2, q2, q2, #1  \n"// d4=r21
-
-                    "vmlal.s8   q8, d6, d8      \n"
-                    "vmlal.s8   q9, d6, d9      \n"
-
-                    "vdup.s8    d12, d2[4]      \n"
-                    "vdup.s8    d13, d2[5]      \n"
-
-                    "vmlal.s8   q10, d6, d10    \n"
-                    "vmlal.s8   q11, d6, d11    \n"
-
-                    "vdup.s8    d14, d2[6]      \n"
-                    "vdup.s8    d15, d2[7]      \n"
-
-                    "vmlal.s8   q12, d4, d8     \n"
-                    "vmlal.s8   q13, d4, d9     \n"
-
-                    "vext.s8    q3, q3, q3, #1  \n"// d6=r12
-
-                    "vmlal.s8   q14, d4, d10    \n"
-                    "vmlal.s8   q15, d4, d11    \n"
-
-                    "vext.s8    q2, q2, q2, #1  \n"// d4=r22
-
-                    "vmlal.s8   q8, d6, d12     \n"
-                    "vmlal.s8   q9, d6, d13     \n"
-
-                    "vdup.s8    d8, d3[0]       \n"
-                    "vdup.s8    d9, d3[1]       \n"
-
-                    "vmlal.s8   q10, d6, d14    \n"
-                    "vmlal.s8   q11, d6, d15    \n"
-
-                    "vdup.s8    d10, d3[2]      \n"
-                    "vdup.s8    d11, d3[3]      \n"
-
-                    "vmlal.s8   q12, d4, d12    \n"
-                    "vmlal.s8   q13, d4, d13    \n"
-
-                    "pld        [%8, #128]      \n"
-                    "vld1.s8    {d6-d7}, [%8]   \n"// d6=r30 d6=r30n
-                    "add        %8, #8          \n"
-
-                    "vmlal.s8   q14, d4, d14    \n"
-                    "vmlal.s8   q15, d4, d15    \n"
-
-                    ///
-                    "vext.s8    q2, q2, q2, #14 \n"// d4=r20
-
-                    "vmlal.s8   q8, d4, d8      \n"
-                    "vmlal.s8   q9, d4, d9      \n"
-
-                    "vdup.s8    d12, d3[4]      \n"
-                    "vdup.s8    d13, d3[5]      \n"
-
-                    "vmlal.s8   q10, d4, d10    \n"
-                    "vmlal.s8   q11, d4, d11    \n"
-
-                    "vdup.s8    d14, d3[6]      \n"
-                    "vdup.s8    d15, d3[7]      \n"
-
-                    "vmlal.s8   q12, d6, d8     \n"
-                    "vmlal.s8   q13, d6, d9     \n"
-
-                    "vext.s8    q2, q2, q2, #1  \n"// d4=r21
-
-                    "vmlal.s8   q14, d6, d10    \n"
-                    "vmlal.s8   q15, d6, d11    \n"
-
-                    "vext.s8    q3, q3, q3, #1  \n"// d6=r31
-
-//                     "pld        [%9, #128]      \n"
-                    "vld1.s8    {d0}, [%9]      \n"
-                    "add        %9, #4          \n"
-
-                    "vmlal.s8   q8, d4, d12     \n"
-                    "vmlal.s8   q9, d4, d13     \n"
-
-                    "vdup.s8    d8, d0[0]       \n"
-                    "vdup.s8    d9, d0[1]       \n"
-
-                    "vmlal.s8   q10, d4, d14    \n"
-                    "vmlal.s8   q11, d4, d15    \n"
-
-                    "vdup.s8    d10, d0[2]      \n"
-                    "vdup.s8    d11, d0[3]      \n"
-
-                    "vmlal.s8   q12, d6, d12    \n"
-                    "vmlal.s8   q13, d6, d13    \n"
-
-                    "vext.s8    q2, q2, q2, #1  \n"// d4=r22
-
-                    "vmlal.s8   q14, d6, d14    \n"
-                    "vmlal.s8   q15, d6, d15    \n"
-
-                    "vext.s8    q3, q3, q3, #1  \n"// d6=r32
-
-                    "vmlal.s8   q8, d4, d8      \n"
-                    "vmlal.s8   q9, d4, d9      \n"
-
-                    "pld        [%1, #256]      \n"
-                    "vld1.s32   {d12-d15}, [%1] \n"
-
-                    "vmlal.s8   q10, d4, d10    \n"
-                    "vmlal.s8   q11, d4, d11    \n"
-
-                    "pld        [%2, #256]      \n"
-                    "vld1.s32   {d0-d3}, [%2]   \n"
-
-                    "vaddw.s16  q6, q6, d16     \n"
-                    "vaddw.s16  q7, q7, d17     \n"
-                    "vaddw.s16  q0, q0, d18     \n"
-                    "vaddw.s16  q1, q1, d19     \n"
-
-                    "pld        [%3, #256]      \n"
-                    "vld1.s32   {d16-d19}, [%3]  \n"
-
-                    "vmlal.s8   q12, d6, d8     \n"
-                    "vmlal.s8   q13, d6, d9     \n"
-
-                    "vst1.s32   {d12-d15}, [%1] \n"
-                    "add        %1, %1, %20, lsl #2 \n"
-
-                    "vmlal.s8   q14, d6, d10    \n"
-                    "vmlal.s8   q15, d6, d11    \n"
-
-                    "pld        [%4, #256]      \n"
-                    "vld1.s32   {d4-d7}, [%4]   \n"
-
-                    "vst1.s32   {d0-d3}, [%2]   \n"
-                    "add        %2, %2, %20, lsl #2 \n"
-
-                    "vaddw.s16  q8, q8, d20     \n"
-                    "vaddw.s16  q9, q9, d21     \n"
-
-                    "pld        [%1, #256]      \n"
-                    "vld1.s32   {d12-d15}, [%1] \n"
-
-                    "vaddw.s16  q2, q2, d22     \n"
-                    "vaddw.s16  q3, q3, d23     \n"
-
-                    ///
-                    "pld        [%2, #256]      \n"
-                    "vld1.s32   {d0-d3}, [%2]   \n"
-
-                    "vaddw.s16  q6, q6, d24     \n"
-
-                    "vst1.s32   {d16-d19}, [%3] \n"
-                    "add        %3, %3, %20, lsl #2 \n"
-
-                    "vaddw.s16  q7, q7, d25     \n"
-
-                    "pld        [%3, #256]      \n"
-                    "vld1.s32   {d8-d11}, [%3] \n"
-
-                    "vaddw.s16  q0, q0, d26     \n"
-
-                    "vst1.s32   {d4-d7}, [%4]   \n"
-                    "add        %4, %4, %20, lsl #2 \n"
-
-                    ///
-                    "vaddw.s16  q1, q1, d27     \n"
-
-                    "pld        [%4, #256]      \n"
-                    "vld1.s32   {d4-d7}, [%4]   \n"
-
-                    "vaddw.s16  q4, q4, d28     \n"
-
-                    "vst1.s32   {d12-d15}, [%1]! \n"
-
-                    "vaddw.s16  q5, q5, d29     \n"
-
-                    "vst1.s32   {d0-d3}, [%2]!  \n"
-
-                    "vaddw.s16  q2, q2, d30     \n"
-
-                    "vst1.s32   {d8-d11}, [%3]! \n"
-
-                    "vaddw.s16  q3, q3, d31     \n"
-
-                    "sub        %9, #36         \n"
-                    "subs       %0, #1          \n"
-
-                    "sub        %1, %1, %20, lsl #2 \n"
-                    "sub        %2, %2, %20, lsl #2 \n"
-                    "sub        %3, %3, %20, lsl #2 \n"
-
-                    "vst1.s32   {d4-d7}, [%4]!  \n"
-
-                    "sub        %4, %4, %20, lsl #2 \n"
-
-                    "bne        0b              \n"
-
-                    : "=r"(nn),         // %0
-                      "=r"(outptr0),    // %1
-                      "=r"(outptr1),    // %2
-                      "=r"(outptr2),    // %3
-                      "=r"(outptr3),    // %4
-                      "=r"(r0),         // %5
-                      "=r"(r1),         // %6
-                      "=r"(r2),         // %7
-                      "=r"(r3),         // %8
-                      "=r"(ktmp)        // %9
-                    : "0"(nn),
-                      "1"(outptr0),
-                      "2"(outptr1),
-                      "3"(outptr2),
-                      "4"(outptr3),
-                      "5"(r0),
-                      "6"(r1),
-                      "7"(r2),
-                      "8"(r3),
-                      "9"(ktmp),
-                      "r"(outw)         // %20
-                    : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                );
-                }
-#endif
-#if __ARM_NEON
-                if (remain >= 4)
-                {
-                    remain -= 4;
-                    asm volatile(
-                        "vld1.s8    {d0}, [%4]          \n"// d0 = r00 r00n
-                        "add        %4, #4              \n"
-                        "vld1.s8    {d2}, [%5]          \n"// d2 = r10 r10n
-                        "add        %5, #4              \n"
-
-                        "vld1.s8    {d1}, [%6]          \n"// d1 = r20 r20n
-                        "add        %6, #4              \n"
-                        "vld1.s8    {d3}, [%7]          \n"// d3 = r30 r30n
-                        "add        %7, #4              \n"
-
-                        "vext.s8    d4, d0, d0, #1      \n"// d4 = r01
-                        "vext.s8    d6, d2, d2, #1      \n"// d6 = r11
-                        "vext.s8    d5, d1, d1, #1      \n"// d5 = r21
-                        "vext.s8    d7, d3, d3, #1      \n"// d7 = r31
-
-                        "vext.s8    d8, d0, d0, #2      \n"// d8 = r02
-                        "vext.s8    d10, d2, d2, #2     \n"// d10 = r12
-                        "vext.s8    d9, d1, d1, #2      \n"// d9 = r22
-                        "vext.s8    d11, d3, d3, #2     \n"// d11 = r32
-
-                        "vld1.s8    {d12-d15}, [%8]!    \n"// d12=k00 k01  d13=k02 k10  d14=k11 k12  d15=k20 k21
-
-                        "vsli.64    q0, q1, #32         \n"// d0 = r00 r10  d1 = r20 r30
-
-                        /// r00 r20 r10
-                        "vdup.s8    d24, d12[0]         \n"
-                        "vdup.s8    d25, d12[1]         \n"
-                        "vdup.s8    d26, d12[2]         \n"
-                        "vdup.s8    d27, d12[3]         \n"
-
-                        "vmull.s8   q8, d0, d24         \n"
-                        "vmull.s8   q9, d0, d25         \n"
-
-                        "vdup.s8    d28, d15[0]         \n"
-                        "vdup.s8    d29, d15[1]         \n"
-
-                        "vmull.s8   q10, d0, d26        \n"
-                        "vmull.s8   q11, d0, d27        \n"
-
-                        "vdup.s8    d30, d15[2]         \n"
-                        "vdup.s8    d31, d15[3]         \n"
-
-                        "vmlal.s8   q8, d1, d28         \n"
-                        "vmlal.s8   q9, d1, d29         \n"
-
-                        "vext.s8    d0, d0, d1, #4      \n"// d0 = r10 r20
-
-                        "vdup.s8    d24, d13[4]         \n"
-                        "vdup.s8    d25, d13[5]         \n"
-
-                        "vmlal.s8   q10, d1, d30        \n"
-                        "vmlal.s8   q11, d1, d31        \n"
-
-                        "vdup.s8    d26, d13[6]         \n"
-                        "vdup.s8    d27, d13[7]         \n"
-
-                        "vmlal.s8   q8, d0, d24         \n"
-                        "vmlal.s8   q9, d0, d25         \n"
-
-                        /// r01 r21 r11
-                        "vsli.64    q2, q3, #32         \n"// d4 = r01 r11  d5 = r21 r31
-
-                        "vdup.s8    d28, d12[4]         \n"
-                        "vdup.s8    d29, d12[5]         \n"
-
-                        "vmlal.s8   q10, d0, d26        \n"
-                        "vmlal.s8   q11, d0, d27        \n"
-
-                        "vdup.s8    d30, d12[6]         \n"
-                        "vdup.s8    d31, d12[7]         \n"
-
-                        "vmlal.s8   q8, d4, d28         \n"
-                        "vmlal.s8   q9, d4, d29         \n"
-
-                        "vdup.s8    d24, d15[4]         \n"
-                        "vdup.s8    d25, d15[5]         \n"
-
-                        "vmlal.s8   q10, d4, d30        \n"
-                        "vmlal.s8   q11, d4, d31        \n"
-
-                        "vdup.s8    d26, d15[6]         \n"
-                        "vdup.s8    d27, d15[7]         \n"
-
-                        "vmlal.s8   q8, d5, d24         \n"
-                        "vmlal.s8   q9, d5, d25         \n"
-
-                        "vext.s8    d4, d4, d5, #4      \n"// d4 = r11 r21
-
-                        "vdup.s8    d28, d14[0]         \n"
-                        "vdup.s8    d29, d14[1]         \n"
-
-                        "vmlal.s8   q10, d5, d26        \n"
-                        "vmlal.s8   q11, d5, d27        \n"
-
-                        "vdup.s8    d30, d14[2]         \n"
-                        "vdup.s8    d31, d14[3]         \n"
-
-                        "vmlal.s8   q8, d4, d28         \n"
-                        "vmlal.s8   q9, d4, d29         \n"
-
-                        /// r02 r22 r12
-                        "vsli.64    q4, q5, #32         \n"// d8 = r02 r12  d9 = r22 r32
-
-                        "vld1.s8    {d12}, [%8]         \n"// d12=k22
-                        "add        %8, #4              \n"
-
-                        "vdup.s8    d24, d13[0]         \n"
-                        "vdup.s8    d25, d13[1]         \n"
-
-                        "vmlal.s8   q10, d4, d30        \n"
-                        "vmlal.s8   q11, d4, d31        \n"
-
-                        "vdup.s8    d26, d13[2]         \n"
-                        "vdup.s8    d27, d13[3]         \n"
-
-                        "vmlal.s8   q8, d8, d24         \n"
-                        "vmlal.s8   q9, d8, d25         \n"
-
-                        "vdup.s8    d28, d12[0]         \n"
-                        "vdup.s8    d29, d12[1]         \n"
-
-                        "vmlal.s8   q10, d8, d26        \n"
-                        "vmlal.s8   q11, d8, d27        \n"
-
-                        "vdup.s8    d30, d12[2]         \n"
-                        "vdup.s8    d31, d12[3]         \n"
-
-                        "vmlal.s8   q8, d9, d28         \n"
-                        "vmlal.s8   q9, d9, d29         \n"
-
-                        "vext.s8    d8, d8, d9, #4      \n"// d8 = r12 r22
-
-                        "vdup.s8    d24, d14[4]         \n"
-                        "vdup.s8    d25, d14[5]         \n"
-
-                        "vld1.s32   {d0-d1}, [%0]       \n"
-
-                        "vmlal.s8   q10, d9, d30        \n"
-                        "vmlal.s8   q11, d9, d31        \n"
-
-                        "vdup.s8    d26, d14[6]         \n"
-                        "vdup.s8    d27, d14[7]         \n"
-
-                        "vld1.s32   {d2-d3}, [%1]       \n"
-
-                        "vmlal.s8   q8, d8, d24         \n"
-                        "vmlal.s8   q9, d8, d25         \n"
-
-                        "vld1.s32   {d4-d5}, [%2]       \n"
-
-                        "vmlal.s8   q10, d8, d26        \n"
-                        "vmlal.s8   q11, d8, d27        \n"
-
-                        "vld1.s32   {d6-d7}, [%3]       \n"
-
-                        "vaddw.s16  q0, q0, d16         \n"
-                        "vaddw.s16  q1, q1, d18         \n"
-
-                        "vst1.s32   {d0-d1}, [%0]       \n"
-                        "add        %0, %0, %18, lsl #2 \n"
-
-                        "vaddw.s16  q2, q2, d20         \n"
-
-                        "vst1.s32   {d2-d3}, [%1]       \n"
-                        "add        %1, %1, %18, lsl #2 \n"
-
-                        "vaddw.s16  q3, q3, d22         \n"
-
-                        "vld1.s32   {d8-d9}, [%0]       \n"
-
-                        "vld1.s32   {d10-d11}, [%1]     \n"
-
-                        "vst1.s32   {d4-d5}, [%2]       \n"
-                        "add        %2, %2, %18, lsl #2 \n"
-                        "vst1.s32   {d6-d7}, [%3]       \n"
-                        "add        %3, %3, %18, lsl #2 \n"
-
-                        "vld1.s32   {d28-d29}, [%2]     \n"
-
-                        "vld1.s32   {d30-d31}, [%3]     \n"
-
-                        "vaddw.s16  q4, q4, d17         \n"
-                        "vaddw.s16  q5, q5, d19         \n"
-
-                        "sub        %8, #36             \n"
-
-                        "vst1.s32   {d8-d9}, [%0]!      \n"
-
-                        "vaddw.s16  q14, q14, d21       \n"
-                        "vaddw.s16  q15, q15, d23       \n"
-
-                        "vst1.s32   {d10-d11}, [%1]!    \n"
-
-                        "sub        %0, %0, %18, lsl #2 \n"
-                        "sub        %1, %1, %18, lsl #2 \n"
-
-                        "vst1.s32   {d28-d29}, [%2]!    \n"
-                        "vst1.s32   {d30-d31}, [%3]!    \n"
-
-                        "sub        %2, %2, %18, lsl #2 \n"
-                        "sub        %3, %3, %18, lsl #2 \n"
-
-                        : "=r"(outptr0),    // %0
-                          "=r"(outptr1),    // %1
-                          "=r"(outptr2),    // %2
-                          "=r"(outptr3),    // %3
-                          "=r"(r0),         // %4
-                          "=r"(r1),         // %5
-                          "=r"(r2),         // %6
-                          "=r"(r3),         // %7
-                          "=r"(ktmp)        // %8
-                        : "0"(outptr0),
-                          "1"(outptr1),
-                          "2"(outptr2),
-                          "3"(outptr3),
-                          "4"(r0),
-                          "5"(r1),
-                          "6"(r2),
-                          "7"(r3),
-                          "8"(ktmp),
-                          "r"(outw)         // %18
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
-                }
-#endif
-                for (; remain>0; remain--)
-                {
-#if __ARM_NEON
-                    asm volatile(
-                        "vld1.s8    {d0[]}, [%4]!       \n"// d0 = 00 00
-                        "vld1.s8    {d1[]}, [%4]!       \n"// d1 = 01 01
-                        "vld1.s8    {d2[]}, [%4]        \n"// d2 = 02 02
-                        "sub        %4, %4, #2          \n"
-
-                        "vld1.s8    {d3[]}, [%5]!       \n"// d3 = 10 10
-                        "vld1.s8    {d4[]}, [%5]!       \n"// d4 = 11 11
-                        "vld1.s8    {d5[]}, [%5]        \n"// d5 = 12 12
-                        "sub        %5, %5, #2          \n"
-
-                        "vld1.s8    {d6[]}, [%6]!       \n"// d6 = 20 20
-                        "vld1.s8    {d7[]}, [%6]!       \n"// d7 = 21 21
-                        "vld1.s8    {d8[]}, [%6]        \n"// d8 = 22 22
-                        "sub        %6, %6, #2          \n"
-
-                        "vld1.s8    {d9[]}, [%7]!       \n"// d9 = 30 30
-                        "vld1.s8    {d10[]}, [%7]!      \n"// d10 = 31 31
-                        "vld1.s8    {d11[]}, [%7]       \n"// d11 = 32 32
-                        "sub        %7, %7, #2          \n"
-
-                        "vld1.s8    {d12-d15}, [%8]!    \n"// d12 d13 d14 d15 = 0~7
-
-                        "vsli.64    d0, d1, #32         \n"// d0 = 00 01
-
-                        "vsli.64    d3, d4, #32         \n"// d3 = 10 11
-
-                        "vmull.s8   q8, d0, d12         \n"
-
-                        "vsli.64    d2, d3, #32         \n"// d2 = 02 10
-
-                        "vmull.s8   q9, d3, d12         \n"
-
-                        "vsli.64    d5, d6, #32         \n"// d5 = 12 20
-
-                        "vmlal.s8   q8, d2, d13         \n"
-
-                        "vsli.64    d4, d5, #32         \n"// d4 = 11 12
-
-                        "vmlal.s8   q9, d5, d13         \n"
-
-                        "vsli.64    d7, d8, #32         \n"// d7 = 21 22
-
-                        "vmlal.s8   q8, d4, d14         \n"
-
-                        "vsli.64    d6, d7, #32         \n"// d6 = 20 21
-
-                        "vmlal.s8   q9, d7, d14         \n"
-
-                        "vsli.64    d9, d10, #32        \n"// d9 = 30 31
-
-                        "vld1.s32   {d20[0]}, [%0]      \n"
-                        "vld1.s32   {d20[1]}, [%1]      \n"
-
-                        "add        %0, %0, %18, lsl #2 \n"
-                        "add        %1, %1, %18, lsl #2 \n"
-
-                        "vmlal.s8   q8, d6, d15         \n"
-
-                        "vsli.64    d8, d11, #32        \n"// d8 = 22 32
-
-                        "vmlal.s8   q9, d9, d15         \n"
-
-                        "vld1.s8    {d14}, [%8]         \n"
-                        "add        %8, #4              \n"
-
-                        "vld1.s32   {d21[0]}, [%2]      \n"
-                        "vld1.s32   {d21[1]}, [%3]      \n"
-
-                        "add        %2, %2, %18, lsl #2 \n"
-                        "add        %3, %3, %18, lsl #2 \n"
-
-                        "vadd.s16   d12, d16, d17       \n"
-
-                        "vadd.s16   d13, d18, d19       \n"// q6 = sum0123 sum0123n
-
-                        "vsli.64    d14, d14, #32       \n"// d14 = 0~3 0~3
-
-                        "vld1.s32   {d22[0]}, [%0]      \n"
-                        "vld1.s32   {d22[1]}, [%1]      \n"
-
-                        "vmlal.s8   q6, d8, d14         \n"
-
-                        "sub        %8, #36             \n"
-
-                        ///
-                        "vld1.s32   {d23[0]}, [%2]      \n"
-                        "vld1.s32   {d23[1]}, [%3]      \n"
-
-                        "sub        %0, %0, %18, lsl #2 \n"
-                        "sub        %1, %1, %18, lsl #2 \n"
-
-                        // addw
-                        "vaddw.s16  q10, q10, d12       \n"
-                        "vaddw.s16  q11, q11, d13       \n"
-
-                        "sub        %2, %2, %18, lsl #2 \n"
-                        "sub        %3, %3, %18, lsl #2 \n"
-
-                        "vst1.s32   {d20[0]}, [%0]      \n"
-                        "vst1.s32   {d20[1]}, [%1]      \n"
-
-                        "add        %0, %0, %18, lsl #2 \n"
-                        "add        %1, %1, %18, lsl #2 \n"
-
-                        "vst1.s32   {d21[0]}, [%2]      \n"
-                        "vst1.s32   {d21[1]}, [%3]      \n"
-
-                        "add        %2, %2, %18, lsl #2 \n"
-                        "add        %3, %3, %18, lsl #2 \n"
-
-                        "vst1.s32   {d22[0]}, [%0]!     \n"
-                        "vst1.s32   {d22[1]}, [%1]!     \n"
-
-                        "sub        %0, %0, %18, lsl #2 \n"
-                        "sub        %1, %1, %18, lsl #2 \n"
-
-                        "vst1.s32   {d23[0]}, [%2]!     \n"
-                        "vst1.s32   {d23[1]}, [%3]!     \n"
-
-                        "sub        %2, %2, %18, lsl #2 \n"
-                        "sub        %3, %3, %18, lsl #2 \n"
-
-                        : "=r"(outptr0),    // %0
-                          "=r"(outptr1),    // %1
-                          "=r"(outptr2),    // %2
-                          "=r"(outptr3),    // %3
-                          "=r"(r0),         // %4
-                          "=r"(r1),         // %5
-                          "=r"(r2),         // %6
-                          "=r"(r3),         // %7
-                          "=r"(ktmp)        // %8
-                        : "0"(outptr0),
-                          "1"(outptr1),
-                          "2"(outptr2),
-                          "3"(outptr3),
-                          "4"(r0),
-                          "5"(r1),
-                          "6"(r2),
-                          "7"(r3),
-                          "8"(ktmp),
-                          "r"(outw)         // %18
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11"
-                    );
-#else
-                    int sum0 = 0;
-                    int sum1 = 0;
-                    int sum2 = 0;
-                    int sum3 = 0;
-
-                    int sum0n = 0;
-                    int sum1n = 0;
-                    int sum2n = 0;
-                    int sum3n = 0;
-
-                    sum0 += r0[0] * ktmp[0];
-                    sum1 += r0[0] * ktmp[1];
-                    sum2 += r0[0] * ktmp[2];
-                    sum3 += r0[0] * ktmp[3];
-                    sum0 += r0[1] * ktmp[4];
-                    sum1 += r0[1] * ktmp[5];
-                    sum2 += r0[1] * ktmp[6];
-                    sum3 += r0[1] * ktmp[7];
-
-                    sum0n += r1[0] * ktmp[0];
-                    sum1n += r1[0] * ktmp[1];
-                    sum2n += r1[0] * ktmp[2];
-                    sum3n += r1[0] * ktmp[3];
-                    sum0n += r1[1] * ktmp[4];
-                    sum1n += r1[1] * ktmp[5];
-                    sum2n += r1[1] * ktmp[6];
-                    sum3n += r1[1] * ktmp[7];
-
-                    ktmp += 8;
-
-                    sum0 += r0[2] * ktmp[0];
-                    sum1 += r0[2] * ktmp[1];
-                    sum2 += r0[2] * ktmp[2];
-                    sum3 += r0[2] * ktmp[3];
-                    sum0 += r1[0] * ktmp[4];
-                    sum1 += r1[0] * ktmp[5];
-                    sum2 += r1[0] * ktmp[6];
-                    sum3 += r1[0] * ktmp[7];
-
-                    sum0n += r1[2] * ktmp[0];
-                    sum1n += r1[2] * ktmp[1];
-                    sum2n += r1[2] * ktmp[2];
-                    sum3n += r1[2] * ktmp[3];
-                    sum0n += r2[0] * ktmp[4];
-                    sum1n += r2[0] * ktmp[5];
-                    sum2n += r2[0] * ktmp[6];
-                    sum3n += r2[0] * ktmp[7];
-
-                    ktmp += 8;
-
-                    sum0 += r1[1] * ktmp[0];
-                    sum1 += r1[1] * ktmp[1];
-                    sum2 += r1[1] * ktmp[2];
-                    sum3 += r1[1] * ktmp[3];
-                    sum0 += r1[2] * ktmp[4];
-                    sum1 += r1[2] * ktmp[5];
-                    sum2 += r1[2] * ktmp[6];
-                    sum3 += r1[2] * ktmp[7];
-
-                    sum0n += r2[1] * ktmp[0];
-                    sum1n += r2[1] * ktmp[1];
-                    sum2n += r2[1] * ktmp[2];
-                    sum3n += r2[1] * ktmp[3];
-                    sum0n += r2[2] * ktmp[4];
-                    sum1n += r2[2] * ktmp[5];
-                    sum2n += r2[2] * ktmp[6];
-                    sum3n += r2[2] * ktmp[7];
-
-                    ktmp += 8;
-
-                    ///
-                    sum0 += r2[0] * ktmp[0];
-                    sum1 += r2[0] * ktmp[1];
-                    sum2 += r2[0] * ktmp[2];
-                    sum3 += r2[0] * ktmp[3];
-                    sum0 += r2[1] * ktmp[4];
-                    sum1 += r2[1] * ktmp[5];
-                    sum2 += r2[1] * ktmp[6];
-                    sum3 += r2[1] * ktmp[7];
-
-                    sum0n += r3[0] * ktmp[0];
-                    sum1n += r3[0] * ktmp[1];
-                    sum2n += r3[0] * ktmp[2];
-                    sum3n += r3[0] * ktmp[3];
-                    sum0n += r3[1] * ktmp[4];
-                    sum1n += r3[1] * ktmp[5];
-                    sum2n += r3[1] * ktmp[6];
-                    sum3n += r3[1] * ktmp[7];
-
-                    ktmp += 8;
-
-                    sum0 += r2[2] * ktmp[0];
-                    sum1 += r2[2] * ktmp[1];
-                    sum2 += r2[2] * ktmp[2];
-                    sum3 += r2[2] * ktmp[3];
-
-                    sum0n += r3[2] * ktmp[0];
-                    sum1n += r3[2] * ktmp[1];
-                    sum2n += r3[2] * ktmp[2];
-                    sum3n += r3[2] * ktmp[3];
-
-                    ktmp += 4;
-
-                    *outptr0 += sum0;
-                    *outptr1 += sum1;
-                    *outptr2 += sum2;
-                    *outptr3 += sum3;
-
-                    *(outptr0 + outw) += sum0n;
-                    *(outptr1 + outw) += sum1n;
-                    *(outptr2 + outw) += sum2n;
-                    *(outptr3 + outw) += sum3n;
-
-                    ktmp -= 12*3;
-
-                    outptr0++;
-                    outptr1++;
-                    outptr2++;
-                    outptr3++;
-#endif
-                    r0++;
-                    r1++;
-                    r2++;
-                    r3++;
-                }
-
-                r0 += 2 + w;
-                r1 += 2 + w;
-                r2 += 2 + w;
-                r3 += 2 + w;
-
-                outptr0 += outw;
-                outptr1 += outw;
-                outptr2 += outw;
-                outptr3 += outw;
-            }
+            int i = 0;    
 
             for (; i < outh; i++)
             {
@@ -5427,190 +2617,160 @@ static void conv3x3s1_packed_int8_neon(const Mat &bottom_blob, Mat &top_blob, co
                 {
                 asm volatile(
                     "0:                         \n"
-//                     "pld        [%8, #256]      \n"
-                    "vld1.s8    {d0-d3}, [%8]!  \n"// d0=k00 k01  d1=k02 k10  d2=k11 k12  d3=k20 k21
-
+                    "vld1.s8    {d0-d3}, [%8]!  \n"// d0=(k00-k30 k01-k31) d1=(k02-k32 k03-k33) d2=(k04-k34 k05-k35) d3=(k06-k36 k07-k37)
+                    // r0
                     "pld        [%5, #128]      \n"
-                    "vld1.s8    {d4-d5}, [%5]   \n"// d4=r00 d5=r00n
+                    "vld1.s8    {d8-d9}, [%5]   \n"// d8=r00-r07 d9=r08-r015 q4
                     "add        %5, #8          \n"
+                    "pld        [%1, #128]      \n"
+                    "vld1.s32   {d12-d15}, [%1] \n"// sum00-sum07 q6 q7
+                    "pld        [%2, #128]      \n"
+                    "vld1.s32   {d16-d19}, [%2] \n"// sum10-sum17 q8 q9
+                    "pld        [%3, #128]      \n"
+                    "vld1.s32   {d20-d23}, [%3] \n"// sum20-sum27 q10 q11
+                    "pld        [%4, #128]      \n"
+                    "vld1.s32   {d24-d27}, [%4] \n"// sum30-sum37 q12 q13
+                    
+                    "vmovl.s8   q3, d3          \n"// d6(k06-k36) d7(k07-k37) 
+                    "vmovl.s8   q2, d2          \n"// d4(k04-k34) d5(k05-k35)
+                    "vmovl.s8   q1, d1          \n"// d2(k02-k32) d3(k03-k33)
+                    "vmovl.s8   q0, d0          \n"// d0(k00-k30) d1(k01-k31)
+                    "vmovl.s8   q5, d8          \n"// d10(r00-r03) d11(r04-r07)
+                    
+                    "vmlal.s16  q6, d10, d0[0]  \n"// sum(00-07) += (r00-r07) * k00
+                    "vmlal.s16  q7, d11, d0[0]  \n"
+                    "vmlal.s16  q8, d10, d0[1]  \n"// sum(10-17) += (r00-r07) * k10
+                    "vmlal.s16  q9, d11, d0[1]  \n"     
+                    "vmlal.s16  q10, d10, d0[2] \n"// sum(20-27) += (r00-r07) * k20
+                    "vmlal.s16  q11, d11, d0[2] \n"
+                    "vmlal.s16  q12, d10, d0[3] \n"// sum(30-37) += (r00-r07) * k30
+                    "vmlal.s16  q13, d11, d0[3] \n"
 
-                    "vdup.s8    d8, d0[0]       \n"
-                    "vdup.s8    d9, d0[1]       \n"
-                    "vdup.s8    d10, d0[2]      \n"
-                    "vdup.s8    d11, d0[3]      \n"
-
-                    "vmull.s8   q8, d4, d8      \n"
-                    "vmull.s8   q9, d4, d9      \n"
-
-                    "vext.s8    d24, d4, d5, #1 \n"// d24=r01
-
-                    "vdup.s8    d12, d0[4]      \n"
-                    "vdup.s8    d13, d0[5]      \n"
-
-                    "vmull.s8   q10, d4, d10    \n"
-                    "vmull.s8   q11, d4, d11    \n"
-
-                    "vdup.s8    d14, d0[6]      \n"
-                    "vdup.s8    d15, d0[7]      \n"
-
-                    "vmlal.s8   q8, d24, d12    \n"
-                    "vmlal.s8   q9, d24, d13    \n"
-
-                    "vext.s8    d25, d4, d5, #2 \n"// d25=r02
-
-                    "vdup.s8    d8, d1[0]       \n"
-                    "vdup.s8    d9, d1[1]       \n"
-
-                    "vmlal.s8   q10, d24, d14   \n"
-                    "vmlal.s8   q11, d24, d15   \n"
-
-                    "vdup.s8    d10, d1[2]      \n"
-                    "vdup.s8    d11, d1[3]      \n"
-
-                    "vmlal.s8   q8, d25, d8     \n"
-                    "vmlal.s8   q9, d25, d9     \n"
-
+                    "vext.s8    q4, q4, #1      \n"// d8=r01-r08 q4
+                    "vmovl.s8   q5, d8          \n"// d10(r01-r04) d11(r05-r08)
+                    
+                    "vmlal.s16  q6, d10, d1[0]  \n"// sum(00-07) += (r01-r08) * k01
+                    "vmlal.s16  q7, d11, d1[0]  \n"
+                    "vmlal.s16  q8, d10, d1[1]  \n"// sum(10-17) += (r01-r08) * k11
+                    "vmlal.s16  q9, d11, d1[1]  \n"     
+                    "vmlal.s16  q10, d10, d1[2] \n"// sum(20-27) += (r01-r08) * k21
+                    "vmlal.s16  q11, d11, d1[2] \n"
+                    "vmlal.s16  q12, d10, d1[3] \n"// sum(30-37) += (r01-r08) * k31
+                    "vmlal.s16  q13, d11, d1[3] \n"
+                    
+                    "vext.s8    q4, q4, #1      \n"// d8=r02-r09 q4
+                    "vmovl.s8   q5, d8          \n"// d10(r02-r05) d11(r06-r09)
+                    
+                    "vmlal.s16  q6, d10, d2[0]  \n"// sum(00-07) += (r02-r09) * k02
+                    "vmlal.s16  q7, d11, d2[0]  \n"
+                    "vmlal.s16  q8, d10, d2[1]  \n"// sum(10-17) += (r02-r09) * k12
+                    "vmlal.s16  q9, d11, d2[1]  \n"     
+                    "vmlal.s16  q10, d10, d2[2] \n"// sum(20-27) += (r02-r09) * k22
+                    "vmlal.s16  q11, d11, d2[2] \n"
+                    "vmlal.s16  q12, d10, d2[3] \n"// sum(30-37) += (r02-r09) * k32
+                    "vmlal.s16  q13, d11, d2[3] \n"                 
+                    
+                    // r1
                     "pld        [%6, #128]      \n"
-                    "vld1.s8    {d6-d7}, [%6]   \n"// d6=r10 d7=r10n
+                    "vld1.s8    {d8-d9}, [%6]   \n"// d8=r10-r17 d9=r18-r115 q4
                     "add        %6, #8          \n"
+                    "vmovl.s8   q5, d8          \n"// d10(r10-r13) d11(r14-r17)
+                    
+                    "vmlal.s16  q6, d10, d3[0]  \n"// sum(00-07) += (r10-r17) * k03
+                    "vmlal.s16  q7, d11, d3[0]  \n"
+                    "vmlal.s16  q8, d10, d3[1]  \n"// sum(10-17) += (r10-r17) * k13
+                    "vmlal.s16  q9, d11, d3[1]  \n"     
+                    "vmlal.s16  q10, d10, d3[2] \n"// sum(20-27) += (r10-r17) * k23
+                    "vmlal.s16  q11, d11, d3[2] \n"
+                    "vmlal.s16  q12, d10, d3[3] \n"// sum(30-37) += (r10-r17) * k33
+                    "vmlal.s16  q13, d11, d3[3] \n"
+                    
+                    "vext.s8    q4, q4, #1      \n"// d8=r11-r18 q4
+                    "vmovl.s8   q5, d8          \n"// d10(r11-r14) d11(r15-r18)
 
-                    "vdup.s8    d12, d1[4]      \n"
-                    "vdup.s8    d13, d1[5]      \n"
+                    "vmlal.s16  q6, d10, d4[0]  \n"// sum(00-07) += (r11-r18) * k04
+                    "vmlal.s16  q7, d11, d4[0]  \n"
+                    "vmlal.s16  q8, d10, d4[1]  \n"// sum(10-17) += (r11-r18) * k14
+                    "vmlal.s16  q9, d11, d4[1]  \n"     
+                    "vmlal.s16  q10, d10, d4[2] \n"// sum(20-27) += (r11-r18) * k24
+                    "vmlal.s16  q11, d11, d4[2] \n"
+                    "vmlal.s16  q12, d10, d4[3] \n"// sum(30-37) += (r11-r18) * k34
+                    "vmlal.s16  q13, d11, d4[3] \n"
+                    
+                    "vext.s8    q4, q4, #1      \n"// d8=r12-r19 q4
+                    "vmovl.s8   q5, d8          \n"// d10(r12-r15) d11(r16-r19)
 
-                    "vmlal.s8   q10, d25, d10   \n"
-                    "vmlal.s8   q11, d25, d11   \n"
+                    "vmlal.s16  q6, d10, d5[0]  \n"// sum(00-07) += (r12-r19) * k05
+                    "vmlal.s16  q7, d11, d5[0]  \n"
+                    "vmlal.s16  q8, d10, d5[1]  \n"// sum(10-17) += (r12-r19) * k15
+                    "vmlal.s16  q9, d11, d5[1]  \n"     
+                    "vmlal.s16  q10, d10, d5[2] \n"// sum(20-27) += (r12-r19) * k25
+                    "vmlal.s16  q11, d11, d5[2] \n"
+                    "vmlal.s16  q12, d10, d5[3] \n"// sum(30-37) += (r12-r19) * k35
+                    "vmlal.s16  q13, d11, d5[3] \n"
 
-                    "vdup.s8    d14, d1[6]      \n"
-                    "vdup.s8    d15, d1[7]      \n"
-
-                    "vmlal.s8   q8, d6, d12     \n"
-                    "vmlal.s8   q9, d6, d13     \n"
-
-                    "vext.s8    d26, d6, d7, #1 \n"// d26=r11
-
-                    "vdup.s8    d8, d2[0]       \n"
-                    "vdup.s8    d9, d2[1]       \n"
-
-                    "vmlal.s8   q10, d6, d14    \n"
-                    "vmlal.s8   q11, d6, d15    \n"
-
-                    "vdup.s8    d10, d2[2]      \n"
-                    "vdup.s8    d11, d2[3]      \n"
-
-                    "vmlal.s8   q8, d26, d8     \n"
-                    "vmlal.s8   q9, d26, d9     \n"
-
-                    "vext.s8    d27, d6, d7, #2 \n"// d27=r12
-
-                    "vdup.s8    d12, d2[4]      \n"
-                    "vdup.s8    d13, d2[5]      \n"
-
-                    "vmlal.s8   q10, d26, d10   \n"
-                    "vmlal.s8   q11, d26, d11   \n"
-
-                    "vdup.s8    d14, d2[6]      \n"
-                    "vdup.s8    d15, d2[7]      \n"
-
-                    "vmlal.s8   q8, d27, d12    \n"
-                    "vmlal.s8   q9, d27, d13    \n"
-
+                    // r2
                     "pld        [%7, #128]      \n"
-                    "vld1.s8    {d4-d5}, [%7]   \n"// d4=r20 d5=r20n
+                    "vld1.s8    {d8-d9}, [%7]   \n"// d8=r20-r27 d9=r28-r215 q4
                     "add        %7, #8          \n"
+                    "vmovl.s8   q5, d8          \n"// d10(r20-r23) d11(r24-r27)
 
-                    "vdup.s8    d8, d3[0]       \n"
-                    "vdup.s8    d9, d3[1]       \n"
+                    "vmlal.s16  q6, d10, d6[0]  \n"// sum(00-07) += (r20-r27) * k06
+                    "vmlal.s16  q7, d11, d6[0]  \n"
+                    "vmlal.s16  q8, d10, d6[1]  \n"// sum(10-17) += (r20-r27) * k16
+                    "vmlal.s16  q9, d11, d6[1]  \n"     
+                    "vmlal.s16  q10, d10, d6[2] \n"// sum(20-27) += (r20-r27) * k26
+                    "vmlal.s16  q11, d11, d6[2] \n"
+                    "vmlal.s16  q12, d10, d6[3] \n"// sum(30-37) += (r20-r27) * k36
+                    "vmlal.s16  q13, d11, d6[3] \n"
+                    
+                    "vext.s8    q4, q4, #1      \n"// d8=r21-r28 q4
+                    "vmovl.s8   q5, d8          \n"// d10(r21-r24) d11(r25-r28)
 
-                    "vmlal.s8   q10, d27, d14   \n"
-                    "vmlal.s8   q11, d27, d15   \n"
-
-                    "vdup.s8    d10, d3[2]      \n"
-                    "vdup.s8    d11, d3[3]      \n"
-
-                    "vmlal.s8   q8, d4, d8      \n"
-                    "vmlal.s8   q9, d4, d9      \n"
-
-                    "vext.s8    d24, d4, d5, #1 \n"// d24=r21
-
-                    "vdup.s8    d12, d3[4]      \n"
-                    "vdup.s8    d13, d3[5]      \n"
-
-                    "vmlal.s8   q10, d4, d10    \n"
-                    "vmlal.s8   q11, d4, d11    \n"
-
-                    "vdup.s8    d14, d3[6]      \n"
-                    "vdup.s8    d15, d3[7]      \n"
-
-                    "vmlal.s8   q8, d24, d12    \n"
-                    "vmlal.s8   q9, d24, d13    \n"
-
-//                     "pld        [%8, #128]      \n"
-                    "vld1.s8    {d0}, [%8]      \n"
+                    "vmlal.s16  q6, d10, d7[0]  \n"// sum(00-07) += (r21-r28) * k07
+                    "vmlal.s16  q7, d11, d7[0]  \n"
+                    "vmlal.s16  q8, d10, d7[1]  \n"// sum(10-17) += (r21-r28) * k17
+                    "vmlal.s16  q9, d11, d7[1]  \n"     
+                    "vmlal.s16  q10, d10, d7[2] \n"// sum(20-27) += (r21-r28) * k27
+                    "vmlal.s16  q11, d11, d7[2] \n"
+                    "vmlal.s16  q12, d10, d7[3] \n"// sum(30-37) += (r21-r28) * k37
+                    "vmlal.s16  q13, d11, d7[3] \n"
+                    
+                    "vld1.s8    {d0}, [%8]      \n"// d0(k08-k38 xx-xx)
                     "add        %8, #4          \n"
+                    "vmovl.s8   q0, d0          \n"// d0(k08-k38) d1(xx-xx)
 
-                    "vext.s8    d25, d4, d5, #2 \n"// d25=r22
+                    "vext.s8    q4, q4, #1      \n"// d8=r22-r29 q4
+                    "vmovl.s8   q5, d8          \n"// d10(r22-r25) d11(r26-r29)
 
-                    "vdup.s8    d8, d0[0]       \n"
-                    "vdup.s8    d9, d0[1]       \n"
+                    "vmlal.s16  q6, d10, d0[0]  \n"// sum(00-07) += (r22-r29) * k08
+                    "vmlal.s16  q7, d11, d0[0]  \n"
+                    "vmlal.s16  q8, d10, d0[1]  \n"// sum(10-17) += (r22-r29) * k18
+                    "vmlal.s16  q9, d11, d0[1]  \n"     
+                    "vmlal.s16  q10, d10, d0[2] \n"// sum(20-27) += (r22-r29) * k28
+                    "vmlal.s16  q11, d11, d0[2] \n"
+                    "vmlal.s16  q12, d10, d0[3] \n"// sum(30-37) += (r22-r29) * k38
+                    "vmlal.s16  q13, d11, d0[3] \n"
+                    
+                    "vst1.s32   {d12-d15}, [%1]! \n"// sum00-sum07 q6 q7
+                    "vst1.s32   {d16-d19}, [%2]! \n"// sum10-sum17 q8 q9
+                    "vst1.s32   {d20-d23}, [%3]! \n"// sum20-sum27 q10 q11
+                    "vst1.s32   {d24-d27}, [%4]! \n"// sum30-sum37 q12 q13
 
-                    "vmlal.s8   q10, d24, d14   \n"
-                    "vmlal.s8   q11, d24, d15   \n"
+                    "sub        %8, #36          \n"
+                    "subs       %0, #1           \n"
 
-                    "vdup.s8    d10, d0[2]      \n"
-                    "vdup.s8    d11, d0[3]      \n"
+                    "bne        0b               \n"
 
-                    "pld        [%1, #256]      \n"
-                    "vld1.s32   {d12-d15}, [%1] \n"
-
-                    "vmlal.s8   q8, d25, d8     \n"
-                    "vmlal.s8   q9, d25, d9     \n"
-
-                    "pld        [%2, #256]      \n"
-                    "vld1.s32   {d0-d3}, [%2]   \n"
-
-                    "vaddw.s16  q6, q6, d16     \n"
-                    "vaddw.s16  q7, q7, d17     \n"
-
-                    "vmlal.s8   q10, d25, d10   \n"
-                    "vmlal.s8   q11, d25, d11   \n"
-
-                    "vaddw.s16  q0, q0, d18     \n"
-                    "vaddw.s16  q1, q1, d19     \n"
-
-                    "pld        [%3, #256]      \n"
-                    "vld1.s32   {d16-d19}, [%3]  \n"
-
-                    "vst1.s32   {d12-d15}, [%1]! \n"
-
-                    "pld        [%4, #256]      \n"
-                    "vld1.s32   {d4-d7}, [%4]   \n"
-
-                    "vst1.s32   {d0-d3}, [%2]!  \n"
-
-                    "vaddw.s16  q8, q8, d20     \n"
-                    "vaddw.s16  q9, q9, d21     \n"
-                    "vaddw.s16  q2, q2, d22     \n"
-                    "vaddw.s16  q3, q3, d23     \n"
-
-                    "sub        %8, #36         \n"
-
-                    "vst1.s32   {d16-d19}, [%3]! \n"
-
-                    "subs       %0, #1          \n"
-
-                    "vst1.s32   {d4-d7}, [%4]!  \n"
-
-                    "bne        0b              \n"
-
-                    : "=r"(nn),
-                      "=r"(outptr0),
-                      "=r"(outptr1),
-                      "=r"(outptr2),
-                      "=r"(outptr3),
-                      "=r"(r0),
-                      "=r"(r1),
-                      "=r"(r2),
-                      "=r"(ktmp)
+                    : "=r"(nn),         // %0
+                      "=r"(outptr0),    // %1
+                      "=r"(outptr1),    // %2
+                      "=r"(outptr2),    // %3
+                      "=r"(outptr3),    // %4
+                      "=r"(r0),         // %5
+                      "=r"(r1),         // %6
+                      "=r"(r2),         // %7
+                      "=r"(ktmp)        // %8
                     : "0"(nn),
                       "1"(outptr0),
                       "2"(outptr1),
@@ -5620,7 +2780,7 @@ static void conv3x3s1_packed_int8_neon(const Mat &bottom_blob, Mat &top_blob, co
                       "6"(r1),
                       "7"(r2),
                       "8"(ktmp)
-                    : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13"
+                    : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15" //q14 q15 not be used...
                 );
                 }
 #endif
@@ -5628,230 +2788,202 @@ static void conv3x3s1_packed_int8_neon(const Mat &bottom_blob, Mat &top_blob, co
                 if (remain >= 4)
                 {
                     remain -= 4;
-                    asm volatile(
-                        "vld1.s8    {d0}, [%4]          \n"// d0 = r00 r00n
-                        "add        %4, #4              \n"
-                        "vld1.s8    {d3}, [%5]          \n"// d3 = r10 r10n
-                        "add        %5, #4              \n"
-                        "vld1.s8    {d6}, [%6]          \n"// d6 = r20 r20n
-                        "add        %6, #4              \n"
+                asm volatile(
+                    "vld1.s8    {d0-d3}, [%7]!  \n"// d0=(k00-k30 k01-k31) d1=(k02-k32 k03-k33) d2=(k04-k34 k05-k35) d3=(k06-k36 k07-k37)
+                    // r0
+                    "vld1.s8    {d8}, [%4]      \n"// d8=r00-r07
+                    "add        %4, #4          \n"
+                    "vld1.s32   {d12-d13}, [%0] \n"// sum00-sum03 q6
+                    "vld1.s32   {d16-d17}, [%1] \n"// sum10-sum13 q8
+                    "vld1.s32   {d20-d21}, [%2] \n"// sum20-sum23 q10
+                    "vld1.s32   {d24-d25}, [%3] \n"// sum30-sum33 q12
+                    
+                    "vmovl.s8   q3, d3          \n"// d6(k06-k36) d7(k07-k37) 
+                    "vmovl.s8   q2, d2          \n"// d4(k04-k34) d5(k05-k35)
+                    "vmovl.s8   q1, d1          \n"// d2(k02-k32) d3(k03-k33)
+                    "vmovl.s8   q0, d0          \n"// d0(k00-k30) d1(k01-k31)
+                    "vmovl.s8   q5, d8          \n"// d10(r00-r03)
+                    
+                    "vmlal.s16  q6, d10, d0[0]  \n"// sum(00-03) += (r00-r03) * k00
+                    "vmlal.s16  q8, d10, d0[1]  \n"// sum(10-13) += (r00-r03) * k10
+                    "vmlal.s16  q10, d10, d0[2] \n"// sum(20-23) += (r00-r03) * k20
+                    "vmlal.s16  q12, d10, d0[3] \n"// sum(30-33) += (r00-r03) * k30
 
-                        "vld1.s8    {d12-d15}, [%7]!    \n"// d12=k00 k01  d13=k02 k10  d14=k11 k12  d15=k20 k21
+                    "vext.s8    d8, d8, #1      \n"// d8=r01-r08
+                    "vmovl.s8   q5, d8          \n"// d10(r01-r04)
+                    
+                    "vmlal.s16  q6, d10, d1[0]  \n"// sum(00-03) += (r01-r04) * k01
+                    "vmlal.s16  q8, d10, d1[1]  \n"// sum(10-13) += (r01-r04) * k11
+                    "vmlal.s16  q10, d10, d1[2] \n"// sum(20-23) += (r01-r04) * k21
+                    "vmlal.s16  q12, d10, d1[3] \n"// sum(30-33) += (r01-r04) * k31
+                    
+                    "vext.s8    d8, d8, #1      \n"// d8=r02-r09
+                    "vmovl.s8   q5, d8          \n"// d10(r02-r05)
+                    
+                    "vmlal.s16  q6, d10, d2[0]  \n"// sum(00-03) += (r02-r05) * k02
+                    "vmlal.s16  q8, d10, d2[1]  \n"// sum(10-13) += (r02-r05) * k12
+                    "vmlal.s16  q10, d10, d2[2] \n"// sum(20-23) += (r02-r05) * k22
+                    "vmlal.s16  q12, d10, d2[3] \n"// sum(30-33) += (r02-r05) * k32
+                    
+                    // r1
+                    "vld1.s8    {d8}, [%5]      \n"// d8=r10-r17
+                    "add        %5, #4          \n"
+                    "vmovl.s8   q5, d8          \n"// d10(r10-r13)
+                    
+                    "vmlal.s16  q6, d10, d3[0]  \n"// sum(00-03) += (r10-r13) * k03
+                    "vmlal.s16  q8, d10, d3[1]  \n"// sum(10-13) += (r10-r13) * k13
+                    "vmlal.s16  q10, d10, d3[2] \n"// sum(20-23) += (r10-r13) * k23
+                    "vmlal.s16  q12, d10, d3[3] \n"// sum(30-33) += (r10-r13) * k33
+                    
+                    "vext.s8    d8, d8, #1      \n"// d8=r11-r18
+                    "vmovl.s8   q5, d8          \n"// d10(r11-r14)
 
-                        /// r00 r01 r02
-                        "vext.s8    d1, d0, d0, #1      \n"
-                        "vext.s8    d2, d0, d0, #2      \n"
+                    "vmlal.s16  q6, d10, d4[0]  \n"// sum(00-03) += (r11-r14) * k04
+                    "vmlal.s16  q8, d10, d4[1]  \n"// sum(10-13) += (r11-r14) * k14
+                    "vmlal.s16  q10, d10, d4[2] \n"// sum(20-23) += (r11-r14) * k24
+                    "vmlal.s16  q12, d10, d4[3] \n"// sum(30-33) += (r11-r14) * k34
+                    
+                    "vext.s8    d8, d8, #1      \n"// d8=r12-r19 q4
+                    "vmovl.s8   q5, d8          \n"// d10(r12-r15)
 
-                        "vdup.s8    d24, d12[0]         \n"
-                        "vdup.s8    d26, d12[1]         \n"
-                        "vdup.s8    d25, d12[2]         \n"
-                        "vdup.s8    d27, d12[3]         \n"
+                    "vmlal.s16  q6, d10, d5[0]  \n"// sum(00-03) += (r12-r15) * k05
+                    "vmlal.s16  q8, d10, d5[1]  \n"// sum(10-13) += (r12-r15) * k15
+                    "vmlal.s16  q10, d10, d5[2] \n"// sum(20-23) += (r12-r15) * k25
+                    "vmlal.s16  q12, d10, d5[3] \n"// sum(30-33) += (r12-r15) * k35
 
-                        "vsli.64    d0, d0, #32         \n"// d0 = r00 r00
-                        "vsli.64    d1, d1, #32         \n"// d1 = r01 r01
-                        "vsli.64    d2, d2, #32         \n"// d2 = r02 r02
+                    // r2
+                    "vld1.s8    {d8}, [%6]      \n"// d8=r20-r27
+                    "add        %6, #4          \n"
+                    "vmovl.s8   q5, d8          \n"// d10(r20-r23)
 
-                        "vsli.64    q12, q13, #32       \n"
+                    "vmlal.s16  q6, d10, d6[0]  \n"// sum(00-03) += (r20-r23) * k06
+                    "vmlal.s16  q8, d10, d6[1]  \n"// sum(10-13) += (r20-r23) * k16
+                    "vmlal.s16  q10, d10, d6[2] \n"// sum(20-23) += (r20-r23) * k26
+                    "vmlal.s16  q12, d10, d6[3] \n"// sum(30-33) += (r20-r23) * k36
+                    
+                    "vext.s8    q4, q4, #1      \n"// d8=r21-r28 q4
+                    "vmovl.s8   q5, d8          \n"// d10(r21-r24)
 
-                        "vdup.s8    d28, d12[4]         \n"
-                        "vdup.s8    d30, d12[5]         \n"
-                        "vdup.s8    d29, d12[6]         \n"
-                        "vdup.s8    d31, d12[7]         \n"
+                    "vmlal.s16  q6, d10, d7[0]  \n"// sum(00-03) += (r21-r24) * k07
+                    "vmlal.s16  q8, d10, d7[1]  \n"// sum(10-13) += (r21-r24) * k17
+                    "vmlal.s16  q10, d10, d7[2] \n"// sum(20-23) += (r21-r24) * k27
+                    "vmlal.s16  q12, d10, d7[3] \n"// sum(30-33) += (r21-r24) * k37
+                    
+                    "vld1.s8    {d0}, [%7]      \n"// d0(k08-k38 xx-xx)
+                    "add        %7, #4          \n"
+                    "vmovl.s8   q0, d0          \n"// d0(k08-k38) d1(xx-xx)
 
-                        "vsli.64    q14, q15, #32       \n"
+                    "vext.s8    d8, d8, #1      \n"// d8=r22-r25
+                    "vmovl.s8   q5, d8          \n"// d10(r22-r25)
 
-                        "vmull.s8   q8, d0, d24         \n"
-                        "vmull.s8   q9, d0, d25         \n"
+                    "vmlal.s16  q6, d10, d0[0]  \n"// sum(00-03) += (r22-r25) * k08
+                    "vmlal.s16  q8, d10, d0[1]  \n"// sum(10-13) += (r22-r25) * k18
+                    "vmlal.s16  q10, d10, d0[2] \n"// sum(20-23) += (r22-r25) * k28
+                    "vmlal.s16  q12, d10, d0[3] \n"// sum(30-33) += (r22-r25) * k38
+                    
+                    "vst1.s32   {d12-d13}, [%0]! \n"// sum00-sum03 q6
+                    "vst1.s32   {d16-d17}, [%1]! \n"// sum10-sum13 q8
+                    "vst1.s32   {d20-d21}, [%2]! \n"// sum20-sum23 q10
+                    "vst1.s32   {d24-d25}, [%3]! \n"// sum30-sum33 q12 
 
-                        "vdup.s8    d24, d13[0]         \n"
-                        "vdup.s8    d26, d13[1]         \n"
-                        "vdup.s8    d25, d13[2]         \n"
-                        "vdup.s8    d27, d13[3]         \n"
+                    "sub        %7, #36          \n"
 
-                        "vsli.64    q12, q13, #32       \n"
-
-                        "vmlal.s8   q8, d1, d28         \n"
-                        "vmlal.s8   q9, d1, d29         \n"
-
-                        /// r10 r11 r12
-                        "vext.s8    d4, d3, d3, #1      \n"
-                        "vext.s8    d5, d3, d3, #2      \n"
-
-                        "vdup.s8    d28, d13[4]         \n"
-                        "vdup.s8    d30, d13[5]         \n"
-                        "vdup.s8    d29, d13[6]         \n"
-                        "vdup.s8    d31, d13[7]         \n"
-
-                        "vsli.64    d3, d3, #32         \n"// d3 = r10 r10
-                        "vsli.64    d4, d4, #32         \n"// d4 = r11 r11
-                        "vsli.64    d5, d5, #32         \n"// d5 = r12 r12
-
-                        "vsli.64    q14, q15, #32       \n"
-
-                        "vmlal.s8   q8, d2, d24         \n"
-                        "vmlal.s8   q9, d2, d25         \n"
-
-                        "vdup.s8    d24, d14[0]         \n"
-                        "vdup.s8    d26, d14[1]         \n"
-                        "vdup.s8    d25, d14[2]         \n"
-                        "vdup.s8    d27, d14[3]         \n"
-
-                        "vsli.64    q12, q13, #32       \n"
-
-                        "vmlal.s8   q8, d3, d28         \n"
-                        "vmlal.s8   q9, d3, d29         \n"
-
-                        "vdup.s8    d28, d14[4]         \n"
-                        "vdup.s8    d30, d14[5]         \n"
-                        "vdup.s8    d29, d14[6]         \n"
-                        "vdup.s8    d31, d14[7]         \n"
-
-                        "vsli.64    q14, q15, #32       \n"
-
-                        "vmlal.s8   q8, d4, d24         \n"
-                        "vmlal.s8   q9, d4, d25         \n"
-
-                        /// r20 r21 r22
-                        "vext.s8    d7, d6, d6, #1      \n"
-                        "vext.s8    d8, d6, d6, #2      \n"
-
-                        "vdup.s8    d24, d15[0]         \n"
-                        "vdup.s8    d26, d15[1]         \n"
-                        "vdup.s8    d25, d15[2]         \n"
-                        "vdup.s8    d27, d15[3]         \n"
-
-                        "vsli.64    d6, d6, #32         \n"// d6 = r20 r20
-                        "vsli.64    d7, d7, #32         \n"// d7 = r21 r21
-                        "vsli.64    d8, d8, #32         \n"// d8 = r22 r22
-
-                        "vsli.64    q12, q13, #32       \n"
-
-                        "vmlal.s8   q8, d5, d28         \n"
-                        "vmlal.s8   q9, d5, d29         \n"
-
-                        "vdup.s8    d28, d15[4]         \n"
-                        "vdup.s8    d30, d15[5]         \n"
-                        "vdup.s8    d29, d15[6]         \n"
-                        "vdup.s8    d31, d15[7]         \n"
-
-                        "vsli.64    q14, q15, #32       \n"
-
-                        "vld1.s8    {d12}, [%7]         \n"// d12=k22
-                        "add        %7, #4              \n"
-
-                        "vmlal.s8   q8, d6, d24         \n"
-                        "vmlal.s8   q9, d6, d25         \n"
-
-                        "vdup.s8    d24, d12[0]         \n"
-                        "vdup.s8    d26, d12[1]         \n"
-                        "vdup.s8    d25, d12[2]         \n"
-                        "vdup.s8    d27, d12[3]         \n"
-
-                        "vsli.64    q12, q13, #32       \n"
-
-                        "vmlal.s8   q8, d7, d28         \n"
-                        "vmlal.s8   q9, d7, d29         \n"
-
-                        "vld1.s32   {d0-d1}, [%0]       \n"
-                        "vld1.s32   {d2-d3}, [%1]       \n"
-
-                        "vmlal.s8   q8, d8, d24         \n"
-                        "vmlal.s8   q9, d8, d25         \n"
-
-                        ///
-                        "vld1.s32   {d4-d5}, [%2]       \n"
-                        "vld1.s32   {d6-d7}, [%3]       \n"
-
-                        "vaddw.s16  q0, q0, d16         \n"
-                        "vaddw.s16  q1, q1, d17         \n"
-                        "vaddw.s16  q2, q2, d18         \n"
-                        "vaddw.s16  q3, q3, d19         \n"
-
-                        "vst1.s32   {d0-d1}, [%0]!      \n"
-                        "vst1.s32   {d2-d3}, [%1]!      \n"
-
-                        "sub        %7, #36             \n"
-
-                        "vst1.s32   {d4-d5}, [%2]!      \n"
-                        "vst1.s32   {d6-d7}, [%3]!      \n"
-
-                        : "=r"(outptr0),    // %0
-                          "=r"(outptr1),    // %1
-                          "=r"(outptr2),    // %2
-                          "=r"(outptr3),    // %3
-                          "=r"(r0),         // %4
-                          "=r"(r1),         // %5
-                          "=r"(r2),         // %6
-                          "=r"(ktmp)        // %7
-                        : "0"(outptr0),
-                          "1"(outptr1),
-                          "2"(outptr2),
-                          "3"(outptr3),
-                          "4"(r0),
-                          "5"(r1),
-                          "6"(r2),
-                          "7"(ktmp)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q6", "q7", "q8", "q9", "q12", "q13", "q14", "q15"
-                    );
+                    : "=r"(outptr0),    // %0
+                      "=r"(outptr1),    // %1
+                      "=r"(outptr2),    // %2
+                      "=r"(outptr3),    // %3
+                      "=r"(r0),         // %4
+                      "=r"(r1),         // %5
+                      "=r"(r2),         // %6
+                      "=r"(ktmp)        // %7
+                    : "0"(outptr0),
+                      "1"(outptr1),
+                      "2"(outptr2),
+                      "3"(outptr3),
+                      "4"(r0),
+                      "5"(r1),
+                      "6"(r2),
+                      "7"(ktmp)
+                    : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13" //q14 q15 not be used...
+                );
                 }
 #endif
                 for (; remain>0; remain--)
                 {
 #if __ARM_NEON
                     asm volatile(
-                        "vld1.s8    {d0[]}, [%4]!       \n"
-                        "vld1.s8    {d1[]}, [%4]!       \n"
+                        "vld1.s8    {d0[]}, [%4]!       \n"// d0(r00)
+                        "vld1.s8    {d1[]}, [%4]!       \n"// d1(r01)
 
-                        "vld1.s8    {d4-d7}, [%7]!      \n"// d4 d5 d6 d7 = 0~7
+                        "vld1.s8    {d4-d7}, [%7]!      \n"// d4(k00-k30 k01-k31) d5(k02-k32 k03-k33) d6(k04-k34 k05-k35) d7(k06-k36 k07-k37)
 
-                        "vsli.64    d0, d1, #32         \n"// d0 = 00 01
+                        "vsli.64    d0, d1, #32         \n"// d0(r00 r00 r00 r00 r01 r01 r01 r01)
 
-                        "vld1.s8    {d2[]}, [%4]        \n"
+                        "vld1.s8    {d2[]}, [%4]        \n"// d2(r02 r02 r02 r02 r02 r02 r02 r02)
                         "sub        %4, %4, #2          \n"
-                        "vld1.s8    {d3[]}, [%5]!       \n"
+                        "vld1.s8    {d3[]}, [%5]!       \n"// d3(r10 r10 r10 r10 r10 r10 r10 r10)
+                        
+                        "vmovl.s8   q5, d7              \n"// d10(k06-k36) d11(k07-k37)
+                        "vmovl.s8   q4, d6              \n"// d8(k04-k34) d9(k05-k35)
+                        "vmovl.s8   q3, d5              \n"// d6(k02-k32) d7(k03-k33)
+                        "vmovl.s8   q2, d4              \n"// d4(k00-k30) d5(k01-k31)
+                        
+                        "vmovl.s8   q0, d0              \n"// d0(r00 r00 r00 r00) d1(r01 r01 r01 r01)
 
-                        "vsli.64    d2, d3, #32         \n"// d2 = 02 10
+                        "vsli.64    d2, d3, #32         \n"// d2(r02 r02 r02 r02 r10 r10 r10 r10)
+                        
+                        "vmull.s16  q8, d0, d4          \n"// (r00) * (k00-k30)
+                        "vmull.s16  q9, d1, d5          \n"// (r01) * (k01-k31)
+                        
+                        "vmovl.s8   q10, d2             \n"// d20(r02 r02 r02 r02) d21(r10 r10 r10 r10)
 
-                        "vmull.s8   q8, d0, d4          \n"
-
-                        "vld1.s8    {d0[]}, [%5]!       \n"
-                        "vld1.s8    {d1[]}, [%5]        \n"
+                        "vld1.s8    {d0[]}, [%5]!       \n"// d0(r11 r11 r11 r11 r11 r11 r11 r11)
+                        "vld1.s8    {d1[]}, [%5]        \n"// d1(r12 r12 r12 r12 r12 r12 r12 r12)
                         "sub        %5, %5, #2          \n"
 
-                        "vsli.64    d0, d1, #32         \n"// d0 = 11 12
+                        "vsli.64    d0, d1, #32         \n"// d0(r11 r11 r11 r11 r12 r12 r12 r12)
 
-                        "vmlal.s8   q8, d2, d5          \n"
+                        "vmlal.s16  q8, d20, d6         \n"// (r02) * (k02-k32)
+                        "vmlal.s16  q9, d21, d7         \n"// (r10) * (k03-k33)
+                        
+                        "vmovl.s8   q0, d0              \n"// d0(r11 r11 r11 r11 ) d1(r12 r12 r12 r12)
 
-                        "vld1.s8    {d2[]}, [%6]!       \n"
-                        "vld1.s8    {d3[]}, [%6]!       \n"
+                        "vld1.s8    {d2[]}, [%6]!       \n"// d2(r20 r20 r20 r20 r20 r20 r20 r20)
+                        "vld1.s8    {d3[]}, [%6]!       \n"// d3(r21 r21 r21 r21 r21 r21 r21 r21)
 
-                        "vsli.64    d2, d3, #32         \n"// d2 = 20 21
+                        "vsli.64    d2, d3, #32         \n"// d2(r20 r20 r20 r20 r21 r21 r21 r21)
 
-                        "vmlal.s8   q8, d0, d6          \n"
+                        "vmlal.s16  q8, d0, d8          \n"// (r11) * (k04-k34)
+                        "vmlal.s16  q9, d1, d9          \n"// (r12) * (k05-k35)     
 
-                        "vld1.s8    {d0[]}, [%6]        \n"
+                        "vmovl.s8   q2, d2              \n"// d4(r20 r20 r20 r20) d5(r21 r21 r21 r21)
+
+                        "vld1.s8    {d0[]}, [%6]        \n"// d0(r22 r22 r22 r22 r22 r22 r22 r22)
                         "sub        %6, %6, #2          \n"
-                        "veor       d1, d1, d1          \n"
+                        "veor       d1, d1, d1          \n"// d1 = 0
 
-                        "vld1.s8    {d4}, [%7]          \n"// d4 = 0~4 xxxx
+                        "vld1.s8    {d6}, [%7]          \n"// d6 = k08-k38 xxxx
                         "sub        %7, #32             \n"
 
-                        "vsli.64    d0, d1, #32         \n"// d0 = 22 zero
+                        "vsli.64    d0, d1, #32         \n"// d0(r22 r22 r22 r22 0 0 0 0)
+                        "vmovl.s8   q4, d6              \n"// d8(k08-k38)
+                        "vmovl.s8   q0, d0              \n"// d0(r22 r22 r22 r22) d1(0 0 0 0)
 
-                        "vmlal.s8   q8, d2, d7          \n"
+                        "vmlal.s16  q8, d4, d10         \n"// (r20) * (k06-k36)
+                        "vmlal.s16  q9, d5, d11         \n"// (r21) * (k07-k37)
 
                         "vld1.s32   {d20[0]}, [%0]      \n"
 
-                        "vmlal.s8   q8, d0, d4          \n"
+                        "vmlal.s16  q8, d0, d8          \n"// (r22) * (k08-k38)
 
                         "vld1.s32   {d20[1]}, [%1]      \n"
 
-                        "vadd.s16   d16, d16, d17       \n"
+                        "vadd.s32   q8, q8, q9          \n"
 
                         "vld1.s32   {d21[0]}, [%2]      \n"
                         "vld1.s32   {d21[1]}, [%3]      \n"
 
-                        "vaddw.s16  q10, q10, d16       \n"
+                        "vadd.s32   q10, q10, q8        \n"
 
                         "vst1.s32   {d20[0]}, [%0]!     \n"
                         "vst1.s32   {d20[1]}, [%1]!     \n"
@@ -5874,7 +3006,7 @@ static void conv3x3s1_packed_int8_neon(const Mat &bottom_blob, Mat &top_blob, co
                           "5"(r1),
                           "6"(r2),
                           "7"(ktmp)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q8", "q10"
+                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q8", "q9", "q10"
                     );
 #else
                     int sum0 = 0;
@@ -5979,17 +3111,17 @@ static void conv3x3s1_packed_int8_neon(const Mat &bottom_blob, Mat &top_blob, co
             const signed char* r2 = img0 + w * 2;
             const signed char* r3 = img0 + w * 3;
 
-            int8x8_t _k00 = vdup_n_s8(ktmp[0]);
-            int8x8_t _k01 = vdup_n_s8(ktmp[1]);
-            int8x8_t _k02 = vdup_n_s8(ktmp[2]);
-            int8x8_t _k10 = vdup_n_s8(ktmp[3]);
-            int8x8_t _k11 = vdup_n_s8(ktmp[4]);
-            int8x8_t _k12 = vdup_n_s8(ktmp[5]);
-            int8x8_t _k20 = vdup_n_s8(ktmp[6]);
-            int8x8_t _k21 = vdup_n_s8(ktmp[7]);
-            int8x8_t _k22 = vdup_n_s8(ktmp[8]);
-
             int i = 0;
+
+#if __ARM_NEON
+            int8x16_t _k0123456789x = vld1q_s8(ktmp);
+            int16x8_t _k_s16 = vmovl_s8(vget_low_s8(_k0123456789x));
+            int16x8_t _kn_s16 = vmovl_s8(vget_high_s8(_k0123456789x));
+
+            int16x4_t _k0123 = vget_low_s16(_k_s16);
+            int16x4_t _k4567 = vget_high_s16(_k_s16);
+            int16x4_t _k8xxx = vget_low_s16(_kn_s16);
+#endif // __ARM_NEON
 
             for (; i+1 < outh; i+=2)
             {
@@ -6001,224 +3133,222 @@ static void conv3x3s1_packed_int8_neon(const Mat &bottom_blob, Mat &top_blob, co
 #endif // __ARM_NEON
 
 #if __ARM_NEON
-                if (nn > 0)
+                for (; nn >0; nn--)
                 {
-                asm volatile(
-                    "0:                         \n"
+                    // r0
+                    int8x8_t _r0 = vld1_s8(r0);
+                    int8x8_t _r0n = vld1_s8(r0+8);
+                    int8x8_t _r01 = vext_s8(_r0, _r0n, 1);
+                    int8x8_t _r02 = vext_s8(_r0, _r0n, 2);
+                    int16x8_t _r0_s16 = vmovl_s8(_r0);   // r00 - r07
+                    int16x8_t _r01_s16 = vmovl_s8(_r01); // r01 - r08 
+                    int16x8_t _r02_s16 = vmovl_s8(_r02); // r02 - r09
 
-                    "pld        [%3, #128]      \n"
-                    "vld1.s8    {d4-d5}, [%3]   \n"// d4=r00 d5=r00n
-                    "add        %3, #8          \n"
+                    int32x4_t _sum0 = vmull_lane_s16(vget_low_s16(_r0_s16), _k0123, 0); // (r00 - r07) * k00
+                    int32x4_t _sum0n = vmull_lane_s16(vget_high_s16(_r0_s16), _k0123, 0);
 
-                    "pld        [%6, #128]      \n"
-                    "vld1.s8    {d6-d7}, [%6]   \n"// d6=r30 d7=r30n
-                    "add        %6, #8          \n"
+                    int32x4_t _sum1 = vmull_lane_s16(vget_low_s16(_r01_s16), _k0123, 1); // (r01 - r08) * k01
+                    int32x4_t _sum1n = vmull_lane_s16(vget_high_s16(_r01_s16), _k0123, 1);
 
-                    "vext.s8    d8, d4, d5, #1  \n"// d8=r01
-                    "vext.s8    d10, d6, d7, #1 \n"// d10=r31
+                    int32x4_t _sum2 = vmull_lane_s16(vget_low_s16(_r02_s16), _k0123, 2); // (r02 - r09) * k02
+                    int32x4_t _sum2n = vmull_lane_s16(vget_high_s16(_r02_s16), _k0123, 2);
 
-                    "vmull.s8   q8, d4, %P14    \n"
-                    "vmull.s8   q9, d6, %P20    \n"
+                    // r1
+                    int8x8_t _r1 = vld1_s8(r1);
+                    int8x8_t _r1n = vld1_s8(r1+8);
+                    int8x8_t _r11 = vext_s8(_r1, _r1n, 1);
+                    int8x8_t _r12 = vext_s8(_r1, _r1n, 2);
+                    int16x8_t _r1_s16 = vmovl_s8(_r1);   // r10 - r17
+                    int16x8_t _r11_s16 = vmovl_s8(_r11); // r11 - r18
+                    int16x8_t _r12_s16 = vmovl_s8(_r12); // r12 - r19
 
-                    "vext.s8    d9, d4, d5, #2  \n"// d9=r02
-                    "vext.s8    d11, d6, d7, #2 \n"// d11=r32
+                    _sum0 = vmlal_lane_s16(_sum0, vget_low_s16(_r1_s16), _k0123, 3); // (r10 - r17) * k03
+                    _sum0n = vmlal_lane_s16(_sum0n, vget_high_s16(_r1_s16), _k0123, 3);
 
-                    "vmlal.s8   q8, d8, %P15    \n"
-                    "vmlal.s8   q9, d10, %P21   \n"
+                    _sum1 = vmlal_lane_s16(_sum1, vget_low_s16(_r11_s16), _k4567, 0); // (r11 - r18) * k04
+                    _sum1n = vmlal_lane_s16(_sum1n, vget_high_s16(_r11_s16), _k4567, 0);
 
-                    "pld        [%4, #128]      \n"
-                    "vld1.s8    {d4-d5}, [%4]   \n"// d4=r10 d5=r10n
-                    "add        %4, #8          \n"
+                    _sum2 = vmlal_lane_s16(_sum2, vget_low_s16(_r12_s16), _k4567, 1); // (r12 - r19) * k05
+                    _sum2n = vmlal_lane_s16(_sum2n, vget_high_s16(_r12_s16), _k4567, 1); 
 
-                    "vmlal.s8   q8, d9, %P16    \n"
-                    "vmlal.s8   q9, d11, %P22   \n"
+                    int32x4_t _sum4 = vmull_lane_s16(vget_low_s16(_r1_s16), _k0123, 0); // (r10 - r17) * k00
+                    int32x4_t _sum4n = vmull_lane_s16(vget_high_s16(_r1_s16), _k0123, 0);
 
-                    "vext.s8    d8, d4, d5, #1  \n"// d8=r11
+                    int32x4_t _sum5 = vmull_lane_s16(vget_low_s16(_r11_s16), _k0123, 1); // (r11 - r18) * k01
+                    int32x4_t _sum5n = vmull_lane_s16(vget_high_s16(_r11_s16), _k0123, 1);
 
-                    "vmlal.s8   q8, d4, %P17    \n"
-                    "vmlal.s8   q9, d4, %P14    \n"
+                    int32x4_t _sum6 = vmull_lane_s16(vget_low_s16(_r12_s16), _k0123, 2); // (r12 - r19) * k02
+                    int32x4_t _sum6n = vmull_lane_s16(vget_high_s16(_r12_s16), _k0123, 2);
 
-                    "vext.s8    d9, d4, d5, #2  \n"// d9=r12
+                    // r2
+                    int8x8_t _r2 = vld1_s8(r2);
+                    int8x8_t _r2n = vld1_s8(r2+8);
+                    int8x8_t _r21 = vext_s8(_r2, _r2n, 1);
+                    int8x8_t _r22 = vext_s8(_r2, _r2n, 2);
+                    int16x8_t _r2_s16 = vmovl_s8(_r2);   // r20 - r27
+                    int16x8_t _r21_s16 = vmovl_s8(_r21); // r21 - r28
+                    int16x8_t _r22_s16 = vmovl_s8(_r22); // r22 - r29
 
-                    "vmlal.s8   q8, d8, %P18    \n"
-                    "vmlal.s8   q9, d8, %P15    \n"
+                    _sum0 = vmlal_lane_s16(_sum0, vget_low_s16(_r2_s16), _k4567, 2); // (r20 - r27) * k06
+                    _sum0n = vmlal_lane_s16(_sum0n, vget_high_s16(_r2_s16), _k4567, 2);
 
-                    "pld        [%5, #128]      \n"
-                    "vld1.s8    {d6-d7}, [%5]   \n"// d6=r20 d7=r20n
-                    "add        %5, #8          \n"
+                    _sum1 = vmlal_lane_s16(_sum1, vget_low_s16(_r21_s16), _k4567, 3); // (r21 - r28) * k07
+                    _sum1n = vmlal_lane_s16(_sum1n, vget_high_s16(_r21_s16), _k4567, 3);
 
-                    "vmlal.s8   q8, d9, %P19    \n"
-                    "vmlal.s8   q9, d9, %P16    \n"
+                    _sum2 = vmlal_lane_s16(_sum2, vget_low_s16(_r22_s16), _k8xxx, 0); // (r22 - r29) * k08
+                    _sum2n = vmlal_lane_s16(_sum2n, vget_high_s16(_r22_s16), _k8xxx, 0);
 
-                    "vext.s8    d10, d6, d7, #1 \n"// d10=r21
+                    _sum4 = vmlal_lane_s16(_sum4, vget_low_s16(_r2_s16), _k0123, 3); // (r20 - r27) * k03
+                    _sum4n = vmlal_lane_s16(_sum4n, vget_high_s16(_r2_s16), _k0123, 3);
 
-                    "vmlal.s8   q8, d6, %P20    \n"
-                    "vmlal.s8   q9, d6, %P17    \n"
+                    _sum5 = vmlal_lane_s16(_sum5, vget_low_s16(_r21_s16), _k4567, 0); // (r21 - r28) * k04
+                    _sum5n = vmlal_lane_s16(_sum5n, vget_high_s16(_r21_s16), _k4567, 0);
 
-                    "vext.s8    d11, d6, d7, #2 \n"// d11=r22
+                    _sum6 = vmlal_lane_s16(_sum6, vget_low_s16(_r22_s16), _k4567, 1); // (r22 - r29) * k05
+                    _sum6n = vmlal_lane_s16(_sum6n, vget_high_s16(_r22_s16), _k4567, 1);
 
-                    "vmlal.s8   q8, d10, %P21   \n"
-                    "vmlal.s8   q9, d10, %P18   \n"
+                    // load output sum0 sum0n
+                    int32x4_t _out00 = vld1q_s32(outptr0);
+                    int32x4_t _out01 = vld1q_s32(outptr0+4);
+                    int32x4_t _out10 = vld1q_s32(outptr0n);
+                    int32x4_t _out11 = vld1q_s32(outptr0n+4);
 
-                    "pld        [%1, #256]      \n"
-                    "vld1.s32   {d0-d3}, [%1]   \n"
+                    // r3
+                    int8x8_t _r3 = vld1_s8(r3);
+                    int8x8_t _r3n = vld1_s8(r3+8);
+                    int8x8_t _r31 = vext_s8(_r3, _r3n, 1);
+                    int8x8_t _r32 = vext_s8(_r3, _r3n, 2);
+                    int16x8_t _r3_s16 = vmovl_s8(_r3);   // r30 - r37
+                    int16x8_t _r31_s16 = vmovl_s8(_r31); // r31 - r38
+                    int16x8_t _r32_s16 = vmovl_s8(_r32); // r32 - r39
 
-                    "vmlal.s8   q8, d11, %P22   \n"
-                    "vmlal.s8   q9, d11, %P19   \n"
+                    _sum0 = vaddq_s32(_sum0, _sum1);
+                    _sum0n = vaddq_s32(_sum0n, _sum1n);
+                    _sum2 = vaddq_s32(_sum2, _sum0);
+                    _sum2n = vaddq_s32(_sum2n, _sum0n);
 
-                    "pld        [%2, #256]      \n"
-                    "vld1.s32   {d12-d15}, [%2] \n"
+                    _out00 = vaddq_s32(_out00, _sum2);
+                    _out01 = vaddq_s32(_out01, _sum2n);
 
-                    "vaddw.s16  q0, q0, d16     \n"
-                    "vaddw.s16  q1, q1, d17     \n"
-                    "vaddw.s16  q6, q6, d18     \n"
-                    "vaddw.s16  q7, q7, d19     \n"
+                    vst1q_s32(outptr0, _out00);
+                    vst1q_s32(outptr0+4, _out01);
 
-                    "vst1.s32   {d0-d3}, [%1]!  \n"
+                    _sum4 = vmlal_lane_s16(_sum4, vget_low_s16(_r3_s16), _k4567, 2); // (r30 - r37) * k06
+                    _sum4n = vmlal_lane_s16(_sum4n, vget_high_s16(_r3_s16), _k4567, 2);
 
-                    "subs       %0, #1          \n"
+                    _sum5 = vmlal_lane_s16(_sum5, vget_low_s16(_r31_s16), _k4567, 3); // (r31 - r38) * k07
+                    _sum5n = vmlal_lane_s16(_sum5n, vget_high_s16(_r31_s16), _k4567, 3);
 
-                    "vst1.s32   {d12-d15}, [%2]! \n"
+                    _sum6 = vmlal_lane_s16(_sum6, vget_low_s16(_r32_s16), _k8xxx, 0); // (r32 - r39) * k08
+                    _sum6n = vmlal_lane_s16(_sum6n, vget_high_s16(_r32_s16), _k8xxx, 0); 
 
-                    "bne        0b              \n"
+                    _sum4 = vaddq_s32(_sum4, _sum5);
+                    _sum4n = vaddq_s32(_sum4n, _sum5n);
+                    _sum6 = vaddq_s32(_sum6, _sum4);
+                    _sum6n = vaddq_s32(_sum6n, _sum4n);
 
-                    : "=r"(nn),         // %0
-                      "=r"(outptr0),    // %1
-                      "=r"(outptr0n),   // %2
-                      "=r"(r0),         // %3
-                      "=r"(r1),         // %4
-                      "=r"(r2),         // %5
-                      "=r"(r3)          // %6
-                    : "0"(nn),
-                      "1"(outptr0),
-                      "2"(outptr0n),
-                      "3"(r0),
-                      "4"(r1),
-                      "5"(r2),
-                      "6"(r3),
-                      "w"(_k00),        // %14
-                      "w"(_k01),        // %15
-                      "w"(_k02),        // %16
-                      "w"(_k10),        // %17
-                      "w"(_k11),        // %18
-                      "w"(_k12),        // %19
-                      "w"(_k20),        // %20
-                      "w"(_k21),        // %21
-                      "w"(_k22)         // %22
-                    : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9"
-                );
+                    _out10 = vaddq_s32(_out10, _sum6);
+                    _out11 = vaddq_s32(_out11, _sum6n);
+
+                    vst1q_s32(outptr0n, _out10);
+                    vst1q_s32(outptr0n+4, _out11);
+
+                    r0 += 8;
+                    r1 += 8;
+                    r2 += 8;
+                    r3 += 8;
+                    outptr0 += 8;
+                    outptr0n += 8;
                 }
 #endif
 #if __ARM_NEON
                 if (remain >= 4)
                 {
                     remain -= 4;
-                    asm volatile(
 
-                        "vld1.s8    {d12}, [%6]!        \n"// d12=0~7
+                    // r0
+                    int8x8_t _r0 = vld1_s8(r0);
+                    int8x8_t _r0n = vld1_s8(r0+8);
+                    int8x8_t _r01 = vext_s8(_r0, _r0n, 1);
+                    int8x8_t _r02 = vext_s8(_r0, _r0n, 2);
+                    int16x8_t _r0_s16 = vmovl_s8(_r0);   // r00 - r07
+                    int16x8_t _r01_s16 = vmovl_s8(_r01); // r01 - r08
+                    int16x8_t _r02_s16 = vmovl_s8(_r02); // r02 - r09
 
-                        /// r00 r01 r02
-                        "vld1.s8    {d0}, [%2]          \n"// d0 = r00 r00n
-                        "add        %2, #4              \n"
+                    int32x4_t _sum0 = vmull_lane_s16(vget_low_s16(_r0_s16), _k0123, 0); // (r00 - r07) * k00
+                    int32x4_t _sum1 = vmull_lane_s16(vget_low_s16(_r01_s16), _k0123, 1); // (r01 - r08) * k01
+                    int32x4_t _sum2 = vmull_lane_s16(vget_low_s16(_r02_s16), _k0123, 2); // (r02 - r09) * k02
 
-                        "vdup.s8    d24, d12[0]         \n"
+                    // r1
+                    int8x8_t _r1 = vld1_s8(r1);
+                    int8x8_t _r1n = vld1_s8(r1+8);
+                    int8x8_t _r11 = vext_s8(_r1, _r1n, 1);
+                    int8x8_t _r12 = vext_s8(_r1, _r1n, 2);
+                    int16x8_t _r1_s16 = vmovl_s8(_r1);   // r10 - r17
+                    int16x8_t _r11_s16 = vmovl_s8(_r11); // r11 - r18
+                    int16x8_t _r12_s16 = vmovl_s8(_r12); // r12 - r19
 
-                        "vext.s8    d1, d0, d0, #1      \n"
-                        "vext.s8    d2, d0, d0, #2      \n"
+                    _sum0 = vmlal_lane_s16(_sum0, vget_low_s16(_r1_s16), _k0123, 3); // (r10 - r17) * k03
+                    _sum1 = vmlal_lane_s16(_sum1, vget_low_s16(_r11_s16), _k4567, 0); // (r11 - r18) * k04
+                    _sum2 = vmlal_lane_s16(_sum2, vget_low_s16(_r12_s16), _k4567, 1); // (r12 - r19) * k05
 
-                        /// r10 r11 r12
-                        "vld1.s8    {d3}, [%3]          \n"// d3 = r10 r10n
-                        "add        %3, #4              \n"
+                    int32x4_t _sum4 = vmull_lane_s16(vget_low_s16(_r1_s16), _k0123, 0); // (r10 - r17) * k00
+                    int32x4_t _sum5 = vmull_lane_s16(vget_low_s16(_r11_s16), _k0123, 1); // (r11 - r18) * k01
+                    int32x4_t _sum6 = vmull_lane_s16(vget_low_s16(_r12_s16), _k0123, 2); // (r12 - r19) * k02
 
-                        "vdup.s8    d25, d12[1]         \n"
+                    // r2
+                    int8x8_t _r2 = vld1_s8(r2);
+                    int8x8_t _r2n = vld1_s8(r2+8);
+                    int8x8_t _r21 = vext_s8(_r2, _r2n, 1);
+                    int8x8_t _r22 = vext_s8(_r2, _r2n, 2);
+                    int16x8_t _r2_s16 = vmovl_s8(_r2);   // r20 - r27
+                    int16x8_t _r21_s16 = vmovl_s8(_r21); // r21 - r28
+                    int16x8_t _r22_s16 = vmovl_s8(_r22); // r22 - r29
 
-                        "vext.s8    d4, d3, d3, #1      \n"
-                        "vext.s8    d5, d3, d3, #2      \n"
+                    _sum0 = vmlal_lane_s16(_sum0, vget_low_s16(_r2_s16), _k4567, 2); // (r20 - r27) * k06
+                    _sum1 = vmlal_lane_s16(_sum1, vget_low_s16(_r21_s16), _k4567, 3); // (r21 - r28) * k07
+                    _sum2 = vmlal_lane_s16(_sum2, vget_low_s16(_r22_s16), _k8xxx, 0); // (r22 - r29) * k08
 
-                        "vdup.s8    d26, d12[2]         \n"
+                    _sum4 = vmlal_lane_s16(_sum4, vget_low_s16(_r2_s16), _k0123, 3); // (r20 - r27) * k03
+                    _sum5 = vmlal_lane_s16(_sum5, vget_low_s16(_r21_s16), _k4567, 0); // (r21 - r28) * k04
+                    _sum6 = vmlal_lane_s16(_sum6, vget_low_s16(_r22_s16), _k4567, 1); // (r22 - r29) * k05
 
-                        "vsli.64    d0, d3, #32         \n"// d0 = r00 r10
-                        "vsli.64    d1, d4, #32         \n"// d1 = r01 r11
-                        "vsli.64    d2, d5, #32         \n"// d2 = r02 r12
+                    // load output sum0 sum0n
+                    int32x4_t _out00 = vld1q_s32(outptr0);
+                    int32x4_t _out10 = vld1q_s32(outptr0n);
 
-                        "vmull.s8   q8, d0, d24         \n"
-                        "vmull.s8   q9, d1, d25         \n"
+                    // r3
+                    int8x8_t _r3 = vld1_s8(r3);
+                    int8x8_t _r3n = vld1_s8(r3+8);
+                    int8x8_t _r31 = vext_s8(_r3, _r3n, 1);
+                    int8x8_t _r32 = vext_s8(_r3, _r3n, 2);
+                    int16x8_t _r3_s16 = vmovl_s8(_r3);   // r30 - r37
+                    int16x8_t _r31_s16 = vmovl_s8(_r31); // r31 - r38
+                    int16x8_t _r32_s16 = vmovl_s8(_r32); // r32 - r39
 
-                        /// r20 r21 r22
-                        "vld1.s8    {d6}, [%4]          \n"// d6 = r20 r20n
-                        "add        %4, #4              \n"
+                    _sum0 = vaddq_s32(_sum0, _sum1);
+                    _sum2 = vaddq_s32(_sum2, _sum0);
+                    _out00 = vaddq_s32(_out00, _sum2);
 
-                        "vdup.s8    d27, d12[3]         \n"
-                        "vdup.s8    d28, d12[4]         \n"
+                    vst1q_s32(outptr0, _out00);
 
-                        "vext.s8    d7, d6, d6, #1      \n"
-                        "vext.s8    d8, d6, d6, #2      \n"
+                    _sum4 = vmlal_lane_s16(_sum4, vget_low_s16(_r3_s16), _k4567, 2); // (r30 - r37) * k06
+                    _sum5 = vmlal_lane_s16(_sum5, vget_low_s16(_r31_s16), _k4567, 3); // (r31 - r38) * k07
+                    _sum6 = vmlal_lane_s16(_sum6, vget_low_s16(_r32_s16), _k8xxx, 0); // (r32 - r39) * k08
 
-                        "vsli.64    d3, d6, #32         \n"// d3 = r10 r20
+                    _sum4 = vaddq_s32(_sum4, _sum5);
+                    _sum6 = vaddq_s32(_sum6, _sum4);
 
-                        "vdup.s8    d29, d12[5]         \n"
+                    _out10 = vaddq_s32(_out10, _sum6);
 
-                        "vmlal.s8   q8, d2, d26         \n"
-                        "vmlal.s8   q9, d3, d27         \n"
+                    vst1q_s32(outptr0n, _out10);
 
-                        "vsli.64    d4, d7, #32         \n"// d4 = r11 r21
-                        "vsli.64    d5, d8, #32         \n"// d5 = r12 r22
-
-                        /// r30 r31 r32
-                        "vld1.s8    {d9}, [%5]          \n"// d9 = r30 r30n
-                        "add        %5, #4              \n"
-
-                        "vdup.s8    d30, d12[6]         \n"
-                        "vdup.s8    d31, d12[7]         \n"
-
-                        "vmlal.s8   q8, d4, d28         \n"
-                        "vmlal.s8   q9, d5, d29         \n"
-
-                        "vext.s8    d10, d9, d9, #1     \n"
-                        "vext.s8    d11, d9, d9, #2     \n"
-
-                        "vsli.64    d6, d9, #32         \n"// d6 = r20 r30
-                        "vsli.64    d7, d10, #32        \n"// d7 = r21 r31
-
-                        "vmlal.s8   q8, d6, d30         \n"
-                        "vmlal.s8   q9, d7, d31         \n"
-
-                        "vld1.s8    {d13[]}, [%6]!      \n"
-                        "vsli.64    d8, d11, #32        \n"// d8 = r22 r32
-
-                        "vmlal.s8   q8, d8, d13         \n"
-
-                        ///
-                        "vld1.s32   {d0-d1}, [%0]       \n"
-
-                        "vadd.s16   q8, q8, q9          \n"
-
-                        "vld1.s32   {d2-d3}, [%1]       \n"
-
-                        "vaddw.s16  q0, q0, d16         \n"
-                        "vaddw.s16  q1, q1, d17         \n"
-
-                        "sub        %6, #9              \n"
-
-                        "vst1.s32   {d0-d1}, [%0]!      \n"
-                        "vst1.s32   {d2-d3}, [%1]!      \n"
-
-                        : "=r"(outptr0),    // %0
-                          "=r"(outptr0n),   // %1
-                          "=r"(r0),         // %2
-                          "=r"(r1),         // %3
-                          "=r"(r2),         // %4
-                          "=r"(r3),         // %5
-                          "=r"(ktmp)        // %6
-                        : "0"(outptr0),
-                          "1"(outptr0n),
-                          "2"(r0),
-                          "3"(r1),
-                          "4"(r2),
-                          "5"(r3),
-                          "6"(ktmp)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
-                    );
+                    r0 += 4;
+                    r1 += 4;
+                    r2 += 4;
+                    r3 += 4;
+                    outptr0 += 4;
+                    outptr0n += 4;
                 }
 #endif
                 for (; remain>0; remain--)
@@ -6236,41 +3366,45 @@ static void conv3x3s1_packed_int8_neon(const Mat &bottom_blob, Mat &top_blob, co
                         "sub        %3, #2          \n"
 
                         "vld1.s8    {d0[6]}, [%4]!  \n"
-                        "vld1.s8    {d0[7]}, [%4]!  \n"// d0=r
+                        "vld1.s8    {d0[7]}, [%4]!  \n"// d0(r00 r01 r02 r10 r11 r12 r22 r21)
 
-                        "vld1.s8    {d4[]}, [%4]    \n"// d4=r22
+                        "vld1.s8    {d4[]}, [%4]    \n"// d4(r22 r22 r22 r22 r22 r22 r22 r22) 
                         "sub        %4, #2          \n"
 
-                        "vext.s8    d1, d0, d4, #3  \n"
+                        "vext.s8    d1, d0, d4, #3  \n"// d1(r10 r11 r12 r22 r21 r22 r22 r22)
 
                         "vld1.s8    {d1[6]}, [%5]!  \n"
-                        "vld1.s8    {d1[7]}, [%5]!  \n"// d1=rn
+                        "vld1.s8    {d1[7]}, [%5]!  \n"// d1(r10 r11 r12 r22 r21 r22 r30 r31)
 
-                        "vld1.s8    {d2}, [%6]!     \n"// d2=k01234567
+                        "vld1.s8    {d2}, [%6]!     \n"// d2(k00 k01 k02 k10 k11 k12 k20 k21)
 
-                        "vld1.s8    {d5[]}, [%5]    \n"// d5=r32
+                        "vld1.s8    {d5[]}, [%5]    \n"// d5(r32 r32 r32 r32 r32 r32 r32 r32)
                         "sub        %5, #2          \n"
 
-                        "veor       d3, d3          \n"
+                        "veor       d3, d3          \n"// d3(00 00 00 00 00 00 00 00)
 
-                        "vmull.s8   q8, d0, d2      \n"
-                        "vmull.s8   q9, d1, d2      \n"
+                        "vmull.s8   q8, d0, d2      \n"// sum0 = (r00 - r21) * (k00 - k21)
+                        "vmull.s8   q9, d1, d2      \n"// sum1 = (r10 - r31) * (k00 - k21)
 
-                        "vld1.s8    {d3[0]}, [%6]   \n"// d3=k8 ... zeros
+                        "vld1.s8    {d3[0]}, [%6]   \n"// d3(k22 00 00 00 00 00 00 00)
                         "sub        %6, #8          \n"
 
-                        "vmlal.s8   q8, d4, d3      \n"
-                        "vmlal.s8   q9, d5, d3      \n"
+                        "vmull.s8   q10, d4, d3     \n"// r22 * k22
+                        "vmull.s8   q11, d5, d3     \n"// r22 * k22
 
                         "vld1.s32   {d6[0]}, [%0]   \n"
 
-                        "vadd.s16   d16, d16, d17   \n"
-                        "vadd.s16   d18, d18, d19   \n"
+                        "vaddl.s16  q10, d16, d18   \n"
+                        "vaddl.s16  q11, d18, d22   \n"
+                        "vaddw.s16  q10, q10, d17   \n"
+                        "vaddw.s16  q11, q11, d19   \n"
 
                         "vld1.s32   {d6[1]}, [%1]   \n"
 
-                        "vpadd.s16  d16, d16, d18   \n"
-                        "vpadal.s16 d6, d16         \n"
+                        "vpadd.s32  d20, d20, d21   \n"
+                        "vpadd.s32  d22, d22, d23   \n"
+                        "vpadd.s32  d20, d20, d22   \n"
+                        "vpadd.s32  d6, d6, d20     \n"
 
                         "vst1.s32   {d6[0]}, [%0]!  \n"
                         "vst1.s32   {d6[1]}, [%1]!  \n"
@@ -6289,7 +3423,7 @@ static void conv3x3s1_packed_int8_neon(const Mat &bottom_blob, Mat &top_blob, co
                           "4"(r2),
                           "5"(r3),
                           "6"(ktmp)
-                        : "cc", "memory", "q0", "q1", "q2", "q3", "q8", "q9"
+                        : "cc", "memory", "q0", "q1", "q2", "q3", "q8", "q9", "q10", "q11"
                     );
 #else
                     int sum0 = 0;
@@ -6348,88 +3482,83 @@ static void conv3x3s1_packed_int8_neon(const Mat &bottom_blob, Mat &top_blob, co
 #endif // __ARM_NEON
 
 #if __ARM_NEON
-                if (nn > 0)
+                for (; nn >0; nn--)
                 {
-                asm volatile(
-                    "0:                         \n"
+                    // r0
+                    int8x8_t _r0 = vld1_s8(r0);
+                    int8x8_t _r0n = vld1_s8(r0+8);
+                    int8x8_t _r01 = vext_s8(_r0, _r0n, 1);
+                    int8x8_t _r02 = vext_s8(_r0, _r0n, 2);
+                    int16x8_t _r0_s16 = vmovl_s8(_r0);   // r00 - r07
+                    int16x8_t _r01_s16 = vmovl_s8(_r01); // r01 - r08 
+                    int16x8_t _r02_s16 = vmovl_s8(_r02); // r02 - r09
 
-                    "pld        [%2, #128]      \n"
-                    "vld1.s8    {d4-d5}, [%2]   \n"// d4=r00 d5=r00n
-                    "add        %2, #8          \n"
+                    int32x4_t _sum0 = vmull_lane_s16(vget_low_s16(_r0_s16), _k0123, 0); // (r00 - r07) * k00
+                    int32x4_t _sum0n = vmull_lane_s16(vget_high_s16(_r0_s16), _k0123, 0);
 
-                    "vext.s8    d8, d4, d5, #1  \n"// d8=r01
+                    int32x4_t _sum1 = vmull_lane_s16(vget_low_s16(_r01_s16), _k0123, 1); // (r01 - r08) * k01
+                    int32x4_t _sum1n = vmull_lane_s16(vget_high_s16(_r01_s16), _k0123, 1);
 
-                    "vmull.s8   q8, d4, %P10    \n"
+                    int32x4_t _sum2 = vmull_lane_s16(vget_low_s16(_r02_s16), _k0123, 2); // (r02 - r09) * k02
+                    int32x4_t _sum2n = vmull_lane_s16(vget_high_s16(_r02_s16), _k0123, 2);
 
-                    "vext.s8    d9, d4, d5, #2  \n"// d9=r02
+                    // r1
+                    int8x8_t _r1 = vld1_s8(r1);
+                    int8x8_t _r1n = vld1_s8(r1+8);
+                    int8x8_t _r11 = vext_s8(_r1, _r1n, 1);
+                    int8x8_t _r12 = vext_s8(_r1, _r1n, 2);
+                    int16x8_t _r1_s16 = vmovl_s8(_r1);   // r10 - r17
+                    int16x8_t _r11_s16 = vmovl_s8(_r11); // r11 - r18
+                    int16x8_t _r12_s16 = vmovl_s8(_r12); // r12 - r19
 
-                    "vmull.s8   q9, d8, %P11    \n"
+                    _sum0 = vmlal_lane_s16(_sum0, vget_low_s16(_r1_s16), _k0123, 3); // (r10 - r17) * k03
+                    _sum0n = vmlal_lane_s16(_sum0n, vget_high_s16(_r1_s16), _k0123, 3);
 
-                    "pld        [%3, #128]      \n"
-                    "vld1.s8    {d6-d7}, [%3]   \n"// d6=r10 d7=r10n
-                    "add        %3, #8          \n"
+                    _sum1 = vmlal_lane_s16(_sum1, vget_low_s16(_r11_s16), _k4567, 0); // (r11 - r18) * k04
+                    _sum1n = vmlal_lane_s16(_sum1n, vget_high_s16(_r11_s16), _k4567, 0);
 
-                    "vmlal.s8   q8, d9, %P12    \n"
+                    _sum2 = vmlal_lane_s16(_sum2, vget_low_s16(_r12_s16), _k4567, 1); // (r12 - r19) * k05
+                    _sum2n = vmlal_lane_s16(_sum2n, vget_high_s16(_r12_s16), _k4567, 1);
 
-                    "vext.s8    d10, d6, d7, #1 \n"// d10=r11
+                    // r2
+                    int8x8_t _r2 = vld1_s8(r2);
+                    int8x8_t _r2n = vld1_s8(r2+8);
+                    int8x8_t _r21 = vext_s8(_r2, _r2n, 1);
+                    int8x8_t _r22 = vext_s8(_r2, _r2n, 2);
+                    int16x8_t _r2_s16 = vmovl_s8(_r2);   // r20 - r27
+                    int16x8_t _r21_s16 = vmovl_s8(_r21); // r21 - r28
+                    int16x8_t _r22_s16 = vmovl_s8(_r22); // r22 - r29
 
-                    "vmlal.s8   q9, d6, %P13    \n"
+                    _sum0 = vmlal_lane_s16(_sum0, vget_low_s16(_r2_s16), _k4567, 2); // (r20 - r27) * k06
+                    _sum0n = vmlal_lane_s16(_sum0n, vget_high_s16(_r2_s16), _k4567, 2);
 
-                    "vext.s8    d11, d6, d7, #2 \n"// d11=r12
+                    _sum1 = vmlal_lane_s16(_sum1, vget_low_s16(_r21_s16), _k4567, 3); // (r21 - r28) * k07
+                    _sum1n = vmlal_lane_s16(_sum1n, vget_high_s16(_r21_s16), _k4567, 3);
 
-                    "vmlal.s8   q8, d10, %P14   \n"
+                    _sum2 = vmlal_lane_s16(_sum2, vget_low_s16(_r22_s16), _k8xxx, 0); // (r22 - r29) * k08
+                    _sum2n = vmlal_lane_s16(_sum2n, vget_high_s16(_r22_s16), _k8xxx, 0); 
 
-                    "pld        [%4, #128]      \n"
-                    "vld1.s8    {d4-d5}, [%4]   \n"// d4=r20 d5=r20n
-                    "add        %4, #8          \n"
+                    // load output sum0 sum0n
+                    int32x4_t _out00 = vld1q_s32(outptr0);
+                    int32x4_t _out01 = vld1q_s32(outptr0+4);
 
-                    "vmlal.s8   q9, d11, %P15   \n"
+                    _sum0 = vaddq_s32(_sum0, _sum1);
+                    _sum0n = vaddq_s32(_sum0n, _sum1n);
+                    _sum2 = vaddq_s32(_sum2, _sum0);
+                    _sum2n = vaddq_s32(_sum2n, _sum0n);
 
-                    "vext.s8    d8, d4, d5, #1  \n"// d8=r21
+                    _out00 = vaddq_s32(_out00, _sum2);
+                    _out01 = vaddq_s32(_out01, _sum2n);
 
-                    "vmlal.s8   q8, d4, %P16    \n"
+                    vst1q_s32(outptr0, _out00);
+                    vst1q_s32(outptr0+4, _out01);
 
-                    "vext.s8    d9, d4, d5, #2  \n"// d9=r22
-
-                    "vmlal.s8   q9, d8, %P17    \n"
-
-                    "vmlal.s8   q8, d9, %P18    \n"
-
-                    "pld        [%1, #256]      \n"
-                    "vld1.s32   {d0-d3}, [%1]   \n"
-
-                    "vadd.s16   q8, q8, q9      \n"
-
-                    "vaddw.s16  q0, q0, d16     \n"
-                    "vaddw.s16  q1, q1, d17     \n"
-
-                    "subs       %0, #1          \n"
-
-                    "vst1.s32   {d0-d3}, [%1]!  \n"
-
-                    "bne        0b              \n"
-
-                    : "=r"(nn),         // %0
-                      "=r"(outptr0),    // %1
-                      "=r"(r0),         // %2
-                      "=r"(r1),         // %3
-                      "=r"(r2)          // %4
-                    : "0"(nn),
-                      "1"(outptr0),
-                      "2"(r0),
-                      "3"(r1),
-                      "4"(r2),
-                      "w"(_k00),        // %10
-                      "w"(_k01),        // %11
-                      "w"(_k02),        // %12
-                      "w"(_k10),        // %13
-                      "w"(_k11),        // %14
-                      "w"(_k12),        // %15
-                      "w"(_k20),        // %16
-                      "w"(_k21),        // %17
-                      "w"(_k22)         // %18
-                    : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q8", "q9"
-                );
+                    r0 += 8;
+                    r1 += 8;
+                    r2 += 8;
+                    r3 += 8;
+                    outptr0 += 8;
+                    outptr0n += 8;
                 }
 #endif
                 for (; remain>0; remain--)
@@ -6462,32 +3591,6 @@ static void conv3x3s1_packed_int8_neon(const Mat &bottom_blob, Mat &top_blob, co
             ktmp += 9;
         }
     }
-}
-
-static void conv3x3s2_int8_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
-{
-    int outw = top_blob.w;
-    int remain = outw & 7;
-    
-    typedef void (*conv_func_int8)(const Mat&, Mat&, const Mat&, const Option&);
-
-    conv_func_int8 conv_func_table[8] =
-    {
-        conv3x3s2_neon_s8,      //0
-        conv3x3s2_neon_s8,      //1
-        conv3x3s2_neon_s8,      //2
-        conv3x3s2_neon_s8,      //3
-        conv3x3s2_neon_s8,      //4
-        conv3x3s2_neon_s8,      //5
-        conv3x3s2_neon_s8,      //6
-        conv3x3s2_neon_s8,      //7
-    };   
-
-    conv_func_int8 conv = conv_func_table[remain];
-
-    conv(bottom_blob, top_blob, _kernel, opt);
-
-    return;
 }
 
 static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Option& opt)
@@ -6591,7 +3694,7 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
 
                     "vmovl.s8   q2, d2              \n"// q2(k02-k72)
                     "vmovl.s8   q1, d1              \n"// q1(k01-k71)
-                    "vmovl.s8   q0, d0              \n"// q0(k00-k70)               
+                    "vmovl.s8   q0, d0              \n"// q0(k00-k70)
                     "vext.s8    d12, d8, d8, #1     \n"// d12(a02 a04 a06 a08 x x x x)
 
                     "pld        [%7, #128]          \n"
@@ -6644,10 +3747,10 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
 
                     "vmovl.s8   q2, d2              \n"// q2(k05-k75)
                     "vmovl.s8   q1, d1              \n"// q1(k04-k74)
-                    "vmovl.s8   q0, d0              \n"// q0(k03-k73)               
-                    "vmovl.s8   q5, d9              \n"// q5(a11-a115) 
-                    "vmovl.s8   q4, d8              \n"// q4(a10-a114) 
-                    "vmovl.s8   q6, d12             \n"// q6(a12-a116) 
+                    "vmovl.s8   q0, d0              \n"// q0(k03-k73)
+                    "vmovl.s8   q5, d9              \n"// q5(a11-a115)
+                    "vmovl.s8   q4, d8              \n"// q4(a10-a114)
+                    "vmovl.s8   q6, d12             \n"// q6(a12-a116)
 
                     "vmlal.s16  q8, d8, d0[0]       \n"// sum0 += (a10-a16) * k03
                     "vmlal.s16  q9, d8, d0[1]       \n"// sum1 += (a10-a16) * k13
@@ -6665,7 +3768,7 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
                     "vmlal.s16  q12, d10, d3[0]     \n"// sum4 += (a11-a17) * k44
                     "vmlal.s16  q13, d10, d3[1]     \n"// sum5 += (a11-a17) * k54
                     "vmlal.s16  q14, d10, d3[2]     \n"// sum6 += (a11-a17) * k64
-                    "vmlal.s16  q15, d10, d3[3]     \n"// sum7 += (a11-a17) * k74   
+                    "vmlal.s16  q15, d10, d3[3]     \n"// sum7 += (a11-a17) * k74
 
                     "pld        [%11, #64]         \n"
                     "vld2.s8    {d8-d9}, [%11]      \n"// d8(a20 a22 a24 a26 a28 a210 a212 a214), d9(a21 a23 a25 a27 a29 a211 a213 a215)
@@ -6689,10 +3792,10 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
                     
                     "vmovl.s8   q2, d2              \n"// q2(k08-k78)
                     "vmovl.s8   q1, d1              \n"// q1(k07-k77)
-                    "vmovl.s8   q0, d0              \n"// q0(k06-k76)               
-                    "vmovl.s8   q5, d9              \n"// q5(a21-a215) 
-                    "vmovl.s8   q4, d8              \n"// q4(a20-a214) 
-                    "vmovl.s8   q6, d12             \n"// q6(a22-a216) 
+                    "vmovl.s8   q0, d0              \n"// q0(k06-k76) 
+                    "vmovl.s8   q5, d9              \n"// q5(a21-a215)
+                    "vmovl.s8   q4, d8              \n"// q4(a20-a214)
+                    "vmovl.s8   q6, d12             \n"// q6(a22-a216)
 
                     "vmlal.s16  q8, d8, d0[0]       \n"// sum0 += (a20-a26) * k06
                     "vmlal.s16  q9, d8, d0[1]       \n"// sum1 += (a20-a26) * k16
@@ -6710,7 +3813,7 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
                     "vmlal.s16  q12, d10, d3[0]     \n"// sum4 += (a21-a27) * k47
                     "vmlal.s16  q13, d10, d3[1]     \n"// sum5 += (a21-a27) * k57
                     "vmlal.s16  q14, d10, d3[2]     \n"// sum6 += (a21-a27) * k67
-                    "vmlal.s16  q15, d10, d3[3]     \n"// sum7 += (a21-a27) * k77   
+                    "vmlal.s16  q15, d10, d3[3]     \n"// sum7 += (a21-a27) * k77
 
                     "vmlal.s16  q8, d12, d4[0]      \n"// sum0 += (a22-a28) * k08
                     "vmlal.s16  q9, d12, d4[1]      \n"// sum1 += (a22-a28) * k18
@@ -6731,7 +3834,7 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
                     "vst1.s32   {d24-d25}, [%5]!    \n"// out4
                     "vst1.s32   {d26-d27}, [%6]!    \n"// out5
                     "vst1.s32   {d28-d29}, [%7]!    \n"// out6
-                    "vst1.s32   {d30-d31}, [%8]!    \n"// out7  
+                    "vst1.s32   {d30-d31}, [%8]!    \n"// out7
                                                  
                     "bne        0b                  \n"
                     : "=r"(nn),         // %0
@@ -6843,8 +3946,8 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
 
                         "vst1.s32   {d20[0]}, [%0]!    \n"// out0
                         "vst1.s32   {d20[1]}, [%1]!    \n"// out1
-                        "vst1.s32   {d21[0]}, [%2]!    \n"// out2 
-                        "vst1.s32   {d21[1]}, [%3]!    \n"// out3                        
+                        "vst1.s32   {d21[0]}, [%2]!    \n"// out2
+                        "vst1.s32   {d21[1]}, [%3]!    \n"// out3
                         "vst1.s32   {d22[0]}, [%4]!    \n"// out4
                         "vst1.s32   {d22[1]}, [%5]!    \n"// out5
                         "vst1.s32   {d23[0]}, [%6]!    \n"// out6
@@ -7052,7 +4155,7 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
                     "add        %5, #9              \n"
                     "vmovl.s8   q1, d1              \n"// d2(k8 ...)
                     "vmovl.s8   q0, d0              \n"// d0(k0 - k3) d1(k4 - k7)
-                    "0: 							\n"
+                    "0:                             \n"
                     "pld        [%2, #192]          \n"
                     "vld2.s8    {d4-d5}, [%2]!      \n"// r0 d4(a00 a02 ... a014) d5(a01 a03 ... a015)
                     "vld2.s8    {d8-d9}, [%2]       \n"//    d8(a016 ....)
@@ -7076,7 +4179,7 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
 
                     "vmovl.s8   q9, d17             \n"// q9(a21 a23 ... a215)
                     "vmovl.s8   q8, d16             \n"// q8(a20 a22 ... a214)
-                    "vmovl.s8   q10, d20            \n"// q10(a22 a24 ... a216)                                     
+                    "vmovl.s8   q10, d20            \n"// q10(a22 a24 ... a216)
         
                     "vmlal.s16  q11, d4, d0[0]      \n"// k0
                     "vmlal.s16  q12, d5, d0[0]      \n"
@@ -7102,10 +4205,10 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
                     "vadd.s32   q11, q11, q13       \n"
                     "vadd.s32   q12, q12, q14       \n"
                     
-                    "vst1.32    {d22-d25}, [%1]!    \n"		
+                    "vst1.32    {d22-d25}, [%1]!    \n"     
 
-                    "subs		%0, #1				\n"
-                    "bne		0b					\n"
+                    "subs       %0, #1              \n"
+                    "bne        0b                  \n"
                     : "=r"(nn),     // %0
                       "=r"(outptr), // %1
                       "=r"(r0),     // %2

--- a/src/layer/arm/convolutiondepthwise_5x5.h
+++ b/src/layer/arm/convolutiondepthwise_5x5.h
@@ -1672,11 +1672,11 @@ static void convdw5x5s1_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _
 static void convdw5x5s2_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Mat& _bias, const Option& opt)
 {
     int w = bottom_blob.w;
-    int inch = bottom_blob.c;
+    //int inch = bottom_blob.c;
 
     int outw = top_blob.w;
     int outh = top_blob.h;
-    int outch = top_blob.c;
+    //int outch = top_blob.c;
 
     const int tailstep = w - 2*outw + w;
 


### PR DESCRIPTION
1. add the armv7a conv3x3s1 implement without overflow;
2. remove old codes;
3. fix the bug of conv3x3s2 packed int8.

By The Way,fix the bug that int8 overflow on armv7a platform has been completed!