### PR TITLE
add split op support for onnx2ncnn

### DIFF
--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -1213,6 +1213,10 @@ int main(int argc, char** argv)
         {
             fprintf(pp, "%-16s", "Softmax");
         }
+        else if (op == "Split")
+        {
+            fprintf(pp, "%-16s", "Slice");
+        }
         else if (op == "Sqrt")
         {
             fprintf(pp, "%-16s", "UnaryOp");
@@ -2022,6 +2026,21 @@ int main(int argc, char** argv)
             int axis = get_node_attr_i(node, "axis", 1);
             fprintf(pp, " 0=%d", axis-1);
             fprintf(pp, " 1=1");
+        }
+        else if (op == "Split")
+        {
+            int axis = get_node_attr_i(node, "axis", 0);
+            std::vector<int> split = get_node_attr_ai(node, "split");
+            if (axis < 1 || split.size() < 2)
+                fprintf(stderr, "Unsupported split attributes !\n");
+
+            fprintf(pp, " -23300=%d", output_size);
+            for (int i=0; i< split.size() - 1; i++)
+            {
+                fprintf(pp, ",%d", split[i]);
+            }
+            fprintf(pp, ",-233");
+            fprintf(pp, " 1=%d", axis - 1);
         }
         else if (op == "Sqrt")
         {


### PR DESCRIPTION
Some of our models use the [split](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Split) op in onnx, but the onnx2ncnn do not support it, so I implement it according to the related code in caffe2ncnn
https://github.com/Tencent/ncnn/blob/25979c1bdb73d58d0a463abb7742a46c44e30f47/tools/caffe/caffe2ncnn.cpp#L1574-L1601
I test it on two of our models, and it works fine. But I'm not sure if it cover all the edge cases, please review it @nihui 