### PR TITLE
[ncnn] fix simplestl header not installed

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -323,6 +323,7 @@ if(NCNN_INSTALL_SDK)
         paramdict.h
         pipeline.h
         pipelinecache.h
+        simplestl.h
         ${CMAKE_CURRENT_BINARY_DIR}/layer_shader_type_enum.h
         ${CMAKE_CURRENT_BINARY_DIR}/layer_type_enum.h
         ${CMAKE_CURRENT_BINARY_DIR}/platform.h


### PR DESCRIPTION
`make install` 缺少 simplestl.h

`#include "simplestl.h"` 由 `NCNN_SIMPLESTL` 控制