### PR TITLE
fix onnx2ncnn MemoryData dims problem #1330

### DIFF
--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -932,11 +932,13 @@ int main(int argc, char** argv)
             fprintf(pp, " 0=%d", (int)M.dims(0));
         } else if (M.dims_size() == 2) {
             fprintf(pp, " 0=%d", (int)M.dims(1));
-            fprintf(pp, " 1=%d", (int)M.dims(0));
         } else if (M.dims_size() == 3) {
             fprintf(pp, " 0=%d", (int)M.dims(2));
             fprintf(pp, " 1=%d", (int)M.dims(1));
-            fprintf(pp, " 2=%d", (int)M.dims(0));
+        } else if (M.dims_size() == 4) {
+            fprintf(pp, " 0=%d", (int)M.dims(3));
+            fprintf(pp, " 1=%d", (int)M.dims(2));
+            fprintf(pp, " 2=%d", (int)M.dims(1));
         }
 
         fprintf(pp, "\n");


### PR DESCRIPTION
I meet the problem when I use [onnx-simplifier](https://github.com/daquexian/onnx-simplifier) tool to simplify the onnx model (for example, remove Reshape, Gather, Unsqueeze Op). `onnx-simplifier` will generate new number id op name such as "401". And the converted onnx model convert to ncnn model using onnx2ncnn tool, it will invoke [onnx2ncnn.cpp#L929-L940](https://github.com/Tencent/ncnn/blob/master/tools/onnx/onnx2ncnn.cpp#L929) code, where do not remove batch dimension (ncnn suppose batch dimension aways be one, so will discard batch dimension).