### PR TITLE
Add CPU, GPU benchmark of Qualcomm Snapdragon 835

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -81,6 +81,122 @@ gpu_device = -1
     mobilenet-yolov3  min =  164.52  max =  182.49  avg =  174.72
 ```
 
+Qualcomm MSM8998 Snapdragon 835 (Kyro 2.45GHz x 4 + Kyro 1.9GHz x 4)
+
+```shell
+chiron:/data/local/tmp/ncnn $ ./benchncnn 8 4 2
+loop_count = 8                                                   
+num_threads = 4                                                  
+powersave = 2                                                    
+gpu_device = -1                                                  
+          squeezenet  min =   65.27  max =   66.26  avg =   65.88                                                                           
+     squeezenet-int8  min =   49.28  max =   49.97  avg =   49.65                                                     
+           mobilenet  min =  112.08  max =  114.48  avg =  113.08                                                    
+      mobilenet-int8  min =   85.81  max =   87.38  avg =   86.27                                                         
+        mobilenet_v2  min =   82.68  max =   85.76  avg =   83.70                                           
+          shufflenet  min =   35.30  max =   35.98  avg =   35.69
+             mnasnet  min =   73.79  max =   75.71  avg =   74.64
+     proxylessnasnet  min =   86.91  max =   88.23  avg =   87.53
+           googlenet  min =  268.29  max =  271.47  avg =  269.84
+      googlenet-int8  min =  195.26  max =  196.51  avg =  195.76
+            resnet18  min =  239.90  max =  242.86  avg =  241.71
+       resnet18-int8  min =  156.40  max =  158.20  avg =  157.25
+             alexnet  min =  371.74  max =  373.92  avg =  372.68
+               vgg16  min = 1328.42  max = 1332.51  avg = 1330.63
+            resnet50  min = 1133.19  max = 1142.07  avg = 1136.81
+       resnet50-int8  min =  389.55  max =  394.21  avg =  391.63
+      squeezenet-ssd  min =  147.25  max =  149.50  avg =  148.61
+ squeezenet-ssd-int8  min =  121.94  max =  124.15  avg =  123.03
+       mobilenet-ssd  min =  224.45  max =  227.93  avg =  226.53
+  mobilenet-ssd-int8  min =  173.62  max =  176.98  avg =  174.91
+      mobilenet-yolo  min =  531.38  max =  547.12  avg =  539.23
+    mobilenet-yolov3  min =  517.41  max =  531.32  avg =  522.69
+
+chiron:/data/local/tmp/ncnn $ ./benchncnn 8 1 2
+loop_count = 8                                                                                                                
+num_threads = 1
+powersave = 2
+gpu_device = -1
+          squeezenet  min =   65.12  max =   66.86  avg =   66.00
+     squeezenet-int8  min =   48.97  max =   49.54  avg =   49.27
+           mobilenet  min =  111.55  max =  112.73  avg =  111.99
+      mobilenet-int8  min =   85.71  max =   88.36  avg =   86.65
+        mobilenet_v2  min =   80.73  max =   81.90  avg =   81.17
+          shufflenet  min =   34.92  max =   35.93  avg =   35.49
+             mnasnet  min =   73.25  max =   75.38  avg =   73.92
+     proxylessnasnet  min =   85.13  max =   86.21  avg =   85.60
+           googlenet  min =  270.40  max =  272.73  avg =  271.72
+      googlenet-int8  min =  195.78  max =  196.62  avg =  196.22
+            resnet18  min =  239.18  max =  241.32  avg =  239.89
+       resnet18-int8  min =  157.11  max =  158.92  avg =  157.92
+             alexnet  min =  371.06  max =  372.05  avg =  371.62
+               vgg16  min = 1331.08  max = 1333.58  avg = 1332.19
+            resnet50  min = 1123.01  max = 1127.04  avg = 1125.54
+       resnet50-int8  min =  391.26  max =  394.80  avg =  392.04
+      squeezenet-ssd  min =  148.16  max =  149.86  avg =  148.95
+ squeezenet-ssd-int8  min =  120.99  max =  123.27  avg =  121.98
+       mobilenet-ssd  min =  224.85  max =  229.22  avg =  226.98
+  mobilenet-ssd-int8  min =  174.85  max =  176.97  avg =  175.54
+      mobilenet-yolo  min =  531.72  max =  539.70  avg =  535.78
+    mobilenet-yolov3  min =  521.13  max =  530.07  avg =  525.99
+
+chiron:/data/local/tmp/ncnn $ ./benchncnn 8 4 1
+loop_count = 8                                                                                                                 
+num_threads = 4
+powersave = 1
+gpu_device = -1
+          squeezenet  min =  133.09  max =  137.01  avg =  134.68
+     squeezenet-int8  min =  121.84  max =  127.75  avg =  124.90
+           mobilenet  min =  184.89  max =  188.13  avg =  186.10
+      mobilenet-int8  min =  212.83  max =  221.24  avg =  215.76
+        mobilenet_v2  min =  164.30  max =  166.67  avg =  165.42
+          shufflenet  min =   79.81  max =   82.43  avg =   81.63
+             mnasnet  min =  140.28  max =  141.62  avg =  140.66
+     proxylessnasnet  min =  166.34  max =  169.82  avg =  167.73
+           googlenet  min =  527.60  max =  531.85  avg =  530.27
+      googlenet-int8  min =  457.37  max =  466.83  avg =  461.72
+            resnet18  min =  509.07  max =  523.23  avg =  518.65
+       resnet18-int8  min =  425.97  max =  431.27  avg =  428.72
+             alexnet  min =  602.90  max =  607.35  avg =  605.37
+               vgg16  min = 2582.28  max = 2586.84  avg = 2584.57
+            resnet50  min = 2212.14  max = 2254.06  avg = 2235.96
+       resnet50-int8  min =  953.75  max =  962.85  avg =  958.71
+      squeezenet-ssd  min =  325.27  max =  328.12  avg =  326.76
+ squeezenet-ssd-int8  min =  325.17  max =  330.14  avg =  327.33
+       mobilenet-ssd  min =  387.46  max =  392.53  avg =  390.53
+  mobilenet-ssd-int8  min =  420.80  max =  432.58  avg =  425.32
+      mobilenet-yolo  min =  914.54  max =  917.58  avg =  916.17
+    mobilenet-yolov3  min =  890.64  max =  899.53  avg =  894.33
+
+chiron:/data/local/tmp/ncnn $ ./benchncnn 8 4 1
+loop_count = 8
+num_threads = 1
+powersave = 1
+gpu_device = -1
+          squeezenet  min =  133.69  max =  136.25  avg =  135.23
+     squeezenet-int8  min =  121.91  max =  127.30  avg =  123.87
+           mobilenet  min =  185.80  max =  187.75  avg =  186.47
+      mobilenet-int8  min =  212.57  max =  221.60  avg =  217.44
+        mobilenet_v2  min =  165.16  max =  166.66  avg =  165.56
+          shufflenet  min =   80.51  max =   82.45  avg =   81.97
+             mnasnet  min =  140.55  max =  141.01  avg =  140.73
+     proxylessnasnet  min =  165.80  max =  167.46  avg =  166.54
+           googlenet  min =  518.66  max =  521.32  avg =  520.14
+      googlenet-int8  min =  458.02  max =  460.91  avg =  459.62
+            resnet18  min =  509.60  max =  517.68  avg =  513.08
+       resnet18-int8  min =  424.82  max =  432.92  avg =  429.42
+             alexnet  min =  603.25  max =  609.40  avg =  607.35
+               vgg16  min = 2584.60  max = 2596.92  avg = 2588.16
+            resnet50  min = 2233.94  max = 2298.26  avg = 2264.29
+       resnet50-int8  min =  960.52  max =  967.26  avg =  963.40
+      squeezenet-ssd  min =  326.37  max =  328.98  avg =  327.39
+ squeezenet-ssd-int8  min =  329.80  max =  336.15  avg =  332.04
+       mobilenet-ssd  min =  392.81  max =  400.24  avg =  396.08
+  mobilenet-ssd-int8  min =  419.71  max =  426.52  avg =  423.30
+      mobilenet-yolo  min =  917.36  max =  922.24  avg =  919.42
+    mobilenet-yolov3  min =  890.79  max =  906.92  avg =  895.84
+```
+
 Qualcomm MSM8996 Snapdragon 820 (Kyro 2.15GHz x 2 + Kyro 1.6GHz x 2)
 ```
 root@msm8996:/data/local/tmp/ncnn # ./benchncnn 8 4 0

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -88,113 +88,113 @@ chiron:/data/local/tmp/ncnn $ ./benchncnn 8 4 2
 loop_count = 8                                                   
 num_threads = 4                                                  
 powersave = 2                                                    
-gpu_device = -1                                                  
-          squeezenet  min =   65.27  max =   66.26  avg =   65.88                                                                           
-     squeezenet-int8  min =   49.28  max =   49.97  avg =   49.65                                                     
-           mobilenet  min =  112.08  max =  114.48  avg =  113.08                                                    
-      mobilenet-int8  min =   85.81  max =   87.38  avg =   86.27                                                         
-        mobilenet_v2  min =   82.68  max =   85.76  avg =   83.70                                           
-          shufflenet  min =   35.30  max =   35.98  avg =   35.69
-             mnasnet  min =   73.79  max =   75.71  avg =   74.64
-     proxylessnasnet  min =   86.91  max =   88.23  avg =   87.53
-           googlenet  min =  268.29  max =  271.47  avg =  269.84
-      googlenet-int8  min =  195.26  max =  196.51  avg =  195.76
-            resnet18  min =  239.90  max =  242.86  avg =  241.71
-       resnet18-int8  min =  156.40  max =  158.20  avg =  157.25
-             alexnet  min =  371.74  max =  373.92  avg =  372.68
-               vgg16  min = 1328.42  max = 1332.51  avg = 1330.63
-            resnet50  min = 1133.19  max = 1142.07  avg = 1136.81
-       resnet50-int8  min =  389.55  max =  394.21  avg =  391.63
-      squeezenet-ssd  min =  147.25  max =  149.50  avg =  148.61
- squeezenet-ssd-int8  min =  121.94  max =  124.15  avg =  123.03
-       mobilenet-ssd  min =  224.45  max =  227.93  avg =  226.53
-  mobilenet-ssd-int8  min =  173.62  max =  176.98  avg =  174.91
-      mobilenet-yolo  min =  531.38  max =  547.12  avg =  539.23
-    mobilenet-yolov3  min =  517.41  max =  531.32  avg =  522.69
+gpu_device = -1                                            
+          squeezenet  min =   65.94  max =   67.21  avg =   66.45
+     squeezenet-int8  min =   48.98  max =   49.86  avg =   49.43
+           mobilenet  min =  111.67  max =  113.43  avg =  112.56
+      mobilenet-int8  min =   85.64  max =   87.90  avg =   86.34
+        mobilenet_v2  min =   80.65  max =   82.71  avg =   81.61
+          shufflenet  min =   35.74  max =   36.21  avg =   35.97
+             mnasnet  min =   73.00  max =   73.72  avg =   73.26
+     proxylessnasnet  min =   84.94  max =   86.00  avg =   85.53
+           googlenet  min =  271.56  max =  273.25  avg =  272.35
+      googlenet-int8  min =  196.39  max =  196.87  avg =  196.72
+            resnet18  min =  240.00  max =  242.66  avg =  241.56
+       resnet18-int8  min =  157.31  max =  162.83  avg =  159.48
+             alexnet  min =  371.29  max =  373.70  avg =  372.16
+               vgg16  min = 1334.23  max = 1341.28  avg = 1336.78
+            resnet50  min = 1123.25  max = 1135.48  avg = 1128.16
+       resnet50-int8  min =  391.42  max =  394.31  avg =  393.12
+      squeezenet-ssd  min =  148.35  max =  149.79  avg =  148.99
+ squeezenet-ssd-int8  min =  121.79  max =  123.74  avg =  122.48
+       mobilenet-ssd  min =  225.88  max =  229.36  avg =  226.80
+  mobilenet-ssd-int8  min =  174.10  max =  176.13  avg =  174.77
+      mobilenet-yolo  min =  529.33  max =  542.65  avg =  535.95
+    mobilenet-yolov3  min =  518.32  max =  532.25  avg =  527.50
 
 chiron:/data/local/tmp/ncnn $ ./benchncnn 8 1 2
 loop_count = 8                                                                                                                
 num_threads = 1
 powersave = 2
 gpu_device = -1
-          squeezenet  min =   65.12  max =   66.86  avg =   66.00
-     squeezenet-int8  min =   48.97  max =   49.54  avg =   49.27
-           mobilenet  min =  111.55  max =  112.73  avg =  111.99
-      mobilenet-int8  min =   85.71  max =   88.36  avg =   86.65
-        mobilenet_v2  min =   80.73  max =   81.90  avg =   81.17
-          shufflenet  min =   34.92  max =   35.93  avg =   35.49
-             mnasnet  min =   73.25  max =   75.38  avg =   73.92
-     proxylessnasnet  min =   85.13  max =   86.21  avg =   85.60
-           googlenet  min =  270.40  max =  272.73  avg =  271.72
-      googlenet-int8  min =  195.78  max =  196.62  avg =  196.22
-            resnet18  min =  239.18  max =  241.32  avg =  239.89
-       resnet18-int8  min =  157.11  max =  158.92  avg =  157.92
-             alexnet  min =  371.06  max =  372.05  avg =  371.62
-               vgg16  min = 1331.08  max = 1333.58  avg = 1332.19
-            resnet50  min = 1123.01  max = 1127.04  avg = 1125.54
-       resnet50-int8  min =  391.26  max =  394.80  avg =  392.04
-      squeezenet-ssd  min =  148.16  max =  149.86  avg =  148.95
- squeezenet-ssd-int8  min =  120.99  max =  123.27  avg =  121.98
-       mobilenet-ssd  min =  224.85  max =  229.22  avg =  226.98
-  mobilenet-ssd-int8  min =  174.85  max =  176.97  avg =  175.54
-      mobilenet-yolo  min =  531.72  max =  539.70  avg =  535.78
-    mobilenet-yolov3  min =  521.13  max =  530.07  avg =  525.99
-
+          squeezenet  min =   65.24  max =   66.49  avg =   65.81
+     squeezenet-int8  min =   48.86  max =   50.01  avg =   49.38
+           mobilenet  min =  111.69  max =  113.35  avg =  112.70
+      mobilenet-int8  min =   85.85  max =   87.54  avg =   86.50
+        mobilenet_v2  min =   82.39  max =   83.72  avg =   83.14
+          shufflenet  min =   35.17  max =   35.94  avg =   35.60
+             mnasnet  min =   74.53  max =   76.39  avg =   74.95
+     proxylessnasnet  min =   86.70  max =   87.88  avg =   87.38
+           googlenet  min =  270.46  max =  271.62  avg =  270.95
+      googlenet-int8  min =  195.48  max =  196.68  avg =  195.78
+            resnet18  min =  238.77  max =  240.24  avg =  239.51
+       resnet18-int8  min =  157.01  max =  158.65  avg =  157.99
+             alexnet  min =  371.29  max =  373.62  avg =  371.94
+               vgg16  min = 1333.04  max = 1337.15  avg = 1334.98
+            resnet50  min = 1122.75  max = 1128.38  avg = 1124.76
+       resnet50-int8  min =  391.01  max =  394.48  avg =  392.56
+      squeezenet-ssd  min =  148.50  max =  150.05  avg =  149.06
+ squeezenet-ssd-int8  min =  119.68  max =  122.65  avg =  121.17
+       mobilenet-ssd  min =  224.59  max =  228.75  avg =  226.74
+  mobilenet-ssd-int8  min =  174.05  max =  176.43  avg =  175.09
+      mobilenet-yolo  min =  538.96  max =  552.49  avg =  544.25
+    mobilenet-yolov3  min =  519.88  max =  529.00  avg =  525.78
+            
 chiron:/data/local/tmp/ncnn $ ./benchncnn 8 4 1
 loop_count = 8                                                                                                                 
 num_threads = 4
 powersave = 1
 gpu_device = -1
-          squeezenet  min =  133.09  max =  137.01  avg =  134.68
-     squeezenet-int8  min =  121.84  max =  127.75  avg =  124.90
-           mobilenet  min =  184.89  max =  188.13  avg =  186.10
-      mobilenet-int8  min =  212.83  max =  221.24  avg =  215.76
-        mobilenet_v2  min =  164.30  max =  166.67  avg =  165.42
-          shufflenet  min =   79.81  max =   82.43  avg =   81.63
-             mnasnet  min =  140.28  max =  141.62  avg =  140.66
-     proxylessnasnet  min =  166.34  max =  169.82  avg =  167.73
-           googlenet  min =  527.60  max =  531.85  avg =  530.27
-      googlenet-int8  min =  457.37  max =  466.83  avg =  461.72
-            resnet18  min =  509.07  max =  523.23  avg =  518.65
-       resnet18-int8  min =  425.97  max =  431.27  avg =  428.72
-             alexnet  min =  602.90  max =  607.35  avg =  605.37
-               vgg16  min = 2582.28  max = 2586.84  avg = 2584.57
-            resnet50  min = 2212.14  max = 2254.06  avg = 2235.96
-       resnet50-int8  min =  953.75  max =  962.85  avg =  958.71
-      squeezenet-ssd  min =  325.27  max =  328.12  avg =  326.76
- squeezenet-ssd-int8  min =  325.17  max =  330.14  avg =  327.33
-       mobilenet-ssd  min =  387.46  max =  392.53  avg =  390.53
-  mobilenet-ssd-int8  min =  420.80  max =  432.58  avg =  425.32
-      mobilenet-yolo  min =  914.54  max =  917.58  avg =  916.17
-    mobilenet-yolov3  min =  890.64  max =  899.53  avg =  894.33
+          squeezenet  min =  135.31  max =  136.54  avg =  135.75
+     squeezenet-int8  min =  122.45  max =  127.51  avg =  124.96
+           mobilenet  min =  186.20  max =  188.43  avg =  187.00
+      mobilenet-int8  min =  210.57  max =  216.30  avg =  213.34
+        mobilenet_v2  min =  165.81  max =  167.78  avg =  166.98
+          shufflenet  min =   80.39  max =   82.65  avg =   81.90
+             mnasnet  min =  140.51  max =  141.42  avg =  140.84
+     proxylessnasnet  min =  167.03  max =  168.36  avg =  167.88
+           googlenet  min =  527.51  max =  532.99  avg =  529.69
+      googlenet-int8  min =  458.53  max =  466.34  avg =  461.44
+            resnet18  min =  517.85  max =  522.66  avg =  520.47
+       resnet18-int8  min =  425.12  max =  430.51  avg =  428.47
+             alexnet  min =  604.40  max =  610.09  avg =  607.98
+               vgg16  min = 2603.45  max = 2622.63  avg = 2609.04
+            resnet50  min = 2270.84  max = 2317.89  avg = 2297.23
+       resnet50-int8  min =  958.39  max =  969.29  avg =  963.67
+      squeezenet-ssd  min =  327.39  max =  329.83  avg =  328.13
+ squeezenet-ssd-int8  min =  332.56  max =  334.99  avg =  334.26
+       mobilenet-ssd  min =  392.91  max =  396.02  avg =  394.19
+  mobilenet-ssd-int8  min =  420.02  max =  431.07  avg =  425.94
+      mobilenet-yolo  min =  919.09  max =  924.17  avg =  921.23
+    mobilenet-yolov3  min =  894.44  max =  899.94  avg =  897.71
 
-chiron:/data/local/tmp/ncnn $ ./benchncnn 8 4 1
+chiron:/data/local/tmp/ncnn $ ./benchncnn 8 1 1
 loop_count = 8
 num_threads = 1
 powersave = 1
 gpu_device = -1
-          squeezenet  min =  133.69  max =  136.25  avg =  135.23
-     squeezenet-int8  min =  121.91  max =  127.30  avg =  123.87
-           mobilenet  min =  185.80  max =  187.75  avg =  186.47
-      mobilenet-int8  min =  212.57  max =  221.60  avg =  217.44
-        mobilenet_v2  min =  165.16  max =  166.66  avg =  165.56
-          shufflenet  min =   80.51  max =   82.45  avg =   81.97
-             mnasnet  min =  140.55  max =  141.01  avg =  140.73
-     proxylessnasnet  min =  165.80  max =  167.46  avg =  166.54
-           googlenet  min =  518.66  max =  521.32  avg =  520.14
-      googlenet-int8  min =  458.02  max =  460.91  avg =  459.62
-            resnet18  min =  509.60  max =  517.68  avg =  513.08
-       resnet18-int8  min =  424.82  max =  432.92  avg =  429.42
-             alexnet  min =  603.25  max =  609.40  avg =  607.35
-               vgg16  min = 2584.60  max = 2596.92  avg = 2588.16
-            resnet50  min = 2233.94  max = 2298.26  avg = 2264.29
-       resnet50-int8  min =  960.52  max =  967.26  avg =  963.40
-      squeezenet-ssd  min =  326.37  max =  328.98  avg =  327.39
- squeezenet-ssd-int8  min =  329.80  max =  336.15  avg =  332.04
-       mobilenet-ssd  min =  392.81  max =  400.24  avg =  396.08
-  mobilenet-ssd-int8  min =  419.71  max =  426.52  avg =  423.30
-      mobilenet-yolo  min =  917.36  max =  922.24  avg =  919.42
-    mobilenet-yolov3  min =  890.79  max =  906.92  avg =  895.84
+          squeezenet  min =  134.92  max =  135.61  avg =  135.35
+     squeezenet-int8  min =  122.44  max =  127.64  avg =  125.03
+           mobilenet  min =  185.50  max =  190.17  avg =  187.28
+      mobilenet-int8  min =  210.99  max =  217.09  avg =  213.48
+        mobilenet_v2  min =  164.94  max =  166.15  avg =  165.34
+          shufflenet  min =   81.27  max =   82.90  avg =   82.11
+             mnasnet  min =  140.62  max =  142.05  avg =  141.00
+     proxylessnasnet  min =  164.84  max =  166.90  avg =  166.09
+           googlenet  min =  518.03  max =  524.79  avg =  520.41
+      googlenet-int8  min =  460.19  max =  470.69  avg =  465.11
+            resnet18  min =  519.78  max =  522.12  avg =  520.62
+       resnet18-int8  min =  426.46  max =  431.34  avg =  427.99
+             alexnet  min =  604.82  max =  609.51  avg =  606.60
+               vgg16  min = 2593.64  max = 2618.21  avg = 2605.11
+            resnet50  min = 2200.74  max = 2330.16  avg = 2271.50
+       resnet50-int8  min =  953.85  max =  962.52  avg =  958.78
+      squeezenet-ssd  min =  327.71  max =  329.92  avg =  328.68
+ squeezenet-ssd-int8  min =  326.55  max =  331.14  avg =  328.59
+       mobilenet-ssd  min =  388.36  max =  391.68  avg =  390.09
+  mobilenet-ssd-int8  min =  426.13  max =  432.57  avg =  428.40
+      mobilenet-yolo  min =  918.35  max =  922.32  avg =  920.61
+    mobilenet-yolov3  min =  892.86  max =  899.50  avg =  896.61
 ```
 
 Qualcomm MSM8996 Snapdragon 820 (Kyro 2.15GHz x 2 + Kyro 1.6GHz x 2)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -195,6 +195,34 @@ gpu_device = -1
   mobilenet-ssd-int8  min =  451.12  max =  462.66  avg =  454.15
       mobilenet-yolo  min =  922.58  max =  924.53  avg =  923.63
     mobilenet-yolov3  min =  897.05  max =  908.41  avg =  901.31
+    
+chiron:/data/local/tmp/ncnn $ ./benchncnn 8 1 1 0                
+[0 Adreno (TM) 540]  queueC=0  queueT=0  memU=2  memDL=2  memHV=2
+[0 Adreno (TM) 540]  fp16s=0  fp16a=0  int8s=0  int8a=0          
+loop_count = 8                                                   
+num_threads = 1                                                  
+powersave = 1           
+gpu_device = 0                                                   
+          squeezenet  min =   99.87  max =  100.37  avg =  100.18
+           mobilenet  min =  152.85  max =  154.95  avg =  153.70
+        mobilenet_v2  min =  105.75  max =  106.83  avg =  106.37
+          shufflenet  min =   51.94  max =   53.05  avg =   52.46
+             mnasnet  min =   93.11  max =   94.35  avg =   93.76
+     proxylessnasnet  min =   94.90  max =   99.87  avg =   98.62
+           googlenet  min =  400.21  max =  403.04  avg =  401.75
+            resnet18  min =  481.49  max =  487.42  avg =  485.33
+             alexnet  min =  610.22  max =  616.31  avg =  613.54
+###############################################################################
+# below models have problems with vkQueueSubmit and  vkWaitForFences failed ###
+###############################################################################
+vkQueueSubmit failed -3 
+vkWaitForFences failed 2
+               vgg16  min =    1.16  max =    1.51  avg =    1.37
+            resnet50  min =    5.75  max =    8.85  avg =    6.84
+      squeezenet-ssd  min =   18.65  max =   19.15  avg =   18.88
+       mobilenet-ssd  min =    7.05  max =    8.74  avg =    7.64
+      mobilenet-yolo  min =   11.29  max =   12.74  avg =   11.64
+    mobilenet-yolov3  min =    7.47  max =    9.95  avg =    8.25
 ```
 
 Qualcomm MSM8996 Snapdragon 820 (Kyro 2.15GHz x 2 + Kyro 1.6GHz x 2)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -195,34 +195,6 @@ gpu_device = -1
   mobilenet-ssd-int8  min =  451.12  max =  462.66  avg =  454.15
       mobilenet-yolo  min =  922.58  max =  924.53  avg =  923.63
     mobilenet-yolov3  min =  897.05  max =  908.41  avg =  901.31
-    
-chiron:/data/local/tmp/ncnn $ ./benchncnn 8 1 1 0
-loop_count = 8
-num_threads = 1
-powersave = 1
-gpu_device = 0
-          squeezenet  min =  132.37  max =  133.70  avg =  132.93
-     squeezenet-int8  min =  126.03  max =  131.91  avg =  130.04
-           mobilenet  min =  188.93  max =  191.73  avg =  189.56
-      mobilenet-int8  min =  234.09  max =  242.58  avg =  237.70
-        mobilenet_v2  min =  167.38  max =  168.70  avg =  168.11
-          shufflenet  min =   82.22  max =   85.10  avg =   83.98
-             mnasnet  min =  142.59  max =  143.46  avg =  143.00
-     proxylessnasnet  min =  173.17  max =  176.41  avg =  174.99
-           googlenet  min =  515.87  max =  527.00  avg =  519.25
-      googlenet-int8  min =  469.62  max =  478.21  avg =  472.05
-            resnet18  min =  514.43  max =  522.21  avg =  518.67
-       resnet18-int8  min =  430.92  max =  436.20  avg =  433.53
-             alexnet  min =  600.88  max =  604.74  avg =  603.00
-               vgg16  min = 2560.83  max = 2574.10  avg = 2568.22
-            resnet50  min = 2299.05  max = 2309.38  avg = 2301.75
-       resnet50-int8  min =  998.82  max = 1010.28  avg = 1002.70
-      squeezenet-ssd  min =  324.99  max =  326.99  avg =  325.90
- squeezenet-ssd-int8  min =  333.94  max =  343.45  avg =  337.99
-       mobilenet-ssd  min =  395.95  max =  402.56  avg =  397.69
-  mobilenet-ssd-int8  min =  448.18  max =  459.66  avg =  454.65
-      mobilenet-yolo  min =  923.50  max =  928.08  avg =  925.08
-    mobilenet-yolov3  min =  898.08  max =  904.30  avg =  900.84
 ```
 
 Qualcomm MSM8996 Snapdragon 820 (Kyro 2.15GHz x 2 + Kyro 1.6GHz x 2)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -89,112 +89,112 @@ loop_count = 8
 num_threads = 4                                                  
 powersave = 2                                                    
 gpu_device = -1                                            
-          squeezenet  min =   65.94  max =   67.21  avg =   66.45
-     squeezenet-int8  min =   48.98  max =   49.86  avg =   49.43
-           mobilenet  min =  111.67  max =  113.43  avg =  112.56
-      mobilenet-int8  min =   85.64  max =   87.90  avg =   86.34
-        mobilenet_v2  min =   80.65  max =   82.71  avg =   81.61
-          shufflenet  min =   35.74  max =   36.21  avg =   35.97
-             mnasnet  min =   73.00  max =   73.72  avg =   73.26
-     proxylessnasnet  min =   84.94  max =   86.00  avg =   85.53
-           googlenet  min =  271.56  max =  273.25  avg =  272.35
-      googlenet-int8  min =  196.39  max =  196.87  avg =  196.72
-            resnet18  min =  240.00  max =  242.66  avg =  241.56
-       resnet18-int8  min =  157.31  max =  162.83  avg =  159.48
-             alexnet  min =  371.29  max =  373.70  avg =  372.16
-               vgg16  min = 1334.23  max = 1341.28  avg = 1336.78
-            resnet50  min = 1123.25  max = 1135.48  avg = 1128.16
-       resnet50-int8  min =  391.42  max =  394.31  avg =  393.12
-      squeezenet-ssd  min =  148.35  max =  149.79  avg =  148.99
- squeezenet-ssd-int8  min =  121.79  max =  123.74  avg =  122.48
-       mobilenet-ssd  min =  225.88  max =  229.36  avg =  226.80
-  mobilenet-ssd-int8  min =  174.10  max =  176.13  avg =  174.77
-      mobilenet-yolo  min =  529.33  max =  542.65  avg =  535.95
-    mobilenet-yolov3  min =  518.32  max =  532.25  avg =  527.50
+          squeezenet  min =   38.51  max =   39.25  avg =   38.94
+     squeezenet-int8  min =   30.54  max =   31.11  avg =   30.80
+           mobilenet  min =   67.14  max =   68.90  avg =   68.00
+      mobilenet-int8  min =   27.85  max =   28.17  avg =   28.01
+        mobilenet_v2  min =   52.23  max =  251.20  avg =   77.76
+          shufflenet  min =   37.54  max =   38.52  avg =   37.99
+             mnasnet  min =   51.02  max =   51.70  avg =   51.37
+     proxylessnasnet  min =   29.59  max =   30.37  avg =   29.90
+           googlenet  min =   84.33  max =   84.84  avg =   84.56
+      googlenet-int8  min =  116.08  max =  116.58  avg =  116.37
+            resnet18  min =  136.64  max =  337.54  avg =  168.20
+       resnet18-int8  min =  113.72  max =  114.97  avg =  114.25
+             alexnet  min =  205.68  max =  358.51  avg =  234.93
+               vgg16  min =  709.03  max =  887.07  avg =  763.75
+            resnet50  min =  609.71  max =  840.24  avg =  688.00
+       resnet50-int8  min =  280.26  max =  479.41  avg =  306.38
+      squeezenet-ssd  min =  119.71  max =  122.11  avg =  120.90
+ squeezenet-ssd-int8  min =  103.92  max =  303.06  avg =  130.58
+       mobilenet-ssd  min =  141.68  max =  342.35  avg =  167.57
+  mobilenet-ssd-int8  min =  110.75  max =  114.24  avg =  111.66
+      mobilenet-yolo  min =  324.39  max =  523.89  avg =  375.21
+    mobilenet-yolov3  min =  167.07  max =  170.77  avg =  168.55
 
 chiron:/data/local/tmp/ncnn $ ./benchncnn 8 1 2
 loop_count = 8                                                                                                                
 num_threads = 1
 powersave = 2
 gpu_device = -1
-          squeezenet  min =   65.24  max =   66.49  avg =   65.81
-     squeezenet-int8  min =   48.86  max =   50.01  avg =   49.38
-           mobilenet  min =  111.69  max =  113.35  avg =  112.70
-      mobilenet-int8  min =   85.85  max =   87.54  avg =   86.50
-        mobilenet_v2  min =   82.39  max =   83.72  avg =   83.14
-          shufflenet  min =   35.17  max =   35.94  avg =   35.60
-             mnasnet  min =   74.53  max =   76.39  avg =   74.95
-     proxylessnasnet  min =   86.70  max =   87.88  avg =   87.38
-           googlenet  min =  270.46  max =  271.62  avg =  270.95
-      googlenet-int8  min =  195.48  max =  196.68  avg =  195.78
-            resnet18  min =  238.77  max =  240.24  avg =  239.51
-       resnet18-int8  min =  157.01  max =  158.65  avg =  157.99
-             alexnet  min =  371.29  max =  373.62  avg =  371.94
-               vgg16  min = 1333.04  max = 1337.15  avg = 1334.98
-            resnet50  min = 1122.75  max = 1128.38  avg = 1124.76
-       resnet50-int8  min =  391.01  max =  394.48  avg =  392.56
-      squeezenet-ssd  min =  148.50  max =  150.05  avg =  149.06
- squeezenet-ssd-int8  min =  119.68  max =  122.65  avg =  121.17
-       mobilenet-ssd  min =  224.59  max =  228.75  avg =  226.74
-  mobilenet-ssd-int8  min =  174.05  max =  176.43  avg =  175.09
-      mobilenet-yolo  min =  538.96  max =  552.49  avg =  544.25
-    mobilenet-yolov3  min =  519.88  max =  529.00  avg =  525.78
+          squeezenet  min =   65.12  max =   66.80  avg =   66.11
+     squeezenet-int8  min =   51.58  max =   52.14  avg =   51.75
+           mobilenet  min =  112.89  max =  114.90  avg =  113.68
+      mobilenet-int8  min =   92.25  max =   94.40  avg =   93.34
+        mobilenet_v2  min =   82.48  max =   83.63  avg =   82.94
+          shufflenet  min =   36.13  max =   36.97  avg =   36.52
+             mnasnet  min =   74.46  max =   75.34  avg =   74.87
+     proxylessnasnet  min =   88.85  max =   89.50  avg =   89.12
+           googlenet  min =  271.41  max =  274.74  avg =  273.31
+      googlenet-int8  min =  201.53  max =  203.06  avg =  202.23
+            resnet18  min =  237.97  max =  240.65  avg =  239.17
+       resnet18-int8  min =  159.75  max =  161.64  avg =  160.36
+             alexnet  min =  365.06  max =  366.67  avg =  365.91
+               vgg16  min = 1314.94  max = 1318.95  avg = 1316.50
+            resnet50  min = 1106.64  max = 1115.68  avg = 1110.61
+       resnet50-int8  min =  400.05  max =  405.72  avg =  402.34
+      squeezenet-ssd  min =  150.17  max =  151.11  avg =  150.61
+ squeezenet-ssd-int8  min =  124.49  max =  125.98  avg =  125.31
+       mobilenet-ssd  min =  228.97  max =  231.75  avg =  230.97
+  mobilenet-ssd-int8  min =  183.39  max =  185.90  avg =  184.85
+      mobilenet-yolo  min =  529.68  max =  540.27  avg =  534.55
+    mobilenet-yolov3  min =  522.93  max =  531.25  avg =  525.13
             
 chiron:/data/local/tmp/ncnn $ ./benchncnn 8 4 1
 loop_count = 8                                                                                                                 
 num_threads = 4
 powersave = 1
 gpu_device = -1
-          squeezenet  min =  135.31  max =  136.54  avg =  135.75
-     squeezenet-int8  min =  122.45  max =  127.51  avg =  124.96
-           mobilenet  min =  186.20  max =  188.43  avg =  187.00
-      mobilenet-int8  min =  210.57  max =  216.30  avg =  213.34
-        mobilenet_v2  min =  165.81  max =  167.78  avg =  166.98
-          shufflenet  min =   80.39  max =   82.65  avg =   81.90
-             mnasnet  min =  140.51  max =  141.42  avg =  140.84
-     proxylessnasnet  min =  167.03  max =  168.36  avg =  167.88
-           googlenet  min =  527.51  max =  532.99  avg =  529.69
-      googlenet-int8  min =  458.53  max =  466.34  avg =  461.44
-            resnet18  min =  517.85  max =  522.66  avg =  520.47
-       resnet18-int8  min =  425.12  max =  430.51  avg =  428.47
-             alexnet  min =  604.40  max =  610.09  avg =  607.98
-               vgg16  min = 2603.45  max = 2622.63  avg = 2609.04
-            resnet50  min = 2270.84  max = 2317.89  avg = 2297.23
-       resnet50-int8  min =  958.39  max =  969.29  avg =  963.67
-      squeezenet-ssd  min =  327.39  max =  329.83  avg =  328.13
- squeezenet-ssd-int8  min =  332.56  max =  334.99  avg =  334.26
-       mobilenet-ssd  min =  392.91  max =  396.02  avg =  394.19
-  mobilenet-ssd-int8  min =  420.02  max =  431.07  avg =  425.94
-      mobilenet-yolo  min =  919.09  max =  924.17  avg =  921.23
-    mobilenet-yolov3  min =  894.44  max =  899.94  avg =  897.71
+          squeezenet  min =   40.29  max =   40.66  avg =   40.46
+     squeezenet-int8  min =   40.61  max =   50.62  avg =   42.08
+           mobilenet  min =   50.78  max =   51.42  avg =   51.00
+      mobilenet-int8  min =   62.09  max =   62.55  avg =   62.32
+        mobilenet_v2  min =   52.83  max =   53.13  avg =   52.93
+          shufflenet  min =   29.74  max =   29.97  avg =   29.84
+             mnasnet  min =   43.11  max =   43.62  avg =   43.37
+     proxylessnasnet  min =   50.32  max =   50.73  avg =   50.47
+           googlenet  min =  140.51  max =  141.20  avg =  140.90
+      googlenet-int8  min =  140.47  max =  140.91  avg =  140.67
+            resnet18  min =  141.60  max =  144.12  avg =  142.42
+       resnet18-int8  min =  130.68  max =  131.50  avg =  130.95
+             alexnet  min =  151.18  max =  153.49  avg =  152.28
+               vgg16  min =  674.35  max =  696.00  avg =  682.37
+            resnet50  min =  575.88  max =  584.70  avg =  580.19
+       resnet50-int8  min =  297.85  max =  298.65  avg =  298.18
+      squeezenet-ssd  min =  106.52  max =  108.75  avg =  107.35
+ squeezenet-ssd-int8  min =  119.45  max =  121.27  avg =  120.03
+       mobilenet-ssd  min =  109.81  max =  114.22  avg =  110.72
+  mobilenet-ssd-int8  min =  118.19  max =  119.55  avg =  118.65
+      mobilenet-yolo  min =  266.90  max =  268.14  avg =  267.51
+    mobilenet-yolov3  min =  245.19  max =  247.02  avg =  245.71
 
 chiron:/data/local/tmp/ncnn $ ./benchncnn 8 1 1
 loop_count = 8
 num_threads = 1
 powersave = 1
 gpu_device = -1
-          squeezenet  min =  134.92  max =  135.61  avg =  135.35
-     squeezenet-int8  min =  122.44  max =  127.64  avg =  125.03
-           mobilenet  min =  185.50  max =  190.17  avg =  187.28
-      mobilenet-int8  min =  210.99  max =  217.09  avg =  213.48
-        mobilenet_v2  min =  164.94  max =  166.15  avg =  165.34
-          shufflenet  min =   81.27  max =   82.90  avg =   82.11
-             mnasnet  min =  140.62  max =  142.05  avg =  141.00
-     proxylessnasnet  min =  164.84  max =  166.90  avg =  166.09
-           googlenet  min =  518.03  max =  524.79  avg =  520.41
-      googlenet-int8  min =  460.19  max =  470.69  avg =  465.11
-            resnet18  min =  519.78  max =  522.12  avg =  520.62
-       resnet18-int8  min =  426.46  max =  431.34  avg =  427.99
-             alexnet  min =  604.82  max =  609.51  avg =  606.60
-               vgg16  min = 2593.64  max = 2618.21  avg = 2605.11
-            resnet50  min = 2200.74  max = 2330.16  avg = 2271.50
-       resnet50-int8  min =  953.85  max =  962.52  avg =  958.78
-      squeezenet-ssd  min =  327.71  max =  329.92  avg =  328.68
- squeezenet-ssd-int8  min =  326.55  max =  331.14  avg =  328.59
-       mobilenet-ssd  min =  388.36  max =  391.68  avg =  390.09
-  mobilenet-ssd-int8  min =  426.13  max =  432.57  avg =  428.40
-      mobilenet-yolo  min =  918.35  max =  922.32  avg =  920.61
-    mobilenet-yolov3  min =  892.86  max =  899.50  avg =  896.61
+          squeezenet  min =  132.23  max =  133.57  avg =  132.55
+     squeezenet-int8  min =  125.51  max =  131.38  avg =  128.10
+           mobilenet  min =  187.55  max =  190.19  avg =  188.53
+      mobilenet-int8  min =  233.87  max =  242.32  avg =  238.71
+        mobilenet_v2  min =  167.12  max =  168.25  avg =  167.58
+          shufflenet  min =   83.73  max =   84.38  avg =   84.04
+             mnasnet  min =  142.07  max =  143.37  avg =  142.78
+     proxylessnasnet  min =  173.35  max =  177.28  avg =  174.93
+           googlenet  min =  525.40  max =  534.24  avg =  530.01
+      googlenet-int8  min =  470.90  max =  479.06  avg =  473.84
+            resnet18  min =  502.06  max =  507.12  avg =  505.31
+       resnet18-int8  min =  425.31  max =  439.68  avg =  434.78
+             alexnet  min =  601.74  max =  606.15  avg =  603.52
+               vgg16  min = 2565.99  max = 2589.02  avg = 2573.64
+            resnet50  min = 2237.39  max = 2281.13  avg = 2261.25
+       resnet50-int8  min = 1000.02  max = 1011.14  avg = 1006.33
+      squeezenet-ssd  min =  323.94  max =  327.63  avg =  325.21
+ squeezenet-ssd-int8  min =  337.32  max =  341.70  avg =  339.42
+       mobilenet-ssd  min =  398.51  max =  401.32  avg =  399.86
+  mobilenet-ssd-int8  min =  451.12  max =  462.66  avg =  454.15
+      mobilenet-yolo  min =  922.58  max =  924.53  avg =  923.63
+    mobilenet-yolov3  min =  897.05  max =  908.41  avg =  901.31
 ```
 
 Qualcomm MSM8996 Snapdragon 820 (Kyro 2.15GHz x 2 + Kyro 1.6GHz x 2)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -81,7 +81,7 @@ gpu_device = -1
     mobilenet-yolov3  min =  164.52  max =  182.49  avg =  174.72
 ```
 
-Qualcomm MSM8998 Snapdragon 835 (Kyro 2.45GHz x 4 + Kyro 1.9GHz x 4)
+Qualcomm MSM8998 Snapdragon 835 (Kyro 2.45GHz x 4 + Kyro 1.9GHz x 4 + Adreno 540)
 
 ```shell
 chiron:/data/local/tmp/ncnn $ ./benchncnn 8 4 2
@@ -195,6 +195,34 @@ gpu_device = -1
   mobilenet-ssd-int8  min =  451.12  max =  462.66  avg =  454.15
       mobilenet-yolo  min =  922.58  max =  924.53  avg =  923.63
     mobilenet-yolov3  min =  897.05  max =  908.41  avg =  901.31
+    
+chiron:/data/local/tmp/ncnn $ ./benchncnn 8 1 1 0
+loop_count = 8
+num_threads = 1
+powersave = 1
+gpu_device = 0
+          squeezenet  min =  132.37  max =  133.70  avg =  132.93
+     squeezenet-int8  min =  126.03  max =  131.91  avg =  130.04
+           mobilenet  min =  188.93  max =  191.73  avg =  189.56
+      mobilenet-int8  min =  234.09  max =  242.58  avg =  237.70
+        mobilenet_v2  min =  167.38  max =  168.70  avg =  168.11
+          shufflenet  min =   82.22  max =   85.10  avg =   83.98
+             mnasnet  min =  142.59  max =  143.46  avg =  143.00
+     proxylessnasnet  min =  173.17  max =  176.41  avg =  174.99
+           googlenet  min =  515.87  max =  527.00  avg =  519.25
+      googlenet-int8  min =  469.62  max =  478.21  avg =  472.05
+            resnet18  min =  514.43  max =  522.21  avg =  518.67
+       resnet18-int8  min =  430.92  max =  436.20  avg =  433.53
+             alexnet  min =  600.88  max =  604.74  avg =  603.00
+               vgg16  min = 2560.83  max = 2574.10  avg = 2568.22
+            resnet50  min = 2299.05  max = 2309.38  avg = 2301.75
+       resnet50-int8  min =  998.82  max = 1010.28  avg = 1002.70
+      squeezenet-ssd  min =  324.99  max =  326.99  avg =  325.90
+ squeezenet-ssd-int8  min =  333.94  max =  343.45  avg =  337.99
+       mobilenet-ssd  min =  395.95  max =  402.56  avg =  397.69
+  mobilenet-ssd-int8  min =  448.18  max =  459.66  avg =  454.65
+      mobilenet-yolo  min =  923.50  max =  928.08  avg =  925.08
+    mobilenet-yolov3  min =  898.08  max =  904.30  avg =  900.84
 ```
 
 Qualcomm MSM8996 Snapdragon 820 (Kyro 2.15GHz x 2 + Kyro 1.6GHz x 2)


### PR DESCRIPTION
Add CPU, GPU benchmark of Qualcomm Snapdragon 835

**Qualcomm MSM8998 Snapdragon 835 (Kyro 2.45GHz x 4 + Kyro 1.9GHz x 4 + Adreno 540)**

- code version: e7071452d3f master 2019-4-10
- Ubuntu 16.04 Docker on MacOS
- cmake version 3.11.3
- android-ndk-r19c
- armv8

After changing NDK-r19c to NDK-r18b, logs about omp version showed:

```shell
-- Found OpenMP_C: -fopenmp=libomp (found version "3.1")                      
-- Found OpenMP_CXX: -fopenmp=libomp (found version "3.1")          
-- Found OpenMP: TRUE (found version "3.1") 
```

And multi-threadings enabled.