### PR TITLE
fix NaN(var maybe minus due to accuracy sometimes) issue in InstanceNorm

### DIFF
--- a/src/layer/instancenorm.cpp
+++ b/src/layer/instancenorm.cpp
@@ -65,15 +65,23 @@ int InstanceNorm::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
         for (int i=0; i<size; i++)
         {
             sum += ptr[i];
-            sqsum += ptr[i] * ptr[i];
+            //sqsum += ptr[i] * ptr[i];
         }
         float mean = sum / size;
-        float var = sqsum / size - mean * mean;
+        float tmp = 0.f;
+        for (int i=0; i<size; i++)
+        {
+            tmp = ptr[i] - mean;
+            sqsum += tmp * tmp;
+        }
+        float var = sqsum / size;
+        // the var maybe minus due to accuracy
+        //float var = sqsum / size - mean * mean;
 
         float gamma = gamma_data[q];
         float beta = beta_data[q];
 
-        float a = gamma / (sqrt(var) + eps);
+        float a = gamma / (sqrt(var + eps));
         float b = - mean * a + beta;
 
         for (int i=0; i<size; i++)


### PR DESCRIPTION
The 'var' maybe minus due to float accuracy sometimes.
 I modify the process according the source code of MXNET.

the test code:
```
float sum = 0.f;
float sqsum = 0.f;
float tmp = -2.77808977674856981365843268e-19;
for (int i=0; i<3136; i++)
{
    sum += tmp;
    sqsum += tmp * tmp;
}
float mean = sum / size;
float var = sqsum / size - mean * mean;
cout << "var = " << var << ", mean = " << mean << endl;
```
test the code above on pc, the result: var = -2.7017e-42, mean = -2.77816e-19
