### PR TITLE
eliminate the warning msg when compile the onnx2ncnn

### DIFF
--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -567,13 +567,13 @@ int main(int argc, char** argv)
 
 //             fprintf(stderr, "  input = %s\n", input_name.c_str());
         }
-
+        /*
         for (int j=0; j<(int)node.output_size(); j++)
         {
             const std::string& output_name = node.output(j);
-
-//             fprintf(stderr, "  output = %s\n", output_name.c_str());
-        }
+            fprintf(stderr, "  output = %s\n", output_name.c_str());
+        } 
+        */
 
         if (op == "Abs")
         {
@@ -1650,7 +1650,7 @@ int main(int argc, char** argv)
                 }
                 else if (attr.type() == 2)
                 {
-                    fprintf(stderr, "  # %s=%d\n", attr.name().c_str(), attr.i());
+                    fprintf(stderr, "  # %s=%ld\n", attr.name().c_str(), attr.i());
                 }
                 else if (attr.type() == 3)
                 {


### PR DESCRIPTION
When compile the onnx2ncnn tool, following warning msg may occur:
```bash
gemfield@ThinkPad-X1C:~/github/ncnn/build$ make
[  0%] Built target generate-spirv
Scanning dependencies of target ncnn
[  1%] Building CXX object src/CMakeFiles/ncnn.dir/net.cpp.o
[  2%] Linking CXX static library libncnn.a
[ 84%] Built target ncnn
[ 85%] Linking CXX executable benchncnn
[ 86%] Built target benchncnn
[ 87%] Linking CXX executable ncnn2mem
[ 88%] Built target ncnn2mem
[ 93%] Built target caffe2ncnn
[ 95%] Built target mxnet2ncnn
Scanning dependencies of target onnx2ncnn
[ 96%] Building CXX object tools/onnx/CMakeFiles/onnx2ncnn.dir/onnx2ncnn.cpp.o
/home/gemfield/github/ncnn/tools/onnx/onnx2ncnn.cpp: In function ‘int main(int, char**)’:
/home/gemfield/github/ncnn/tools/onnx/onnx2ncnn.cpp:573:32: warning: unused variable ‘output_name’ [-Wunused-variable]
             const std::string& output_name = node.output(j);
                                ^~~~~~~~~~~
/home/gemfield/github/ncnn/tools/onnx/onnx2ncnn.cpp:1653:81: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘google::protobuf::int64 {aka long int}’ [-Wformat=]
                     fprintf(stderr, "  # %s=%d\n", attr.name().c_str(), attr.i());
                                                                         ~~~~~~~~^
[ 97%] Linking CXX executable onnx2ncnn
[100%] Built target onnx2ncnn
```
This fix will eliminate these warning msg during compiling.