### PR TITLE
fix bug that MemoryData as multi operations input

### DIFF
--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -944,6 +944,31 @@ int main(int argc, char** argv)
         fprintf(pp, "\n");
 
         fwrite_tensor_proto_data(M, bp);
+
+        // split the input
+        if (node_reference.find(input_name) == node_reference.end()){
+            continue;
+        }
+
+        int refcount = node_reference[input_name];
+        if (refcount <= 1){
+            continue;
+        }   
+
+        char splitname[256];
+        sprintf(splitname, "splitncnn_%d", internal_split);
+        fprintf(pp, "%-16s %-24s %d %d", "Split", splitname, 1, refcount);
+
+        fprintf(pp, " %s", input_name.c_str());
+
+        for (int k=0; k<refcount; k++)
+        {
+            fprintf(pp, " %s_splitncnn_%d", input_name.c_str(), k);
+        }
+        fprintf(pp, "\n");
+
+        internal_split++;
+
     }
 
     for (int i=0; i<node_count; i++)

--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -932,11 +932,13 @@ int main(int argc, char** argv)
             fprintf(pp, " 0=%d", (int)M.dims(0));
         } else if (M.dims_size() == 2) {
             fprintf(pp, " 0=%d", (int)M.dims(1));
-            fprintf(pp, " 1=%d", (int)M.dims(0));
         } else if (M.dims_size() == 3) {
             fprintf(pp, " 0=%d", (int)M.dims(2));
             fprintf(pp, " 1=%d", (int)M.dims(1));
-            fprintf(pp, " 2=%d", (int)M.dims(0));
+        } else if (M.dims_size() == 4) {
+            fprintf(pp, " 0=%d", (int)M.dims(3));
+            fprintf(pp, " 1=%d", (int)M.dims(2));
+            fprintf(pp, " 2=%d", (int)M.dims(1));
         }
 
         fprintf(pp, "\n");

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -77,12 +77,31 @@ public:
     int get_conv_names();
     int get_conv_bottom_blob_names();
     int get_conv_weight_blob_scales();
+    int get_input_names();
 
 public:
     std::vector<std::string> conv_names;
     std::map<std::string,std::string> conv_bottom_blob_names;
     std::map<std::string,std::vector<float> > weight_scales;
+    std::vector<std::string> input_names;
 };
+
+int QuantNet::get_input_names()
+{
+    for (size_t i=0; i<layers.size(); i++)
+    {
+        ncnn::Layer* layer = layers[i];
+        if (layer->type == "Input")
+        {
+            for (size_t  j=0; j<layer->tops.size(); j++)
+            {
+                int blob_index = layer->tops[j];
+                std::string name = blobs[blob_index].name.c_str();
+                input_names.push_back(name);
+            }
+        }
+    }
+}
 
 int QuantNet::get_conv_names()
 {
@@ -573,7 +592,7 @@ static int post_training_quantize(const std::vector<std::string> filenames, cons
         in.substract_mean_normalize(mean_vals, norm_vals);
 
         ncnn::Extractor ex = net.create_extractor();
-        ex.input("data", in);
+        ex.input(net.input_names[0].c_str(), in);
 
         for (size_t i=0; i<net.conv_names.size(); i++)
         {
@@ -635,7 +654,7 @@ static int post_training_quantize(const std::vector<std::string> filenames, cons
         in.substract_mean_normalize(mean_vals, norm_vals);
       
         ncnn::Extractor ex = net.create_extractor();
-        ex.input("data", in);
+        ex.input(net.input_names[0].c_str(), in);
 
         for (size_t i=0; i<net.conv_names.size(); i++)
         {

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -535,6 +535,7 @@ static int post_training_quantize(const std::vector<std::string> filenames, cons
     g_blob_pool_allocator.clear();
     g_workspace_pool_allocator.clear();
 
+    net.get_input_names();
     net.get_conv_names();
     net.get_conv_bottom_blob_names();
     net.get_conv_weight_blob_scales();


### PR DESCRIPTION
When I convert tensorflow pb to onnx format model firstly, I meet  MemoryData as multi operations input problem when I using `onnx2ncnn` tool convert onnx model to ncnn model. I double check there are miss a `Split` operation for MemoryData type if it as multi operations input.