### PR TITLE
Fix ncnn2mem crash issue

### DIFF
--- a/tools/ncnn2mem.cpp
+++ b/tools/ncnn2mem.cpp
@@ -78,6 +78,11 @@ static int dump_param(const char* parampath, const char* parambinpath, const cha
 {
     FILE* fp = fopen(parampath, "rb");
 
+    if (!fp){
+        fprintf(stderr, "fopen %s failed\n", parampath);
+        return -1;
+    }
+
     FILE* mp = fopen(parambinpath, "wb");
     FILE* ip = fopen(idcpppath, "wb");
 
@@ -251,6 +256,11 @@ static int write_memcpp(const char* parambinpath, const char* modelpath, const c
 
     FILE* mp = fopen(parambinpath, "rb");
 
+    if (!mp){
+        fprintf(stderr, "fopen %s failed\n", parambinpath);
+        return -1;
+    }
+
     fprintf(cppfp, "#ifndef NCNN_INCLUDE_GUARD_%s\n", include_guard_var.c_str());
     fprintf(cppfp, "#define NCNN_INCLUDE_GUARD_%s\n", include_guard_var.c_str());
 
@@ -280,6 +290,11 @@ static int write_memcpp(const char* parambinpath, const char* modelpath, const c
     std::string model_var = path_to_varname(modelpath);
 
     FILE* bp = fopen(modelpath, "rb");
+
+    if (!bp){
+        fprintf(stderr, "fopen %s failed\n", modelpath);
+        return -1;
+    }
 
     fprintf(cppfp, "\n#ifdef _MSC_VER\n__declspec(align(4))\n#else\n__attribute__((aligned(4)))\n#endif\n");
     fprintf(cppfp, "static const unsigned char %s[] = {\n", model_var.c_str());


### PR DESCRIPTION
Currently ncnn2mem has no defense to the missing input file, which may cause crash issue:
```bash
gemfield@ThinkPad-X1C:~/github/ncnn/build/tools$ gdb ncnn2mem core
......
Core was generated by `./ncnn2mem gemfield.param gemfield.bin gemfield.id.h gemfield.mem.h'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  _IO_feof (fp=0x0) at feof.c:35
35      feof.c: No such file or directory.
(gdb) bt
#0  _IO_feof (fp=0x0) at feof.c:35
#1  0x0000000000403720 in main ()
```
This fix will add the defense.