### PR TITLE
adding detailed how to build for NVIDAI Jetson

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ ncnn 是一个为手机端极致优化的高性能神经网络前向计算框架
 
 ### HowTo
 
-**[how to build ncnn library](https://github.com/Tencent/ncnn/wiki/how-to-build) on Linux / Windows / Raspberry Pi3 / Android  / iOS**
+**[how to build ncnn library](https://github.com/Tencent/ncnn/wiki/how-to-build) on Linux / Windows / Raspberry Pi3 / Android / NVIDIA Jetson / iOS**
 
+* [Build for Jetson](#build-for-jetson)
 * [Build for Linux x86](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-linux-x86)
 * [Build for Windows x64 using VS2017](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-windows-x64-using-visual-studio-community-2017)
 * [Build for MacOSX](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-macosx)
@@ -53,6 +54,57 @@ ncnn 是一个为手机端极致优化的高性能神经网络前向计算框架
 [ncnn operation param weight table](https://github.com/Tencent/ncnn/wiki/operation-param-weight-table)
 
 [how to implement custom layer step by step](https://github.com/Tencent/ncnn/wiki/how-to-implement-custom-layer-step-by-step)
+
+---
+
+### build for jeston
+
+#### download Vulkan SDK from NVIDIA
+please click the `Vulkan SDK File` link on [https://developer.nvidia.com/embedded/vulkan](https://developer.nvidia.com/embedded/vulkan), at the time of writing we got `Vulkan_loader_demos_1.1.100.tar.gz`
+
+scp the downloaded SDK to your Jetson device
+
+```bash
+scp Vulkan_loader_demos_1.1.100.tar.gz USERNAME@JETSON_IP:~/
+```
+
+from this monment on, we will work on the Jetson device
+```bash
+ssh USERNAME@JETSON_IP
+```
+
+#### install Vulkan SDK
+
+```bash
+cd ~/Vulkanloader_demos_1.1.100
+sudo cp loader/libvulkan.so.1.1.100 /usr/lib/aarch64-linux-gnu/
+cd /usr/lib/aarch64-linux-gnu/
+sudo rm -rf libvulkan.so.1 libvulkan.so
+sudo ln -s libvulkan.so.1.1.100 libvulkan.so
+sudo ln -s libvulkan.so.1.1.100 libvulkan.so.1
+cd ~/
+```
+
+#### install glslang dependency
+glslang is a dependency of Tencent/ncnn
+```bash
+git clone --depth=1 https://github.com/KhronosGroup/glslang.git
+# assure that SPIR-V generated from HLSL is legal for Vulkan
+./update_glslang_sources.py
+cd glslang && mkdir -p build && cd build
+sudo make -j`nproc` install && cd ..
+```
+
+#### compile ncnn
+```
+git clone https://github.com/Tencent/ncnn.git
+# while aarch64-linux-gnu.toolchain.cmake would compile Tencent/ncnn as well
+# but why not compile with more native features w
+cd ncnn && mkdir -p build && cd build
+cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/jetson.toolchain.cmake -DNCNN_VULKAN=ON -DCMAKE_BUILD_TYPE=Release ..
+make -j`nproc`
+sudo make install
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ncnn 是一个为手机端极致优化的高性能神经网络前向计算框架
 
 **[how to build ncnn library](https://github.com/Tencent/ncnn/wiki/how-to-build) on Linux / Windows / Raspberry Pi3 / Android / NVIDIA Jetson / iOS**
 
-* [Build for Jetson](#build-for-jetson)
+* [Build for NVIDIA Jetson](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-nvidia-jetson)
 * [Build for Linux x86](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-linux-x86)
 * [Build for Windows x64 using VS2017](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-windows-x64-using-visual-studio-community-2017)
 * [Build for MacOSX](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-macosx)
@@ -54,57 +54,6 @@ ncnn 是一个为手机端极致优化的高性能神经网络前向计算框架
 [ncnn operation param weight table](https://github.com/Tencent/ncnn/wiki/operation-param-weight-table)
 
 [how to implement custom layer step by step](https://github.com/Tencent/ncnn/wiki/how-to-implement-custom-layer-step-by-step)
-
----
-
-### build for jeston
-
-#### download Vulkan SDK from NVIDIA
-please click the `Vulkan SDK File` link on [https://developer.nvidia.com/embedded/vulkan](https://developer.nvidia.com/embedded/vulkan), at the time of writing we got `Vulkan_loader_demos_1.1.100.tar.gz`
-
-scp the downloaded SDK to your Jetson device
-
-```bash
-scp Vulkan_loader_demos_1.1.100.tar.gz USERNAME@JETSON_IP:~/
-```
-
-from this monment on, we will work on the Jetson device
-```bash
-ssh USERNAME@JETSON_IP
-```
-
-#### install Vulkan SDK
-
-```bash
-cd ~/Vulkanloader_demos_1.1.100
-sudo cp loader/libvulkan.so.1.1.100 /usr/lib/aarch64-linux-gnu/
-cd /usr/lib/aarch64-linux-gnu/
-sudo rm -rf libvulkan.so.1 libvulkan.so
-sudo ln -s libvulkan.so.1.1.100 libvulkan.so
-sudo ln -s libvulkan.so.1.1.100 libvulkan.so.1
-cd ~/
-```
-
-#### install glslang dependency
-glslang is a dependency of Tencent/ncnn
-```bash
-git clone --depth=1 https://github.com/KhronosGroup/glslang.git
-# assure that SPIR-V generated from HLSL is legal for Vulkan
-./update_glslang_sources.py
-cd glslang && mkdir -p build && cd build
-sudo make -j`nproc` install && cd ..
-```
-
-#### compile ncnn
-```
-git clone https://github.com/Tencent/ncnn.git
-# while aarch64-linux-gnu.toolchain.cmake would compile Tencent/ncnn as well
-# but why not compile with more native features w
-cd ncnn && mkdir -p build && cd build
-cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/jetson.toolchain.cmake -DNCNN_VULKAN=ON -DCMAKE_BUILD_TYPE=Release ..
-make -j`nproc`
-sudo make install
-```
 
 ---
 

--- a/toolchains/jetson.toolchain.cmake
+++ b/toolchains/jetson.toolchain.cmake
@@ -1,0 +1,19 @@
+# set cross-compiled system type, it's better not use the type which cmake cannot recognized.
+SET ( CMAKE_SYSTEM_NAME Linux )
+SET ( CMAKE_SYSTEM_PROCESSOR aarch64 )
+# for the reason of aarch64-linux-gnu-gcc DONOT need to be installed, make sure aarch64-linux-gnu-gcc and aarch64-linux-gnu-g++ can be found in $PATH: 
+SET ( CMAKE_C_COMPILER "aarch64-linux-gnu-gcc" )
+SET ( CMAKE_CXX_COMPILER "aarch64-linux-gnu-g++" )
+
+# set ${CMAKE_C_FLAGS} and ${CMAKE_CXX_FLAGS}flag for cross-compiled process
+# -march=armv8-a could work on Jetson, but will compile without some extra cpu features
+SET ( CMAKE_CXX_FLAGS "-std=c++11 -march=native -fopenmp ${CMAKE_CXX_FLAGS}" )
+
+# other settings
+# Jetson CPU supports asimd
+add_definitions ( -D__ARM_NEON)
+# Jetson does NOT run ANDROID
+# but `__ANDROID__` marco is tested before `__aarch64__`
+# and currently no negative effect is caused by this marco
+add_definitions( -D__ANDROID__)
+SET ( ANDROID true)


### PR DESCRIPTION
The Vulkan SDK for NVIDIA Jetson Series (Jetson AGX Xavier, Jetson TX2, Jetson TX, and Jetson Nano) is released on NVIDIA developer site instead of its official site.

However, the glslang required by Tencent/ncnn is missing from the NVIDIA release, thus we've to build the glslang from source.

Besides, the arch flag in aarch64-linux-gnu.toolchain.cmake is `-march=armv8-a` while the embedded CPU in NVIDIA Jetson series could support more features. 

Thus the arch parameter is changed to `-march=native` to automatically enable all native features, and to avoid conflicts on other aarch64 platform, the changed version is placed at `toolchains/jetson.toolchain.cmake`.