### PR TITLE
Replace all occurrences of std::{unary|binary}_function<> with std::function<>

### DIFF
--- a/src/layer/arm/binaryop_arm.cpp
+++ b/src/layer/arm/binaryop_arm.cpp
@@ -519,22 +519,22 @@ static int binary_op_scalar_inplace(Mat& a, float b, const Option& opt)
 }
 
 template<typename T>
-struct binary_op_add : std::binary_function<T,T,T> {
+struct binary_op_add {
     T operator() (const T& x, const T& y) const { return vaddq_f32(x, y); }
 };
 
 template<typename T>
-struct binary_op_sub : std::binary_function<T,T,T> {
+struct binary_op_sub {
     T operator() (const T& x, const T& y) const { return vsubq_f32(x, y); }
 };
 
 template<typename T>
-struct binary_op_mul : std::binary_function<T,T,T> {
+struct binary_op_mul {
     T operator() (const T& x, const T& y) const { return vmulq_f32(x, y); }
 };
 
 template<typename T>
-struct binary_op_div : std::binary_function<T,T,T> {
+struct binary_op_div {
     T operator() (const T& x, const T& y) const
 #if __aarch64__
     { return vdivq_f32(x, y); }
@@ -544,27 +544,27 @@ struct binary_op_div : std::binary_function<T,T,T> {
 };
 
 template<typename T>
-struct binary_op_max : std::binary_function<T,T,T> {
+struct binary_op_max {
     T operator() (const T& x, const T& y) const { return vmaxq_f32(x, y); }
 };
 
 template<typename T>
-struct binary_op_min : std::binary_function<T,T,T> {
+struct binary_op_min {
     T operator() (const T& x, const T& y) const { return vminq_f32(x, y); }
 };
 
 template<typename T>
-struct binary_op_pow : std::binary_function<T,T,T> {
+struct binary_op_pow {
     T operator() (const T& x, const T& y) const { return pow_ps(x, y); }
 };
 
 template<typename T>
-struct binary_op_rsub : std::binary_function<T,T,T> {
+struct binary_op_rsub {
     T operator() (const T& x, const T& y) const { return vsubq_f32(y, x); }
 };
 
 template<typename T>
-struct binary_op_rdiv : std::binary_function<T,T,T> {
+struct binary_op_rdiv {
     T operator() (const T& x, const T& y) const
 #if __aarch64__
     { return vdivq_f32(y, x); }

--- a/src/layer/arm/unaryop_arm.cpp
+++ b/src/layer/arm/unaryop_arm.cpp
@@ -61,17 +61,17 @@ static int unary_op_inplace(Mat& a, const Option& opt)
 }
 
 template<typename T>
-struct unary_op_abs : std::unary_function<T,T> {
+struct unary_op_abs {
     T operator() (const T& x) const { return vabsq_f32(x); }
 };
 
 template<typename T>
-struct unary_op_neg : std::unary_function<T,T> {
+struct unary_op_neg {
     T operator() (const T& x) const { return vnegq_f32(x); }
 };
 
 template<typename T>
-struct unary_op_floor : std::unary_function<T,T> {
+struct unary_op_floor {
     T operator() (const T& x) const
     {
         int32x4_t _xi = vcvtq_s32_f32(x);
@@ -81,7 +81,7 @@ struct unary_op_floor : std::unary_function<T,T> {
 };
 
 template<typename T>
-struct unary_op_ceil : std::unary_function<T,T> {
+struct unary_op_ceil {
     T operator() (const T& x) const
     {
         int32x4_t _xi = vcvtq_s32_f32(x);
@@ -91,12 +91,12 @@ struct unary_op_ceil : std::unary_function<T,T> {
 };
 
 template<typename T>
-struct unary_op_square : std::unary_function<T,T> {
+struct unary_op_square {
     T operator() (const T& x) const { return vmulq_f32(x, x); }
 };
 
 template<typename T>
-struct unary_op_sqrt : std::unary_function<T,T> {
+struct unary_op_sqrt {
     T operator() (const T& x) const
     {
 #if __aarch64__
@@ -111,7 +111,7 @@ struct unary_op_sqrt : std::unary_function<T,T> {
 };
 
 template<typename T>
-struct unary_op_rsqrt : std::unary_function<T,T> {
+struct unary_op_rsqrt {
     T operator() (const T& x) const
     {
         float32x4_t _reciprocal = vrsqrteq_f32(x);
@@ -122,47 +122,47 @@ struct unary_op_rsqrt : std::unary_function<T,T> {
 };
 
 template<typename T>
-struct unary_op_exp : std::unary_function<T,T> {
+struct unary_op_exp {
     T operator() (const T& x) const { return exp_ps(x); }
 };
 
 template<typename T>
-struct unary_op_log : std::unary_function<T,T> {
+struct unary_op_log {
     T operator() (const T& x) const { return log_ps(x); }
 };
 
 template<typename T>
-struct unary_op_sin : std::unary_function<T,T> {
+struct unary_op_sin {
     T operator() (const T& x) const { return sin_ps(x); }
 };
 
 template<typename T>
-struct unary_op_cos : std::unary_function<T,T> {
+struct unary_op_cos {
     T operator() (const T& x) const { return cos_ps(x); }
 };
 
 // template<typename T>
-// struct unary_op_tan : std::unary_function<T,T> {
+// struct unary_op_tan {
 //     T operator() (const T& x) const { return tan(x); }
 // };
 
 // template<typename T>
-// struct unary_op_asin : std::unary_function<T,T> {
+// struct unary_op_asin {
 //     T operator() (const T& x) const { return asin(x); }
 // };
 
 // template<typename T>
-// struct unary_op_acos : std::unary_function<T,T> {
+// struct unary_op_acos {
 //     T operator() (const T& x) const { return acos(x); }
 // };
 
 // template<typename T>
-// struct unary_op_atan : std::unary_function<T,T> {
+// struct unary_op_atan {
 //     T operator() (const T& x) const { return atan(x); }
 // };
 
 template<typename T>
-struct unary_op_reciprocal : std::unary_function<T,T> {
+struct unary_op_reciprocal {
     T operator() (const T& x) const
     {
         float32x4_t _reciprocal = vrecpeq_f32(x);
@@ -173,7 +173,7 @@ struct unary_op_reciprocal : std::unary_function<T,T> {
 };
 
 template<typename T>
-struct unary_op_tanh : std::unary_function<T,T> {
+struct unary_op_tanh {
     T operator() (const T& x) const { return tanh_ps(x); }
 };
 #endif // __ARM_NEON

--- a/src/layer/binaryop.cpp
+++ b/src/layer/binaryop.cpp
@@ -432,27 +432,27 @@ static int binary_op_scalar_inplace(Mat& a, float b, const Option& opt)
 }
 
 template<typename T>
-struct binary_op_max : std::binary_function<T,T,T> {
+struct binary_op_max {
     T operator() (const T& x, const T& y) const { return std::max(x, y); }
 };
 
 template<typename T>
-struct binary_op_min : std::binary_function<T,T,T> {
+struct binary_op_min {
     T operator() (const T& x, const T& y) const { return std::min(x, y); }
 };
 
 template<typename T>
-struct binary_op_pow : std::binary_function<T,T,T> {
+struct binary_op_pow {
     T operator() (const T& x, const T& y) const { return pow(x, y); }
 };
 
 template<typename T>
-struct binary_op_rsub : std::binary_function<T,T,T> {
+struct binary_op_rsub {
     T operator() (const T& x, const T& y) const { return y - x; }
 };
 
 template<typename T>
-struct binary_op_rdiv : std::binary_function<T,T,T> {
+struct binary_op_rdiv {
     T operator() (const T& x, const T& y) const { return y / x; }
 };
 

--- a/src/layer/reduction.cpp
+++ b/src/layer/reduction.cpp
@@ -747,42 +747,42 @@ static int reduction(const Mat& a, Mat& b, float v0, bool reduce_w, bool reduce_
 }
 
 template<typename T>
-struct post_process_identity : std::unary_function<T,T> {
+struct post_process_identity {
     T operator() (const T& x) const { return x; }
 };
 
 template<typename T>
-struct post_process_sqrt : std::unary_function<T,T> {
+struct post_process_sqrt {
     T operator() (const T& x) const { return sqrt(x); }
 };
 
 template<typename T>
-struct post_process_log : std::unary_function<T,T> {
+struct post_process_log {
     T operator() (const T& x) const { return log(x); }
 };
 
 template<typename T>
-struct reduction_op_asum : std::binary_function<T,T,T> {
+struct reduction_op_asum {
     T operator() (const T& x, const T& y) const { return x + fabs(y); }
 };
 
 template<typename T>
-struct reduction_op_sumsq : std::binary_function<T,T,T> {
+struct reduction_op_sumsq {
     T operator() (const T& x, const T& y) const { return x + y * y; }
 };
 
 template<typename T>
-struct reduction_op_sumsexp : std::binary_function<T,T,T> {
+struct reduction_op_sumsexp {
     T operator() (const T& x, const T& y) const { return x + exp(y); }
 };
 
 template<typename T>
-struct reduction_op_max : std::binary_function<T,T,T> {
+struct reduction_op_max {
     T operator() (const T& x, const T& y) const { return std::max(x, y); }
 };
 
 template<typename T>
-struct reduction_op_min : std::binary_function<T,T,T> {
+struct reduction_op_min {
     T operator() (const T& x, const T& y) const { return std::min(x, y); }
 };
 

--- a/src/layer/unaryop.cpp
+++ b/src/layer/unaryop.cpp
@@ -50,87 +50,87 @@ static int unary_op_inplace(Mat& a, const Option& opt)
 }
 
 template<typename T>
-struct unary_op_abs : std::unary_function<T,T> {
+struct unary_op_abs {
     T operator() (const T& x) const { return fabs(x); }
 };
 
 template<typename T>
-struct unary_op_neg : std::unary_function<T,T> {
+struct unary_op_neg {
     T operator() (const T& x) const { return -x; }
 };
 
 template<typename T>
-struct unary_op_floor : std::unary_function<T,T> {
+struct unary_op_floor {
     T operator() (const T& x) const { return floor(x); }
 };
 
 template<typename T>
-struct unary_op_ceil : std::unary_function<T,T> {
+struct unary_op_ceil {
     T operator() (const T& x) const { return ceil(x); }
 };
 
 template<typename T>
-struct unary_op_square : std::unary_function<T,T> {
+struct unary_op_square {
     T operator() (const T& x) const { return x * x; }
 };
 
 template<typename T>
-struct unary_op_sqrt : std::unary_function<T,T> {
+struct unary_op_sqrt {
     T operator() (const T& x) const { return sqrt(x); }
 };
 
 template<typename T>
-struct unary_op_rsqrt : std::unary_function<T,T> {
+struct unary_op_rsqrt {
     T operator() (const T& x) const { return 1.f / sqrt(x); }
 };
 
 template<typename T>
-struct unary_op_exp : std::unary_function<T,T> {
+struct unary_op_exp {
     T operator() (const T& x) const { return exp(x); }
 };
 
 template<typename T>
-struct unary_op_log : std::unary_function<T,T> {
+struct unary_op_log {
     T operator() (const T& x) const { return log(x); }
 };
 
 template<typename T>
-struct unary_op_sin : std::unary_function<T,T> {
+struct unary_op_sin {
     T operator() (const T& x) const { return sin(x); }
 };
 
 template<typename T>
-struct unary_op_cos : std::unary_function<T,T> {
+struct unary_op_cos {
     T operator() (const T& x) const { return cos(x); }
 };
 
 template<typename T>
-struct unary_op_tan : std::unary_function<T,T> {
+struct unary_op_tan {
     T operator() (const T& x) const { return tan(x); }
 };
 
 template<typename T>
-struct unary_op_asin : std::unary_function<T,T> {
+struct unary_op_asin {
     T operator() (const T& x) const { return asin(x); }
 };
 
 template<typename T>
-struct unary_op_acos : std::unary_function<T,T> {
+struct unary_op_acos {
     T operator() (const T& x) const { return acos(x); }
 };
 
 template<typename T>
-struct unary_op_atan : std::unary_function<T,T> {
+struct unary_op_atan {
     T operator() (const T& x) const { return atan(x); }
 };
 
 template<typename T>
-struct unary_op_reciprocal : std::unary_function<T,T> {
+struct unary_op_reciprocal {
     T operator() (const T& x) const { return 1.f / x; }
 };
 
 template<typename T>
-struct unary_op_tanh : std::unary_function<T,T> {
+struct unary_op_tanh {
     T operator() (const T& x) const { return tanh(x); }
 };
 


### PR DESCRIPTION
std::{unary|binary}_function<> are deprecated in C++11 and removed in C++17.

Actually, these were unnecessary in general. In the C++98/03 era, many user-
defined function object classes derived from these base classes in an attempt
to imitate STL conventions. However, STL containers and algorithms have never
required such inheritance (or the typedefs that they provide). Only the
function object adaptors (like bind1st()) needed such typedefs. Currently,
there are no uses of function object adapters in our codebase, so we can
eliminate the inheritance completely.