### PR TITLE
Enhance upsample scale value retrieval with raw_data API

### DIFF
--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -1472,8 +1472,15 @@ int main(int argc, char** argv)
             else
             {
                 const onnx::TensorProto& scales_tp = weights[node.input(1)];
-                const float* shape_data = scales_tp.float_data().data();
-                for (int j=0; j<scales_tp.float_data_size(); j++)
+                const float* shape_data = scales_tp.has_raw_data() ? (const float*)scales_tp.raw_data().data() : scales_tp.float_data().data();
+                
+                int float_data_size = scales_tp.float_data_size();
+                //float data is None, use raw data instead
+                if (float_data_size == 0) {
+                    float_data_size = scales_tp.dims().Get(0);
+                }
+
+                for (int j=0; j<float_data_size; j++)
                 {
                     scales.push_back(shape_data[j]);
                 }


### PR DESCRIPTION
Enhance upsample scale value retrieval with raw_data API, otherwise we may meet following error:
```bash
gemfield@ThinkPad-X1C:~/github/ncnn/build$ tools/onnx/onnx2ncnn ~/gemfieldlast1.0.onnx 
Unsupported Upsample scales !
Unsupported Upsample scales !
Unsupported Upsample scales !
Unsupported Upsample scales !
Unsupported Upsample scales !
Unsupported Upsample scales !
Unsupported Upsample scales !
Unsupported Upsample scales !
```
Onnx proto use raw data in this situation, so the return value of float_data() is None.