### PR TITLE
Downgrade minimum cmake required to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT DEFINED CMAKE_INSTALL_PREFIX)
 endif()
 message(STATUS "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}")
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 2.8)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE release CACHE STRING "Choose the type of build" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT DEFINED CMAKE_INSTALL_PREFIX)
 endif()
 message(STATUS "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}")
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE release CACHE STRING "Choose the type of build" FORCE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -317,11 +317,15 @@ endif()
 
 add_dependencies(ncnn generate-spirv)
 
-if(NCNN_OPENMP AND OpenMP_CXX_FOUND)
+if(NCNN_OPENMP AND (OpenMP_CXX_FOUND OR OPENMP_FOUND))
     if(NCNN_CMAKE_VERBOSE)
         message("Building with OpenMP")
     endif()
-    target_link_libraries(ncnn PUBLIC OpenMP::OpenMP_CXX)
+    if(OpenMP_CXX_FOUND)
+        target_link_libraries(ncnn PUBLIC OpenMP::OpenMP_CXX)
+    else()
+        target_link_libraries(ncnn PRIVATE "${OpenMP_CXX_FLAGS}")
+    endif()
 endif()
 
 if(NCNN_INSTALL_SDK)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,7 +135,7 @@ macro(ncnn_add_layer class)
     endif()
 
     # generate layer_type_enum file
-    string(APPEND layer_type_enum "${class} = ${__LAYER_TYPE_ENUM_INDEX},\n")
+    set(layer_type_enum "${layer_type_enum}${class} = ${__LAYER_TYPE_ENUM_INDEX},\n")
     math(EXPR __LAYER_TYPE_ENUM_INDEX "${__LAYER_TYPE_ENUM_INDEX}+1")
 endmacro()
 

--- a/tools/caffe/CMakeLists.txt
+++ b/tools/caffe/CMakeLists.txt
@@ -8,7 +8,7 @@ if(PROTOBUF_FOUND)
         PRIVATE
             ${PROTOBUF_INCLUDE_DIR}
             ${CMAKE_CURRENT_BINARY_DIR})
-    target_compile_features(caffe2ncnn PRIVATE cxx_std_11)
+    target_compile_options(caffe2ncnn PRIVATE -std=c++11)
     target_link_libraries(caffe2ncnn PRIVATE ${PROTOBUF_LIBRARIES})
 else()
     message(WARNING "Protobuf not found, caffe model convert tool won't be built")

--- a/tools/onnx/CMakeLists.txt
+++ b/tools/onnx/CMakeLists.txt
@@ -8,7 +8,7 @@ if(PROTOBUF_FOUND)
         PRIVATE
             ${PROTOBUF_INCLUDE_DIR}
             ${CMAKE_CURRENT_BINARY_DIR})
-    target_compile_features(onnx2ncnn PRIVATE cxx_std_11)
+    target_compile_options(onnx2ncnn PRIVATE -std=c++11)
     target_link_libraries(onnx2ncnn PRIVATE ${PROTOBUF_LIBRARIES})
 else()
     message(WARNING "Protobuf not found, onnx model convert tool won't be built")


### PR DESCRIPTION
In some embedded system, the cmake version is still 2.8.x. So use
SET instead of APPEND to adapt to more envir.