### PR TITLE
add the benchmark of qcom855

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ option(NCNN_PIXEL "convert and resize from/to image pixel" ON)
 option(NCNN_PIXEL_ROTATE "rotate image pixel orientation" OFF)
 option(NCNN_CMAKE_VERBOSE "print verbose cmake messages" OFF)
 option(NCNN_VULKAN "vulkan compute support" OFF)
-option(NCNN_REQUANT "auto merge int8 quant and dequant" OFF)
+option(NCNN_REQUANT "auto merge int8 quant and dequant" ON)
 option(NCNN_AVX2 "optimize x86 platform with avx2" OFF)
 
 if(ANDROID OR IOS)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -50,65 +50,51 @@ Parameter
 
 Typical output (executed in android adb shell)
 
-Qualcomm MSM6150 Snapdragon 675 (Kyro460 2.0GHz x 2 + Kyro460 1.7GHz x 6 + Adreno 612)
+Qualcomm SM8150 Snapdragon 855 (Kyro485 Gold 2.8GHz x 1 + Kyro485 Gold 2.4GHz x 3 + Kyro485 1.7GHz x 4 + Adreno 640)
 ```
-violet:/data/local/tmp/ncnn $ ./benchncnn 8 2 0
+OnePlus7:/data/local/tmp/ncnn $ ./benchncnn 8 4 2
 loop_count = 8
-num_threads = 2
-powersave = 0
+num_threads = 4
+powersave = 2
 gpu_device = -1
-          squeezenet  min =   23.29  max =   24.65  avg =   23.95
-     squeezenet_int8  min =   23.24  max =   61.55  avg =   31.20
-           mobilenet  min =   31.60  max =   32.10  avg =   31.80
-      mobilenet_int8  min =   30.35  max =   32.03  avg =   30.95
-        mobilenet_v2  min =   25.92  max =   26.45  avg =   26.08
-          shufflenet  min =   11.91  max =   12.11  avg =   12.00
-             mnasnet  min =   21.38  max =   21.71  avg =   21.51
-     proxylessnasnet  min =   25.53  max =   25.78  avg =   25.62
-           googlenet  min =   93.62  max =  100.67  avg =   94.86
-      googlenet_int8  min =   90.74  max =   91.06  avg =   90.87
-            resnet18  min =   85.84  max =   87.37  avg =   86.50
-       resnet18_int8  min =   77.88  max =   78.11  avg =   78.00
-             alexnet  min =  196.33  max =  201.73  avg =  200.19
-               vgg16  min =  560.71  max =  571.75  avg =  564.84
-          vgg16_int8  min =  651.51  max =  652.68  avg =  652.12
-            resnet50  min =  178.25  max =  179.86  avg =  178.77
-       resnet50_int8  min =  181.07  max =  183.26  avg =  181.64
-      squeezenet_ssd  min =   64.86  max =   68.39  avg =   66.05
- squeezenet_ssd_int8  min =   69.61  max =   70.37  avg =   69.93
-       mobilenet_ssd  min =   65.92  max =   67.03  avg =   66.41
-  mobilenet_ssd_int8  min =   61.54  max =   63.38  avg =   62.27
-      mobilenet_yolo  min =  143.42  max =  146.69  avg =  144.33
-    mobilenet_yolov3  min =  150.45  max =  152.30  avg =  151.36
+          squeezenet  min =    8.75  max =    8.96  avg =    8.87
+           mobilenet  min =   12.17  max =   12.25  avg =   12.21
+        mobilenet_v2  min =    9.68  max =    9.85  avg =    9.79
+        mobilenet_v3  min =    8.40  max =    8.77  avg =    8.69
+          shufflenet  min =    9.23  max =   19.25  avg =   14.49
+             mnasnet  min =    8.55  max =   17.36  avg =   11.77
+     proxylessnasnet  min =   10.22  max =   11.18  avg =   10.37
+           googlenet  min =   29.12  max =   30.05  avg =   29.50
+            resnet18  min =   30.49  max =   30.69  avg =   30.57
+             alexnet  min =   51.68  max =   52.29  avg =   51.86
+               vgg16  min =  204.49  max =  209.23  avg =  207.39
+            resnet50  min =   66.22  max =   66.70  avg =   66.44
+      squeezenet_ssd  min =   28.39  max =   28.97  avg =   28.63
+       mobilenet_ssd  min =   24.44  max =   25.40  avg =   24.67
+      mobilenet_yolo  min =   54.06  max =   56.04  avg =   54.72
+  mobilenetv2_yolov3  min =   32.27  max =   32.94  avg =   32.52
 
-violet:/data/local/tmp/ncnn $ ./benchncnn 8 1 0
+OnePlus7:/data/local/tmp/ncnn $ ./benchncnn 8 4 1
 loop_count = 8
-num_threads = 1
-powersave = 0
+num_threads = 4
+powersave = 1
 gpu_device = -1
-          squeezenet  min =   36.04  max =   37.25  avg =   36.48
-     squeezenet_int8  min =   37.82  max =   79.20  avg =   43.13
-           mobilenet  min =   54.29  max =   54.73  avg =   54.41
-      mobilenet_int8  min =   58.90  max =   60.11  avg =   59.39
-        mobilenet_v2  min =   38.64  max =   40.22  avg =   38.97
-          shufflenet  min =   18.05  max =   18.39  avg =   18.19
-             mnasnet  min =   34.65  max =   34.98  avg =   34.79
-     proxylessnasnet  min =   42.61  max =   43.12  avg =   42.80
-           googlenet  min =  164.74  max =  165.89  avg =  165.34
-      googlenet_int8  min =  159.93  max =  160.38  avg =  160.12
-            resnet18  min =  135.76  max =  137.93  avg =  136.98
-       resnet18_int8  min =  140.22  max =  144.06  avg =  141.92
-             alexnet  min =  391.01  max =  396.85  avg =  392.74
-               vgg16  min = 1019.35  max = 1022.75  avg = 1021.26
-          vgg16_int8  min = 1122.25  max = 1137.99  avg = 1124.78
-            resnet50  min =  302.16  max =  304.22  avg =  303.05
-       resnet50_int8  min =  318.35  max =  319.50  avg =  318.84
-      squeezenet_ssd  min =   91.26  max =   94.86  avg =   92.39
- squeezenet_ssd_int8  min =  105.06  max =  106.17  avg =  105.56
-       mobilenet_ssd  min =  105.01  max =  105.95  avg =  105.40
-  mobilenet_ssd_int8  min =  119.93  max =  120.50  avg =  120.19
-      mobilenet_yolo  min =  229.87  max =  230.76  avg =  230.21
-    mobilenet_yolov3  min =  242.10  max =  242.91  avg =  242.47  
+          squeezenet  min =   27.90  max =   28.53  avg =   28.22
+           mobilenet  min =   42.18  max =   58.93  avg =   45.13
+        mobilenet_v2  min =   29.87  max =   34.39  avg =   30.97
+        mobilenet_v3  min =   28.33  max =   30.57  avg =   29.11
+          shufflenet  min =   21.95  max =   23.49  avg =   22.72
+             mnasnet  min =   28.81  max =   30.79  avg =   29.88
+     proxylessnasnet  min =   35.93  max =   37.06  avg =   36.46
+           googlenet  min =   95.73  max =   99.78  avg =   97.18
+            resnet18  min =   87.93  max =   92.45  avg =   89.35
+             alexnet  min =  176.07  max =  184.55  avg =  180.33
+               vgg16  min =  534.43  max =  545.83  avg =  538.96
+            resnet50  min =  202.04  max =  206.26  avg =  203.68
+      squeezenet_ssd  min =   79.69  max =   83.62  avg =   80.84
+       mobilenet_ssd  min =   86.07  max =   87.00  avg =   86.54
+      mobilenet_yolo  min =  187.25  max =  190.34  avg =  188.96
+  mobilenetv2_yolov3  min =   99.47  max =  101.07  avg =  100.43
 ```
 
 Kirin 970 (Cortex-A73 2.4GHz x 4 + Cortex-A53 1.8GHz x 4)

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -259,6 +259,26 @@ static int get_max_freq_khz(int cpuid)
         sprintf(path, "/sys/devices/system/cpu/cpu%d/cpufreq/stats/time_in_state", cpuid);
         fp = fopen(path, "rb");
 
+        int max_freq_khz = 0;
+        while (!feof(fp))
+        {
+            int freq_khz = 0;
+            int nscan = fscanf(fp, "%d %*d", &freq_khz);
+            if (nscan != 1)
+                break;
+
+            if (freq_khz > max_freq_khz)
+                max_freq_khz = freq_khz;
+        }
+
+        fclose(fp);
+
+        if (max_freq_khz != 0)
+            return max_freq_khz;
+        else
+            fp = NULL;
+
+
         if (!fp)
         {
             // third try, for online cpu
@@ -354,7 +374,7 @@ static int sort_cpuid_by_max_frequency(std::vector<int>& cpuids, int* little_clu
     {
         int max_freq_khz = get_max_freq_khz(i);
 
-//         printf("%d max freq = %d khz\n", i, max_freq_khz);
+        // printf("%d max freq = %d khz\n", i, max_freq_khz);
 
         cpuids[i] = i;
         cpu_max_freq_khz[i] = max_freq_khz;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -965,7 +965,7 @@ int Net::fuse_network()
                         if (layer_next_2->type == "ConvolutionDepthWise" && ((ConvolutionDepthWise*)layer_next_2)->use_int8_inference == false)
                             continue;    
 
-                        fprintf(stderr, "%s, %s, %s\n", layer->name.c_str(), layer_next->name.c_str(), layer_next_2->name.c_str());
+                        // fprintf(stderr, "%s, %s, %s\n", layer->name.c_str(), layer_next->name.c_str(), layer_next_2->name.c_str());
                         if (layer->type == "Convolution" && layer_next_2->type == "Convolution")
                         {
                             ((Convolution*)layer)->use_int8_requantize = true;


### PR DESCRIPTION
- create the benchmark of qcom855 with pack4;
- comment a debug fprintf;
- reopen the NCNN_REQUANT to BaiZuo;
- fix the bug of "SMP cpu powersave not supported".

![image](https://user-images.githubusercontent.com/13964381/67281247-92500180-f501-11e9-8fd8-3eb879a903c2.png)
