### PR TITLE
massive simd optimize in compute shader

### DIFF
--- a/src/command.h
+++ b/src/command.h
@@ -174,7 +174,6 @@ protected:
 
 protected:
     VkBufferMemory* staging_data;
-    void* mapped_ptr;
 
     // delayed record
     struct record_type

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -64,15 +64,12 @@ Layer::Layer()
     support_vulkan = false;
 
 #if NCNN_VULKAN
-    pipeline = 0;
+    vkdev = 0;
 #endif // NCNN_VULKAN
 }
 
 Layer::~Layer()
 {
-#if NCNN_VULKAN
-    delete pipeline;
-#endif // NCNN_VULKAN
 }
 
 int Layer::load_param(const ParamDict& /*pd*/)
@@ -130,6 +127,11 @@ int Layer::upload_model(VkTransfer& /*cmd*/)
 }
 
 int Layer::create_pipeline()
+{
+    return 0;
+}
+
+int Layer::destroy_pipeline()
 {
     return 0;
 }
@@ -221,30 +223,5 @@ Layer* create_layer(int index)
 
     return layer_creator();
 }
-
-#if NCNN_VULKAN
-#if NCNN_STRING
-Layer* create_layer(const char* type, const VulkanDevice* vkdev)
-{
-    int index = layer_to_index(type);
-    if (index == -1)
-        return 0;
-
-    return create_layer(index, vkdev);
-}
-#endif // NCNN_STRING
-
-Layer* create_layer(int index, const VulkanDevice* vkdev)
-{
-    Layer* layer = create_layer(index);
-    if (!layer)
-        return 0;
-
-    layer->vkdev = vkdev;
-    layer->pipeline = new Pipeline(vkdev);
-
-    return layer;
-}
-#endif // NCNN_VULKAN
 
 } // namespace ncnn

--- a/src/layer.h
+++ b/src/layer.h
@@ -120,6 +120,7 @@ public:
     virtual int upload_model(VkTransfer& cmd);
 
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
 public:
     // implement inference
@@ -133,10 +134,8 @@ public:
     virtual int forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Option& opt = get_default_option()) const;
 
 public:
+    // assigned immediately after creating this layer
     const VulkanDevice* vkdev;
-
-    // compute pipeline
-    Pipeline* pipeline;
 #endif // NCNN_VULKAN
 
 public:
@@ -173,15 +172,6 @@ Layer* create_layer(const char* type);
 #endif // NCNN_STRING
 // create layer from layer type
 Layer* create_layer(int index);
-
-#if NCNN_VULKAN
-#if NCNN_STRING
-// create layer from type name, enable vulkan if possible
-Layer* create_layer(const char* type, const VulkanDevice* vkdev);
-#endif // NCNN_STRING
-// create layer from layer type, enable vulkan if possible
-Layer* create_layer(int index, const VulkanDevice* vkdev);
-#endif // NCNN_VULKAN
 
 #define DEFINE_LAYER_CREATOR(name) \
     ::ncnn::Layer* name##_layer_creator() { return new name; }

--- a/src/layer/batchnorm.cpp
+++ b/src/layer/batchnorm.cpp
@@ -25,6 +25,11 @@ BatchNorm::BatchNorm()
     one_blob_only = true;
     support_inplace = true;
     support_vulkan = true;
+
+#if NCNN_VULKAN
+    pipeline_batchnorm = 0;
+    pipeline_batchnorm_pack4 = 0;
+#endif // NCNN_VULKAN
 }
 
 int BatchNorm::load_param(const ParamDict& pd)
@@ -139,28 +144,59 @@ int BatchNorm::upload_model(VkTransfer& cmd)
     cmd.record_upload(a_data, a_data_gpu);
     cmd.record_upload(b_data, b_data_gpu);
 
+    // pack4
+    if (channels % 4 == 0)
+    {
+        convert_packing(a_data, a_data_pack4, 4);
+        cmd.record_upload(a_data_pack4, a_data_gpu_pack4);
+
+        convert_packing(b_data, b_data_pack4, 4);
+        cmd.record_upload(b_data_pack4, b_data_gpu_pack4);
+    }
+
     return 0;
 }
 
 int BatchNorm::create_pipeline()
 {
-    pipeline->set_optimal_local_size_xyz(32, 32, channels);
+    pipeline_batchnorm = new Pipeline(vkdev);
+    pipeline_batchnorm->set_optimal_local_size_xyz(32, 32, channels);
 
     std::vector<vk_specialization_type> specializations(0);
 
-    pipeline->create("batchnorm", specializations, 3, 5);
+    pipeline_batchnorm->create("batchnorm", specializations, 3, 5);
+
+    // pack4
+    if (channels % 4 == 0)
+    {
+        pipeline_batchnorm_pack4 = new Pipeline(vkdev);
+        pipeline_batchnorm_pack4->set_optimal_local_size_xyz(32, 32, channels / 4);
+        pipeline_batchnorm_pack4->create("batchnorm_pack4", specializations, 3, 5);
+    }
+
+    return 0;
+}
+
+int BatchNorm::destroy_pipeline()
+{
+    delete pipeline_batchnorm;
+    pipeline_batchnorm = 0;
+
+    delete pipeline_batchnorm_pack4;
+    pipeline_batchnorm_pack4 = 0;
 
     return 0;
 }
 
 int BatchNorm::forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Option& opt) const
 {
+    int packing = bottom_top_blob.packing;
 //     fprintf(stderr, "BatchNorm::forward_inplace %p\n", bottom_top_blob.buffer());
 
     std::vector<VkMat> bindings(3);
     bindings[0] = bottom_top_blob;
-    bindings[1] = a_data_gpu;
-    bindings[2] = b_data_gpu;
+    bindings[1] = packing == 4 ? a_data_gpu_pack4 : a_data_gpu;
+    bindings[2] = packing == 4 ? b_data_gpu_pack4 : b_data_gpu;
 
     std::vector<vk_constant_type> constants(5);
     constants[0].i = bottom_top_blob.dims;
@@ -168,6 +204,8 @@ int BatchNorm::forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Opt
     constants[2].i = bottom_top_blob.h;
     constants[3].i = bottom_top_blob.c;
     constants[4].i = bottom_top_blob.cstep;
+
+    const Pipeline* pipeline = packing == 4 ? pipeline_batchnorm_pack4 : pipeline_batchnorm;
 
     // record
     cmd.record_prepare_compute_barrier(bottom_top_blob);

--- a/src/layer/batchnorm.h
+++ b/src/layer/batchnorm.h
@@ -34,6 +34,7 @@ public:
     virtual int upload_model(VkTransfer& cmd);
 
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
     virtual int forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Option& opt) const;
 #endif // NCNN_VULKAN
@@ -55,6 +56,14 @@ public:
 #if NCNN_VULKAN
     VkMat a_data_gpu;
     VkMat b_data_gpu;
+
+    Pipeline* pipeline_batchnorm;
+
+    Mat a_data_pack4;
+    Mat b_data_pack4;
+    VkMat a_data_gpu_pack4;
+    VkMat b_data_gpu_pack4;
+    Pipeline* pipeline_batchnorm_pack4;
 #endif // NCNN_VULKAN
 
 };

--- a/src/layer/binaryop.h
+++ b/src/layer/binaryop.h
@@ -32,6 +32,7 @@ public:
 
 #if NCNN_VULKAN
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
     virtual int forward(const std::vector<VkMat>& bottom_blobs, std::vector<VkMat>& top_blobs, VkCompute& cmd, const Option& opt) const;
 
@@ -55,6 +56,10 @@ public:
     int op_type;
     int with_scalar;
     float b;
+
+#if NCNN_VULKAN
+    Pipeline* pipeline_binaryop;
+#endif // NCNN_VULKAN
 };
 
 } // namespace ncnn

--- a/src/layer/binaryop.h
+++ b/src/layer/binaryop.h
@@ -59,6 +59,7 @@ public:
 
 #if NCNN_VULKAN
     Pipeline* pipeline_binaryop;
+    Pipeline* pipeline_binaryop_pack4;
 #endif // NCNN_VULKAN
 };
 

--- a/src/layer/convolution.h
+++ b/src/layer/convolution.h
@@ -35,6 +35,7 @@ public:
     virtual int upload_model(VkTransfer& cmd);
 
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
     virtual int forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const;
 #endif // NCNN_VULKAN
@@ -61,12 +62,21 @@ public:
     Mat bias_data;
 
 #if NCNN_VULKAN
+    ncnn::Layer* padding;
+    ncnn::Layer* convolution_fc;
+
     VkMat weight_data_gpu;
     VkMat bias_data_gpu;
 
-    ncnn::Layer* padding;
-    ncnn::Layer* convolution_fc;
-    Pipeline* convolution_1x1s1d1;
+    Pipeline* pipeline_convolution;
+    Pipeline* pipeline_convolution_1x1s1d1;
+
+    // pack4
+    Mat weight_data_pack4;
+    Mat bias_data_pack4;
+    VkMat weight_data_gpu_pack4;
+    VkMat bias_data_gpu_pack4;
+    Pipeline* pipeline_convolution_pack4;
 #endif // NCNN_VULKAN
 
     float weight_data_int8_scale;

--- a/src/layer/convolutiondepthwise.h
+++ b/src/layer/convolutiondepthwise.h
@@ -35,6 +35,7 @@ public:
     virtual int upload_model(VkTransfer& cmd);
 
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
     virtual int forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const;
 #endif // NCNN_VULKAN
@@ -66,6 +67,16 @@ public:
     VkMat bias_data_gpu;
 
     ncnn::Layer* padding;
+
+    std::vector<ncnn::Layer*> convolution_group_ops;
+
+    Pipeline* pipeline_convolutiondepthwise;
+
+    Mat weight_data_pack4;
+    Mat bias_data_pack4;
+    VkMat weight_data_gpu_pack4;
+    VkMat bias_data_gpu_pack4;
+    Pipeline* pipeline_convolutiondepthwise_pack4;
 #endif // NCNN_VULKAN
 
     Mat weight_data_int8_scales;

--- a/src/layer/dropout.cpp
+++ b/src/layer/dropout.cpp
@@ -24,6 +24,11 @@ Dropout::Dropout()
     one_blob_only = true;
     support_inplace = true;
     support_vulkan = true;
+
+#if NCNN_VULKAN
+    pipeline_dropout = 0;
+    pipeline_dropout_pack4 = 0;
+#endif // NCNN_VULKAN
 }
 
 int Dropout::load_param(const ParamDict& pd)
@@ -62,12 +67,31 @@ int Dropout::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
 #if NCNN_VULKAN
 int Dropout::create_pipeline()
 {
-    pipeline->set_optimal_local_size_xyz();
+    pipeline_dropout = new Pipeline(vkdev);
+    pipeline_dropout->set_optimal_local_size_xyz();
 
     std::vector<vk_specialization_type> specializations(1);
     specializations[0].f = scale;
 
-    pipeline->create("dropout", specializations, 1, 5);
+    pipeline_dropout->create("dropout", specializations, 1, 5);
+
+    // pack4
+    {
+        pipeline_dropout_pack4 = new Pipeline(vkdev);
+        pipeline_dropout_pack4->set_optimal_local_size_xyz();
+        pipeline_dropout_pack4->create("dropout_pack4", specializations, 1, 5);
+    }
+
+    return 0;
+}
+
+int Dropout::destroy_pipeline()
+{
+    delete pipeline_dropout;
+    pipeline_dropout = 0;
+
+    delete pipeline_dropout_pack4;
+    pipeline_dropout_pack4 = 0;
 
     return 0;
 }
@@ -78,6 +102,8 @@ int Dropout::forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Optio
     {
         return 0;
     }
+
+    int packing = bottom_top_blob.packing;
 
 //     fprintf(stderr, "Dropout::forward_inplace %p\n", bottom_top_blob.buffer());
 
@@ -90,6 +116,8 @@ int Dropout::forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Optio
     constants[2].i = bottom_top_blob.h;
     constants[3].i = bottom_top_blob.c;
     constants[4].i = bottom_top_blob.cstep;
+
+    const Pipeline* pipeline = packing == 4 ? pipeline_dropout_pack4 : pipeline_dropout;
 
     // record
     cmd.record_prepare_compute_barrier(bottom_top_blob);

--- a/src/layer/dropout.h
+++ b/src/layer/dropout.h
@@ -30,12 +30,18 @@ public:
 
 #if NCNN_VULKAN
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
     virtual int forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Option& opt) const;
 #endif // NCNN_VULKAN
 
 public:
     float scale;
+
+#if NCNN_VULKAN
+    Pipeline* pipeline_dropout;
+    Pipeline* pipeline_dropout_pack4;
+#endif // NCNN_VULKAN
 };
 
 } // namespace ncnn

--- a/src/layer/eltwise.cpp
+++ b/src/layer/eltwise.cpp
@@ -24,6 +24,11 @@ Eltwise::Eltwise()
     one_blob_only = false;
     support_inplace = false;// TODO inplace reduction
     support_vulkan = true;
+
+#if NCNN_VULKAN
+    pipeline_eltwise = 0;
+    pipeline_eltwise_pack4 = 0;
+#endif // NCNN_VULKAN
 }
 
 int Eltwise::load_param(const ParamDict& pd)
@@ -193,13 +198,32 @@ int Eltwise::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top
 #if NCNN_VULKAN
 int Eltwise::create_pipeline()
 {
-    pipeline->set_optimal_local_size_xyz();
+    pipeline_eltwise = new Pipeline(vkdev);
+    pipeline_eltwise->set_optimal_local_size_xyz();
 
     std::vector<vk_specialization_type> specializations(2);
     specializations[0].i = op_type;
     specializations[1].i = coeffs.w == 0 ? 0 : 1;
 
-    pipeline->create("eltwise", specializations, 3, 5+2);
+    pipeline_eltwise->create("eltwise", specializations, 3, 5+2);
+
+    // pack4
+    {
+        pipeline_eltwise_pack4 = new Pipeline(vkdev);
+        pipeline_eltwise_pack4->set_optimal_local_size_xyz();
+        pipeline_eltwise_pack4->create("eltwise_pack4", specializations, 3, 5+2);
+    }
+
+    return 0;
+}
+
+int Eltwise::destroy_pipeline()
+{
+    delete pipeline_eltwise;
+    pipeline_eltwise = 0;
+
+    delete pipeline_eltwise_pack4;
+    pipeline_eltwise_pack4 = 0;
 
     return 0;
 }
@@ -236,7 +260,7 @@ int Eltwise::forward(const std::vector<VkMat>& bottom_blobs, std::vector<VkMat>&
     // record
     cmd.record_prepare_compute_barrier(bottom_blob);
     cmd.record_prepare_compute_barrier(bottom_blob1);
-    cmd.record_pipeline(pipeline, bindings, constants, top_blob);
+    cmd.record_pipeline(pipeline_eltwise, bindings, constants, top_blob);
 
     for (size_t b=2; b<bottom_blobs.size(); b++)
     {
@@ -259,7 +283,7 @@ int Eltwise::forward(const std::vector<VkMat>& bottom_blobs, std::vector<VkMat>&
         // record
         cmd.record_prepare_compute_barrier(top_blob);
         cmd.record_prepare_compute_barrier(bottom_blobs[b]);
-        cmd.record_pipeline(pipeline, bindings, constants, top_blob);
+        cmd.record_pipeline(pipeline_eltwise, bindings, constants, top_blob);
     }
 
     return 0;

--- a/src/layer/eltwise.h
+++ b/src/layer/eltwise.h
@@ -30,6 +30,7 @@ public:
 
 #if NCNN_VULKAN
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
     virtual int forward(const std::vector<VkMat>& bottom_blobs, std::vector<VkMat>& top_blobs, VkCompute& cmd, const Option& opt) const;
 #endif // NCNN_VULKAN
@@ -40,6 +41,11 @@ public:
     // param
     int op_type;
     Mat coeffs;
+
+#if NCNN_VULKAN
+    Pipeline* pipeline_eltwise;
+    Pipeline* pipeline_eltwise_pack4;
+#endif // NCNN_VULKAN
 };
 
 } // namespace ncnn

--- a/src/layer/innerproduct.h
+++ b/src/layer/innerproduct.h
@@ -35,6 +35,7 @@ public:
     virtual int upload_model(VkTransfer& cmd);
 
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
     virtual int forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const;
 #endif // NCNN_VULKAN
@@ -55,6 +56,15 @@ public:
 #if NCNN_VULKAN
     VkMat weight_data_gpu;
     VkMat bias_data_gpu;
+
+    Pipeline* pipeline_innerproduct;
+
+    // pack4
+    Mat weight_data_pack4;
+    Mat bias_data_pack4;
+    VkMat weight_data_gpu_pack4;
+    VkMat bias_data_gpu_pack4;
+    Pipeline* pipeline_innerproduct_pack4;
 #endif // NCNN_VULKAN
 
     float weight_data_int8_scale;

--- a/src/layer/padding.h
+++ b/src/layer/padding.h
@@ -30,6 +30,7 @@ public:
 
 #if NCNN_VULKAN
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
     virtual int forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const;
 #endif // NCNN_VULKAN
@@ -41,6 +42,11 @@ public:
     int right;
     int type;// 0=BORDER_CONSTANT 1=BORDER_REPLICATE
     float value;
+
+#if NCNN_VULKAN
+    Pipeline* pipeline_padding;
+    Pipeline* pipeline_padding_pack4;
+#endif // NCNN_VULKAN
 };
 
 } // namespace ncnn

--- a/src/layer/pooling.h
+++ b/src/layer/pooling.h
@@ -23,7 +23,6 @@ class Pooling : public Layer
 {
 public:
     Pooling();
-    ~Pooling();
 
     virtual int load_param(const ParamDict& pd);
 
@@ -31,6 +30,7 @@ public:
 
 #if NCNN_VULKAN
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
     virtual int forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const;
 #endif // NCNN_VULKAN
@@ -54,7 +54,10 @@ public:
 #if NCNN_VULKAN
     ncnn::Layer* padding;
 
-    Pipeline* pooling_global;
+    Pipeline* pipeline_pooling;
+    Pipeline* pipeline_pooling_global;
+    Pipeline* pipeline_pooling_pack4;
+    Pipeline* pipeline_pooling_global_pack4;
 #endif // NCNN_VULKAN
 
 };

--- a/src/layer/relu.h
+++ b/src/layer/relu.h
@@ -30,12 +30,18 @@ public:
 
 #if NCNN_VULKAN
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
     virtual int forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Option& opt) const;
 #endif // NCNN_VULKAN
 
 public:
     float slope;
+
+#if NCNN_VULKAN
+    Pipeline* pipeline_relu;
+    Pipeline* pipeline_relu_pack4;
+#endif // NCNN_VULKAN
 };
 
 } // namespace ncnn

--- a/src/layer/scale.cpp
+++ b/src/layer/scale.cpp
@@ -23,6 +23,11 @@ Scale::Scale()
     one_blob_only = true;
     support_inplace = true;
     support_vulkan = true;
+
+#if NCNN_VULKAN
+    pipeline_scale = 0;
+    pipeline_scale_pack4 = 0;
+#endif // NCNN_VULKAN
 }
 
 int Scale::load_param(const ParamDict& pd)
@@ -180,11 +185,23 @@ int Scale::upload_model(VkTransfer& cmd)
     if (scale_data_size != -233)
     {
         cmd.record_upload(scale_data, scale_data_gpu);
+
+        // pack4
+        {
+            convert_packing(scale_data, scale_data_pack4, 4);
+            cmd.record_upload(scale_data_pack4, scale_data_gpu_pack4);
+        }
     }
 
     if (bias_term)
     {
         cmd.record_upload(bias_data, bias_data_gpu);
+
+        // pack4
+        {
+            convert_packing(bias_data, bias_data_pack4, 4);
+            cmd.record_upload(bias_data_pack4, bias_data_gpu_pack4);
+        }
     }
 
     return 0;
@@ -192,15 +209,38 @@ int Scale::upload_model(VkTransfer& cmd)
 
 int Scale::create_pipeline()
 {
+    pipeline_scale = new Pipeline(vkdev);
     if (scale_data_size == -233)
-        pipeline->set_optimal_local_size_xyz();
+        pipeline_scale->set_optimal_local_size_xyz();
     else
-        pipeline->set_optimal_local_size_xyz(8, 8, scale_data_size);
+        pipeline_scale->set_optimal_local_size_xyz(8, 8, scale_data_size);
 
     std::vector<vk_specialization_type> specializations(1);
     specializations[0].i = bias_term;
 
-    pipeline->create("scale", specializations, 3, 5);
+    pipeline_scale->create("scale", specializations, 3, 5);
+
+    // pack4
+    {
+        pipeline_scale_pack4 = new Pipeline(vkdev);
+        if (scale_data_size == -233)
+            pipeline_scale_pack4->set_optimal_local_size_xyz();
+        else
+            pipeline_scale_pack4->set_optimal_local_size_xyz(8, 8, scale_data_size / 4);
+
+        pipeline_scale_pack4->create("scale_pack4", specializations, 3, 5);
+    }
+
+    return 0;
+}
+
+int Scale::destroy_pipeline()
+{
+    delete pipeline_scale;
+    pipeline_scale = 0;
+
+    delete pipeline_scale_pack4;
+    pipeline_scale_pack4 = 0;
 
     return 0;
 }
@@ -210,12 +250,14 @@ int Scale::forward_inplace(std::vector<VkMat>& bottom_top_blobs, VkCompute& cmd,
     VkMat& bottom_top_blob = bottom_top_blobs[0];
     const VkMat& scale_blob = bottom_top_blobs[1];
 
+    int packing = bottom_top_blob.packing;
+
 //     fprintf(stderr, "Scale::forward_inplace %p\n", bottom_top_blob.buffer());
 
     std::vector<VkMat> bindings(3);
     bindings[0] = bottom_top_blob;
     bindings[1] = scale_blob;
-    bindings[2] = bias_term ? bias_data_gpu : scale_blob;// TODO use dummy buffer
+    bindings[2] = bias_term ? (packing == 4 ? bias_data_gpu_pack4 : bias_data_gpu) : scale_blob;// TODO use dummy buffer
 
     std::vector<vk_constant_type> constants(5);
     constants[0].i = bottom_top_blob.dims;
@@ -223,6 +265,8 @@ int Scale::forward_inplace(std::vector<VkMat>& bottom_top_blobs, VkCompute& cmd,
     constants[2].i = bottom_top_blob.h;
     constants[3].i = bottom_top_blob.c;
     constants[4].i = bottom_top_blob.cstep;
+
+    const Pipeline* pipeline = packing == 4 ? pipeline_scale_pack4 : pipeline_scale;
 
     // record
     cmd.record_prepare_compute_barrier(bottom_top_blob);
@@ -235,9 +279,11 @@ int Scale::forward_inplace(std::vector<VkMat>& bottom_top_blobs, VkCompute& cmd,
 
 int Scale::forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Option& opt) const
 {
+    int packing = bottom_top_blob.packing;
+
     std::vector<VkMat> bottom_top_blobs(2);
     bottom_top_blobs[0] = bottom_top_blob;
-    bottom_top_blobs[1] = scale_data_gpu;
+    bottom_top_blobs[1] = packing == 4 ? scale_data_gpu_pack4 : scale_data_gpu;
 
     return forward_inplace(bottom_top_blobs, cmd, opt);
 }

--- a/src/layer/scale.h
+++ b/src/layer/scale.h
@@ -35,6 +35,7 @@ public:
     virtual int upload_model(VkTransfer& cmd);
 
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
     virtual int forward_inplace(std::vector<VkMat>& bottom_top_blobs, VkCompute& cmd, const Option& opt) const;
     virtual int forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Option& opt) const;
@@ -52,6 +53,14 @@ public:
 #if NCNN_VULKAN
     VkMat scale_data_gpu;
     VkMat bias_data_gpu;
+
+    Pipeline* pipeline_scale;
+
+    Mat scale_data_pack4;
+    Mat bias_data_pack4;
+    VkMat scale_data_gpu_pack4;
+    VkMat bias_data_gpu_pack4;
+    Pipeline* pipeline_scale_pack4;
 #endif // NCNN_VULKAN
 
 };

--- a/src/layer/shader/batchnorm_pack4.comp
+++ b/src/layer/shader/batchnorm_pack4.comp
@@ -1,0 +1,79 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+layout (local_size_x_id = 233) in;
+layout (local_size_y_id = 234) in;
+layout (local_size_z_id = 235) in;
+
+layout (binding = 0) buffer bottom_top_blob { vec4 bottom_top_blob_data[]; };
+layout (binding = 1) readonly buffer a { vec4 a_data[]; };
+layout (binding = 2) readonly buffer b { vec4 b_data[]; };
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= p.w || gy >= p.h || gz >= p.c)
+        return;
+
+    if (p.dims == 1)
+    {
+        vec4 v = bottom_top_blob_data[gx];
+
+        v = b_data[gx] * v + a_data[gx];
+
+        bottom_top_blob_data[gx] = v;
+
+        return;
+    }
+
+    if (p.dims == 2)
+    {
+        const int gi = gy * p.w + gx;
+
+        vec4 v = bottom_top_blob_data[gi];
+
+        v = b_data[gy] * v + a_data[gy];
+
+        bottom_top_blob_data[gi] = v;
+
+        return;
+    }
+
+    if (p.dims == 3)
+    {
+        const int gi = gz * p.cstep + gy * p.w + gx;
+
+        vec4 v = bottom_top_blob_data[gi];
+
+        v = b_data[gz] * v + a_data[gz];
+
+        bottom_top_blob_data[gi] = v;
+
+        return;
+    }
+}

--- a/src/layer/shader/binaryop_pack4.comp
+++ b/src/layer/shader/binaryop_pack4.comp
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making ncnn available.
 //
-// Copyright (C) 2018 THL A29 Limited, a Tencent company. All rights reserved.
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
 //
 // Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at
@@ -22,9 +22,9 @@ layout (local_size_x_id = 233) in;
 layout (local_size_y_id = 234) in;
 layout (local_size_z_id = 235) in;
 
-layout (binding = 0) buffer a_blob { float a_blob_data[]; };
-layout (binding = 2) readonly buffer b_blob { float b_blob_data[]; };
-layout (binding = 1) writeonly buffer top_blob { float top_blob_data[]; };
+layout (binding = 0) buffer a_blob { vec4 a_blob_data[]; };
+layout (binding = 2) readonly buffer b_blob { vec4 b_blob_data[]; };
+layout (binding = 1) writeonly buffer top_blob { vec4 top_blob_data[]; };
 
 layout (push_constant) uniform parameter
 {
@@ -58,9 +58,9 @@ void main()
 
     const int gi = gz * p.outcstep + gy * p.outw + gx;
 
-    float v1 = a_blob_data[gi];
+    vec4 v1 = a_blob_data[gi];
 
-    float res;
+    vec4 res;
 
     if (with_scalar == 1)
     {
@@ -70,7 +70,7 @@ void main()
         if (op_type == 3) res = v1 / b;
         if (op_type == 4) res = max(v1, b);
         if (op_type == 5) res = min(v1, b);
-        if (op_type == 6) res = pow(v1, b);
+        if (op_type == 6) res = pow(v1, vec4(b));
         if (op_type == 7) res = b - v1;
         if (op_type == 8) res = b / v1;
 
@@ -81,7 +81,7 @@ void main()
 
     if (p.adims == p.bdims)
     {
-        float v2 = b_blob_data[gi];
+        vec4 v2 = b_blob_data[gi];
 
         if (op_type == 0) res = v1 + v2;
         if (op_type == 1) res = v1 - v2;

--- a/src/layer/shader/convolution_pack4.comp
+++ b/src/layer/shader/convolution_pack4.comp
@@ -1,0 +1,95 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+layout (constant_id = 0) const int kernel_w = 1;
+layout (constant_id = 1) const int kernel_h = 1;
+layout (constant_id = 2) const int dilation_w = 1;
+layout (constant_id = 3) const int dilation_h = 1;
+layout (constant_id = 4) const int stride_w = 1;
+layout (constant_id = 5) const int stride_h = 1;
+layout (constant_id = 6) const int bias_term = 0;
+
+layout (local_size_x_id = 233) in;
+layout (local_size_y_id = 234) in;
+layout (local_size_z_id = 235) in;
+
+layout (binding = 0) readonly buffer bottom_blob { vec4 bottom_blob_data[]; };
+layout (binding = 1) writeonly buffer top_blob { vec4 top_blob_data[]; };
+layout (binding = 2) readonly buffer weight_blob { mat4 weight_data[]; };
+layout (binding = 3) readonly buffer bias_blob { vec4 bias_data[]; };
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= p.outw || gy >= p.outh || gz >= p.outc)
+        return;
+
+    vec4 sum;
+
+    if (bias_term == 1)
+    {
+        sum = bias_data[gz];
+    }
+    else
+    {
+        sum = vec4(0.0);
+    }
+
+    int w_offset = gz * p.c * kernel_w * kernel_h;
+
+    for (int z = 0; z < p.c; z++)
+    {
+        int v_offset = z * p.cstep + gy * stride_h * p.w + gx * stride_w;
+
+        for (int y = 0; y < kernel_h; y++)
+        {
+            for (int x = 0; x < kernel_w; x++)
+            {
+                // weight = kw-kh-inch-outch
+                //        = 4-4-kw-kh-inch/4-outch/4
+
+                vec4 v = bottom_blob_data[v_offset + x * dilation_w];
+
+                mat4 k = weight_data[w_offset + x];
+
+                sum += k * v;
+            }
+
+            v_offset += dilation_h * p.w;
+            w_offset += kernel_w;
+        }
+    }
+
+    top_blob_data[gz * p.outcstep + gy * p.outw + gx] = sum;
+}

--- a/src/layer/shader/convolutiondepthwise_pack4.comp
+++ b/src/layer/shader/convolutiondepthwise_pack4.comp
@@ -27,10 +27,10 @@ layout (local_size_x_id = 233) in;
 layout (local_size_y_id = 234) in;
 layout (local_size_z_id = 235) in;
 
-layout (binding = 0) readonly buffer bottom_blob { float bottom_blob_data[]; };
-layout (binding = 1) writeonly buffer top_blob { float top_blob_data[]; };
-layout (binding = 2) readonly buffer weight_blob { float weight_data[]; };
-layout (binding = 3) readonly buffer bias_blob { float bias_data[]; };
+layout (binding = 0) readonly buffer bottom_blob { vec4 bottom_blob_data[]; };
+layout (binding = 1) writeonly buffer top_blob { vec4 top_blob_data[]; };
+layout (binding = 2) readonly buffer weight_blob { vec4 weight_data[]; };
+layout (binding = 3) readonly buffer bias_blob { vec4 bias_data[]; };
 
 layout (push_constant) uniform parameter
 {
@@ -56,11 +56,15 @@ void main()
     if (gx >= p.outw || gy >= p.outh || gz >= p.outc)
         return;
 
-    float sum = 0;
+    vec4 sum;
 
     if (bias_term == 1)
     {
         sum = bias_data[gz];
+    }
+    else
+    {
+        sum = vec4(0.0);
     }
 
     // depth-wise convolution
@@ -71,7 +75,11 @@ void main()
     {
         for (int x = 0; x < kernel_w; x++)
         {
-            sum += weight_data[w_offset + x] * bottom_blob_data[v_offset + x * dilation_w];
+            vec4 v = bottom_blob_data[v_offset + x * dilation_w];
+
+            vec4 k = weight_data[w_offset + x];
+
+            sum += v * k;
         }
 
         v_offset += dilation_h * p.w;

--- a/src/layer/shader/dropout_pack4.comp
+++ b/src/layer/shader/dropout_pack4.comp
@@ -1,0 +1,50 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+layout (constant_id = 0) const float scale = 1;
+
+layout (local_size_x_id = 233) in;
+layout (local_size_y_id = 234) in;
+layout (local_size_z_id = 235) in;
+
+layout (binding = 0) buffer bottom_top_blob { vec4 bottom_top_blob_data[]; };
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= p.w || gy >= p.h || gz >= p.c)
+        return;
+
+    const int gi = gz * p.cstep + gy * p.w + gx;
+
+    vec4 v = bottom_top_blob_data[gi];
+
+    v *= scale;
+
+    bottom_top_blob_data[gi] = v;
+}

--- a/src/layer/shader/eltwise_pack4.comp
+++ b/src/layer/shader/eltwise_pack4.comp
@@ -1,0 +1,80 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+layout (constant_id = 0) const int op_type = 0;
+layout (constant_id = 1) const int coeff_term = 0;
+
+layout (local_size_x_id = 233) in;
+layout (local_size_y_id = 234) in;
+layout (local_size_z_id = 235) in;
+
+layout (binding = 0) readonly buffer bottom_blob1 { vec4 bottom_blob1_data[]; };
+layout (binding = 1) readonly buffer bottom_blob2 { vec4 bottom_blob2_data[]; };
+layout (binding = 2) writeonly buffer top_blob { vec4 top_blob_data[]; };
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    float coeff0;
+    float coeff1;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= p.w || gy >= p.h || gz >= p.c)
+        return;
+
+    const int gi = gz * p.cstep + gy * p.w + gx;
+
+    vec4 v1 = bottom_blob1_data[gi];
+    vec4 v2 = bottom_blob2_data[gi];
+
+    vec4 res;
+
+    if (coeff_term == 0)
+    {
+        if (op_type == 0)
+            res = v1 * v2;
+
+        if (op_type == 1)
+            res = v1 + v2;
+
+        if (op_type == 2)
+            res = max(v1, v2);
+    }
+    else
+    {
+        if (op_type == 0)
+            res = v1 * p.coeff0 * v2 * p.coeff1;
+
+        if (op_type == 1)
+            res = v1 * p.coeff0 + v2 * p.coeff1;
+
+        if (op_type == 2)
+            res = max(v1 * p.coeff0, v2 * p.coeff1);
+    }
+
+    top_blob_data[gi] = res;
+}

--- a/src/layer/shader/innerproduct_pack4.comp
+++ b/src/layer/shader/innerproduct_pack4.comp
@@ -14,13 +14,7 @@
 
 #version 450
 
-layout (constant_id = 0) const int kernel_w = 1;
-layout (constant_id = 1) const int kernel_h = 1;
-layout (constant_id = 2) const int dilation_w = 1;
-layout (constant_id = 3) const int dilation_h = 1;
-layout (constant_id = 4) const int stride_w = 1;
-layout (constant_id = 5) const int stride_h = 1;
-layout (constant_id = 6) const int bias_term = 0;
+layout (constant_id = 0) const int bias_term = 0;
 
 layout (local_size_x_id = 233) in;
 layout (local_size_y_id = 234) in;
@@ -28,8 +22,8 @@ layout (local_size_z_id = 235) in;
 
 layout (binding = 0) readonly buffer bottom_blob { vec4 bottom_blob_data[]; };
 layout (binding = 1) writeonly buffer top_blob { vec4 top_blob_data[]; };
-layout (binding = 2) readonly buffer weight_blob { mat4 weight_data[]; };
-layout (binding = 3) readonly buffer bias_blob { vec4 bias_data[]; };
+layout (binding = 2) readonly buffer weight { mat4 weight_data[]; };
+layout (binding = 3) readonly buffer bias { vec4 bias_data[]; };
 
 layout (push_constant) uniform parameter
 {
@@ -59,34 +53,32 @@ void main()
 
     if (bias_term == 1)
     {
-        sum = bias_data[gz];
+        sum = bias_data[gx];
     }
     else
     {
         sum = vec4(0.0);
     }
 
-    int w_offset = gz * p.c * kernel_w * kernel_h;
+    const int size = p.w * p.h;
+
+    int w_offset = gx * size * p.c;
 
     for (int z = 0; z < p.c; z++)
     {
-        int v_offset = z * p.cstep + gy * stride_h * p.w + gx * stride_w;
+        int v_offset = z * p.cstep;
 
-        for (int y = 0; y < kernel_h; y++)
+        for (int i = 0; i < size; i++)
         {
-            for (int x = 0; x < kernel_w; x++)
-            {
-                vec4 v = bottom_blob_data[v_offset + x * dilation_w];
+            vec4 v = bottom_blob_data[v_offset + i];
 
-                mat4 k = weight_data[w_offset + x];
+            mat4 k = weight_data[w_offset + i];
 
-                sum += v * k;
-            }
-
-            v_offset += dilation_h * p.w;
-            w_offset += kernel_w;
+            sum += v * k;
         }
+
+        w_offset += size;
     }
 
-    top_blob_data[gz * p.outcstep + gy * p.outw + gx] = sum;
+    top_blob_data[gx] = sum;
 }

--- a/src/layer/shader/padding_pack4.comp
+++ b/src/layer/shader/padding_pack4.comp
@@ -14,13 +14,12 @@
 
 #version 450
 
-layout (constant_id = 0) const int kernel_w = 1;
-layout (constant_id = 1) const int kernel_h = 1;
-layout (constant_id = 2) const int dilation_w = 1;
-layout (constant_id = 3) const int dilation_h = 1;
-layout (constant_id = 4) const int stride_w = 1;
-layout (constant_id = 5) const int stride_h = 1;
-layout (constant_id = 6) const int bias_term = 0;
+layout (constant_id = 0) const int top = 0;
+layout (constant_id = 1) const int bottom = 1;
+layout (constant_id = 2) const int left = 1;
+layout (constant_id = 3) const int right = 1;
+layout (constant_id = 4) const int type = 1;
+layout (constant_id = 5) const float value = 0;
 
 layout (local_size_x_id = 233) in;
 layout (local_size_y_id = 234) in;
@@ -28,8 +27,6 @@ layout (local_size_z_id = 235) in;
 
 layout (binding = 0) readonly buffer bottom_blob { vec4 bottom_blob_data[]; };
 layout (binding = 1) writeonly buffer top_blob { vec4 top_blob_data[]; };
-layout (binding = 2) readonly buffer weight_blob { mat4 weight_data[]; };
-layout (binding = 3) readonly buffer bias_blob { vec4 bias_data[]; };
 
 layout (push_constant) uniform parameter
 {
@@ -55,38 +52,31 @@ void main()
     if (gx >= p.outw || gy >= p.outh || gz >= p.outc)
         return;
 
-    vec4 sum;
+    vec4 res;
 
-    if (bias_term == 1)
+    int x = gx - left;
+    int y = gy - top;
+
+    if (type == 0)
     {
-        sum = bias_data[gz];
-    }
-    else
-    {
-        sum = vec4(0.0);
-    }
-
-    int w_offset = gz * p.c * kernel_w * kernel_h;
-
-    for (int z = 0; z < p.c; z++)
-    {
-        int v_offset = z * p.cstep + gy * stride_h * p.w + gx * stride_w;
-
-        for (int y = 0; y < kernel_h; y++)
+        if (x >= 0 && x < p.w && y >= 0 && y < p.h)
         {
-            for (int x = 0; x < kernel_w; x++)
-            {
-                vec4 v = bottom_blob_data[v_offset + x * dilation_w];
-
-                mat4 k = weight_data[w_offset + x];
-
-                sum += v * k;
-            }
-
-            v_offset += dilation_h * p.w;
-            w_offset += kernel_w;
+            int v_offset = gz * p.cstep + y * p.w + x;
+            res = bottom_blob_data[v_offset];
+        }
+        else
+        {
+            res = vec4(value);
         }
     }
+    else if (type == 1)
+    {
+        x = clamp(x, 0, p.w - 1);
+        y = clamp(y, 0, p.h - 1);
 
-    top_blob_data[gz * p.outcstep + gy * p.outw + gx] = sum;
+        int v_offset = gz * p.cstep + y * p.w + x;
+        res = bottom_blob_data[v_offset];
+    }
+
+    top_blob_data[gz * p.outcstep + gy * p.outw + gx] = res;
 }

--- a/src/layer/shader/pooling_global_pack4.comp
+++ b/src/layer/shader/pooling_global_pack4.comp
@@ -20,8 +20,8 @@ layout (local_size_x_id = 233) in;
 layout (local_size_y_id = 234) in;
 layout (local_size_z_id = 235) in;
 
-layout (binding = 0) readonly buffer bottom_blob { float bottom_blob_data[]; };
-layout (binding = 1) writeonly buffer top_blob { float top_blob_data[]; };
+layout (binding = 0) readonly buffer bottom_blob { vec4 bottom_blob_data[]; };
+layout (binding = 1) writeonly buffer top_blob { vec4 top_blob_data[]; };
 
 layout (push_constant) uniform parameter
 {
@@ -50,11 +50,11 @@ void main()
     int size = p.w * p.h;
     int v_offset = gx * p.cstep;
 
-    float res;
+    vec4 res;
 
     if (pooling_type == 0)
     {
-        res = -99999999;
+        res = vec4(-99999999);
 
         for (int i = 0; i < size; i++)
         {
@@ -63,7 +63,7 @@ void main()
     }
     else if (pooling_type == 1)
     {
-        res = 0;
+        res = vec4(0.0);
 
         for (int i = 0; i < size; i++)
         {

--- a/src/layer/shader/pooling_pack4.comp
+++ b/src/layer/shader/pooling_pack4.comp
@@ -15,13 +15,19 @@
 #version 450
 
 layout (constant_id = 0) const int pooling_type = 0;
+layout (constant_id = 1) const int kernel_w = 1;
+layout (constant_id = 2) const int kernel_h = 1;
+layout (constant_id = 3) const int stride_w = 1;
+layout (constant_id = 4) const int stride_h = 1;
+layout (constant_id = 5) const int global_pooling = 0;
+layout (constant_id = 6) const int pad_mode = 0;
 
 layout (local_size_x_id = 233) in;
 layout (local_size_y_id = 234) in;
 layout (local_size_z_id = 235) in;
 
-layout (binding = 0) readonly buffer bottom_blob { float bottom_blob_data[]; };
-layout (binding = 1) writeonly buffer top_blob { float top_blob_data[]; };
+layout (binding = 0) readonly buffer bottom_blob { vec4 bottom_blob_data[]; };
+layout (binding = 1) writeonly buffer top_blob { vec4 top_blob_data[]; };
 
 layout (push_constant) uniform parameter
 {
@@ -47,31 +53,42 @@ void main()
     if (gx >= p.outw || gy >= p.outh || gz >= p.outc)
         return;
 
-    int size = p.w * p.h;
-    int v_offset = gx * p.cstep;
-
-    float res;
+    vec4 res;
 
     if (pooling_type == 0)
     {
-        res = -99999999;
+        res = vec4(-99999999);
 
-        for (int i = 0; i < size; i++)
+        int v_offset = gz * p.cstep + gy * stride_h * p.w + gx * stride_w;
+
+        for (int y = 0; y < kernel_h; y++)
         {
-            res = max(res, bottom_blob_data[v_offset + i]);
+            for (int x = 0; x < kernel_w; x++)
+            {
+                res = max(res, bottom_blob_data[v_offset + x]);
+            }
+
+            v_offset += p.w;
         }
     }
     else if (pooling_type == 1)
     {
-        res = 0;
+        res = vec4(0.0);
 
-        for (int i = 0; i < size; i++)
+        int v_offset = gz * p.cstep + gy * stride_h * p.w + gx * stride_w;
+
+        for (int y = 0; y < kernel_h; y++)
         {
-            res += bottom_blob_data[v_offset + i];
+            for (int x = 0; x < kernel_w; x++)
+            {
+                res += bottom_blob_data[v_offset + x];
+            }
+
+            v_offset += p.w;
         }
 
-        res /= size;
+        res /= kernel_w * kernel_h;
     }
 
-    top_blob_data[gx] = res;
+    top_blob_data[gz * p.outcstep + gy * p.outw + gx] = res;
 }

--- a/src/layer/shader/relu_pack4.comp
+++ b/src/layer/shader/relu_pack4.comp
@@ -1,0 +1,53 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+layout (constant_id = 0) const float slope = 0;
+
+layout (local_size_x_id = 233) in;
+layout (local_size_y_id = 234) in;
+layout (local_size_z_id = 235) in;
+
+layout (binding = 0) buffer bottom_top_blob { vec4 bottom_top_blob_data[]; };
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= p.w || gy >= p.h || gz >= p.c)
+        return;
+
+    const int gi = gz * p.cstep + gy * p.w + gx;
+
+    vec4 v = bottom_top_blob_data[gi];
+
+    if (slope == 0)
+        v = max(v, 0.0);
+    else
+        v = mix(v, v * slope, lessThan(v, vec4(0.0)));
+
+    bottom_top_blob_data[gi] = v;
+}

--- a/src/layer/shader/scale_pack4.comp
+++ b/src/layer/shader/scale_pack4.comp
@@ -1,0 +1,90 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+layout (constant_id = 0) const int bias_term = 0;
+
+layout (local_size_x_id = 233) in;
+layout (local_size_y_id = 234) in;
+layout (local_size_z_id = 235) in;
+
+layout (binding = 0) buffer bottom_top_blob { vec4 bottom_top_blob_data[]; };
+layout (binding = 1) readonly buffer scale_blob { vec4 scale_blob_data[]; };
+layout (binding = 2) readonly buffer bias_blob { vec4 bias_blob_data[]; };
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= p.w || gy >= p.h || gz >= p.c)
+        return;
+
+    if (p.dims == 1)
+    {
+        vec4 v = bottom_top_blob_data[gx];
+
+        if (bias_term == 1)
+            v = scale_blob_data[gx] * v + bias_blob_data[gx];
+        else
+            v = scale_blob_data[gx] * v;
+
+        bottom_top_blob_data[gx] = v;
+
+        return;
+    }
+
+    if (p.dims == 2)
+    {
+        const int gi = gy * p.w + gx;
+
+        vec4 v = bottom_top_blob_data[gi];
+
+        if (bias_term == 1)
+            v = scale_blob_data[gy] * v + bias_blob_data[gy];
+        else
+            v = scale_blob_data[gy] * v;
+
+        bottom_top_blob_data[gi] = v;
+
+        return;
+    }
+
+    if (p.dims == 3)
+    {
+        const int gi = gz * p.cstep + gy * p.w + gx;
+
+        vec4 v = bottom_top_blob_data[gi];
+
+        if (bias_term == 1)
+            v = scale_blob_data[gz] * v + bias_blob_data[gz];
+        else
+            v = scale_blob_data[gz] * v;
+
+        bottom_top_blob_data[gi] = v;
+
+        return;
+    }
+}

--- a/src/layer/shader/softmax_div_sum_pack4.comp
+++ b/src/layer/shader/softmax_div_sum_pack4.comp
@@ -1,0 +1,86 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+layout (constant_id = 0) const int axis = 0;
+
+layout (local_size_x_id = 233) in;
+layout (local_size_y_id = 234) in;
+layout (local_size_z_id = 235) in;
+
+layout (binding = 0) buffer bottom_top_blob { vec4 bottom_top_blob_data[]; };
+layout (binding = 1) readonly buffer sum_workspace { float sum_workspace_data[]; };
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= p.w || gy >= p.h || gz >= p.c)
+        return;
+
+    if (p.dims == 1) // axis == 0
+    {
+        bottom_top_blob_data[gx] /= sum_workspace_data[0];
+        return;
+    }
+
+    if (p.dims == 2 && axis == 0)
+    {
+        // FIXME TODO
+        return;
+    }
+
+    if (p.dims == 2 && axis == 1)
+    {
+        // FIXME TODO
+        return;
+    }
+
+    if (p.dims == 3 && axis == 0)
+    {
+        int gi = gz * p.cstep + gy * p.w + gx;
+        bottom_top_blob_data[gi] /= sum_workspace_data[ gy * p.w + gx ];
+        return;
+    }
+
+    if (p.dims == 3 && axis == 1)
+    {
+        // FIXME TODO
+        return;
+    }
+
+    if (p.dims == 3 && axis == 2)
+    {
+        // FIXME TODO
+        return;
+    }
+}

--- a/src/layer/shader/softmax_exp_sub_max_pack4.comp
+++ b/src/layer/shader/softmax_exp_sub_max_pack4.comp
@@ -1,0 +1,86 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+layout (constant_id = 0) const int axis = 0;
+
+layout (local_size_x_id = 233) in;
+layout (local_size_y_id = 234) in;
+layout (local_size_z_id = 235) in;
+
+layout (binding = 0) buffer bottom_top_blob { vec4 bottom_top_blob_data[]; };
+layout (binding = 1) readonly buffer max_workspace { float max_workspace_data[]; };
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= p.w || gy >= p.h || gz >= p.c)
+        return;
+
+    if (p.dims == 1) // axis == 0
+    {
+        bottom_top_blob_data[gx] = exp(bottom_top_blob_data[gx] - max_workspace_data[0]);
+        return;
+    }
+
+    if (p.dims == 2 && axis == 0)
+    {
+        // FIXME TODO
+        return;
+    }
+
+    if (p.dims == 2 && axis == 1)
+    {
+        // FIXME TODO
+        return;
+    }
+
+    if (p.dims == 3 && axis == 0)
+    {
+        int gi = gz * p.cstep + gy * p.w + gx;
+        bottom_top_blob_data[gi] = exp(bottom_top_blob_data[gi] - max_workspace_data[ gy * p.w + gx ]);
+        return;
+    }
+
+    if (p.dims == 3 && axis == 1)
+    {
+        // FIXME TODO
+        return;
+    }
+
+    if (p.dims == 3 && axis == 2)
+    {
+        // FIXME TODO
+        return;
+    }
+}

--- a/src/layer/shader/softmax_reduce_max_pack4.comp
+++ b/src/layer/shader/softmax_reduce_max_pack4.comp
@@ -1,0 +1,100 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+layout (constant_id = 0) const int axis = 0;
+
+layout (local_size_x_id = 233) in;
+layout (local_size_y_id = 234) in;
+layout (local_size_z_id = 235) in;
+
+layout (binding = 0) readonly buffer bottom_top_blob { vec4 bottom_top_blob_data[]; };
+layout (binding = 1) writeonly buffer max_workspace { float max_workspace_data[]; };
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= p.w || gy >= p.h || gz >= p.c)
+        return;
+
+    if (p.dims == 1) // axis == 0
+    {
+        vec4 max_value = vec4(-99999999);
+        for (int i=0; i<p.w; i++)
+        {
+            max_value = max(max_value, bottom_top_blob_data[i]);
+        }
+        vec2 max2 = max(max_value.rg, max_value.ba);
+        max_workspace_data[0] = max(max2.r, max2.g);
+
+        return;
+    }
+
+    if (p.dims == 2 && axis == 0)
+    {
+        // FIXME TODO
+        return;
+    }
+
+    if (p.dims == 2 && axis == 1)
+    {
+        // FIXME TODO
+        return;
+    }
+
+    if (p.dims == 3 && axis == 0)
+    {
+        vec4 max_value = vec4(-99999999);
+        for (int z = 0; z < p.c; z++)
+        {
+            int v_offset = z * p.cstep + gy * p.w + gx;
+            max_value = max(max_value, bottom_top_blob_data[v_offset]);
+        }
+        vec2 max2 = max(max_value.rg, max_value.ba);
+        max_workspace_data[ gy * p.w + gx ] = max(max2.r, max2.g);
+
+        return;
+    }
+
+    if (p.dims == 3 && axis == 1)
+    {
+        // FIXME TODO
+        return;
+    }
+
+    if (p.dims == 3 && axis == 2)
+    {
+        // FIXME TODO
+        return;
+    }
+}

--- a/src/layer/shader/softmax_reduce_sum_pack4.comp
+++ b/src/layer/shader/softmax_reduce_sum_pack4.comp
@@ -1,0 +1,100 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+layout (constant_id = 0) const int axis = 0;
+
+layout (local_size_x_id = 233) in;
+layout (local_size_y_id = 234) in;
+layout (local_size_z_id = 235) in;
+
+layout (binding = 0) readonly buffer bottom_top_blob { vec4 bottom_top_blob_data[]; };
+layout (binding = 1) writeonly buffer sum_workspace { float sum_workspace_data[]; };
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= p.w || gy >= p.h || gz >= p.c)
+        return;
+
+    if (p.dims == 1) // axis == 0
+    {
+        vec4 sum_value = vec4(0.0);
+        for (int i=0; i<p.w; i++)
+        {
+            sum_value += bottom_top_blob_data[i];
+        }
+        vec2 sum2 = sum_value.rg + sum_value.ba;
+        sum_workspace_data[0] = sum2.r + sum2.g;
+
+        return;
+    }
+
+    if (p.dims == 2 && axis == 0)
+    {
+        // FIXME TODO
+        return;
+    }
+
+    if (p.dims == 2 && axis == 1)
+    {
+        // FIXME TODO
+        return;
+    }
+
+    if (p.dims == 3 && axis == 0)
+    {
+        vec4 sum_value = vec4(0.0);
+        for (int z = 0; z < p.c; z++)
+        {
+            int v_offset = z * p.cstep + gy * p.w + gx;
+            sum_value += bottom_top_blob_data[v_offset];
+        }
+        vec2 sum2 = sum_value.rg + sum_value.ba;
+        sum_workspace_data[ gy * p.w + gx ] = sum2.r + sum2.g;
+
+        return;
+    }
+
+    if (p.dims == 3 && axis == 1)
+    {
+        // FIXME TODO
+        return;
+    }
+
+    if (p.dims == 3 && axis == 2)
+    {
+        // FIXME TODO
+        return;
+    }
+}

--- a/src/layer/shader/unaryop_pack4.comp
+++ b/src/layer/shader/unaryop_pack4.comp
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making ncnn available.
 //
-// Copyright (C) 2018 THL A29 Limited, a Tencent company. All rights reserved.
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
 //
 // Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@ layout (local_size_x_id = 233) in;
 layout (local_size_y_id = 234) in;
 layout (local_size_z_id = 235) in;
 
-layout (binding = 0) buffer bottom_top_blob { float bottom_top_blob_data[]; };
+layout (binding = 0) buffer bottom_top_blob { vec4 bottom_top_blob_data[]; };
 
 layout (push_constant) uniform parameter
 {
@@ -42,9 +42,9 @@ void main()
 
     const int gi = gz * p.cstep + gy * p.w + gx;
 
-    float v = bottom_top_blob_data[gi];
+    vec4 v = bottom_top_blob_data[gi];
 
-    float res;
+    vec4 res;
 
     if (op_type == 0) res = abs(v);
     if (op_type == 1) res = -v;
@@ -52,7 +52,7 @@ void main()
     if (op_type == 3) res = ceil(v);
     if (op_type == 4) res = v * v;
     if (op_type == 5) res = sqrt(v);
-    if (op_type == 6) res = 1.f / sqrt(v);
+    if (op_type == 6) res = inversesqrt(v);
     if (op_type == 7) res = exp(v);
     if (op_type == 8) res = log(v);
     if (op_type == 9) res = sin(v);

--- a/src/layer/softmax.h
+++ b/src/layer/softmax.h
@@ -43,6 +43,11 @@ public:
     Pipeline* softmax_exp_sub_max;
     Pipeline* softmax_reduce_sum;
     Pipeline* softmax_div_sum;
+
+    Pipeline* softmax_reduce_max_pack4;
+    Pipeline* softmax_exp_sub_max_pack4;
+    Pipeline* softmax_reduce_sum_pack4;
+    Pipeline* softmax_div_sum_pack4;
 #endif // NCNN_VULKAN
 };
 

--- a/src/layer/unaryop.h
+++ b/src/layer/unaryop.h
@@ -30,6 +30,7 @@ public:
 
 #if NCNN_VULKAN
     virtual int create_pipeline();
+    virtual int destroy_pipeline();
 
     virtual int forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Option& opt) const;
 #endif // NCNN_VULKAN
@@ -56,6 +57,10 @@ public:
 public:
     // param
     int op_type;
+
+#if NCNN_VULKAN
+    Pipeline* pipeline_unaryop;
+#endif // NCNN_VULKAN
 };
 
 } // namespace ncnn

--- a/src/layer/unaryop.h
+++ b/src/layer/unaryop.h
@@ -60,6 +60,7 @@ public:
 
 #if NCNN_VULKAN
     Pipeline* pipeline_unaryop;
+    Pipeline* pipeline_unaryop_pack4;
 #endif // NCNN_VULKAN
 };
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -168,11 +168,7 @@ int Net::load_param(FILE* fp)
             continue;
         }
 
-#if NCNN_VULKAN
-        Layer* layer = use_vulkan_compute ? create_layer(layer_type, vkdev) : create_layer(layer_type);
-#else
         Layer* layer = create_layer(layer_type);
-#endif // NCNN_VULKAN
         if (!layer)
         {
             layer = create_custom_layer(layer_type);
@@ -183,6 +179,11 @@ int Net::load_param(FILE* fp)
             clear();
             return -1;
         }
+
+#if NCNN_VULKAN
+        if (use_vulkan_compute)
+            layer->vkdev = vkdev;
+#endif // NCNN_VULKAN
 
         layer->type = std::string(layer_type);
         layer->name = std::string(layer_name);
@@ -336,11 +337,7 @@ int Net::load_param_mem(const char* _mem)
             continue;
         }
 
-#if NCNN_VULKAN
-        Layer* layer = use_vulkan_compute ? create_layer(layer_type, vkdev) : create_layer(layer_type);
-#else
         Layer* layer = create_layer(layer_type);
-#endif // NCNN_VULKAN
         if (!layer)
         {
             layer = create_custom_layer(layer_type);
@@ -351,6 +348,11 @@ int Net::load_param_mem(const char* _mem)
             clear();
             return -1;
         }
+
+#if NCNN_VULKAN
+        if (use_vulkan_compute)
+            layer->vkdev = vkdev;
+#endif // NCNN_VULKAN
 
         layer->type = std::string(layer_type);
         layer->name = std::string(layer_name);
@@ -506,11 +508,7 @@ int Net::load_param_bin(FILE* fp)
         if (!readValue(top_count, fp))
             return -1;
 
-#if NCNN_VULKAN
-        Layer* layer = use_vulkan_compute ? create_layer(typeindex, vkdev) : create_layer(typeindex);
-#else
         Layer* layer = create_layer(typeindex);
-#endif // NCNN_VULKAN
         if (!layer)
         {
             int custom_index = typeindex & ~LayerType::CustomBit;
@@ -522,6 +520,11 @@ int Net::load_param_bin(FILE* fp)
             clear();
             return -1;
         }
+
+#if NCNN_VULKAN
+        if (use_vulkan_compute)
+            layer->vkdev = vkdev;
+#endif // NCNN_VULKAN
 
 //         layer->type = std::string(layer_type);
 //         layer->name = std::string(layer_name);
@@ -887,6 +890,10 @@ void Net::clear()
     blobs.clear();
     for (size_t i=0; i<layers.size(); i++)
     {
+#if NCNN_VULKAN
+        layers[i]->destroy_pipeline();
+#endif // NCNN_VULKAN
+
         delete layers[i];
     }
     layers.clear();


### PR DESCRIPTION
optimize basic CNN layers using vec4 native type

shader
- [x] batchnorm
- [x] binaryop
- [x] convolution
- [x] convolutiondepthwise
- [x] dropout
- [x] eltwise
- [x] innerproduct
- [x] padding
- [x] pooling
- [x] pooling_global
- [x] relu
- [x] scale
- [x] softmax family
- [x] unaryop

glue code
- [x] batchnorm
- [x] binaryop
- [x] convolution
- [x] convolutiondepthwise
- [x] dropout
- [x] eltwise
- [x] innerproduct
- [x] padding
- [x] pooling
- [x] pooling_global
- [x] relu
- [x] scale
- [x] softmax family
- [x] unaryop

