### PR TITLE
Tiny fix mxnet2ncnn tool

### DIFF
--- a/tools/mxnet/mxnet2ncnn.cpp
+++ b/tools/mxnet/mxnet2ncnn.cpp
@@ -2387,7 +2387,8 @@ int main(int argc, char** argv)
             // skip N-dim
             begin.erase(begin.begin());
             end.erase(end.begin());
-            step.erase(step.begin());
+            if(step.size() != 0)
+                step.erase(step.begin());
 
             // assert step == 1
             for (int i=0; i<(int)step.size(); i++)


### PR DESCRIPTION
Hi nihui.
Mxnet slice step parameter is option, if not given in model code, it will ignore in mxnet-symbol.json. So i add check.