### PR TITLE
Fix crash issue during load_model

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -633,6 +633,13 @@ int Net::load_model(FILE* fp)
     for (size_t i=0; i<layers.size(); i++)
     {
         Layer* layer = layers[i];
+        
+        //Here we found inconsistent content in the parameter file.
+        if (!layer){
+            fprintf(stderr, "load_model error at layer %d, parameter file has inconsistent content.\n", (int)i);
+            ret = -1;
+            break;
+        }
 
         int lret = layer->load_model(mb);
         if (lret != 0)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -830,6 +830,12 @@ int Net::load_model(const unsigned char* _mem)
     {
         Layer* layer = layers[i];
 
+        //Here we found inconsistent content in the parameter file.
+        if (!layer){
+            fprintf(stderr, "load_model error at layer %d, parameter file has inconsistent content.\n", (int)i);
+            return -1;
+        }
+
         int lret = layer->load_model(mb);
         if (lret != 0)
         {


### PR DESCRIPTION
Sometimes, convert tool may introduce inconsistent to ncnn.param file . For example, lay_count is 394 while only 393 layer followed. In this situation, calling load_model API will crash the runtime program. 