### PR TITLE
Fixed compile warning for macos in caffe2ncnn (-Wformat)

### DIFF
--- a/tools/caffe/caffe2ncnn.cpp
+++ b/tools/caffe/caffe2ncnn.cpp
@@ -1527,7 +1527,7 @@ int main(int argc, char** argv)
             }
             else if (bs.dim_size() == 3)
             {
-                fprintf(pp, " 0=%zd 1=%zd 2=-233", size_t(bs.dim(2)), bs.dim(1));
+                fprintf(pp, " 0=%zd 1=%zd 2=-233", size_t(bs.dim(2)), size_t(bs.dim(1)));
             }
             else // bs.dim_size() == 4
             {


### PR DESCRIPTION
Hi, NCNN team.

I fixed compile warning in MACOS build. Could you verify and accept my changes, pls?

[100/107] Building CXX object tools/caffe/CMakeFiles/caffe2ncnn.dir/caffe2ncnn.cpp.o
                                                    ^
../tools/caffe/caffe2ncnn.cpp:1530:71: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type '::google::protobuf::int64' (aka 'long long') [-Wformat]
 fprintf(pp, " 0=%zd 1=%zd 2=-233", size_t(bs.dim(2)), bs.dim(1));
_______________________~~~_______________________________^~~~~~~~~
_______________________%lld
1 warnings generated.

I see same warning in Travis CI: https://github.com/Tencent/ncnn/runs/1182818620?check_suite_focus=true

Best regards, Evgeny.