### PR TITLE
Added AVX implementation to cast to/from bfloat and float32

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -399,7 +399,7 @@ elseif(NCNN_AVX2)
         target_compile_options(ncnn PRIVATE /arch:AVX2 /DAVX2)
     #Linux
     else()
-        target_compile_options(ncnn PRIVATE -mfma -mf16c)
+        target_compile_options(ncnn PRIVATE -mfma -mf16c -mavx2)
     endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -399,7 +399,7 @@ elseif(NCNN_AVX2)
         target_compile_options(ncnn PRIVATE /arch:AVX2 /DAVX2)
     #Linux
     else()
-        target_compile_options(ncnn PRIVATE -mfma -mf16c -mavx2)
+        target_compile_options(ncnn PRIVATE -mfma -mf16c)
     endif()
 endif()
 

--- a/src/layer/x86/avx_mathfun.h
+++ b/src/layer/x86/avx_mathfun.h
@@ -28,6 +28,8 @@
 
   (this is the zlib license)
 */
+#ifndef AVX_MATHFUN
+#define AVX_MATHFUN
 
 #include <immintrin.h>
 
@@ -53,7 +55,7 @@ _PI32AVX_CONST(4, 4);
 #define _PS256_CONST(Name, Val)                                            \
   static const ALIGN32_BEG float _ps256_##Name[8] ALIGN32_END = { Val, Val, Val, Val, Val, Val, Val, Val }
 #define _PI32_CONST256(Name, Val)                                            \
-  static const ALIGN32_BEG unsigned int _pi32_256_##Name[8] ALIGN32_END = { Val, Val, Val, Val, Val, Val, Val, Val }
+  static const ALIGN32_BEG int _pi32_256_##Name[8] ALIGN32_END = { Val, Val, Val, Val, Val, Val, Val, Val }
 #define _PS256_CONST_TYPE(Name, Type, Val)                                 \
   static const ALIGN32_BEG Type _ps256_##Name[8] ALIGN32_END = { Val, Val, Val, Val, Val, Val, Val, Val }
 
@@ -64,8 +66,8 @@ _PS256_CONST_TYPE(min_norm_pos, int, 0x00800000);
 _PS256_CONST_TYPE(mant_mask, int, 0x7f800000);
 _PS256_CONST_TYPE(inv_mant_mask, int, ~0x7f800000);
 
-_PS256_CONST_TYPE(sign_mask, int, 0x80000000);
-_PS256_CONST_TYPE(inv_sign_mask, int, ~0x80000000);
+_PS256_CONST_TYPE(sign_mask, unsigned int, 0x80000000);
+_PS256_CONST_TYPE(inv_sign_mask, unsigned int, ~0x80000000);
 
 _PI32_CONST256(0, 0);
 _PI32_CONST256(1, 1);
@@ -733,3 +735,4 @@ void sincos256_ps(v8sf x, v8sf *s, v8sf *c) {
   *c = _mm256_xor_ps(xmm2, sign_bit_cos);
 }
 
+#endif //AVX_MATHFUN

--- a/src/layer/x86/avx_mathfun.h
+++ b/src/layer/x86/avx_mathfun.h
@@ -88,7 +88,6 @@ _PS256_CONST(cephes_log_q1, -2.12194440e-4);
 _PS256_CONST(cephes_log_q2, 0.693359375);
 
 #ifndef __AVX2__
-
 typedef union imm_xmm_union {
   v8si imm;
   v4si xmm[2];
@@ -108,7 +107,7 @@ typedef union imm_xmm_union {
 
 
 #define AVX2_BITOP_USING_SSE2(fn) \
-static inline v8si _mm256_##fn(v8si x, int a) \
+static inline v8si _avx_mm256_##fn(v8si x, int a) \
 { \
   /* use SSE2 instruction to perform the bitop AVX2 */ \
   v4si x1, x2; \
@@ -125,7 +124,7 @@ AVX2_BITOP_USING_SSE2(slli_epi32)
 AVX2_BITOP_USING_SSE2(srli_epi32)
 
 #define AVX2_INTOP_USING_SSE2(fn) \
-static inline v8si _mm256_##fn(v8si x, v8si y) \
+static inline v8si _avx_mm256_##fn(v8si x, v8si y) \
 { \
   /* use SSE2 instructions to perform the AVX2 integer operation */ \
   v4si x1, x2; \
@@ -145,7 +144,31 @@ AVX2_INTOP_USING_SSE2(andnot_si128)
 AVX2_INTOP_USING_SSE2(cmpeq_epi32)
 AVX2_INTOP_USING_SSE2(sub_epi32)
 AVX2_INTOP_USING_SSE2(add_epi32)
+#else
 
+
+#define AVX2_BITOP_USING_SSE2(fn) \
+static inline v8si _avx_mm256_##fn(v8si x, int a) \
+{ \
+  return(_mm256_##fn(x,a);); \
+}
+
+#warning "Using SSE2 to perform AVX2 bitshift ops"
+AVX2_BITOP_USING_SSE2(slli_epi32)
+AVX2_BITOP_USING_SSE2(srli_epi32)
+
+#define AVX2_INTOP_USING_SSE2(fn) \
+static inline v8si _avx_mm256_##fn(v8si x, v8si y) \
+{ \
+  return(_mm256_##fn(x,y)); \
+}
+
+#warning "Using SSE2 to perform AVX2 integer ops"
+AVX2_INTOP_USING_SSE2(and_si128)
+AVX2_INTOP_USING_SSE2(andnot_si128)
+AVX2_INTOP_USING_SSE2(cmpeq_epi32)
+AVX2_INTOP_USING_SSE2(sub_epi32)
+AVX2_INTOP_USING_SSE2(add_epi32)
 #endif /* __AVX2__ */
 
 
@@ -162,14 +185,14 @@ v8sf log256_ps(v8sf x) {
   x = _mm256_max_ps(x, *(v8sf*)_ps256_min_norm_pos);  /* cut off denormalized stuff */
 
   // can be done with AVX2
-  imm0 = _mm256_srli_epi32(_mm256_castps_si256(x), 23);
+  imm0 = _avx_mm256_srli_epi32(_mm256_castps_si256(x), 23);
 
   /* keep only the fractional part */
   x = _mm256_and_ps(x, *(v8sf*)_ps256_inv_mant_mask);
   x = _mm256_or_ps(x, *(v8sf*)_ps256_0p5);
 
   // this is again another AVX2 instruction
-  imm0 = _mm256_sub_epi32(imm0, *(v8si*)_pi32_256_0x7f);
+  imm0 = _avx_mm256_sub_epi32(imm0, *(v8si*)_pi32_256_0x7f);
   v8sf e = _mm256_cvtepi32_ps(imm0);
 
   e = _mm256_add_ps(e, one);
@@ -287,8 +310,8 @@ v8sf exp256_ps(v8sf x) {
   /* build 2^n */
   imm0 = _mm256_cvttps_epi32(fx);
   // another two AVX2 instructions
-  imm0 = _mm256_add_epi32(imm0, *(v8si*)_pi32_256_0x7f);
-  imm0 = _mm256_slli_epi32(imm0, 23);
+  imm0 = _avx_mm256_add_epi32(imm0, *(v8si*)_pi32_256_0x7f);
+  imm0 = _avx_mm256_slli_epi32(imm0, 23);
   v8sf pow2n = _mm256_castsi256_ps(imm0);
   y = _mm256_mul_ps(y, pow2n);
   return y;
@@ -347,7 +370,7 @@ v8sf sin256_ps(v8sf x) { // any x
   imm2 = _mm256_cvttps_epi32(y);
   /* j=(j+1) & (~1) (see the cephes sources) */
   // another two AVX2 instruction
-  imm2 = _mm256_add_epi32(imm2, *(v8si*)_pi32_256_1);
+  imm2 = _avx_mm256_add_epi32(imm2, *(v8si*)_pi32_256_1);
   imm2 = _mm256_and_si128(imm2, *(v8si*)_pi32_256_inv1);
   y = _mm256_cvtepi32_ps(imm2);
 
@@ -464,10 +487,10 @@ v8sf cos256_ps(v8sf x) { // any x
   /* store the integer part of y in mm0 */
   imm2 = _mm256_cvttps_epi32(y);
   /* j=(j+1) & (~1) (see the cephes sources) */
-  imm2 = _mm256_add_epi32(imm2, *(v8si*)_pi32_256_1);
+  imm2 = _avx_mm256_add_epi32(imm2, *(v8si*)_pi32_256_1);
   imm2 = _mm256_and_si128(imm2, *(v8si*)_pi32_256_inv1);
   y = _mm256_cvtepi32_ps(imm2);
-  imm2 = _mm256_sub_epi32(imm2, *(v8si*)_pi32_256_2);
+  imm2 = _avx_avx_mm256_sub_epi32(imm2, *(v8si*)_pi32_256_2);
   
   /* get the swap sign flag */
   imm0 = _mm256_andnot_si128(imm2, *(v8si*)_pi32_256_4);
@@ -587,7 +610,7 @@ void sincos256_ps(v8sf x, v8sf *s, v8sf *c) {
   imm2 = _mm256_cvttps_epi32(y);
 
   /* j=(j+1) & (~1) (see the cephes sources) */
-  imm2 = _mm256_add_epi32(imm2, *(v8si*)_pi32_256_1);
+  imm2 = _avx_avx_mm256_add_epi32(imm2, *(v8si*)_pi32_256_1);
   imm2 = _mm256_and_si128(imm2, *(v8si*)_pi32_256_inv1);
 
   y = _mm256_cvtepi32_ps(imm2);
@@ -650,7 +673,7 @@ void sincos256_ps(v8sf x, v8sf *s, v8sf *c) {
   x = _mm256_add_ps(x, xmm3);
 
 #ifdef __AVX2__
-  imm4 = _mm256_sub_epi32(imm4, *(v8si*)_pi32_256_2);
+  imm4 = _avx_mm256_sub_epi32(imm4, *(v8si*)_pi32_256_2);
   imm4 = _mm256_andnot_si128(imm4, *(v8si*)_pi32_256_4);
   imm4 = _mm256_slli_epi32(imm4, 29);
 #else

--- a/src/layer/x86/avx_mathfun.h
+++ b/src/layer/x86/avx_mathfun.h
@@ -28,8 +28,6 @@
 
   (this is the zlib license)
 */
-#ifndef AVX_MATHFUN
-#define AVX_MATHFUN
 
 #include <immintrin.h>
 
@@ -66,8 +64,8 @@ _PS256_CONST_TYPE(min_norm_pos, int, 0x00800000);
 _PS256_CONST_TYPE(mant_mask, int, 0x7f800000);
 _PS256_CONST_TYPE(inv_mant_mask, int, ~0x7f800000);
 
-_PS256_CONST_TYPE(sign_mask, unsigned int, 0x80000000);
-_PS256_CONST_TYPE(inv_sign_mask, unsigned int, ~0x80000000);
+_PS256_CONST_TYPE(sign_mask, int, 0x80000000);
+_PS256_CONST_TYPE(inv_sign_mask, int, ~0x80000000);
 
 _PI32_CONST256(0, 0);
 _PI32_CONST256(1, 1);
@@ -90,6 +88,7 @@ _PS256_CONST(cephes_log_q1, -2.12194440e-4);
 _PS256_CONST(cephes_log_q2, 0.693359375);
 
 #ifndef __AVX2__
+
 typedef union imm_xmm_union {
   v8si imm;
   v4si xmm[2];
@@ -109,7 +108,7 @@ typedef union imm_xmm_union {
 
 
 #define AVX2_BITOP_USING_SSE2(fn) \
-static inline v8si _avx_mm256_##fn(v8si x, int a) \
+static inline v8si _mm256_##fn(v8si x, int a) \
 { \
   /* use SSE2 instruction to perform the bitop AVX2 */ \
   v4si x1, x2; \
@@ -126,7 +125,7 @@ AVX2_BITOP_USING_SSE2(slli_epi32)
 AVX2_BITOP_USING_SSE2(srli_epi32)
 
 #define AVX2_INTOP_USING_SSE2(fn) \
-static inline v8si _avx_mm256_##fn(v8si x, v8si y) \
+static inline v8si _mm256_##fn(v8si x, v8si y) \
 { \
   /* use SSE2 instructions to perform the AVX2 integer operation */ \
   v4si x1, x2; \
@@ -146,31 +145,7 @@ AVX2_INTOP_USING_SSE2(andnot_si128)
 AVX2_INTOP_USING_SSE2(cmpeq_epi32)
 AVX2_INTOP_USING_SSE2(sub_epi32)
 AVX2_INTOP_USING_SSE2(add_epi32)
-#else
 
-
-#define AVX2_BITOP_USING_SSE2(fn) \
-static inline v8si _avx_mm256_##fn(v8si x, int a) \
-{ \
-  return(_mm256_##fn(x,a);); \
-}
-
-#warning "Using SSE2 to perform AVX2 bitshift ops"
-AVX2_BITOP_USING_SSE2(slli_epi32)
-AVX2_BITOP_USING_SSE2(srli_epi32)
-
-#define AVX2_INTOP_USING_SSE2(fn) \
-static inline v8si _avx_mm256_##fn(v8si x, v8si y) \
-{ \
-  return(_mm256_##fn(x,y)); \
-}
-
-#warning "Using SSE2 to perform AVX2 integer ops"
-AVX2_INTOP_USING_SSE2(and_si128)
-AVX2_INTOP_USING_SSE2(andnot_si128)
-AVX2_INTOP_USING_SSE2(cmpeq_epi32)
-AVX2_INTOP_USING_SSE2(sub_epi32)
-AVX2_INTOP_USING_SSE2(add_epi32)
 #endif /* __AVX2__ */
 
 
@@ -187,14 +162,14 @@ v8sf log256_ps(v8sf x) {
   x = _mm256_max_ps(x, *(v8sf*)_ps256_min_norm_pos);  /* cut off denormalized stuff */
 
   // can be done with AVX2
-  imm0 = _avx_mm256_srli_epi32(_mm256_castps_si256(x), 23);
+  imm0 = _mm256_srli_epi32(_mm256_castps_si256(x), 23);
 
   /* keep only the fractional part */
   x = _mm256_and_ps(x, *(v8sf*)_ps256_inv_mant_mask);
   x = _mm256_or_ps(x, *(v8sf*)_ps256_0p5);
 
   // this is again another AVX2 instruction
-  imm0 = _avx_mm256_sub_epi32(imm0, *(v8si*)_pi32_256_0x7f);
+  imm0 = _mm256_sub_epi32(imm0, *(v8si*)_pi32_256_0x7f);
   v8sf e = _mm256_cvtepi32_ps(imm0);
 
   e = _mm256_add_ps(e, one);
@@ -312,8 +287,8 @@ v8sf exp256_ps(v8sf x) {
   /* build 2^n */
   imm0 = _mm256_cvttps_epi32(fx);
   // another two AVX2 instructions
-  imm0 = _avx_mm256_add_epi32(imm0, *(v8si*)_pi32_256_0x7f);
-  imm0 = _avx_mm256_slli_epi32(imm0, 23);
+  imm0 = _mm256_add_epi32(imm0, *(v8si*)_pi32_256_0x7f);
+  imm0 = _mm256_slli_epi32(imm0, 23);
   v8sf pow2n = _mm256_castsi256_ps(imm0);
   y = _mm256_mul_ps(y, pow2n);
   return y;
@@ -372,7 +347,7 @@ v8sf sin256_ps(v8sf x) { // any x
   imm2 = _mm256_cvttps_epi32(y);
   /* j=(j+1) & (~1) (see the cephes sources) */
   // another two AVX2 instruction
-  imm2 = _avx_mm256_add_epi32(imm2, *(v8si*)_pi32_256_1);
+  imm2 = _mm256_add_epi32(imm2, *(v8si*)_pi32_256_1);
   imm2 = _mm256_and_si128(imm2, *(v8si*)_pi32_256_inv1);
   y = _mm256_cvtepi32_ps(imm2);
 
@@ -489,10 +464,10 @@ v8sf cos256_ps(v8sf x) { // any x
   /* store the integer part of y in mm0 */
   imm2 = _mm256_cvttps_epi32(y);
   /* j=(j+1) & (~1) (see the cephes sources) */
-  imm2 = _avx_mm256_add_epi32(imm2, *(v8si*)_pi32_256_1);
+  imm2 = _mm256_add_epi32(imm2, *(v8si*)_pi32_256_1);
   imm2 = _mm256_and_si128(imm2, *(v8si*)_pi32_256_inv1);
   y = _mm256_cvtepi32_ps(imm2);
-  imm2 = _avx_avx_mm256_sub_epi32(imm2, *(v8si*)_pi32_256_2);
+  imm2 = _mm256_sub_epi32(imm2, *(v8si*)_pi32_256_2);
   
   /* get the swap sign flag */
   imm0 = _mm256_andnot_si128(imm2, *(v8si*)_pi32_256_4);
@@ -612,7 +587,7 @@ void sincos256_ps(v8sf x, v8sf *s, v8sf *c) {
   imm2 = _mm256_cvttps_epi32(y);
 
   /* j=(j+1) & (~1) (see the cephes sources) */
-  imm2 = _avx_avx_mm256_add_epi32(imm2, *(v8si*)_pi32_256_1);
+  imm2 = _mm256_add_epi32(imm2, *(v8si*)_pi32_256_1);
   imm2 = _mm256_and_si128(imm2, *(v8si*)_pi32_256_inv1);
 
   y = _mm256_cvtepi32_ps(imm2);
@@ -675,7 +650,7 @@ void sincos256_ps(v8sf x, v8sf *s, v8sf *c) {
   x = _mm256_add_ps(x, xmm3);
 
 #ifdef __AVX2__
-  imm4 = _avx_mm256_sub_epi32(imm4, *(v8si*)_pi32_256_2);
+  imm4 = _mm256_sub_epi32(imm4, *(v8si*)_pi32_256_2);
   imm4 = _mm256_andnot_si128(imm4, *(v8si*)_pi32_256_4);
   imm4 = _mm256_slli_epi32(imm4, 29);
 #else
@@ -735,4 +710,3 @@ void sincos256_ps(v8sf x, v8sf *s, v8sf *c) {
   *c = _mm256_xor_ps(xmm2, sign_bit_cos);
 }
 
-#endif //AVX_MATHFUN

--- a/src/layer/x86/avx_mathfun.h
+++ b/src/layer/x86/avx_mathfun.h
@@ -53,7 +53,7 @@ _PI32AVX_CONST(4, 4);
 #define _PS256_CONST(Name, Val)                                            \
   static const ALIGN32_BEG float _ps256_##Name[8] ALIGN32_END = { Val, Val, Val, Val, Val, Val, Val, Val }
 #define _PI32_CONST256(Name, Val)                                            \
-  static const ALIGN32_BEG int _pi32_256_##Name[8] ALIGN32_END = { Val, Val, Val, Val, Val, Val, Val, Val }
+  static const ALIGN32_BEG unsigned int _pi32_256_##Name[8] ALIGN32_END = { Val, Val, Val, Val, Val, Val, Val, Val }
 #define _PS256_CONST_TYPE(Name, Type, Val)                                 \
   static const ALIGN32_BEG Type _ps256_##Name[8] ALIGN32_END = { Val, Val, Val, Val, Val, Val, Val, Val }
 

--- a/src/layer/x86/cast_x86.cpp
+++ b/src/layer/x86/cast_x86.cpp
@@ -31,13 +31,40 @@ typedef union m256i
     __m256i  vec;
     uint32_t m256i_u32[8];
 } m256;
+static inline __m256i float2bfloat_avx(__m256 v0, __m256 v1)
+{
+   __m256i a = _mm256_castps_si256(v0);
+    a = _mm256_srli_epi32(a,16);
+    __m256i b = _mm256_castps_si256(v1);
+    b = _mm256_srli_epi32(b,16);
+    __m256i abab = _mm256_packus_epi32(a,b);
+    return _mm256_permutevar8x32_epi32(abab, _mm256_setr_epi32(0,1, 4,5, 2,3, 6,7));
+}
+static inline  __m128i float2bfloat_avx(__m256 v0)
+{
+    __m256i a = _mm256_castps_si256(v0);
+    a = _mm256_srli_epi32(a,16);
+    __m256i aaaa = _mm256_packus_epi32(a,a);
+    return _mm256_castsi256_si128(_mm256_permutevar8x32_epi32(aaaa, _mm256_setr_epi32(0,1, 4,5, 2,3, 6,7)));
+}
+static inline  __m256 bfloat2float_avx(__m128i v0)
+{
+   __m128i zero = _mm_set1_epi32(0);
+   __m128i a = _mm_slli_epi32(_mm_unpacklo_epi16(v0,zero),16);
+   __m128i b = _mm_slli_epi32(_mm_unpackhi_epi16(v0,zero),16);
+   __m256i ab;
+   ab = _mm256_insertf128_pd(ab,a,0);  // insert in low 128-bit lane
+   ab = _mm256_insertf128_pd(ab,b,1);  // insert in high 128-bit lane
+   return _mm256_castsi256_ps(ab);
+}
+
 #endif //NCNN_AVX2
 
 DEFINE_LAYER_CREATOR(Cast_x86)
 
 Cast_x86::Cast_x86()
 {
-
+    support_bf16_storage = true;
 }
 
 int Cast_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const
@@ -164,11 +191,62 @@ int Cast_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) 
             }
         }
     }
-
-    if (type_from == 4 || type_to == 4)
+   if (type_from == 1 && type_to == 4)
     {
-        // TODO
-        return Cast::forward(bottom_blob, top_blob, opt);
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int q=0; q<channels; q++)
+        {
+            const float* ptr = bottom_blob.channel(q);
+            unsigned short* outptr = top_blob.channel(q);
+            int nn = size >> 4;
+            // int remain = size & 15;
+            for (; nn>0; nn--)
+            {
+                _mm256_store_si256((__m256i *) outptr,float2bfloat_avx(_mm256_load_ps(ptr),_mm256_load_ps(ptr+8)));
+                ptr += 16;
+                outptr += 16;
+            }
+            nn = (size-((size>>4)<<4)) >> 3;
+            int remain = size & 7;
+            for (; nn>0; nn--)
+            {
+                _mm_store_si128((__m128i *) outptr,float2bfloat_avx(_mm256_load_ps(ptr)));
+                ptr += 8;
+                outptr += 8;
+            }
+            for (; remain>0; remain--)
+            {
+                *outptr = float32_to_bfloat16(*ptr);
+                outptr++;
+                ptr++;
+            }
+        }
+    }
+    if (type_from == 4 && type_to == 1)
+    {
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int q=0; q<channels; q++)
+        {
+            const unsigned short* ptr = bottom_blob.channel(q);
+            float* outptr = top_blob.channel(q);
+
+            
+            int nn = size >> 3;
+            int remain = size & 7;
+            for (; nn>0; nn--)
+            {
+                _mm256_store_ps(outptr,bfloat2float_avx(_mm_lddqu_si128((__m128i*)ptr)));
+                ptr += 8;
+                outptr += 8;
+            }
+
+            for (; remain>0; remain--)
+            {
+                *outptr = bfloat16_to_float32(*ptr);
+                outptr++;
+                ptr++;
+            }
+        }
     }
 
     return 0;

--- a/src/layer/x86/cast_x86.cpp
+++ b/src/layer/x86/cast_x86.cpp
@@ -207,7 +207,7 @@ int Cast_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) 
             }            
             if(remain >= 8)
             {
-                remain = size & 7;
+                remain -= 8;
                 _mm_store_si128((__m128i *) outptr,float2bfloat_avx(_mm256_load_ps(ptr)));
                 ptr += 8;
                 outptr += 8;

--- a/src/layer/x86/cast_x86.cpp
+++ b/src/layer/x86/cast_x86.cpp
@@ -198,17 +198,16 @@ int Cast_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) 
             const float* ptr = bottom_blob.channel(q);
             unsigned short* outptr = top_blob.channel(q);
             int nn = size >> 4;
-            // int remain = size & 15;
+            int remain = size & 15;
             for (; nn>0; nn--)
             {
                 _mm256_store_si256((__m256i *) outptr,float2bfloat_avx(_mm256_load_ps(ptr),_mm256_load_ps(ptr+8)));
                 ptr += 16;
                 outptr += 16;
-            }
-            nn = (size-((size>>4)<<4)) >> 3;
-            int remain = size & 7;
-            for (; nn>0; nn--)
+            }            
+            if(remain >= 8)
             {
+                remain = size & 7;
                 _mm_store_si128((__m128i *) outptr,float2bfloat_avx(_mm256_load_ps(ptr)));
                 ptr += 8;
                 outptr += 8;

--- a/src/layer/x86/cast_x86.cpp
+++ b/src/layer/x86/cast_x86.cpp
@@ -19,7 +19,6 @@ namespace ncnn {
 #if NCNN_AVX2
 #include <emmintrin.h>
 #include <immintrin.h>
-#include "avx_mathfun.h"
 typedef union m128i
 {
     __m128i vec;
@@ -31,6 +30,16 @@ typedef union m256i
     __m256i  vec;
     uint32_t m256i_u32[8];
 } m256;
+static inline  __m256 bfloat2float_avx(__m128i v0)
+{
+    __m128i zero = _mm_set1_epi32(0);
+    __m128i a = _mm_slli_epi32(_mm_unpacklo_epi16(v0,zero),16);
+    __m128i b = _mm_slli_epi32(_mm_unpackhi_epi16(v0,zero),16);
+    __m256i ab = _mm256_set1_epi32(0);
+    ab = _mm256_insertf128_si256(ab,a,0);  // insert in low 128-bit lane
+    ab = _mm256_insertf128_si256(ab,b,1);  // insert in high 128-bit lane
+    return _mm256_castsi256_ps(ab);
+}
 // #ifdef __AVX2__
 // static inline __m256i float2bfloat_avx(__m256 v0, __m256 v1)
 // {
@@ -49,16 +58,7 @@ typedef union m256i
 //     return _mm256_castsi256_si128(_mm256_permutevar8x32_epi32(aaaa, _mm256_setr_epi32(0,1, 4,5, 2,3, 6,7)));
 // }
 // #endif
-// static inline  __m256 bfloat2float_avx(__m128i v0)
-// {
-//     __m128i zero = _mm_set1_epi32(0);
-//     __m128i a = _mm_slli_epi32(_mm_unpacklo_epi16(v0,zero),16);
-//     __m128i b = _mm_slli_epi32(_mm_unpackhi_epi16(v0,zero),16);
-//     __m256i ab = _mm256_set1_epi32(0);
-//     ab = _mm256_insertf128_si256(ab,a,0);  // insert in low 128-bit lane
-//     ab = _mm256_insertf128_si256(ab,b,1);  // insert in high 128-bit lane
-//     return _mm256_castsi256_ps(ab);
-// }
+
 
 #endif //NCNN_AVX2
 
@@ -192,32 +192,32 @@ int Cast_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) 
             }
         }
     }
-    // if (type_from == 4 && type_to == 1)
-    // {
-    //     #pragma omp parallel for num_threads(opt.num_threads)
-    //     for (int q=0; q<channels; q++)
-    //     {
-    //         const unsigned short* ptr = bottom_blob.channel(q);
-    //         float* outptr = top_blob.channel(q);
+    if (type_from == 4 && type_to == 1)
+    {
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int q=0; q<channels; q++)
+        {
+            const unsigned short* ptr = bottom_blob.channel(q);
+            float* outptr = top_blob.channel(q);
 
             
-    //         int nn = size >> 3;
-    //         int remain = size & 7;
-    //         for (; nn>0; nn--)
-    //         {
-    //             _mm256_store_ps(outptr,bfloat2float_avx(_mm_lddqu_si128((__m128i*)ptr)));
-    //             ptr += 8;
-    //             outptr += 8;
-    //         }
+            int nn = size >> 3;
+            int remain = size & 7;
+            for (; nn>0; nn--)
+            {
+                _mm256_store_ps(outptr,bfloat2float_avx(_mm_lddqu_si128((__m128i*)ptr)));
+                ptr += 8;
+                outptr += 8;
+            }
 
-    //         for (; remain>0; remain--)
-    //         {
-    //             *outptr = bfloat16_to_float32(*ptr);
-    //             outptr++;
-    //             ptr++;
-    //         }
-    //     }
-    // }
+            for (; remain>0; remain--)
+            {
+                *outptr = bfloat16_to_float32(*ptr);
+                outptr++;
+                ptr++;
+            }
+        }
+    }
 
     // #ifdef __AVX2__
     // if (type_from == 1 && type_to == 4)

--- a/src/layer/x86/cast_x86.cpp
+++ b/src/layer/x86/cast_x86.cpp
@@ -205,7 +205,7 @@ int Cast_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) 
             int remain = size & 7;
             for (; nn>0; nn--)
             {
-                _mm256_store_ps(outptr,bfloat2float_avx(_mm_lddqu_si128((__m128i*)ptr)));
+                _mm256_storeu_ps(outptr,bfloat2float_avx(_mm_lddqu_si128 ((__m128i const*)ptr)));
                 ptr += 8;
                 outptr += 8;
             }

--- a/src/layer/x86/cast_x86.cpp
+++ b/src/layer/x86/cast_x86.cpp
@@ -60,7 +60,7 @@ typedef union m256i
 //     return _mm256_castsi256_ps(ab);
 // }
 
-// #endif //NCNN_AVX2
+#endif //NCNN_AVX2
 
 DEFINE_LAYER_CREATOR(Cast_x86)
 

--- a/src/layer/x86/cast_x86.cpp
+++ b/src/layer/x86/cast_x86.cpp
@@ -33,7 +33,7 @@ typedef union m256i
 } m256;
 static inline __m256i float2bfloat_avx(__m256 v0, __m256 v1)
 {
-   __m256i a = _mm256_castps_si256(v0);
+    __m256i a = _mm256_castps_si256(v0);
     a = _mm256_srli_epi32(a,16);
     __m256i b = _mm256_castps_si256(v1);
     b = _mm256_srli_epi32(b,16);
@@ -46,16 +46,16 @@ static inline  __m128i float2bfloat_avx(__m256 v0)
     a = _mm256_srli_epi32(a,16);
     __m256i aaaa = _mm256_packus_epi32(a,a);
     return _mm256_castsi256_si128(_mm256_permutevar8x32_epi32(aaaa, _mm256_setr_epi32(0,1, 4,5, 2,3, 6,7)));
-}
+    }
 static inline  __m256 bfloat2float_avx(__m128i v0)
 {
-   __m128i zero = _mm_set1_epi32(0);
-   __m128i a = _mm_slli_epi32(_mm_unpacklo_epi16(v0,zero),16);
-   __m128i b = _mm_slli_epi32(_mm_unpackhi_epi16(v0,zero),16);
-   __m256i ab;
-   ab = _mm256_insertf128_pd(ab,a,0);  // insert in low 128-bit lane
-   ab = _mm256_insertf128_pd(ab,b,1);  // insert in high 128-bit lane
-   return _mm256_castsi256_ps(ab);
+    __m128i zero = _mm_set1_epi32(0);
+    __m128i a = _mm_slli_epi32(_mm_unpacklo_epi16(v0,zero),16);
+    __m128i b = _mm_slli_epi32(_mm_unpackhi_epi16(v0,zero),16);
+    __m256i ab;
+    ab = _mm256_insertf128_pd(ab,a,0);  // insert in low 128-bit lane
+    ab = _mm256_insertf128_pd(ab,b,1);  // insert in high 128-bit lane
+    return _mm256_castsi256_ps(ab);
 }
 
 #endif //NCNN_AVX2
@@ -190,7 +190,7 @@ int Cast_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) 
             }
         }
     }
-   if (type_from == 1 && type_to == 4)
+    if (type_from == 1 && type_to == 4)
     {
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q=0; q<channels; q++)

--- a/src/layer/x86/cast_x86.cpp
+++ b/src/layer/x86/cast_x86.cpp
@@ -52,9 +52,9 @@ static inline  __m256 bfloat2float_avx(__m128i v0)
     __m128i zero = _mm_set1_epi32(0);
     __m128i a = _mm_slli_epi32(_mm_unpacklo_epi16(v0,zero),16);
     __m128i b = _mm_slli_epi32(_mm_unpackhi_epi16(v0,zero),16);
-    __m256i ab;
-    ab = _mm256_insertf128_pd(ab,a,0);  // insert in low 128-bit lane
-    ab = _mm256_insertf128_pd(ab,b,1);  // insert in high 128-bit lane
+    __m256i ab = _mm256_set1_epi32(0);
+    ab = _mm256_insertf128_si256(ab,a,0);  // insert in low 128-bit lane
+    ab = _mm256_insertf128_si256(ab,b,1);  // insert in high 128-bit lane
     return _mm256_castsi256_ps(ab);
 }
 

--- a/src/layer/x86/cast_x86.cpp
+++ b/src/layer/x86/cast_x86.cpp
@@ -31,36 +31,36 @@ typedef union m256i
     __m256i  vec;
     uint32_t m256i_u32[8];
 } m256;
-#ifdef __AVX2__
-static inline __m256i float2bfloat_avx(__m256 v0, __m256 v1)
-{
-    __m256i a = _mm256_castps_si256(v0);
-    a = _avx_mm256_srli_epi32(a,16);
-    __m256i b = _mm256_castps_si256(v1);
-    b = _avx_mm256_srli_epi32(b,16);
-    __m256i abab = _mm256_packus_epi32(a,b);
-    return _mm256_permutevar8x32_epi32(abab, _mm256_setr_epi32(0,1, 4,5, 2,3, 6,7));
-}
-static inline  __m128i float2bfloat_avx(__m256 v0)
-{
-    __m256i a = _mm256_castps_si256(v0);
-    a = _avx_mm256_srli_epi32(a,16);
-    __m256i aaaa = _mm256_packus_epi32(a,a);
-    return _mm256_castsi256_si128(_mm256_permutevar8x32_epi32(aaaa, _mm256_setr_epi32(0,1, 4,5, 2,3, 6,7)));
-}
-#endif
-static inline  __m256 bfloat2float_avx(__m128i v0)
-{
-    __m128i zero = _mm_set1_epi32(0);
-    __m128i a = _mm_slli_epi32(_mm_unpacklo_epi16(v0,zero),16);
-    __m128i b = _mm_slli_epi32(_mm_unpackhi_epi16(v0,zero),16);
-    __m256i ab = _mm256_set1_epi32(0);
-    ab = _mm256_insertf128_si256(ab,a,0);  // insert in low 128-bit lane
-    ab = _mm256_insertf128_si256(ab,b,1);  // insert in high 128-bit lane
-    return _mm256_castsi256_ps(ab);
-}
+// #ifdef __AVX2__
+// static inline __m256i float2bfloat_avx(__m256 v0, __m256 v1)
+// {
+//     __m256i a = _mm256_castps_si256(v0);
+//     a = _avx_mm256_srli_epi32(a,16);
+//     __m256i b = _mm256_castps_si256(v1);
+//     b = _avx_mm256_srli_epi32(b,16);
+//     __m256i abab = _mm256_packus_epi32(a,b);
+//     return _mm256_permutevar8x32_epi32(abab, _mm256_setr_epi32(0,1, 4,5, 2,3, 6,7));
+// }
+// static inline  __m128i float2bfloat_avx(__m256 v0)
+// {
+//     __m256i a = _mm256_castps_si256(v0);
+//     a = _avx_mm256_srli_epi32(a,16);
+//     __m256i aaaa = _mm256_packus_epi32(a,a);
+//     return _mm256_castsi256_si128(_mm256_permutevar8x32_epi32(aaaa, _mm256_setr_epi32(0,1, 4,5, 2,3, 6,7)));
+// }
+// #endif
+// static inline  __m256 bfloat2float_avx(__m128i v0)
+// {
+//     __m128i zero = _mm_set1_epi32(0);
+//     __m128i a = _mm_slli_epi32(_mm_unpacklo_epi16(v0,zero),16);
+//     __m128i b = _mm_slli_epi32(_mm_unpackhi_epi16(v0,zero),16);
+//     __m256i ab = _mm256_set1_epi32(0);
+//     ab = _mm256_insertf128_si256(ab,a,0);  // insert in low 128-bit lane
+//     ab = _mm256_insertf128_si256(ab,b,1);  // insert in high 128-bit lane
+//     return _mm256_castsi256_ps(ab);
+// }
 
-#endif //NCNN_AVX2
+// #endif //NCNN_AVX2
 
 DEFINE_LAYER_CREATOR(Cast_x86)
 
@@ -192,71 +192,75 @@ int Cast_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) 
             }
         }
     }
-    if (type_from == 4 && type_to == 1)
-    {
-        #pragma omp parallel for num_threads(opt.num_threads)
-        for (int q=0; q<channels; q++)
-        {
-            const unsigned short* ptr = bottom_blob.channel(q);
-            float* outptr = top_blob.channel(q);
+    // if (type_from == 4 && type_to == 1)
+    // {
+    //     #pragma omp parallel for num_threads(opt.num_threads)
+    //     for (int q=0; q<channels; q++)
+    //     {
+    //         const unsigned short* ptr = bottom_blob.channel(q);
+    //         float* outptr = top_blob.channel(q);
 
             
-            int nn = size >> 3;
-            int remain = size & 7;
-            for (; nn>0; nn--)
-            {
-                _mm256_store_ps(outptr,bfloat2float_avx(_mm_lddqu_si128((__m128i*)ptr)));
-                ptr += 8;
-                outptr += 8;
-            }
+    //         int nn = size >> 3;
+    //         int remain = size & 7;
+    //         for (; nn>0; nn--)
+    //         {
+    //             _mm256_store_ps(outptr,bfloat2float_avx(_mm_lddqu_si128((__m128i*)ptr)));
+    //             ptr += 8;
+    //             outptr += 8;
+    //         }
 
-            for (; remain>0; remain--)
-            {
-                *outptr = bfloat16_to_float32(*ptr);
-                outptr++;
-                ptr++;
-            }
-        }
-    }
+    //         for (; remain>0; remain--)
+    //         {
+    //             *outptr = bfloat16_to_float32(*ptr);
+    //             outptr++;
+    //             ptr++;
+    //         }
+    //     }
+    // }
 
-    #ifdef __AVX2__
-    if (type_from == 1 && type_to == 4)
-    {
-        #pragma omp parallel for num_threads(opt.num_threads)
-        for (int q=0; q<channels; q++)
-        {
-            const float* ptr = bottom_blob.channel(q);
-            unsigned short* outptr = top_blob.channel(q);
-            int nn = size >> 4;
-            int remain = size & 15;
-            for (; nn>0; nn--)
-            {
-                _mm256_store_si256((__m256i *) outptr,float2bfloat_avx(_mm256_load_ps(ptr),_mm256_load_ps(ptr+8)));
-                ptr += 16;
-                outptr += 16;
-            }            
-            if(remain >= 8)
-            {
-                remain -= 8;
-                _mm_store_si128((__m128i *) outptr,float2bfloat_avx(_mm256_load_ps(ptr)));
-                ptr += 8;
-                outptr += 8;
-            }
-            for (; remain>0; remain--)
-            {
-                *outptr = float32_to_bfloat16(*ptr);
-                outptr++;
-                ptr++;
-            }
-        }
-    }
-    #else
+    // #ifdef __AVX2__
+    // if (type_from == 1 && type_to == 4)
+    // {
+    //     #pragma omp parallel for num_threads(opt.num_threads)
+    //     for (int q=0; q<channels; q++)
+    //     {
+    //         const float* ptr = bottom_blob.channel(q);
+    //         unsigned short* outptr = top_blob.channel(q);
+    //         int nn = size >> 4;
+    //         int remain = size & 15;
+    //         for (; nn>0; nn--)
+    //         {
+    //             _mm256_store_si256((__m256i *) outptr,float2bfloat_avx(_mm256_load_ps(ptr),_mm256_load_ps(ptr+8)));
+    //             ptr += 16;
+    //             outptr += 16;
+    //         }            
+    //         if(remain >= 8)
+    //         {
+    //             remain -= 8;
+    //             _mm_store_si128((__m128i *) outptr,float2bfloat_avx(_mm256_load_ps(ptr)));
+    //             ptr += 8;
+    //             outptr += 8;
+    //         }
+    //         for (; remain>0; remain--)
+    //         {
+    //             *outptr = float32_to_bfloat16(*ptr);
+    //             outptr++;
+    //             ptr++;
+    //         }
+    //     }
+    // }
+    // #else
     if (type_from == 1 && type_to == 4)
     {
          return Cast::forward(bottom_blob, top_blob, opt);
     }
+    if (type_from == 4 && type_to == 1)
+    {
+         return Cast::forward(bottom_blob, top_blob, opt);
+    }
 
-    #endif
+    // #endif
     
 
     return 0;

--- a/src/layer/x86/cast_x86.cpp
+++ b/src/layer/x86/cast_x86.cpp
@@ -64,7 +64,6 @@ DEFINE_LAYER_CREATOR(Cast_x86)
 
 Cast_x86::Cast_x86()
 {
-    support_bf16_storage = true;
 }
 
 int Cast_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const

--- a/src/layer/x86/cast_x86.cpp
+++ b/src/layer/x86/cast_x86.cpp
@@ -231,14 +231,14 @@ int Cast_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) 
     //         int remain = size & 15;
     //         for (; nn>0; nn--)
     //         {
-    //             _mm256_store_si256((__m256i *) outptr,float2bfloat_avx(_mm256_load_ps(ptr),_mm256_load_ps(ptr+8)));
+    //             _mm256_storeu_si256((__m256i *) outptr,float2bfloat_avx(_mm256_loadu_ps(ptr),_mm256_loadu_ps(ptr+8)));
     //             ptr += 16;
     //             outptr += 16;
     //         }            
     //         if(remain >= 8)
     //         {
     //             remain -= 8;
-    //             _mm_store_si128((__m128i *) outptr,float2bfloat_avx(_mm256_load_ps(ptr)));
+    //             _mm_store_si128((__m128i *) outptr,float2bfloat_avx(_mm256_loadu_ps(ptr)));
     //             ptr += 8;
     //             outptr += 8;
     //         }
@@ -255,11 +255,6 @@ int Cast_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) 
     {
          return Cast::forward(bottom_blob, top_blob, opt);
     }
-    if (type_from == 4 && type_to == 1)
-    {
-         return Cast::forward(bottom_blob, top_blob, opt);
-    }
-
     // #endif
     
 

--- a/tests/test_cast.cpp
+++ b/tests/test_cast.cpp
@@ -44,6 +44,9 @@ static int test_cast_cpu(const ncnn::Mat& a, int type_from, int type_to)
     if (type_from == 2)
     {
         ncnn::cast_float32_to_float16(a, a_fp16, opt);
+    }else if (type_from == 4)
+    {
+        ncnn::cast_float32_to_bfloat16(a, a_fp16, opt);
     }
     else
     {
@@ -97,6 +100,9 @@ static int test_cast_cpu_packed(const ncnn::Mat& a, int type_from, int type_to)
     if (type_from == 2)
     {
         ncnn::cast_float32_to_float16(a, a_fp16, opt);
+    } else if (type_from == 4)
+    {
+        ncnn::cast_float32_to_bfloat16(a, a_fp16, opt);
     }
     else
     {
@@ -113,6 +119,9 @@ static int test_cast_cpu_packed(const ncnn::Mat& a, int type_from, int type_to)
     if (type_from == 2)
     {
         ncnn::cast_float32_to_float16(a4, a4_fp16, opt);
+    }else if (type_from == 4)
+    {
+        ncnn::cast_float32_to_bfloat16(a4, a4_fp16, opt);
     }
     else
     {
@@ -622,6 +631,10 @@ static int test_cast_0()
         || test_cast(RandomMat(3, 5, 13), 1, 2)
         || test_cast(RandomMat(6, 7, 16), 2, 1)
         || test_cast(RandomMat(3, 5, 13), 2, 1)
+        || test_cast(RandomMat(6, 7, 16), 1, 4)
+        || test_cast(RandomMat(3, 5, 13), 1, 4)
+        || test_cast(RandomMat(6, 7, 16), 4, 1)
+        || test_cast(RandomMat(3, 5, 13), 4, 1)
         ;
 }
 
@@ -632,6 +645,10 @@ static int test_cast_1()
         || test_cast(RandomMat(7, 15), 1, 2)
         || test_cast(RandomMat(6, 16), 2, 1)
         || test_cast(RandomMat(7, 15), 2, 1)
+        || test_cast(RandomMat(6, 16), 1, 4)
+        || test_cast(RandomMat(7, 15), 1, 4)
+        || test_cast(RandomMat(6, 16), 4, 1)
+        || test_cast(RandomMat(7, 15), 4, 1)
         ;
 }
 
@@ -642,6 +659,10 @@ static int test_cast_2()
         || test_cast(RandomMat(127), 1, 2)
         || test_cast(RandomMat(128), 2, 1)
         || test_cast(RandomMat(127), 2, 1)
+        || test_cast(RandomMat(128), 1, 4)
+        || test_cast(RandomMat(127), 1, 4)
+        || test_cast(RandomMat(128), 4, 1)
+        || test_cast(RandomMat(127), 4, 1)
         ;
 }
 

--- a/tests/test_cast.cpp
+++ b/tests/test_cast.cpp
@@ -147,6 +147,8 @@ static int test_cast_cpu_packed(const ncnn::Mat& a, int type_from, int type_to)
 #if NCNN_VULKAN
 static int test_cast_gpu_fp16p(const ncnn::Mat& a, int type_from, int type_to)
 {
+    if (type_to == 4 || type_from == 4)
+        return 0;
     ncnn::ParamDict pd;
     pd.set(0, type_from);
     pd.set(1, type_to);
@@ -260,6 +262,8 @@ static int test_cast_gpu_fp16p(const ncnn::Mat& a, int type_from, int type_to)
 
 static int test_cast_gpu_fp16p_pack8(const ncnn::Mat& a, int type_from, int type_to)
 {
+    if (type_to == 4 || type_from == 4)
+        return 0;
     ncnn::ParamDict pd;
     pd.set(0, type_from);
     pd.set(1, type_to);
@@ -376,6 +380,8 @@ static int test_cast_gpu_fp16p_pack8(const ncnn::Mat& a, int type_from, int type
 
 static int test_cast_gpu_image_fp16p(const ncnn::Mat& a, int type_from, int type_to)
 {
+    if (type_to == 4 || type_from == 4)
+        return 0;
     ncnn::ParamDict pd;
     pd.set(0, type_from);
     pd.set(1, type_to);
@@ -492,6 +498,8 @@ static int test_cast_gpu_image_fp16p(const ncnn::Mat& a, int type_from, int type
 
 static int test_cast_gpu_image_fp16p_pack8(const ncnn::Mat& a, int type_from, int type_to)
 {
+    if (type_to == 4 || type_from == 4)
+        return 0;
     ncnn::ParamDict pd;
     pd.set(0, type_from);
     pd.set(1, type_to);


### PR DESCRIPTION
Major changes:
1. added -mavx2 compiler option if NCNN_AVX2 is defined
2. added avx implementation of bfloat16 to float32 casting

AVX2 is required for this operation: _mm256_srli_epi32

@nihui I'm looking to start work towards better x86 optimizations, do you have some input on where to start? I was thinking to start by optimizing the different convolutions similar to the arm version but using only intrinsics, and adding an x86 version of the pooling layer. Currently it seems all convolutional layers use the same im2col sgemm implementation.