### PR TITLE
fix quantize tools cross platform issues

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_subdirectory(caffe)
 add_subdirectory(mxnet)
 add_subdirectory(onnx)
-# add_subdirectory(quantize)
+add_subdirectory(quantize)
 
 add_executable(ncnn2mem ncnn2mem.cpp)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,7 +2,17 @@
 add_subdirectory(caffe)
 add_subdirectory(mxnet)
 add_subdirectory(onnx)
-add_subdirectory(quantize)
+
+find_package(OpenCV QUIET COMPONENTS core highgui imgproc imgcodecs)
+if(NOT OpenCV_FOUND)
+    find_package(OpenCV QUIET COMPONENTS core highgui imgproc)
+endif()
+
+if(OpenCV_FOUND)
+    add_subdirectory(quantize)
+else()
+    message(WARNING "OpenCV not found, quantize tools won't be built")
+endif()
 
 add_executable(ncnn2mem ncnn2mem.cpp)
 

--- a/tools/quantize/ncnn2int8.cpp
+++ b/tools/quantize/ncnn2int8.cpp
@@ -688,9 +688,7 @@ int NetQuantize::save(const char* parampath, const char* binpath)
             fprintf_param_value(" 6=%d", woffset2)
             fprintf_param_value(" 7=%d", hoffset2)
             fprintf_param_value(" 8=%d", coffset2)
-            {
-                if (!op->starts.empty()) fprintf_param_int_array(9, op->starts, pp);
-            }
+            { if (!op->starts.empty()) fprintf_param_int_array(9, op->starts, pp); }
             { if (!op->ends.empty()) fprintf_param_int_array(10, op->ends, pp); }
             { if (!op->axes.empty()) fprintf_param_int_array(11, op->axes, pp); }
         }

--- a/tools/quantize/ncnn2int8.cpp
+++ b/tools/quantize/ncnn2int8.cpp
@@ -94,10 +94,9 @@ static bool read_int8scale_table(const char* filepath, std::map<std::string, std
     std::string key_str;
     std::vector<float> scales;
 
-    char *pch;
-    char *p;
-
-    std::vector<char> line(10240);
+    std::vector<char>line(102400);
+    char *pch = nullptr;
+    size_t len = 0;
 
     while (nullptr != std::fgets(line.data(), static_cast<int>(line.size()), fp))
     {
@@ -105,7 +104,7 @@ static bool read_int8scale_table(const char* filepath, std::map<std::string, std
         char key[256];
         line[strcspn(line.data(), "\r\n")] = 0;
 
-        pch = strtok_s(line.data(), " ", &p);
+        pch = strtok(line.data(), " ");
 
         if (pch == nullptr) break;
 
@@ -562,30 +561,20 @@ int NetQuantize::save(const char* parampath, const char* binpath)
 
             fprintf_param_value(" 0=%d", num_output)
             fprintf_param_value(" 1=%d", kernel_w)
-            {
-                if (op->kernel_h != op->kernel_w) fprintf(pp, " 11=%d", op->kernel_h);
-            }
+            { if (op->kernel_h != op->kernel_w) fprintf(pp, " 11=%d", op->kernel_h); }
             fprintf_param_value(" 2=%d", dilation_w)
-            {
-                if (op->dilation_h != op->dilation_w) fprintf(pp, " 12=%d", op->dilation_h);
-            }
+            { if (op->dilation_h != op->dilation_w) fprintf(pp, " 12=%d", op->dilation_h); }
             fprintf_param_value(" 3=%d", stride_w)
-            {
-                if (op->stride_h != op->stride_w) fprintf(pp, " 13=%d", op->stride_h);
-            }
+            { if (op->stride_h != op->stride_w) fprintf(pp, " 13=%d", op->stride_h); }
             fprintf_param_value(" 4=%d", pad_left)
-            {
-                if (op->pad_top != op->pad_left) fprintf(pp, " 14=%d", op->pad_top);
-            }
+            { if (op->pad_top != op->pad_left) fprintf(pp, " 14=%d", op->pad_top); }
             { if (op->pad_right != op->pad_left) fprintf(pp, " 15=%d", op->pad_right); }
             { if (op->pad_bottom != op->pad_top) fprintf(pp, " 16=%d", op->pad_bottom); }
             fprintf_param_value(" 5=%d", bias_term)
             fprintf_param_value(" 6=%d", weight_data_size)
             fprintf_param_value(" 8=%d", int8_scale_term)
             fprintf_param_value(" 9=%d", activation_type)
-            {
-                if (!op->activation_params.empty()) fprintf_param_float_array(10, op->activation_params, pp);
-            }
+            { if (!op->activation_params.empty()) fprintf_param_float_array(10, op->activation_params, pp); }
 
             fwrite_weight_tag_data(0, op->weight_data, bp);
             fwrite_weight_data(op->bias_data, bp);
@@ -621,21 +610,13 @@ int NetQuantize::save(const char* parampath, const char* binpath)
 
             fprintf_param_value(" 0=%d", num_output)
             fprintf_param_value(" 1=%d", kernel_w)
-            {
-                if (op->kernel_h != op->kernel_w) fprintf(pp, " 11=%d", op->kernel_h);
-            }
+            { if (op->kernel_h != op->kernel_w) fprintf(pp, " 11=%d", op->kernel_h); }
             fprintf_param_value(" 2=%d", dilation_w)
-            {
-                if (op->dilation_h != op->dilation_w) fprintf(pp, " 12=%d", op->dilation_h);
-            }
+            { if (op->dilation_h != op->dilation_w) fprintf(pp, " 12=%d", op->dilation_h); }
             fprintf_param_value(" 3=%d", stride_w)
-            {
-                if (op->stride_h != op->stride_w) fprintf(pp, " 13=%d", op->stride_h);
-            }
+            { if (op->stride_h != op->stride_w) fprintf(pp, " 13=%d", op->stride_h); }
             fprintf_param_value(" 4=%d", pad_left)
-            {
-                if (op->pad_top != op->pad_left) fprintf(pp, " 14=%d", op->pad_top);
-            }
+            { if (op->pad_top != op->pad_left) fprintf(pp, " 14=%d", op->pad_top); }
             { if (op->pad_right != op->pad_left) fprintf(pp, " 15=%d", op->pad_right); }
             { if (op->pad_bottom != op->pad_top) fprintf(pp, " 16=%d", op->pad_bottom); }
             fprintf_param_value(" 5=%d", bias_term)
@@ -643,9 +624,7 @@ int NetQuantize::save(const char* parampath, const char* binpath)
             fprintf_param_value(" 7=%d", group)
             fprintf_param_value(" 8=%d", int8_scale_term)
             fprintf_param_value(" 9=%d", activation_type)
-            {
-                if (!op->activation_params.empty()) fprintf_param_float_array(10, op->activation_params, pp);
-            }
+            { if (!op->activation_params.empty()) fprintf_param_float_array(10, op->activation_params, pp); }
 
             fwrite_weight_tag_data(0, op->weight_data, bp);
             fwrite_weight_data(op->bias_data, bp);
@@ -699,29 +678,19 @@ int NetQuantize::save(const char* parampath, const char* binpath)
 
             fprintf_param_value(" 0=%d", num_output)
             fprintf_param_value(" 1=%d", kernel_w)
-            {
-                if (op->kernel_h != op->kernel_w) fprintf(pp, " 11=%d", op->kernel_h);
-            }
+            { if (op->kernel_h != op->kernel_w) fprintf(pp, " 11=%d", op->kernel_h); }
             fprintf_param_value(" 2=%d", dilation_w)
-            {
-                if (op->dilation_h != op->dilation_w) fprintf(pp, " 12=%d", op->dilation_h);
-            }
+            { if (op->dilation_h != op->dilation_w) fprintf(pp, " 12=%d", op->dilation_h); }
             fprintf_param_value(" 3=%d", stride_w)
-            {
-                if (op->stride_h != op->stride_w) fprintf(pp, " 13=%d", op->stride_h);
-            }
+            { if (op->stride_h != op->stride_w) fprintf(pp, " 13=%d", op->stride_h); }
             fprintf_param_value(" 4=%d", pad_left)
-            {
-                if (op->pad_top != op->pad_left) fprintf(pp, " 14=%d", op->pad_top);
-            }
+            { if (op->pad_top != op->pad_left) fprintf(pp, " 14=%d", op->pad_top); }
             { if (op->pad_right != op->pad_left) fprintf(pp, " 15=%d", op->pad_right); }
             { if (op->pad_bottom != op->pad_top) fprintf(pp, " 16=%d", op->pad_bottom); }
             fprintf_param_value(" 5=%d", bias_term)
             fprintf_param_value(" 6=%d", weight_data_size)
             fprintf_param_value(" 9=%d", activation_type)
-            {
-                if (!op->activation_params.empty()) fprintf_param_float_array(10, op->activation_params, pp);
-            }
+            { if (!op->activation_params.empty()) fprintf_param_float_array(10, op->activation_params, pp); }
 
             fwrite_weight_tag_data(0, op->weight_data, bp);
             fwrite_weight_data(op->bias_data, bp);
@@ -733,30 +702,20 @@ int NetQuantize::save(const char* parampath, const char* binpath)
 
             fprintf_param_value(" 0=%d", num_output)
             fprintf_param_value(" 1=%d", kernel_w)
-            {
-                if (op->kernel_h != op->kernel_w) fprintf(pp, " 11=%d", op->kernel_h);
-            }
+            { if (op->kernel_h != op->kernel_w) fprintf(pp, " 11=%d", op->kernel_h); }
             fprintf_param_value(" 2=%d", dilation_w)
-            {
-                if (op->dilation_h != op->dilation_w) fprintf(pp, " 12=%d", op->dilation_h);
-            }
+            { if (op->dilation_h != op->dilation_w) fprintf(pp, " 12=%d", op->dilation_h); }
             fprintf_param_value(" 3=%d", stride_w)
-            {
-                if (op->stride_h != op->stride_w) fprintf(pp, " 13=%d", op->stride_h);
-            }
+            { if (op->stride_h != op->stride_w) fprintf(pp, " 13=%d", op->stride_h); }
             fprintf_param_value(" 4=%d", pad_left)
-            {
-                if (op->pad_top != op->pad_left) fprintf(pp, " 14=%d", op->pad_top);
-            }
+            { if (op->pad_top != op->pad_left) fprintf(pp, " 14=%d", op->pad_top); }
             { if (op->pad_right != op->pad_left) fprintf(pp, " 15=%d", op->pad_right); }
             { if (op->pad_bottom != op->pad_top) fprintf(pp, " 16=%d", op->pad_bottom); }
             fprintf_param_value(" 5=%d", bias_term)
             fprintf_param_value(" 6=%d", weight_data_size)
             fprintf_param_value(" 7=%d", group)
             fprintf_param_value(" 9=%d", activation_type)
-            {
-                if (!op->activation_params.empty()) fprintf_param_float_array(10, op->activation_params, pp);
-            }
+            { if (!op->activation_params.empty()) fprintf_param_float_array(10, op->activation_params, pp); }
 
             fwrite_weight_tag_data(0, op->weight_data, bp);
             fwrite_weight_data(op->bias_data, bp);
@@ -789,9 +748,7 @@ int NetQuantize::save(const char* parampath, const char* binpath)
             ncnn::Eltwise* op_default = (ncnn::Eltwise*)layer_default;
 
             fprintf_param_value(" 0=%d", op_type)
-            {
-                if (!op->coeffs.empty()) fprintf_param_float_array(1, op->coeffs, pp);
-            }
+            { if (!op->coeffs.empty()) fprintf_param_float_array(1, op->coeffs, pp); }
         }
         else if (layer->type == "ELU")
         {
@@ -819,9 +776,7 @@ int NetQuantize::save(const char* parampath, const char* binpath)
             fprintf_param_value(" 2=%d", weight_data_size)
             fprintf_param_value(" 8=%d", int8_scale_term)
             fprintf_param_value(" 9=%d", activation_type)
-            {
-                if (!op->activation_params.empty()) fprintf_param_float_array(10, op->activation_params, pp);
-            }
+            { if (!op->activation_params.empty()) fprintf_param_float_array(10, op->activation_params, pp); }
 
             fwrite_weight_tag_data(0, op->weight_data, bp);
             fwrite_weight_data(op->bias_data, bp);
@@ -956,17 +911,11 @@ int NetQuantize::save(const char* parampath, const char* binpath)
 
             fprintf_param_value(" 0=%d", pooling_type)
             fprintf_param_value(" 1=%d", kernel_w)
-            {
-                if (op->kernel_h != op->kernel_w) fprintf(pp, " 11=%d", op->kernel_h);
-            }
+            { if (op->kernel_h != op->kernel_w) fprintf(pp, " 11=%d", op->kernel_h); }
             fprintf_param_value(" 2=%d", stride_w)
-            {
-                if (op->stride_h != op->stride_w) fprintf(pp, " 12=%d", op->stride_h);
-            }
+            { if (op->stride_h != op->stride_w) fprintf(pp, " 12=%d", op->stride_h); }
             fprintf_param_value(" 3=%d", pad_left)
-            {
-                if (op->pad_top != op->pad_left) fprintf(pp, " 13=%d", op->pad_top);
-            }
+            { if (op->pad_top != op->pad_left) fprintf(pp, " 13=%d", op->pad_top); }
             { if (op->pad_right != op->pad_left) fprintf(pp, " 14=%d", op->pad_right); }
             { if (op->pad_bottom != op->pad_top) fprintf(pp, " 15=%d", op->pad_bottom); }
             fprintf_param_value(" 4=%d", global_pooling)
@@ -1047,9 +996,7 @@ int NetQuantize::save(const char* parampath, const char* binpath)
             fprintf_param_value(" 0=%d", operation)
             fprintf_param_value(" 1=%d", reduce_all)
             fprintf_param_value(" 2=%f", coeff)
-            {
-                if (!op->axes.empty()) fprintf_param_int_array(3, op->axes, pp);
-            }
+            { if (!op->axes.empty()) fprintf_param_int_array(3, op->axes, pp); }
             fprintf_param_value(" 4=%d", keepdims)
         }
         else if (layer->type == "ReLU")
@@ -1168,9 +1115,7 @@ int NetQuantize::save(const char* parampath, const char* binpath)
             fprintf_param_value(" 1=%d", num_box)
             fprintf_param_value(" 2=%f", confidence_threshold)
             fprintf_param_value(" 3=%f", nms_threshold)
-            {
-                if (!op->biases.empty()) fprintf_param_float_array(4, op->biases, pp);
-            }
+            { if (!op->biases.empty()) fprintf_param_float_array(4, op->biases, pp); }
         }
         else if (layer->type == "Yolov3DetectionOutput")
         {
@@ -1181,9 +1126,7 @@ int NetQuantize::save(const char* parampath, const char* binpath)
             fprintf_param_value(" 1=%d", num_box)
             fprintf_param_value(" 2=%f", confidence_threshold)
             fprintf_param_value(" 3=%f", nms_threshold)
-            {
-                if (!op->biases.empty()) fprintf_param_float_array(4, op->biases, pp);
-            }
+            { if (!op->biases.empty()) fprintf_param_float_array(4, op->biases, pp); }
             { if (!op->mask.empty()) fprintf_param_int_array(5, op->mask, pp); }
             { if (!op->anchors_scale.empty()) fprintf_param_float_array(6, op->anchors_scale, pp); }
         }

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -15,6 +15,10 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_DEPRECATE
+#endif
+
 #include <cstdio>
 #include <cstring>
 #include <vector>
@@ -542,12 +546,7 @@ static int post_training_quantize(const std::vector<std::string>& image_list, co
         return -1;
     }
 
-#ifdef _WIN32
-    FILE *fp;
-    fopen_s(&fp, table_path.c_str(), "w");
-#else
     FILE *fp = fopen(table_path.c_str(), "w");
-#endif
 
     // save quantization scale of weight 
     printf("====> Quantize the parameters.\n");

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -132,24 +132,24 @@ int QuantNet::get_conv_weight_blob_scales()
         if (layer->type == "Convolution")
         {
             std::string name = layer->name;
-            const int weight_data_size_output = dynamic_cast<ncnn::Convolution*>(layer)->weight_data_size / static_cast<ncnn::Convolution*>(layer)->num_output;
+            const int weight_data_size_output = static_cast<ncnn::Convolution*>(layer)->weight_data_size / static_cast<ncnn::Convolution*>(layer)->num_output;
             std::vector<float> scales;
 
             // int8 winograd F43 needs weight data to use 6bit quantization
             bool quant_6bit = false;
-            int kernel_w = dynamic_cast<ncnn::Convolution*>(layer)->kernel_w;
-            int kernel_h = dynamic_cast<ncnn::Convolution*>(layer)->kernel_h;
-            int dilation_w = dynamic_cast<ncnn::Convolution*>(layer)->dilation_w;
-            int dilation_h = dynamic_cast<ncnn::Convolution*>(layer)->dilation_h;
-            int stride_w = dynamic_cast<ncnn::Convolution*>(layer)->stride_w;
-            int stride_h = dynamic_cast<ncnn::Convolution*>(layer)->stride_h;
+            int kernel_w = static_cast<ncnn::Convolution*>(layer)->kernel_w;
+            int kernel_h = static_cast<ncnn::Convolution*>(layer)->kernel_h;
+            int dilation_w = static_cast<ncnn::Convolution*>(layer)->dilation_w;
+            int dilation_h = static_cast<ncnn::Convolution*>(layer)->dilation_h;
+            int stride_w = static_cast<ncnn::Convolution*>(layer)->stride_w;
+            int stride_h = static_cast<ncnn::Convolution*>(layer)->stride_h;
 
             if (kernel_w == 3 && kernel_h == 3 && dilation_w == 1 && dilation_h == 1 && stride_w == 1 && stride_h == 1)
                 quant_6bit = true;
 
-            for (int n = 0; n < dynamic_cast<ncnn::Convolution*>(layer)->num_output; n++)
+            for (int n = 0; n < static_cast<ncnn::Convolution*>(layer)->num_output; n++)
             {
-                const ncnn::Mat weight_data_n = dynamic_cast<ncnn::Convolution*>(layer)->weight_data.range(weight_data_size_output * n, weight_data_size_output);
+                const ncnn::Mat weight_data_n = static_cast<ncnn::Convolution*>(layer)->weight_data.range(weight_data_size_output * n, weight_data_size_output);
                 const float *data_n = weight_data_n;
                 float max_value = std::numeric_limits<float>::min();
 
@@ -174,12 +174,12 @@ int QuantNet::get_conv_weight_blob_scales()
         if (layer->type == "ConvolutionDepthWise")
         {
             std::string name = layer->name;
-            const int weight_data_size_output = dynamic_cast<ncnn::ConvolutionDepthWise*>(layer)->weight_data_size / static_cast<ncnn::ConvolutionDepthWise*>(layer)->group;
+            const int weight_data_size_output = static_cast<ncnn::ConvolutionDepthWise*>(layer)->weight_data_size / static_cast<ncnn::ConvolutionDepthWise*>(layer)->group;
             std::vector<float> scales;
 
-            for (int n = 0; n < dynamic_cast<ncnn::ConvolutionDepthWise*>(layer)->group; n++)
+            for (int n = 0; n < static_cast<ncnn::ConvolutionDepthWise*>(layer)->group; n++)
             {
-                const ncnn::Mat weight_data_n = dynamic_cast<ncnn::ConvolutionDepthWise*>(layer)->weight_data.range(weight_data_size_output * n, weight_data_size_output);
+                const ncnn::Mat weight_data_n = static_cast<ncnn::ConvolutionDepthWise*>(layer)->weight_data.range(weight_data_size_output * n, weight_data_size_output);
                 const float *data_n = weight_data_n;
                 float max_value = std::numeric_limits<float>::min();
 
@@ -197,12 +197,12 @@ int QuantNet::get_conv_weight_blob_scales()
         if (layer->type == "InnerProduct")
         {
             std::string name = layer->name;
-            const int weight_data_size_output = dynamic_cast<ncnn::InnerProduct*>(layer)->weight_data_size / static_cast<ncnn::InnerProduct*>(layer)->num_output;
+            const int weight_data_size_output = static_cast<ncnn::InnerProduct*>(layer)->weight_data_size / static_cast<ncnn::InnerProduct*>(layer)->num_output;
             std::vector<float> scales;
 
-            for (int n = 0; n < dynamic_cast<ncnn::InnerProduct*>(layer)->num_output; n++)
+            for (int n = 0; n < static_cast<ncnn::InnerProduct*>(layer)->num_output; n++)
             {
-                const ncnn::Mat weight_data_n = dynamic_cast<ncnn::InnerProduct*>(layer)->weight_data.range(weight_data_size_output * n, weight_data_size_output);
+                const ncnn::Mat weight_data_n = static_cast<ncnn::InnerProduct*>(layer)->weight_data.range(weight_data_size_output * n, weight_data_size_output);
                 const float *data_n = weight_data_n;
                 float max_value = std::numeric_limits<float>::min();
 

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -15,22 +15,17 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-#include <stdio.h>
-#include <unistd.h>
-#include <getopt.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <vector>
 #include <iostream>
-#include <fstream>
-#include <dirent.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <algorithm>
 #include <map>
-#include <opencv2/core/core.hpp>
-#include <opencv2/highgui/highgui.hpp>
+
+#include <opencv2/opencv.hpp>
 
 // ncnn public header
-#include "platform.h"
 #include "net.h"
 #include "cpu.h"
 #include "benchmark.h"
@@ -44,29 +39,20 @@ static ncnn::Option g_default_option;
 static ncnn::UnlockedPoolAllocator g_blob_pool_allocator;
 static ncnn::PoolAllocator g_workspace_pool_allocator;
 
-// Get the filenames from direct path
-int parse_images_dir(const char *base_path, std::vector<std::string>& file_path)
+// Get the file names from direct path
+int parse_images_dir(const std::string& base_path, std::vector<std::string>& file_path)
 {
-    DIR *dir;
-    struct dirent *ptr;
+    file_path.clear();
 
-    if ((dir=opendir(base_path)) == NULL)
+    const cv::String base_path_str(base_path);
+    std::vector<cv::String> image_list;
+
+    cv::glob(base_path_str, image_list, true);
+
+    for (auto& image_path : image_list)
     {
-        perror("Open dir error...");
-        exit(1);
+        file_path.emplace_back(image_path);
     }
-
-    while ((ptr=readdir(dir)) != NULL)
-    {
-        if(strcmp(ptr->d_name,".")==0 || strcmp(ptr->d_name,"..")==0)    ///current dir OR parrent dir
-        {
-            continue;
-        } 
-
-        std::string path = base_path;
-        file_path.push_back(path + ptr->d_name);
-    }
-    closedir(dir);
 
     return 0;
 }
@@ -81,22 +67,20 @@ public:
 
 public:
     std::vector<std::string> conv_names;
-    std::map<std::string,std::string> conv_bottom_blob_names;
-    std::map<std::string,std::vector<float> > weight_scales;
+    std::map<std::string, std::string> conv_bottom_blob_names;
+    std::map<std::string, std::vector<float> > weight_scales;
     std::vector<std::string> input_names;
 };
 
 int QuantNet::get_input_names()
 {
-    for (size_t i=0; i<layers.size(); i++)
+    for (auto layer : layers)
     {
-        ncnn::Layer* layer = layers[i];
         if (layer->type == "Input")
         {
-            for (size_t  j=0; j<layer->tops.size(); j++)
+            for (int blob_index : layer->tops)
             {
-                int blob_index = layer->tops[j];
-                std::string name = blobs[blob_index].name.c_str();
+                std::string name = blobs[blob_index].name;
                 input_names.push_back(name);
             }
         }
@@ -107,16 +91,16 @@ int QuantNet::get_input_names()
 
 int QuantNet::get_conv_names()
 {
-    for (size_t i=0; i<layers.size(); i++)
+    for (size_t i = 0; i < layers.size(); i++)
     {
-        ncnn::Layer* layer = layers[i];
-        
+        const auto layer = layers[i];
+
         if (layer->type == "Convolution" || layer->type == "ConvolutionDepthWise" || layer->type == "InnerProduct")
         {
             std::string name = layer->name;
             conv_names.push_back(name);
         }
-    }        
+    }
 
     return 0;
 }
@@ -124,14 +108,12 @@ int QuantNet::get_conv_names()
 int QuantNet::get_conv_bottom_blob_names()
 {
     // find conv bottom name or index
-    for (size_t i=0; i<layers.size(); i++)
+    for (auto layer : layers)
     {
-        ncnn::Layer* layer = layers[i];
-        
         if (layer->type == "Convolution" || layer->type == "ConvolutionDepthWise" || layer->type == "InnerProduct")
         {
-            std::string name = layer->name;
-            std::string bottom_blob_name = blobs[layer->bottoms[0]].name;
+            auto name = layer->name;
+            const auto bottom_blob_name = blobs[layer->bottoms[0]].name;
             conv_bottom_blob_names[name] = bottom_blob_name;
         }
     }
@@ -141,88 +123,94 @@ int QuantNet::get_conv_bottom_blob_names()
 
 int QuantNet::get_conv_weight_blob_scales()
 {
-    for (size_t i=0; i<layers.size(); i++)
+    for (auto layer : layers)
     {
-        ncnn::Layer* layer = layers[i];
-        
         if (layer->type == "Convolution")
         {
             std::string name = layer->name;
-            const int weight_data_size_output = ((ncnn::Convolution*)layer)->weight_data_size / ((ncnn::Convolution*)layer)->num_output;
+            const int weight_data_size_output = dynamic_cast<ncnn::Convolution*>(layer)->weight_data_size / static_cast<ncnn::Convolution*>(layer)->num_output;
             std::vector<float> scales;
 
             // int8 winograd F43 needs weight data to use 6bit quantization
             bool quant_6bit = false;
-            int kernel_w = ((ncnn::Convolution*)layer)->kernel_w;
-            int kernel_h = ((ncnn::Convolution*)layer)->kernel_h;
-            int dilation_w = ((ncnn::Convolution*)layer)->dilation_w;
-            int dilation_h = ((ncnn::Convolution*)layer)->dilation_h;
-            int stride_w = ((ncnn::Convolution*)layer)->stride_w;
-            int stride_h = ((ncnn::Convolution*)layer)->stride_h;
+            int kernel_w = dynamic_cast<ncnn::Convolution*>(layer)->kernel_w;
+            int kernel_h = dynamic_cast<ncnn::Convolution*>(layer)->kernel_h;
+            int dilation_w = dynamic_cast<ncnn::Convolution*>(layer)->dilation_w;
+            int dilation_h = dynamic_cast<ncnn::Convolution*>(layer)->dilation_h;
+            int stride_w = dynamic_cast<ncnn::Convolution*>(layer)->stride_w;
+            int stride_h = dynamic_cast<ncnn::Convolution*>(layer)->stride_h;
 
             if (kernel_w == 3 && kernel_h == 3 && dilation_w == 1 && dilation_h == 1 && stride_w == 1 && stride_h == 1)
                 quant_6bit = true;
 
-            for (int n=0; n<((ncnn::Convolution*)layer)->num_output; n++)
+            for (int n = 0; n < dynamic_cast<ncnn::Convolution*>(layer)->num_output; n++)
             {
-                const ncnn::Mat weight_data_n = ((ncnn::Convolution*)layer)->weight_data.range(weight_data_size_output * n, weight_data_size_output);
+                const ncnn::Mat weight_data_n = dynamic_cast<ncnn::Convolution*>(layer)->weight_data.range(weight_data_size_output * n, weight_data_size_output);
                 const float *data_n = weight_data_n;
                 float max_value = std::numeric_limits<float>::min();
 
-                for (int i = 0; i < weight_data_size_output; i++)
-                    max_value = std::max(max_value, std::fabs(data_n[i]));
+                for (int k = 0; k < weight_data_size_output; k++)
+                {
+                    max_value = std::max(max_value, std::fabs(data_n[k]));
+                }
 
                 if (quant_6bit)
+                {
                     scales.push_back(31 / max_value);
+                }
                 else
+                {
                     scales.push_back(127 / max_value);
+                }
             }
 
             weight_scales[name] = scales;
         }
-        
+
         if (layer->type == "ConvolutionDepthWise")
         {
             std::string name = layer->name;
-            const int weight_data_size_output = ((ncnn::ConvolutionDepthWise*)layer)->weight_data_size / ((ncnn::ConvolutionDepthWise*)layer)->group;
+            const int weight_data_size_output = dynamic_cast<ncnn::ConvolutionDepthWise*>(layer)->weight_data_size / static_cast<ncnn::ConvolutionDepthWise*>(layer)->group;
             std::vector<float> scales;
 
-            for (int n=0; n<((ncnn::ConvolutionDepthWise*)layer)->group; n++)
+            for (int n = 0; n < dynamic_cast<ncnn::ConvolutionDepthWise*>(layer)->group; n++)
             {
-                const ncnn::Mat weight_data_n = ((ncnn::ConvolutionDepthWise*)layer)->weight_data.range(weight_data_size_output * n, weight_data_size_output);
+                const ncnn::Mat weight_data_n = dynamic_cast<ncnn::ConvolutionDepthWise*>(layer)->weight_data.range(weight_data_size_output * n, weight_data_size_output);
                 const float *data_n = weight_data_n;
                 float max_value = std::numeric_limits<float>::min();
 
-                for (int i = 0; i < weight_data_size_output; i++)
-                    max_value = std::max(max_value, std::fabs(data_n[i]));
+                for (int k = 0; k < weight_data_size_output; k++)
+                {
+                    max_value = std::max(max_value, std::fabs(data_n[k]));
+                }
 
-                scales.push_back(127 / max_value); 
+                scales.push_back(127 / max_value);
             }
 
-            weight_scales[name] = scales;                
+            weight_scales[name] = scales;
         }
 
         if (layer->type == "InnerProduct")
         {
             std::string name = layer->name;
-            const int weight_data_size_output = ((ncnn::InnerProduct*)layer)->weight_data_size / ((ncnn::InnerProduct*)layer)->num_output;
+            const int weight_data_size_output = dynamic_cast<ncnn::InnerProduct*>(layer)->weight_data_size / static_cast<ncnn::InnerProduct*>(layer)->num_output;
             std::vector<float> scales;
 
-            for (int n=0; n<((ncnn::InnerProduct*)layer)->num_output; n++)
+            for (int n = 0; n < dynamic_cast<ncnn::InnerProduct*>(layer)->num_output; n++)
             {
-                const ncnn::Mat weight_data_n = ((ncnn::InnerProduct*)layer)->weight_data.range(weight_data_size_output * n, weight_data_size_output);
+                const ncnn::Mat weight_data_n = dynamic_cast<ncnn::InnerProduct*>(layer)->weight_data.range(weight_data_size_output * n, weight_data_size_output);
                 const float *data_n = weight_data_n;
                 float max_value = std::numeric_limits<float>::min();
 
-                for (int i = 0; i < weight_data_size_output; i++)
-                    max_value = std::max(max_value, std::fabs(data_n[i]));
+                for (int k = 0; k < weight_data_size_output; k++)
+                    max_value = std::max(max_value, std::fabs(data_n[k]));
 
                 scales.push_back(127 / max_value);
             }
 
-            weight_scales[name] = scales;            
+            weight_scales[name] = scales;
         }
-    }              
+    }
 
     return 0;
 }
@@ -230,17 +218,17 @@ int QuantNet::get_conv_weight_blob_scales()
 class QuantizeData
 {
 public:
-    QuantizeData(std::string layer_name, int num);
+    QuantizeData(const std::string& layer_name, const int& num);
 
     int initial_blob_max(ncnn::Mat data);
     int initial_histogram_interval();
     int initial_histogram_value();
 
-    int normalize_histogram(); 
+    int normalize_histogram();
     int update_histogram(ncnn::Mat data);
 
-    float compute_kl_divergence(const std::vector<float> &dist_a, const std::vector<float> &dist_b);
-    int threshold_distribution(const std::vector<float> &distribution, const int target_bin=128);
+    float compute_kl_divergence(const std::vector<float> &dist_a, const std::vector<float> &dist_b) const;
+    int threshold_distribution(const std::vector<float> &distribution, const int target_bin = 128) const;
     float get_data_blob_scale();
 
 public:
@@ -250,31 +238,35 @@ public:
     int num_bins;
     float histogram_interval;
     std::vector<float> histogram;
-    
+
     float threshold;
     int threshold_bin;
     float scale;
 };
 
-QuantizeData::QuantizeData(std::string layer_name, int num)
+QuantizeData::QuantizeData(const std::string& layer_name, const int& num)
 {
     name = layer_name;
-    max_value = 0.0;
+    max_value = 0.f;
     num_bins = num;
-    histogram_interval = 0.0;
+    histogram_interval = 0.f;
     histogram.resize(num_bins);
     initial_histogram_value();
+
+    threshold = 0.f;
+    threshold_bin = 0;
+    scale = 1.0f;
 }
 
 int QuantizeData::initial_blob_max(ncnn::Mat data)
 {
-    int channel_num = data.c;
-    int size = data.w * data.h;
+    const int channel_num = data.c;
+    const int size = data.w * data.h;
 
-    for (int q=0; q<channel_num; q++)
+    for (int q = 0; q < channel_num; q++)
     {
         const float *data_n = data.channel(q);
-        for(int i=0; i<size; i++)
+        for (int i = 0; i < size; i++)
         {
             max_value = std::max(max_value, std::fabs(data_n[i]));
         }
@@ -285,30 +277,30 @@ int QuantizeData::initial_blob_max(ncnn::Mat data)
 
 int QuantizeData::initial_histogram_interval()
 {
-    histogram_interval = max_value / num_bins;
+    histogram_interval = max_value / static_cast<float>(num_bins);
 
     return 0;
 }
 
 int QuantizeData::initial_histogram_value()
 {
-    for (size_t i=0; i<histogram.size(); i++)
+    for (float& i : histogram)
     {
-        histogram[i] = 0.00001;
+        i = 0.00001f;
     }
 
     return 0;
 }
 
-int QuantizeData::normalize_histogram() 
+int QuantizeData::normalize_histogram()
 {
-    const int length = histogram.size();
+    const auto length = histogram.size();
     float sum = 0;
-    
-    for (int i=0; i<length; i++)
+
+    for (size_t i = 0; i < length; i++)
         sum += histogram[i];
 
-    for (int i=0; i<length; i++) 
+    for (size_t i = 0; i < length; i++)
         histogram[i] /= sum;
 
     return 0;
@@ -316,41 +308,41 @@ int QuantizeData::normalize_histogram()
 
 int QuantizeData::update_histogram(ncnn::Mat data)
 {
-    int channel_num = data.c;
-    int size = data.w * data.h;
+    const int channel_num = data.c;
+    const int size = data.w * data.h;
 
-    for (int q=0; q<channel_num; q++)
+    for (int q = 0; q < channel_num; q++)
     {
         const float *data_n = data.channel(q);
-        for(int i=0; i<size; i++)
+        for (int i = 0; i < size; i++)
         {
             if (data_n[i] == 0)
                 continue;
 
-            int index = std::min(static_cast<int>(std::abs(data_n[i]) / histogram_interval), 2047);
+            const int index = std::min(static_cast<int>(std::abs(data_n[i]) / histogram_interval), 2047);
 
             histogram[index]++;
         }
-    }        
+    }
 
     return 0;
 }
 
-float QuantizeData::compute_kl_divergence(const std::vector<float> &dist_a, const std::vector<float> &dist_b) 
+float QuantizeData::compute_kl_divergence(const std::vector<float> &dist_a, const std::vector<float> &dist_b) const
 {
-    const int length = dist_a.size();
+    const auto length = dist_a.size();
     assert(dist_b.size() == length);
     float result = 0;
 
-    for (int i=0; i<length; i++) 
+    for (size_t i = 0; i < length; i++)
     {
-        if (dist_a[i] != 0) 
+        if (dist_a[i] != 0)
         {
-            if (dist_b[i] == 0) 
+            if (dist_b[i] == 0)
             {
                 result += 1;
-            } 
-            else 
+            }
+            else
             {
                 result += dist_a[i] * log(dist_a[i] / dist_b[i]);
             }
@@ -360,55 +352,55 @@ float QuantizeData::compute_kl_divergence(const std::vector<float> &dist_a, cons
     return result;
 }
 
-int QuantizeData::threshold_distribution(const std::vector<float> &distribution, const int target_bin) 
+int QuantizeData::threshold_distribution(const std::vector<float> &distribution, const int target_bin) const
 {
     int target_threshold = target_bin;
     float min_kl_divergence = 1000;
-    const int length = distribution.size();
+    const int length = static_cast<int>(distribution.size());
 
     std::vector<float> quantize_distribution(target_bin);
 
     float threshold_sum = 0;
-    for (int threshold=target_bin; threshold<length; threshold++) 
+    for (int threshold = target_bin; threshold < length; threshold++)
     {
         threshold_sum += distribution[threshold];
     }
 
-    for (int threshold=target_bin; threshold<length; threshold++) 
+    for (int threshold = target_bin; threshold < length; threshold++)
     {
 
-        std::vector<float> t_distribution(distribution.begin(), distribution.begin()+threshold);
-        
-        t_distribution[threshold-1] += threshold_sum; 
+        std::vector<float> t_distribution(distribution.begin(), distribution.begin() + threshold);
+
+        t_distribution[threshold - 1] += threshold_sum;
         threshold_sum -= distribution[threshold];
 
         // get P
-        fill(quantize_distribution.begin(), quantize_distribution.end(), 0);
-        
-        const float num_per_bin = static_cast<float>(threshold) / target_bin;
+        fill(quantize_distribution.begin(), quantize_distribution.end(), 0.0f);
 
-        for (int i=0; i<target_bin; i++) 
+        const auto num_per_bin = static_cast<float>(threshold) / static_cast<float>(target_bin);
+
+        for (int i = 0; i < target_bin; i++)
         {
-            const float start = i * num_per_bin;
-            const float end = start + num_per_bin;
+            const auto start = static_cast<float>(i) * num_per_bin;
+            const auto end = start + num_per_bin;
 
-            const int left_upper = ceil(start);
-            if (left_upper > start) 
+            const auto left_upper = static_cast<int>(ceil(start));
+            if (static_cast<float>(left_upper) > start)
             {
-                const float left_scale = left_upper - start;
+                const auto left_scale = static_cast<float>(left_upper) - start;
                 quantize_distribution[i] += left_scale * distribution[left_upper - 1];
             }
 
-            const int right_lower = floor(end);
+            const auto right_lower = static_cast<int>(floor(end));
 
-            if (right_lower < end) 
+            if (static_cast<float>(right_lower) < end)
             {
 
-                const float right_scale = end - right_lower;
+                const auto right_scale = end - static_cast<float>(right_lower);
                 quantize_distribution[i] += right_scale * distribution[right_lower];
             }
 
-            for (int j=left_upper; j<right_lower; j++) 
+            for (int j = left_upper; j < right_lower; j++)
             {
                 quantize_distribution[i] += distribution[j];
             }
@@ -417,62 +409,62 @@ int QuantizeData::threshold_distribution(const std::vector<float> &distribution,
         // get Q
         std::vector<float> expand_distribution(threshold, 0);
 
-        for (int i=0; i<target_bin; i++) 
+        for (int i = 0; i < target_bin; i++)
         {
-            const float start = i * num_per_bin;
-            const float end = start + num_per_bin;
+            const auto start = static_cast<float>(i) * num_per_bin;
+            const auto end = start + num_per_bin;
 
             float count = 0;
 
-            const int left_upper = ceil(start);
+            const int left_upper = static_cast<int>(ceil(start));
             float left_scale = 0;
-            if (left_upper > start) 
+            if (static_cast<float>(left_upper) > start)
             {
-                left_scale = left_upper - start;
-                if (distribution[left_upper - 1] != 0) 
+                left_scale = static_cast<float>(left_upper) - start;
+                if (distribution[left_upper - 1] != 0)
                 {
                     count += left_scale;
                 }
             }
 
-            const int right_lower = floor(end);
+            const int right_lower = static_cast<int>(floor(end));
             float right_scale = 0;
-            if (right_lower < end) 
+            if (static_cast<float>(right_lower) < end)
             {
-                right_scale = end - right_lower;
-                if (distribution[right_lower] != 0) 
+                right_scale = end - static_cast<float>(right_lower);
+                if (distribution[right_lower] != 0)
                 {
                     count += right_scale;
                 }
             }
 
-            for (int j=left_upper; j<right_lower; j++) 
+            for (int j = left_upper; j < right_lower; j++)
             {
-                if (distribution[j] != 0) 
+                if (distribution[j] != 0)
                 {
                     count++;
                 }
             }
 
-            const float expand_value = quantize_distribution[i] / count;
+            const auto expand_value = quantize_distribution[i] / count;
 
-            if (left_upper > start) 
+            if (static_cast<float>(left_upper) > start)
             {
-                if (distribution[left_upper - 1] != 0) 
+                if (distribution[left_upper - 1] != 0)
                 {
                     expand_distribution[left_upper - 1] += expand_value * left_scale;
                 }
             }
-            if (right_lower < end) 
+            if (static_cast<float>(right_lower) < end)
             {
-                if (distribution[right_lower] != 0) 
+                if (distribution[right_lower] != 0)
                 {
                     expand_distribution[right_lower] += expand_value * right_scale;
                 }
             }
-            for (int j=left_upper; j<right_lower; j++) 
+            for (int j = left_upper; j < right_lower; j++)
             {
-                if (distribution[j] != 0) 
+                if (distribution[j] != 0)
                 {
                     expand_distribution[j] += expand_value;
                 }
@@ -480,10 +472,10 @@ int QuantizeData::threshold_distribution(const std::vector<float> &distribution,
         }
 
         // kl
-        float kl_divergence = compute_kl_divergence(t_distribution, expand_distribution);
+        const float kl_divergence = compute_kl_divergence(t_distribution, expand_distribution);
 
         // the best num of bin
-        if (kl_divergence < min_kl_divergence) 
+        if (kl_divergence < min_kl_divergence)
         {
             min_kl_divergence = kl_divergence;
             target_threshold = threshold;
@@ -494,10 +486,10 @@ int QuantizeData::threshold_distribution(const std::vector<float> &distribution,
 }
 
 float QuantizeData::get_data_blob_scale()
-{   
+{
     normalize_histogram();
     threshold_bin = threshold_distribution(histogram);
-    threshold = (threshold_bin + 0.5) * histogram_interval;
+    threshold = (static_cast<float>(threshold_bin) + 0.5f) * histogram_interval;
     scale = 127 / threshold;
     return scale;
 }
@@ -506,23 +498,25 @@ struct PreParam
 {
     float mean[3];
     float norm[3];
-    int weith;
+    int width;
     int height;
     bool swapRB;
 };
 
-static int post_training_quantize(const std::vector<std::string> filenames, const char* param_path, const char* bin_path, const char* table_path, struct PreParam per_param)
+static int post_training_quantize(const std::vector<std::string>& image_list, const std::string& param_path, const std::string& bin_path, const std::string& table_path, struct PreParam& per_param)
 {
-    int size = filenames.size();
+    auto size = image_list.size();
 
     QuantNet net;
     net.opt = g_default_option;
 
-    net.load_param(param_path);
-    net.load_model(bin_path);
+    net.load_param(param_path.c_str());
+    net.load_model(bin_path.c_str());
 
-    float mean_vals[3], norm_vals[3];
-    int weith = per_param.weith;
+    float mean_vals[3];
+    float norm_vals[3];
+
+    int width = per_param.width;
     int height = per_param.height;
     bool swapRB = per_param.swapRB;
 
@@ -542,49 +536,58 @@ static int post_training_quantize(const std::vector<std::string> filenames, cons
     net.get_conv_bottom_blob_names();
     net.get_conv_weight_blob_scales();
 
-    if (net.input_names.size() <= 0)
+    if (net.input_names.empty())
     {
         fprintf(stderr, "not found [Input] Layer, Check your ncnn.param \n");
         return -1;
     }
-    
-    FILE *fp=fopen(table_path, "w");
+
+#ifdef _WIN32
+    FILE *fp;
+    fopen_s(&fp, table_path.c_str(), "w");
+#else
+    FILE *fp = fopen(table_path.c_str(), "w");
+#endif
 
     // save quantization scale of weight 
-    printf("====> Quantize the parameters.\n");    
-    for (size_t i=0; i<net.conv_names.size(); i++)
+    printf("====> Quantize the parameters.\n");
+    for (size_t i = 0; i < net.conv_names.size(); i++)
     {
         std::string layer_name = net.conv_names[i];
         std::string blob_name = net.conv_bottom_blob_names[layer_name];
         std::vector<float> weight_scale_n = net.weight_scales[layer_name];
 
         fprintf(fp, "%s_param_0 ", layer_name.c_str());
-        for (size_t j=0; j<weight_scale_n.size(); j++)
-            fprintf(fp, "%f ", weight_scale_n[j]);
-        fprintf(fp, "\n");        
+        for (float j : weight_scale_n)
+        {
+            fprintf(fp, "%f ", j);
+        }
+        fprintf(fp, "\n");
     }
 
     // initial quantization data
     std::vector<QuantizeData> quantize_datas;
-    
-    for (size_t i=0; i<net.conv_names.size(); i++)
+
+    for (size_t i = 0; i < net.conv_names.size(); i++)
     {
         std::string layer_name = net.conv_names[i];
 
         QuantizeData quantize_data(layer_name, 2048);
         quantize_datas.push_back(quantize_data);
-    }    
+    }
 
     // step 1 count the max value
-    printf("====> Quantize the activation.\n"); 
+    printf("====> Quantize the activation.\n");
     printf("    ====> step 1 : find the max value.\n");
 
-    for (size_t i=0; i<filenames.size(); i++)
+    for (size_t i = 0; i < image_list.size(); i++)
     {
-        std::string img_name = filenames[i];
+        std::string img_name = image_list[i];
 
-        if ((i+1)%100 == 0)
-            fprintf(stderr, "          %d/%d\n", (int)(i+1), (int)size);
+        if ((i + 1) % 100 == 0)
+        {
+            fprintf(stderr, "          %d/%d\n", static_cast<int>(i + 1), static_cast<int>(size));
+        }
 
 #if OpenCV_VERSION_MAJOR > 2
         cv::Mat bgr = cv::imread(img_name, cv::IMREAD_COLOR);
@@ -597,57 +600,57 @@ static int post_training_quantize(const std::vector<std::string> filenames, cons
             return -1;
         }
 
-        ncnn::Mat in = ncnn::Mat::from_pixels_resize(bgr.data, swapRB ? ncnn::Mat::PIXEL_BGR2RGB : ncnn::Mat::PIXEL_BGR, bgr.cols, bgr.rows, weith, height);
+        ncnn::Mat in = ncnn::Mat::from_pixels_resize(bgr.data, swapRB ? ncnn::Mat::PIXEL_BGR2RGB : ncnn::Mat::PIXEL_BGR, bgr.cols, bgr.rows, width, height);
         in.substract_mean_normalize(mean_vals, norm_vals);
 
         ncnn::Extractor ex = net.create_extractor();
         ex.input(net.input_names[0].c_str(), in);
 
-        for (size_t i=0; i<net.conv_names.size(); i++)
+        for (size_t j = 0; j < net.conv_names.size(); j++)
         {
-            std::string layer_name = net.conv_names[i];
+            std::string layer_name = net.conv_names[j];
             std::string blob_name = net.conv_bottom_blob_names[layer_name];
 
             ncnn::Mat out;
-            ex.extract(blob_name.c_str(), out);  
+            ex.extract(blob_name.c_str(), out);
 
-            for (size_t j=0; j<quantize_datas.size(); j++)
+            for (auto& quantize_data : quantize_datas)
             {
-                if (quantize_datas[j].name == layer_name)
+                if (quantize_data.name == layer_name)
                 {
-                    quantize_datas[j].initial_blob_max(out);
+                    quantize_data.initial_blob_max(out);
                     break;
                 }
             }
-        }         
+        }
     }
 
     // step 2 histogram_interval
     printf("    ====> step 2 : generate the histogram_interval.\n");
-    for (size_t i=0; i<net.conv_names.size(); i++)
+    for (size_t i = 0; i < net.conv_names.size(); i++)
     {
         std::string layer_name = net.conv_names[i];
 
-        for (size_t j=0; j<quantize_datas.size(); j++)
+        for (auto& quantize_data : quantize_datas)
         {
-            if (quantize_datas[j].name == layer_name)
+            if (quantize_data.name == layer_name)
             {
-                quantize_datas[j].initial_histogram_interval();
+                quantize_data.initial_histogram_interval();
 
-                fprintf(stderr, "%-20s : max = %-15f interval = %-10f\n", quantize_datas[j].name.c_str(), quantize_datas[j].max_value, quantize_datas[j].histogram_interval);
+                fprintf(stderr, "%-20s : max = %-15f interval = %-10f\n", quantize_data.name.c_str(), quantize_data.max_value, quantize_data.histogram_interval);
                 break;
             }
         }
-    }    
+    }
 
     // step 3 histogram
     printf("    ====> step 3 : generate the histogram.\n");
-    for (size_t i=0; i<filenames.size(); i++)
+    for (size_t i = 0; i < image_list.size(); i++)
     {
-        std::string img_name = filenames[i];
+        std::string img_name = image_list[i];
 
-        if ((i+1)%100 == 0)
-            fprintf(stderr, "          %d/%d\n", (int)(i+1), (int)size);
+        if ((i + 1) % 100 == 0)
+            fprintf(stderr, "          %d/%d\n", (int)(i + 1), (int)size);
 #if OpenCV_VERSION_MAJOR > 2
         cv::Mat bgr = cv::imread(img_name, cv::IMREAD_COLOR);
 #else
@@ -657,53 +660,53 @@ static int post_training_quantize(const std::vector<std::string> filenames, cons
         {
             fprintf(stderr, "cv::imread %s failed\n", img_name.c_str());
             return -1;
-        }  
+        }
 
-        ncnn::Mat in = ncnn::Mat::from_pixels_resize(bgr.data, swapRB ? ncnn::Mat::PIXEL_BGR2RGB : ncnn::Mat::PIXEL_BGR, bgr.cols, bgr.rows, weith, height);
+        ncnn::Mat in = ncnn::Mat::from_pixels_resize(bgr.data, swapRB ? ncnn::Mat::PIXEL_BGR2RGB : ncnn::Mat::PIXEL_BGR, bgr.cols, bgr.rows, width, height);
         in.substract_mean_normalize(mean_vals, norm_vals);
-      
+
         ncnn::Extractor ex = net.create_extractor();
         ex.input(net.input_names[0].c_str(), in);
 
-        for (size_t i=0; i<net.conv_names.size(); i++)
+        for (size_t k = 0; k < net.conv_names.size(); k++)
         {
-            std::string layer_name = net.conv_names[i];
+            std::string layer_name = net.conv_names[k];
             std::string blob_name = net.conv_bottom_blob_names[layer_name];
 
             ncnn::Mat out;
-            ex.extract(blob_name.c_str(), out);  
+            ex.extract(blob_name.c_str(), out);
 
-            for (size_t j=0; j<quantize_datas.size(); j++)
+            for (auto& quantize_data : quantize_datas)
             {
-                if (quantize_datas[j].name == layer_name)
+                if (quantize_data.name == layer_name)
                 {
-                    quantize_datas[j].update_histogram(out);
+                    quantize_data.update_histogram(out);
                     break;
                 }
             }
-        }     
+        }
     }
 
     // step4 kld
     printf("    ====> step 4 : using kld to find the best threshold value.\n");
-    for (size_t i=0; i<net.conv_names.size(); i++)
+    for (size_t i = 0; i < net.conv_names.size(); i++)
     {
         std::string layer_name = net.conv_names[i];
         std::string blob_name = net.conv_bottom_blob_names[layer_name];
         fprintf(stderr, "%-20s ", layer_name.c_str());
 
-        for (size_t j=0; j<quantize_datas.size(); j++)
+        for (auto& quantize_data : quantize_datas)
         {
-            if (quantize_datas[j].name == layer_name)
+            if (quantize_data.name == layer_name)
             {
-                quantize_datas[j].get_data_blob_scale();
-                fprintf(stderr, "bin : %-8d threshold : %-15f interval : %-10f scale : %-10f\n", \
-                                                                quantize_datas[j].threshold_bin, \
-                                                                quantize_datas[j].threshold, \
-                                                                quantize_datas[j].histogram_interval, \
-                                                                quantize_datas[j].scale);
+                quantize_data.get_data_blob_scale();
+                fprintf(stderr, "bin : %-8d threshold : %-15f interval : %-10f scale : %-10f\n",
+                    quantize_data.threshold_bin,
+                    quantize_data.threshold,
+                    quantize_data.histogram_interval,
+                    quantize_data.scale);
 
-                fprintf(fp, "%s %f\n", layer_name.c_str(), quantize_datas[j].scale);
+                fprintf(fp, "%s %f\n", layer_name.c_str(), quantize_data.scale);
 
                 break;
             }
@@ -717,163 +720,191 @@ static int post_training_quantize(const std::vector<std::string> filenames, cons
 }
 
 // usage
-void showUsage() 
+void showUsage()
 {
-    std::cout << "usage: ncnn2table [-h] [-p] [-b] [-o] [-m] [-n] [-s] [-t]" << std::endl;
-    std::cout << " -h, --help       show this help message and exit" << std::endl;
-    std::cout << " -p, --param      path to ncnn.param file" << std::endl;
-    std::cout << " -b, --bin        path to ncnn.bin file" << std::endl;
-    std::cout << " -i, --images     path to calibration images" << std::endl;
-    std::cout << " -o, --output     path to output calibration tbale file" << std::endl;
-    std::cout << " -m, --mean       value of mean" << std::endl;
-    std::cout << " -n, --norm       value of normalize(scale value,defualt is 1)" << std::endl;
-    std::cout << " -s, --size       the size of input image(using the resize the original image,default is w=224,h=224)" << std::endl;
-    std::cout << " -c  --swapRB     flag which indicates that swap first and last channels in 3-channel image is necessary" << std::endl;
-    std::cout << " -t, --thread     number of threads(defalut is 1)" << std::endl;    
-    std::cout << "example: ./ncnn2table --param squeezenet-fp32.param --bin squeezenet-fp32.bin --images images/ --output squeezenet.table --mean 104,117,123 --norm 1,1,1 --size 227,227 --swapRB --thread 2" << std::endl;
-}
-
-// string.split('x')
-std::vector<std::string> split(const std::string &str,const std::string &pattern)
-{
-    //const char* convert to char*
-    char * strc = new char[strlen(str.c_str())+1];
-    strcpy(strc, str.c_str());
-    std::vector<std::string> resultVec;
-    char* tmpStr = strtok(strc, pattern.c_str());
-    while (tmpStr != NULL)
-    {
-        resultVec.push_back(std::string(tmpStr));
-        tmpStr = strtok(NULL, pattern.c_str());
-    }
-
-    delete[] strc;
-
-    return resultVec;
+    std::cout << "example: ./ncnn2table --param=squeezenet-fp32.param --bin=squeezenet-fp32.bin --images=images/ --output=squeezenet.table --mean=104,117,123 --norm=1,1,1 --size=227,227 --swapRB --thread=2" << std::endl;
 }
 
 int main(int argc, char** argv)
 {
     std::cout << "--- ncnn post training quantization tool --- " << __TIME__ << " " << __DATE__ << std::endl;
 
-    char* imagepath = NULL;
-    char* parampath = NULL;
-    char* binpath = NULL;
-    char* tablepath = NULL;
-    int num_threads = 1;
+    const cv::CommandLineParser parser(argc, argv,
+        {
 
-    struct PreParam pre_param = {
-        .mean = {104.f, 117.f, 103.f}, 
-        .norm = {1.f, 1.f, 1.f}, 
-        .weith = 224, 
-        .height =224,
-        .swapRB = false
+            "{help h usage ? |   | print this message }"
+            "{param p        |   | path to ncnn.param file }"
+            "{bin b          |   | path to ncnn.bin file }"
+            "{images i       |   | path to calibration images }"
+            "{output o       |   | path to output calibration table file }"
+            "{mean m         |   | value of mean }"
+            "{norm n         |   | value of normalize(scale value,default is 1 }"
+            "{size s         |   | the size of input image(using the resize the original image,default is w=224,h=224) }"
+            "{swapRB c       |   | flag which indicates that swap first and last channels in 3-channel image is necessary }"
+            "{thread t       | 4 | count of processing threads }"
+        });
+
+    if (parser.has("help"))
+    {
+        parser.printMessage();
+        showUsage();
+        return 0;
+    }
+
+    if (!parser.has("param") || !parser.has("bin") || !parser.has("images") || !parser.has("output") || !parser.has("mean") || !parser.has("norm"))
+    {
+        std::cout << "Inputs is does not include all needed param, pleas check..." << std::endl;
+        parser.printMessage();
+        showUsage();
+        return 0;
+    }
+
+    const std::string image_folder_path = parser.get<cv::String>("images");
+    const std::string ncnn_param_file_path = parser.get<cv::String>("param");
+    const std::string ncnn_bin_file_path = parser.get<cv::String>("bin");
+    const std::string saved_table_file_path = parser.get<cv::String>("output");
+
+    // check the input param
+    if (image_folder_path.empty() || ncnn_param_file_path.empty() || ncnn_bin_file_path.empty() || saved_table_file_path.empty())
+    {
+        fprintf(stderr, "One or more path may be empty, please check and try again.\n");
+        return 0;
+    }
+
+    const auto num_threads = parser.get<int>("thread");
+
+    struct PreParam pre_param {
+        {104.f, 117.f, 103.f},
+        { 1.f, 1.f, 1.f },
+            224,
+            224,
+            false
     };
 
-    int c;
-
-    while (1) 
+    const auto find_all_value_in_string = [](const std::string& values_string, std::vector<float>& value)
     {
-        int option_index = 0;
-        static struct option long_options[] = 
+        std::vector<int> masks_pos;
+
+        for (size_t i = 0; i < values_string.size(); i++)
         {
-            {"param",   required_argument, 0,  'p' },
-            {"bin",     required_argument, 0,  'b' },
-            {"images",  required_argument, 0,  'i' },
-            {"output",  required_argument, 0,  'o' },
-            {"mean",    required_argument, 0,  'm' },
-            {"norm",    required_argument, 0,  'n' },
-            {"size",    required_argument, 0,  's' },
-            {"swapRB",  no_argument,       0,  'c' },
-            {"thread",  required_argument, 0,  't' },
-            {"help",    no_argument,       0,  'h' },
-            {0,         0,                 0,  0 }
-        };
-
-        c = getopt_long(argc, argv, "p:b:i:o:m:n:s:ct:h", long_options, &option_index);
-        if (c == -1)
-            break;
-
-        switch (c) 
-        {
-        case 'p':
-            printf("param = '%s'\n", optarg);
-            parampath = optarg;
-            break;
-
-        case 'b':
-            printf("bin = '%s'\n", optarg);
-            binpath = optarg;
-            break;
-
-        case 'i':
-            printf("images = '%s'\n", optarg);
-            imagepath = optarg;
-            break;
-
-        case 'o':
-            printf("output = '%s'\n", optarg);
-            tablepath = optarg;
-            break;
-
-        case 'm':
-        {
-            printf("mean = '%s'\n", optarg);
-            std::string temp(optarg);
-            std::vector<std::string> array = split(temp, ",");
-            pre_param.mean[0] = atof(array[0].c_str());
-            pre_param.mean[1] = atof(array[1].c_str());
-            pre_param.mean[2] = atof(array[2].c_str());
+            if (',' == values_string[i])
+            {
+                masks_pos.push_back(static_cast<int>(i));
+            }
         }
-            break;
 
-        case 'n':
+        // check
+        if (masks_pos.empty())
         {
-            printf("norm = '%s'\n", optarg);
-            std::string temp(optarg);
-            std::vector<std::string> array = split(temp, ",");
-            pre_param.norm[0] = atof(array[0].c_str());
-            pre_param.norm[1] = atof(array[1].c_str());
-            pre_param.norm[2] = atof(array[2].c_str());
+            fprintf(stderr, "ERROR: Cannot find any ',' in string, please check.\n");
+            return -1;
         }
-            break;
 
-        case 's':
+        if (2 != masks_pos.size())
         {
-            printf("size = '%s'\n", optarg);
-            std::string temp(optarg);
-            std::vector<std::string> array = split(temp, ",");
-            pre_param.weith = atoi(array[0].c_str());
-            pre_param.height = atoi(array[1].c_str());
+            fprintf(stderr, "ERROR: Char ',' in fist of string, please check.\n");
+            return -1;
         }
-            break;                        
 
-        case 'c':
+        if (masks_pos.front() == 0)
         {
-            printf("swapRB = '%s'\n", "true");
-            pre_param.swapRB = true;
+            fprintf(stderr, "ERROR: Char ',' in fist of string, please check.\n");
+            return -1;
         }
-            break;
-        case 't':
-            printf("thread = '%s'\n", optarg);
-            num_threads = atoi(optarg);
-            break;            
 
-        case 'h':
-        case '?':
-            showUsage();
-            return 0;
+        if (masks_pos.back() == 0)
+        {
+            fprintf(stderr, "ERROR: Char ',' in last of string, please check.\n");
+            return -1;
+        }
 
-        default:
-            showUsage();
+        for (size_t i = 0; i < masks_pos.size(); i++)
+        {
+            if (i > 0)
+            {
+                if (!(masks_pos[i] - masks_pos[i - 1] > 1))
+                {
+                    fprintf(stderr, "ERROR: Neighbouring char ',' was found.\n");
+                    return -1;
+                }
+            }
+        }
+
+        const cv::String ch0_val_str = values_string.substr(0, masks_pos[0]);
+        const cv::String ch1_val_str = values_string.substr(masks_pos[0] + 1, masks_pos[1] - masks_pos[0] - 1);
+        const cv::String ch2_val_str = values_string.substr(masks_pos[1] + 1, values_string.size() - masks_pos[1] - 1);
+
+        value.emplace_back(static_cast<float>(std::atof(std::string(ch0_val_str).c_str())));
+        value.emplace_back(static_cast<float>(std::atof(std::string(ch1_val_str).c_str())));
+        value.emplace_back(static_cast<float>(std::atof(std::string(ch2_val_str).c_str())));
+
+        return 0;
+    };
+
+    if (parser.has("mean"))
+    {
+        const std::string mean_str = parser.get<std::string>("mean");
+
+        std::vector<float> mean_values;
+        const auto ret = find_all_value_in_string(mean_str, mean_values);
+        if (0 != ret && 3 != mean_values.size())
+        {
+            fprintf(stderr, "ERROR: Searching mean value from --mean was failed.\n");
+
+            return -1;
+        }
+
+        pre_param.mean[0] = mean_values[0];
+        pre_param.mean[1] = mean_values[1];
+        pre_param.mean[2] = mean_values[2];
+    }
+
+    if (parser.has("norm"))
+    {
+        const std::string norm_str = parser.get<std::string>("norm");
+
+        std::vector<float> norm_values;
+        const auto ret = find_all_value_in_string(norm_str, norm_values);
+        if (0 != ret && 3 != norm_values.size())
+        {
+            fprintf(stderr, "ERROR: Searching mean value from --mean was failed, please check --mean param.\n");
+
+            return -1;
+        }
+
+        pre_param.norm[0] = norm_values[0];
+        pre_param.norm[1] = norm_values[1];
+        pre_param.norm[2] = norm_values[2];
+    }
+
+    if (parser.has("size"))
+    {
+        cv::String size_str = parser.get<std::string>("size");
+
+        auto sep_pos = size_str.find_first_of(',');
+
+        if (cv::String::npos != sep_pos && sep_pos < size_str.size())
+        {
+            cv::String width_value_str;
+            cv::String height_value_str;
+
+            width_value_str = size_str.substr(0, sep_pos);
+            height_value_str = size_str.substr(sep_pos + 1, size_str.size() - sep_pos - 1);
+
+            pre_param.width = static_cast<int>(std::atoi(std::string(width_value_str).c_str()));
+            pre_param.height = static_cast<int>(std::atoi(std::string(height_value_str).c_str()));
+        }
+        else
+        {
+            fprintf(stderr, "ERROR: Searching size value from --size was failed, please check --size param.\n");
+
+            return -1;
         }
     }
 
-    // check the input param
-    if (imagepath == NULL || parampath == NULL || binpath == NULL || tablepath == NULL)
+    if (parser.has("swapRB"))
     {
-        fprintf(stderr, "someone path maybe empty,please check it and try again.\n");
-        return 0;
+        pre_param.swapRB = true;
     }
 
     g_blob_pool_allocator.set_size_compare_ratio(0.0f);
@@ -896,17 +927,19 @@ int main(int argc, char** argv)
 
     ncnn::set_cpu_powersave(2);
     ncnn::set_omp_dynamic(0);
-    ncnn::set_omp_num_threads(num_threads);  
+    ncnn::set_omp_num_threads(num_threads);
 
-    std::vector<std::string> filenames;
+    std::vector<std::string> image_file_path_list;
 
     // parse the image file.
-    parse_images_dir(imagepath, filenames);
+    parse_images_dir(image_folder_path, image_file_path_list);
 
     // get the calibration table file, and save it.
-    int ret = post_training_quantize(filenames, parampath, binpath, tablepath, pre_param);
+    const auto ret = post_training_quantize(image_file_path_list, ncnn_param_file_path, ncnn_bin_file_path, saved_table_file_path, pre_param);
     if (!ret)
-        fprintf(stderr, "\nNCNN Int8 Calibration table create success, best wish for your INT8 inference has a low accuracy loss...\\(^▽^)/...233...\n");
+    {
+        fprintf(stderr, "\nNCNN Int8 Calibration table create success, best wish for your INT8 inference has a low accuracy loss...\\(^0^)/...233...\n");
+    }
 
     return 0;
 }


### PR DESCRIPTION
1. for cross platform, use cv::CommandLineParser instead of getopt.h
2. use cv::glob to search folder instead of dirent.h
3. fix some other warnings of function from cstdlib
4. add some const and some auto

now the tools is usable.