### PR TITLE
mxnet2ncnn support list args in attrs

### DIFF
--- a/tools/mxnet/mxnet2ncnn.cpp
+++ b/tools/mxnet/mxnet2ncnn.cpp
@@ -136,7 +136,7 @@ std::vector<int> MXNetNode::attr_ai(const char* key) const
     int i = 0;
     int c = 0;
     int nconsumed = 0;
-    int nscan = sscanf(it->second.c_str() + c, "%*[(,]%d%n", &i, &nconsumed);
+    int nscan = sscanf(it->second.c_str() + c, "%*[\[(,]%d%n", &i, &nconsumed);
     if (nscan != 1)
     {
         // (None


### PR DESCRIPTION
Either tuple or list could be valid argumenst in mxnet.gluon.nn.Conv* classes. 
current mxnet2ncnn tool failed to work when set kernel/pad/stride/dialate with list instead of tuple.
