### PR TITLE
Fix min/max macro issue

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -302,7 +302,7 @@ endif()
 
 if(WIN32)
     target_compile_definitions(ncnn
-        PRIVATE NOMINMAX)
+        PUBLIC NOMINMAX)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -300,11 +300,15 @@ if(NCNN_VULKAN)
     target_link_libraries(ncnn PUBLIC Vulkan::Vulkan)
 endif()
 
+if(WIN32)
+    target_compile_definitions(ncnn
+        PRIVATE NOMINMAX)
+endif()
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC"
     OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES "MSVC"))
     target_compile_definitions(ncnn
-        PRIVATE _SCL_SECURE_NO_WARNINGS _CRT_SECURE_NO_DEPRECATE
-        PUBLIC NOMINMAX)
+        PRIVATE _SCL_SECURE_NO_WARNINGS _CRT_SECURE_NO_DEPRECATE)
 else()
     target_compile_options(ncnn
         PRIVATE -Wall -Wextra -Wno-unused-function)

--- a/src/opencv.h
+++ b/src/opencv.h
@@ -23,6 +23,13 @@
 #include <string>
 #include "mat.h"
 
+#if defined(_MSC_VER) || defined(__GNUC__)
+#pragma push_macro("min")
+#pragma push_macro("max")
+#undef min
+#undef max
+#endif
+
 // minimal opencv style data structure implementation
 namespace cv
 {
@@ -260,6 +267,11 @@ void resize(const Mat& src, Mat& dst, const Size& size, float sw = 0.f, float sh
 #endif // NCNN_PIXEL
 
 } // namespace cv
+
+#if defined(_MSC_VER) || defined(__GNUC__)
+#pragma pop_macro("min")
+#pragma pop_macro("max")
+#endif
 
 #endif // NCNN_OPENCV
 


### PR DESCRIPTION
This patch makes headers of NCNN can be used without bothering by min/max macro issue even not introduced by CMake.