### PR TITLE
Add upsample linear mode

### DIFF
--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -1601,7 +1601,7 @@ int main(int argc, char** argv)
             {
                 resize_type = 1;
             }
-            else if (mode == "bilinear")
+            else if (mode == "bilinear" || mode == "linear")
             {
                 resize_type = 2;
             }


### PR DESCRIPTION
ONNX may use str "linear" in upsample mode:
```json
  node {
    input: "743"
    input: "744"
    output: "gemfieldout"
    op_type: "Upsample"
    attribute {
      name: "mode"
      s: "linear"
      type: STRING
    }
  }
```
According to onnx doc:
```
Two interpolation modes: nearest (default), and linear (including bilinear, trilinear, etc)
```
ncnn will fallback to "nearest" in this situation, and after this enhancement, ncnn will fallback to "bilinear" instead, which is more accurate.