### PR TITLE
Fix ncnn2table coredump

### DIFF
--- a/src/layer/yolov3detectionoutput.cpp
+++ b/src/layer/yolov3detectionoutput.cpp
@@ -14,6 +14,7 @@
 
 #include "yolov3detectionoutput.h"
 #include <algorithm>
+#include <limits>
 #include <math.h>
 #include "layer_type.h"
 

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -542,6 +542,12 @@ static int post_training_quantize(const std::vector<std::string> filenames, cons
     net.get_conv_bottom_blob_names();
     net.get_conv_weight_blob_scales();
 
+    if (net.input_names.size() <= 0)
+    {
+        fprintf(stderr, "not found [Input] Layer, Check your ncnn.param \n");
+        return -1;
+    }
+    
     FILE *fp=fopen(table_path, "w");
 
     // save quantization scale of weight 
@@ -617,7 +623,7 @@ static int post_training_quantize(const std::vector<std::string> filenames, cons
     }
 
     // step 2 histogram_interval
-    printf("    ====> step 2 : generatue the histogram_interval.\n");
+    printf("    ====> step 2 : generate the histogram_interval.\n");
     for (size_t i=0; i<net.conv_names.size(); i++)
     {
         std::string layer_name = net.conv_names[i];
@@ -635,7 +641,7 @@ static int post_training_quantize(const std::vector<std::string> filenames, cons
     }    
 
     // step 3 histogram
-    printf("    ====> step 3 : generatue the histogram.\n");
+    printf("    ====> step 3 : generate the histogram.\n");
     for (size_t i=0; i<filenames.size(); i++)
     {
         std::string img_name = filenames[i];


### PR DESCRIPTION
I download a mobilenet_v2 model from https://github.com/shicai/MobileNet-Caffe , and try to quantize it.  but [Input] layer is not defined in mobilenet_deploy.prototxt. 

when  [Input] layer not found in ncnn.praram, ncnn2table will throw Segment Fault exception, which caused by the following code: 


```
+664         ncnn::Extractor ex = net.create_extractor();
+665         ex.input(net.input_names[0].c_str(), in);
```
there will be better to check the input_names.size()  before quantize