### PR TITLE
windows下的bug

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -237,10 +237,9 @@ static int get_cpucount()
 #endif
 }
 
-static int g_cpucount = get_cpucount();
-
 int get_cpu_count()
 {
+	static int g_cpucount = get_cpucount();
     return g_cpucount;
 }
 

--- a/src/layer/x86/convolution_sgemm.h
+++ b/src/layer/x86/convolution_sgemm.h
@@ -1516,14 +1516,14 @@ static void conv_im2col_sgemm_sse(const Mat &bottom_blob, Mat &top_blob, const M
                         sum[n] += va[1] * vb[n+4];
                         sum[n] += va[2] * vb[n+8];
                         sum[n] += va[3] * vb[n+12];
-                        sum[n] += va[4] * vb[n+16];
-                        sum[n] += va[5] * vb[n+20];
-                        sum[n] += va[6] * vb[n+24];
-                        sum[n] += va[7] * vb[n+28];
+                        //sum[n] += va[4] * vb[n+16];
+                        //sum[n] += va[5] * vb[n+20];
+                        //sum[n] += va[6] * vb[n+24];
+                        //sum[n] += va[7] * vb[n+28];
                     }
 
-                    va += 8;
-                    vb += 32;
+                    va += 4;
+                    vb += 16;
                 }
 
                 for (; k<L; k++)


### PR DESCRIPTION
1,sse卷积部分越界bug;
2,获取cpu核的函数放在get_cpu_count()函数中定义，放在外部会出现未初始化先使用的情况（vs2013下测试结果）