### PR TITLE
add ncnn debug lib postfix 'd' in cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,6 +159,7 @@ configure_file(layer_shader_spv_data.h.in ${CMAKE_CURRENT_BINARY_DIR}/layer_shad
 configure_file(layer_shader_type_enum.h.in ${CMAKE_CURRENT_BINARY_DIR}/layer_shader_type_enum.h)
 
 add_library(ncnn STATIC ${ncnn_SRCS})
+set_target_properties(ncnn PROPERTIES DEBUG_POSTFIX "d")
 
 if(NCNN_SIMPLESTL)
     # link math lib explicitly


### PR DESCRIPTION
给ncnn的debug静态库名字添加了`d`作为后缀，使得Visual Studio中调试时（处于debug模式）的可执行文件，链接debug库；处于release模式时，调用release库。

VS2017 x64 测试可以。
Ubuntu下测试发现，debug/release模式都是叫libncnn.a，不受影响。

P.S. 
放一个使用ncnn库的基于cmake构建的例子： https://github.com/zchrissirhcz/cmake_examples/tree/master/ncnn_example