### PR TITLE
fix output shape of global_pooling

### DIFF
--- a/src/layer/arm/pooling_arm.cpp
+++ b/src/layer/arm/pooling_arm.cpp
@@ -123,6 +123,7 @@ int Pooling_arm::forward(const Mat& bottom_blob, Mat& top_blob, const Option& op
                 }
             }
 
+            top_blob = top_blob.reshape(1, 1, channels, opt.blob_allocator);
             return 0;
         }
 
@@ -476,6 +477,7 @@ int Pooling_arm::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const Opti
             }
         }
 
+        top_blob = top_blob.reshape(1, 1, channels, opt.blob_allocator);
         return 0;
     }
 
@@ -893,6 +895,7 @@ int Pooling_arm::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const Opt
             }
         }
 
+        top_blob = top_blob.reshape(1, 1, channels, opt.blob_allocator);
         return 0;
     }
 
@@ -1323,6 +1326,7 @@ int Pooling_arm::forward_bf16s(const Mat& bottom_blob, Mat& top_blob, const Opti
             }
         }
 
+        top_blob = top_blob.reshape(1, 1, channels, opt.blob_allocator);
         return 0;
     }
 

--- a/src/layer/pooling.cpp
+++ b/src/layer/pooling.cpp
@@ -95,7 +95,8 @@ int Pooling::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) c
                 top_blob[q] = sum / size;
             }
         }
-
+        
+        top_blob = top_blob.reshape(1, 1, channels, opt.blob_allocator);
         return 0;
     }
 

--- a/src/layer/vulkan/pooling_vulkan.cpp
+++ b/src/layer/vulkan/pooling_vulkan.cpp
@@ -308,7 +308,7 @@ int Pooling_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute
 
     if (global_pooling)
     {
-        top_blob.create(channels, elemsize, elempack, opt.blob_vkallocator);
+        top_blob.create(1, 1, channels, elemsize, elempack, opt.blob_vkallocator);
         if (top_blob.empty())
             return -100;
 
@@ -484,7 +484,7 @@ int Pooling_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob,
 
     if (global_pooling)
     {
-        top_blob.create(channels, elemsize, elempack, opt.blob_vkallocator);
+        top_blob.create(1, 1, channels, elemsize, elempack, opt.blob_vkallocator);
         if (top_blob.empty())
             return -100;
 

--- a/src/layer/vulkan/shader/pooling_global.comp
+++ b/src/layer/vulkan/shader/pooling_global.comp
@@ -40,7 +40,7 @@ layout (constant_id = shape_constant_id_offset + 9) const int outcstep = 0;
 
 #if NCNN_image_shader
 layout (binding = 0) uniform unfp sampler3D bottom_blob;
-layout (binding = 1, imfmtc1) writeonly uniform unfp image1D top_blob;
+layout (binding = 1, imfmtc1) writeonly uniform unfp image3D top_blob;
 #else
 layout (binding = 0) readonly buffer bottom_blob { sfp bottom_blob_data[]; };
 layout (binding = 1) writeonly buffer top_blob { sfp top_blob_data[]; };
@@ -67,11 +67,11 @@ void main()
     int gy = int(gl_GlobalInvocationID.y);
     int gz = int(gl_GlobalInvocationID.z);
 
-    if (gx >= psc(outw) || gy >= 1 || gz >= 1)
+    if (gx >= 1 || gy >= 1 || gz >= psc(outc))
         return;
 
     int size = psc(w) * psc(h);
-    int v_offset = gx * psc(cstep);
+    int v_offset = gz * psc(cstep);
 
     afp res;
 
@@ -84,7 +84,7 @@ void main()
         {
             for (int x = 0; x < psc(w); x++)
             {
-                afp v = image3d_ld1(bottom_blob, ivec3(x, y, gx));
+                afp v = image3d_ld1(bottom_blob, ivec3(x, y, gz));
                 res = max(res, v);
             }
         }
@@ -105,7 +105,7 @@ void main()
         {
             for (int x = 0; x < psc(w); x++)
             {
-                res += image3d_ld1(bottom_blob, ivec3(x, y, gx));
+                res += image3d_ld1(bottom_blob, ivec3(x, y, gz));
             }
         }
 #else
@@ -119,8 +119,10 @@ void main()
     }
 
 #if NCNN_image_shader
-    image1d_st1(top_blob, gx, res);
+    image3d_st1(top_blob, ivec3(gx, gy, gz), res);
 #else
-    buffer_st1(top_blob_data, gx, res);
+    const int gi = gz * psc(outcstep) + gy * psc(outw) + gx;
+
+    buffer_st1(top_blob_data, gi, res);
 #endif
 }

--- a/src/layer/vulkan/shader/pooling_global_pack4.comp
+++ b/src/layer/vulkan/shader/pooling_global_pack4.comp
@@ -40,7 +40,7 @@ layout (constant_id = shape_constant_id_offset + 9) const int outcstep = 0;
 
 #if NCNN_image_shader
 layout (binding = 0) uniform unfp sampler3D bottom_blob;
-layout (binding = 1, imfmtc4) writeonly uniform unfp image1D top_blob;
+layout (binding = 1, imfmtc4) writeonly uniform unfp image3D top_blob;
 #else
 layout (binding = 0) readonly buffer bottom_blob { sfpvec4 bottom_blob_data[]; };
 layout (binding = 1) writeonly buffer top_blob { sfpvec4 top_blob_data[]; };
@@ -67,11 +67,11 @@ void main()
     int gy = int(gl_GlobalInvocationID.y);
     int gz = int(gl_GlobalInvocationID.z);
 
-    if (gx >= psc(outw) || gy >= 1 || gz >= 1)
+    if (gx >= 1 || gy >= 1 || gz >= psc(outc))
         return;
 
     int size = psc(w) * psc(h);
-    int v_offset = gx * psc(cstep);
+    int v_offset = gz * psc(cstep);
 
     afpvec4 res;
 
@@ -84,7 +84,7 @@ void main()
         {
             for (int x = 0; x < psc(w); x++)
             {
-                afpvec4 v = image3d_ld4(bottom_blob, ivec3(x, y, gx));
+                afpvec4 v = image3d_ld4(bottom_blob, ivec3(x, y, gz));
                 res = max(res, v);
             }
         }
@@ -105,7 +105,7 @@ void main()
         {
             for (int x = 0; x < psc(w); x++)
             {
-                res += image3d_ld4(bottom_blob, ivec3(x, y, gx));
+                res += image3d_ld4(bottom_blob, ivec3(x, y, gz));
             }
         }
 #else
@@ -119,8 +119,10 @@ void main()
     }
 
 #if NCNN_image_shader
-    image1d_st4(top_blob, gx, res);
+    image3d_st4(top_blob, ivec3(gx, gy, gz), res);
 #else
-    buffer_st4(top_blob_data, gx, res);
+    const int gi = gz * psc(outcstep) + gy * psc(outw) + gx;
+
+    buffer_st4(top_blob_data, gi, res);
 #endif
 }

--- a/src/layer/vulkan/shader/pooling_global_pack8.comp
+++ b/src/layer/vulkan/shader/pooling_global_pack8.comp
@@ -41,7 +41,7 @@ layout (constant_id = shape_constant_id_offset + 9) const int outcstep = 0;
 
 #if NCNN_image_shader
 layout (binding = 0) uniform unfp sampler3D bottom_blob;
-layout (binding = 1, imfmtc4) writeonly uniform unfp image1D top_blob;
+layout (binding = 1, imfmtc4) writeonly uniform unfp image3D top_blob;
 #else
 layout (binding = 0) readonly buffer bottom_blob { sfpvec8 bottom_blob_data[]; };
 layout (binding = 1) writeonly buffer top_blob { sfpvec8 top_blob_data[]; };
@@ -68,11 +68,11 @@ void main()
     int gy = int(gl_GlobalInvocationID.y);
     int gz = int(gl_GlobalInvocationID.z);
 
-    if (gx >= psc(outw) || gy >= 1 || gz >= 1)
+    if (gx >= 1 || gy >= 1 || gz >= psc(outc))
         return;
 
     int size = psc(w) * psc(h);
-    int v_offset = gx * psc(cstep);
+    int v_offset = gz * psc(cstep);
 
     afpvec8 res;
 
@@ -85,7 +85,7 @@ void main()
         {
             for (int x = 0; x < psc(w); x++)
             {
-                afpvec8 v = image3d_ld8(bottom_blob, ivec3(x, y, gx));
+                afpvec8 v = image3d_ld8(bottom_blob, ivec3(x, y, gz));
                 res[0] = max(res[0], v[0]);
                 res[1] = max(res[1], v[1]);
             }
@@ -108,7 +108,7 @@ void main()
         {
             for (int x = 0; x < psc(w); x++)
             {
-                afpvec8 v = image3d_ld8(bottom_blob, ivec3(x, y, gx));
+                afpvec8 v = image3d_ld8(bottom_blob, ivec3(x, y, gz));
                 res[0] += v[0];
                 res[1] += v[1];
             }
@@ -128,8 +128,10 @@ void main()
     }
 
 #if NCNN_image_shader
-    image1d_st8(top_blob, gx, res);
+    image3d_st8(top_blob, ivec3(gx, gy, gz), res);
 #else
-    buffer_st8(top_blob_data, gx, res);
+    const int gi = gz * psc(outcstep) + gy * psc(outw) + gx;
+
+    buffer_st8(top_blob_data, gi, res);
 #endif
 }

--- a/src/layer/x86/pooling_x86.cpp
+++ b/src/layer/x86/pooling_x86.cpp
@@ -102,6 +102,7 @@ int Pooling_x86::forward(const Mat& bottom_blob, Mat& top_blob,
                 }
             }
 
+            top_blob = top_blob.reshape(1, 1, channels, opt.blob_allocator);
             return 0;
         }
 


### PR DESCRIPTION
When input shape is WxHxC, the global_pooling will output Cx1x1.
This pull request will fix the output shape of global_pooling to expect 1x1xC.