### PR TITLE
Add return to QuantNet::get_input_names

### DIFF
--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -101,6 +101,8 @@ int QuantNet::get_input_names()
             }
         }
     }
+
+    return 0;
 }
 
 int QuantNet::get_conv_names()


### PR DESCRIPTION
Using quantitation tool: ./ncnn2table --param mobilenet-nobn-fp32.param --bin mobilenet-nobn-fp32.bin --images images/ --output mobilenet-nobn.table --mean 104,117,123 --norm 0.017,0.017,0.017 --size 224,224 --thread 2
发生段错误

tools/quantize/ncnn2table.cpp QuantNet::get_input_names 遗漏了返回值