### PR TITLE
support OpenCV4 for simplepose example

### DIFF
--- a/examples/simplepose.cpp
+++ b/examples/simplepose.cpp
@@ -19,6 +19,11 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
+#if CV_VERSION_MAJOR >= 4
+#include <opencv2/opencv.hpp>
+#define CV_LOAD_IMAGE_COLOR cv::IMREAD_COLOR
+#endif  // CV_VERSION_MAJOR >= 4
+
 #include "net.h"
 #include "gpu.h"
 


### PR DESCRIPTION
In OpenCV4, `CV_LOAD_IMAGE_COLOR` has been deprecated and replaced with `cv::IMREAD_COLOR`, so I re-define it.