### PR TITLE
add w=1 h=1 op

### DIFF
--- a/src/layer/binaryop.cpp
+++ b/src/layer/binaryop.cpp
@@ -83,7 +83,7 @@ static int binary_op(const Mat& a, const Mat& b, Mat& c, const Option& opt)
                 return 0;
              }
 
-			#pragma omp parallel for num_threads(opt.num_threads)
+            #pragma omp parallel for num_threads(opt.num_threads)
             for (int q=0; q<channels; q++)
             {
                 const float* ptr = a.channel(q);


### PR DESCRIPTION
当矩阵b 是1x1xN的矩阵时dims为3，做乘法op操作时获取b矩阵数据有问题