### PR TITLE
Improve build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,14 @@ ncnn 是一个为手机端极致优化的高性能神经网络前向计算框架
 
 **[how to build ncnn library](https://github.com/Tencent/ncnn/wiki/how-to-build) on Linux / Windows / Raspberry Pi3 / Android / NVIDIA Jetson / iOS**
 
-* [Build for NVIDIA Jetson](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-nvidia-jetson)
-* [Build for Linux x86](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-linux-x86)
+* [Build for Linux / NVIDIA Jetson / Raspberry Pi](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-linux)
 * [Build for Windows x64 using VS2017](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-windows-x64-using-visual-studio-community-2017)
 * [Build for MacOSX](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-macosx)
-* [Build for Raspberry Pi 3](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-raspberry-pi-3)
 * [Build for ARM Cortex-A family with cross-compiling](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-arm-cortex-a-family-with-cross-compiling)
+* [Build for Hisilicon platform with cross-compiling](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-hisilicon-platform-with-cross-compiling)
 * [Build for Android](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-android)
 * [Build for iOS on MacOSX with xcode](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-ios-on-macosx-with-xcode)
 * [Build for iOS on Linux with cctools-port](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-ios-on-linux-with-cctools-port)
-* [Build for Hisilicon platform with cross-compiling](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-hisilicon-platform-with-cross-compiling)
 
 **[download prebuild binary package for android and ios](https://github.com/Tencent/ncnn/releases)**
 

--- a/docs/how-to-build/how-to-build.md
+++ b/docs/how-to-build/how-to-build.md
@@ -6,7 +6,7 @@ $ cd ncnn
 $ git submodule update --init
 ```
 
-* [Build for Linux](#build-for-linux)
+* [Build for Linux / NVIDIA Jetson / Raspberry Pi](#build-for-linux)
 * [Build for Windows x64 using VS2017](#build-for-windows-x64-using-visual-studio-community-2017)
 * [Build for MacOSX](#build-for-macosx)
 * [Build for ARM Cortex-A family with cross-compiling](#build-for-arm-cortex-a-family-with-cross-compiling)

--- a/docs/how-to-build/how-to-build.md
+++ b/docs/how-to-build/how-to-build.md
@@ -2,122 +2,152 @@
 
 ```
 $ git clone https://github.com/Tencent/ncnn.git
-$ cd <ncnn-root-dir>
+$ cd ncnn
 $ git submodule update --init
 ```
 
-* [Build for Linux x86](#build-for-linux-x86)
+* [Build for Linux](#build-for-linux)
 * [Build for Windows x64 using VS2017](#build-for-windows-x64-using-visual-studio-community-2017)
 * [Build for MacOSX](#build-for-macosx)
-* [Build for Raspberry Pi 3](#build-for-raspberry-pi-3)
-* [Build for NVIDIA Jetson](#build-for-nvidia-jetson)
 * [Build for ARM Cortex-A family with cross-compiling](#build-for-arm-cortex-a-family-with-cross-compiling)
+* [Build for Hisilicon platform with cross-compiling](#build-for-hisilicon-platform-with-cross-compiling)
 * [Build for Android](#build-for-android)
 * [Build for iOS on MacOSX with xcode](#build-for-ios-on-macosx-with-xcode)
 * [Build for iOS on Linux with cctools-port](#build-for-ios-on-linux-with-cctools-port)
-* [Build for Hisilicon platform with cross-compiling](#build-for-hisilicon-platform-with-cross-compiling)
 
 ***
 
-### Build for Linux x86
-install g++ cmake protobuf
+### Build for Linux
 
-(optional) download and install vulkan-sdk from https://vulkan.lunarg.com/sdk/home
-```
-$ wget https://sdk.lunarg.com/sdk/download/1.1.114.0/linux/vulkansdk-linux-x86_64-1.1.114.0.tar.gz?Human=true -O vulkansdk-linux-x86_64-1.1.114.0.tar.gz
-$ tar -xf vulkansdk-linux-x86_64-1.1.114.0.tar.gz
+Install required build dependencies:
 
-# setup env
-$ export VULKAN_SDK=`pwd`/1.1.114.0/x86_64
-```
+* git
+* g++
+* cmake
+* protocol buffer (protobuf) headers files and protobuf compiler
+* vulkan header files and loader library
+* glslang
+* (optional) opencv  # For building examples
+
+Generally if you have Intel, AMD or Nvidia GPU from last 10 years, Vulkan can be easily used.
+
+On some systems there are no Vulkan drivers easily available at the moment (October 2020), so you might need to disable use of Vulkan on them. This applies to Raspberry Pi 3 (but there is experimental open source Vulkan driver in the works, which is not ready yet). Nvidia Tegra series devices (like Nvidia Jetson) should support Vulkan. Ensure you have most recent software installed for best expirience.
+
+On Debian, Ubuntu or Raspberry Pi OS, you can install all required dependencies using: `sudo install build-essentials git cmake libprotobuf-dev protobuf-compiler libvulkan-dev glslang-tools vulkan-tools libopencv-dev`
+
+To use Vulkan backend install Vulkan header files, a vulkan driver loader, GLSL to SPIR-V compiler and vulkaninfo tool. Preferably from your distribution repositories. Alternatively download and install full Vulkan SDK (about 200MB in size; it contains all header files, documentation and prebuilt loader, as well some extra tools and source code of everything) from https://vulkan.lunarg.com/sdk/home
 
 ```
-$ cd <ncnn-root-dir>
+$ wget https://sdk.lunarg.com/sdk/download/1.2.154.0/linux/vulkansdk-linux-x86_64-1.2.154.0.tar.gz?Human=true -O vulkansdk-linux-x86_64-1.2.154.0.tar.gz
+$ tar -xf vulkansdk-linux-x86_64-1.2.154.0.tar.gz
+$ export VULKAN_SDK=$(pwd)/1.2.154.0/x86_64
+```
+
+To use Vulkan after building ncnn later, you will also need to have Vulkan driver for your GPU. For AMD and Intel GPUs these can be found in Mesa graphics driver, which usually is installed by default on all distros (i.e. `sudo apt install mesa-vulkan-drivers` on Debian/Ubuntu). For Nvidia GPUs the propietary Nvidia driver must be downloaded and installed (some distros will allow easier installation in some way). After installing Vulkan driver, confirm Vulkan libraries and driver are working, by using `vulkaninfo` or `vulkaninfo | grep deviceType`, it should list GPU device type. If there are more than one GPU installed (including the case of integrated GPU and discrete GPU, commonly found in laptops), you might need to note the order of devices to use later on.
+
+Nvidia Jetson devices the Vulkan support should be present in Nvidia provided SDK (Jetpack) or prebuild OS images.
+
+Raspberry Pi Vulkan drivers do exists, but are not mature. You are free to experiment at your own discretion, and report results and performance.
+
+```
+$ cd ncnn
 $ mkdir -p build
 $ cd build
-
-# cmake option NCNN_VULKAN for enabling vulkan
-$ cmake -DNCNN_VULKAN=ON ..
-
-$ make -j4
+build$ cmake -DCMAKE_BUILD_TYPE=Release -DNCNN_VULKAN=ON -DNCNN_SYSTEM_GLSLANG=ON -NCNN_OPENCV=ON -NCNN_BUILD_EXAMPLES=ON ..
+build$ make -j$(nproc)
 ```
-install opencv for building example
+
+You can add `-GNinja` to `cmake` above to use Ninja build system (invoke build using `ninja` or `cmake --build .`).
+
+For Nvidia Jetson devices, add `-DCMAKE_TOOLCHAIN_FILE=../toolchains/jetson.toolchain.cmake` to cmake.
+
+For Rasberry Pi 3, add `-DCMAKE_TOOLCHAIN_FILE=../toolchains/pi3.toolchain.cmake -DPI3=ON` to cmake. You can also consider disabling Vulkan support as the Vulkan drivers for Rasberry Pi are still not mature, but it doesn't hurt to build the support in, but not use it.
+
+Verify build by running some examples:
+
 ```
-$ cd <ncnn-root-dir>
-
-uncomment add_subdirectory(examples)
- in CMakeLists.txt with your favourite editor
-
-$ mkdir -p build
-$ cd build
-$ cmake ..
-$ make -j4
-
-copy examples/squeezenet_v1.1.param to build/examples
-copy examples/squeezenet_v1.1.bin to build/examples
-
-$ cd build/examples
-$ ./squeezenet yourimage.jpg 
-
-output top-3 class-id and score
-you may refer examples/synset_words.txt to find the class name
-404 = 0.990290
-908 = 0.004464
-405 = 0.003941
+build$ cd ../examples
+examples$ ../build/examples/squeezenet ../images/256-ncnn.png
+[0 AMD RADV FIJI (LLVM 10.0.1)]  queueC=1[4]  queueG=0[1]  queueT=0[1]
+[0 AMD RADV FIJI (LLVM 10.0.1)]  bugsbn1=0  buglbia=0  bugcopc=0  bugihfa=0
+[0 AMD RADV FIJI (LLVM 10.0.1)]  fp16p=1  fp16s=1  fp16a=0  int8s=1  int8a=1
+532 = 0.163452
+920 = 0.093140
+716 = 0.061584
+example$
 ```
+
+You can also run benchmarks (the 4th argument is a GPU device index to use, refer to `vulkaninfo`, if you have more than one GPU):
+
+```
+build$ cd ../benchmark
+benchmark$ ../build/benchmark/benchncnn 10 $(nproc) 0 0
+[0 AMD RADV FIJI (LLVM 10.0.1)]  queueC=1[4]  queueG=0[1]  queueT=0[1]
+[0 AMD RADV FIJI (LLVM 10.0.1)]  bugsbn1=0  buglbia=0  bugcopc=0  bugihfa=0
+[0 AMD RADV FIJI (LLVM 10.0.1)]  fp16p=1  fp16s=1  fp16a=0  int8s=1  int8a=1
+warmup_loop_count = 5
+[1] loop_count = 10
+[2] num_threads = 32
+[3] powersave = 0
+[4] gpu_device = 0
+[5] cooling_down_time = 1
+          squeezenet        max =  297.54/s  median =  271.51/s
+           mobilenet        max =  222.22/s  median =  215.89/s
+        mobilenet_v2        max =  151.51/s  median =  138.20/s
+...
+```
+
+To run benchmarks on a CPU, set the 5th argument to `-1`.
+
 
 ***
 
 ### Build for Windows x64 using Visual Studio Community 2017
 
-install Visual Studio Community 2017
+Download and Install Visual Studio Community 2017 from https://visualstudio.microsoft.com/vs/community/
+
+Start the command prompt: `Start → Programs → Visual Studio 2017 → Visual Studio Tools → x64 Native Tools Command Prompt for VS 2017`
+
+Download protobuf-3.4.0 from https://github.com/google/protobuf/archive/v3.4.0.zip
+
+Build protobuf library:
+
 ```
-download Visual Studio Community 2017 from https://visualstudio.microsoft.com/vs/community/
-install it
-Start → Programs → Visual Studio 2017 → Visual Studio Tools → x64 Native Tools Command Prompt for VS 2017
-```
-build protobuf library
-```
-download protobuf-3.4.0 from https://github.com/google/protobuf/archive/v3.4.0.zip
 > cd <protobuf-root-dir>
-> mkdir build-vs2017
-> cd build-vs2017
+> mkdir build
+> cd build
 > cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%cd%/install -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_MSVC_STATIC_RUNTIME=OFF ../cmake
 > nmake
 > nmake install
 ```
-(optional) download and install vulkan-sdk from https://vulkan.lunarg.com/sdk/home
+(optional) Download and install Vulkan SDK from https://vulkan.lunarg.com/sdk/home
 
-launch VulkanSDK-1.1.114.0-Installer.exe and install
+Build ncnn library (replace <protobuf-root-dir> with a proper path):
 
-build ncnn library (replace <protobuf-root-dir> with your path)
 ```
 > cd <ncnn-root-dir>
-> mkdir -p build-vs2017
-> cd build-vs2017
-
-# cmake option NCNN_VULKAN for enabling vulkan
-> cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%cd%/install -DProtobuf_INCLUDE_DIR=<protobuf-root-dir>/build-vs2017/install/include -DProtobuf_LIBRARIES=<protobuf-root-dir>/build-vs2017/install/lib/libprotobuf.lib -DProtobuf_PROTOC_EXECUTABLE=<protobuf-root-dir>/build-vs2017/install/bin/protoc.exe -DNCNN_VULKAN=ON ..
-
+> mkdir -p build
+> cd build
+> cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%cd%/install -DProtobuf_INCLUDE_DIR=<protobuf-root-dir>/build/install/include -DProtobuf_LIBRARIES=<protobuf-root-dir>/build/install/lib/libprotobuf.lib -DProtobuf_PROTOC_EXECUTABLE=<protobuf-root-dir>/build/install/bin/protoc.exe -DNCNN_VULKAN=ON ..
 > nmake
 > nmake install
-
-pick build-vs2017/install folder for further usage
 ```
+
+Note: To speed up compilation process on multi core machines, configuring `cmake` to use `jom` or `ninja` using `-G` flag is recommended.
 
 ***
 
 ### Build for MacOSX
-install xcode and protobuf
+Install xcode and protobuf
 
-**Because the compiler bundled with xcode do not support openmp feature, you cannot enable the multithreading inference feature of ncnn library, if you build with xcode.**
+**Because the compiler bundled with xcode do not support OpenMP feature, you cannot enable the multithreading inference feature of ncnn library, if you build with xcode.**
 
 ```
-# install protobuf via homebrew
+# Install protobuf via homebrew
 $ brew install protobuf
 ```
 
-(optional) download and install vulkan-sdk from https://vulkan.lunarg.com/sdk/home
+(optional) Download and install Vulkan SDK from https://vulkan.lunarg.com/sdk/home
 ```
 $ wget https://sdk.lunarg.com/sdk/download/1.1.114.0/mac/vulkansdk-macos-1.1.114.0.tar.gz?Human=true -O vulkansdk-macos-1.1.114.0.tar.gz
 $ tar -xf vulkansdk-macos-1.1.114.0.tar.gz
@@ -130,176 +160,145 @@ $ export VULKAN_SDK=`pwd`/vulkansdk-macos-1.1.114.0/macOS
 $ cd <ncnn-root-dir>
 $ mkdir -p build
 $ cd build
-
-# cmake option NCNN_VULKAN for enabling vulkan
 $ cmake -DNCNN_VULKAN=ON ..
-
 $ make -j4
 $ make install
-```
-
-pick build/install folder for further usage
-
-***
-
-### Build for Raspberry Pi 3
-install g++ cmake protobuf
-```bash
-cd <ncnn-root-dir>
-mkdir -p build
-cd build
-cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/pi3.toolchain.cmake -DPI3=ON ..
-make -j4
-make install
-```
-
-pick build/install folder for further usage
-
-***
-
-### Build for NVIDIA Jetson
-work on the Jetson device
-```bash
-ssh USERNAME@JETSON_IP
-```
-
-#### install compile tools and Vulkan SDK
-
-```bash
-sudo apt-get update && sudo apt-get install gcc g++ cmake git libvulkan-dev
-cd ~/
-```
-
-#### compile ncnn
-```bash
-git clone --depth=1 https://github.com/Tencent/ncnn.git
-# download submodule (glslang)
-cd ncnn && git submodule update --depth=1 --init
-# while aarch64-linux-gnu.toolchain.cmake would compile Tencent/ncnn as well
-# but why not compile with more native features w
-mkdir build && cd build
-cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/jetson.toolchain.cmake -DNCNN_VULKAN=ON -DCMAKE_BUILD_TYPE=Release ..
-make -j`nproc`
-sudo make install
 ```
 
 ***
 
 ### Build for ARM Cortex-A family with cross-compiling
-download ARM toolchain from https://developer.arm.com/open-source/gnu-toolchain/gnu-a/downloads
+Download ARM toolchain from https://developer.arm.com/open-source/gnu-toolchain/gnu-a/downloads
+
 ```
-$ export PATH=<your-toolchain-compiler-path>:$PATH
+$ export PATH="<your-toolchain-compiler-path>:${PATH}"
 ```
+
+Alternatively install a cross-compiler provided by the distribution (i.e. on Debian / Ubuntu, you can do `sudo apt install g++-arm-linux-gnueabi g++-arm-linux-gnueabihf g++-aarch64-linux-gnu`).
+
+Depending on your needs build one ore more of the below targets.
+
 AArch32 target with soft float (arm-linux-gnueabi)
 ```
 $ cd <ncnn-root-dir>
 $ mkdir -p build-arm-linux-gnueabi
 $ cd build-arm-linux-gnueabi
 $ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/arm-linux-gnueabi.toolchain.cmake ..
-$ make -j4
-$ make install
+$ make -j$(nproc)
 ```
+
 AArch32 target with hard float (arm-linux-gnueabihf)
 ```
 $ cd <ncnn-root-dir>
 $ mkdir -p build-arm-linux-gnueabihf
 $ cd build-arm-linux-gnueabihf
 $ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/arm-linux-gnueabihf.toolchain.cmake ..
-$ make -j4
-$ make install
+$ make -j$(nproc)
 ```
+
 AArch64 GNU/Linux target (aarch64-linux-gnu)
 ```
 $ cd <ncnn-root-dir>
 $ mkdir -p build-aarch64-linux-gnu
 $ cd build-aarch64-linux-gnu
 $ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/aarch64-linux-gnu.toolchain.cmake ..
-$ make -j4
-$ make install
+$ make -j$(nproc)
 ```
 
-pick build-XXXXX/install folder for further usage
+***
+
+### Build for Hisilicon platform with cross-compiling
+Download and install Hisilicon SDK. The oolchain should be in `/opt/hisi-linux/x86-arm`
+
+```
+$ cd <ncnn-root-dir>
+$ mkdir -p build
+$ cd build
+
+# Choose one cmake toolchain file depends on your target platform
+$ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/hisiv300.toolchain.cmake ..
+$ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/hisiv500.toolchain.cmake ..
+$ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/himix100.toolchain.cmake ..
+$ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/himix200.toolchain.cmake ..
+
+$ make -j$(nproc)
+$ make install
+```
 
 ***
 
 ### Build for Android
-you can use the pre-build ncnn-android-lib.zip from https://github.com/Tencent/ncnn/releases
+You can use the pre-build ncnn-android-lib.zip from https://github.com/Tencent/ncnn/releases
 
-install android-ndk
+Download Android NDK from http://developer.android.com/ndk/downloads/index.html and install it, for example:
+
 ```
-download android-ndk from http://developer.android.com/ndk/downloads/index.html
 $ unzip android-ndk-r21d-linux-x86_64.zip
 $ export ANDROID_NDK=<your-ndk-root-path>
 ```
-(optional) drop debug compile flag to reduce binary size due to [android-ndk issue](https://github.com/android-ndk/ndk/issues/243)
-```
-# edit $ANDROID_NDK/build/cmake/android.toolchain.cmake with your favorite editor
-# remove "-g" line
-list(APPEND ANDROID_COMPILER_FLAGS
-  -g
-  -DANDROID
-```
 
-(optional) download and install vulkan-sdk from https://vulkan.lunarg.com/sdk/home
+(optional) Download and install Vulkan SDK from https://vulkan.lunarg.com/sdk/home
 ```
-$ wget https://sdk.lunarg.com/sdk/download/1.1.114.0/linux/vulkansdk-linux-x86_64-1.1.114.0.tar.gz?Human=true -O vulkansdk-linux-x86_64-1.1.114.0.tar.gz
-$ tar -xf vulkansdk-linux-x86_64-1.1.114.0.tar.gz
+$ https://sdk.lunarg.com/sdk/download/1.2.154.0/linux/vulkansdk-linux-x86_64-1.2.154.0.tar.gz?Human=true -O vulkansdk-linux-x86_64-1.2.154.0.tar.gz
+$ tar -xf vulkansdk-linux-x86_64-1.2.154.0.tar.gz
 
 # setup env
-$ export VULKAN_SDK=`pwd`/1.1.114.0/x86_64
+$ export VULKAN_SDK=`pwd`/1.2.154.0/x86_64
 ```
 
-build armv7 library
+Build armv7 library
+
 ```
 $ cd <ncnn-root-dir>
 $ mkdir -p build-android-armv7
 $ cd build-android-armv7
 
-$ cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+$ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake" \
     -DANDROID_ABI="armeabi-v7a" -DANDROID_ARM_NEON=ON \
     -DANDROID_PLATFORM=android-14 ..
 
-# if you want to enable vulkan, platform api version >= android-24 is needed
-$ cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+# If you want to enable Vulkan, platform api version >= android-24 is needed
+$ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake" \
     -DANDROID_ABI="armeabi-v7a" -DANDROID_ARM_NEON=ON \
     -DANDROID_PLATFORM=android-24 -DNCNN_VULKAN=ON ..
-
-$ make -j4
+$ make -j$(nproc)
 $ make install
-
-pick build-android-armv7/install folder for further jni usage
 ```
-build aarch64 library
+
+Pick `build-android-armv7/install` folder for further JNI usage.
+
+
+Build aarch64 library:
+
 ```
 $ cd <ncnn-root-dir>
 $ mkdir -p build-android-aarch64
 $ cd build-android-aarch64
 
-$ cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+$ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake"\
     -DANDROID_ABI="arm64-v8a" \
     -DANDROID_PLATFORM=android-21 ..
 
-# if you want to enable vulkan, platform api version >= android-24 is needed
-$ cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+# If you want to enable Vulkan, platform api version >= android-24 is needed
+$ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake" \
     -DANDROID_ABI="arm64-v8a" \
     -DANDROID_PLATFORM=android-24 -DNCNN_VULKAN=ON ..
-
-$ make -j4
+$ make -j$(nproc)
 $ make install
-
-pick build-android-aarch64/install folder for further jni usage
 ```
+
+Pick `build-android-aarch64/install` folder for further JNI usage.
 
 ***
 
 ### Build for iOS on MacOSX with xcode
-you can use the pre-build ncnn.framework and openmp.framework from https://github.com/Tencent/ncnn/releases
+You can use the pre-build ncnn.framework and openmp.framework from https://github.com/Tencent/ncnn/releases
 
-install xcode
+Install xcode
 
 **Because the compiler bundled with xcode do not support openmp feature, you cannot enable the multithreading inference feature of ncnn library, if you build with xcode.**
 
-(optional) download and install vulkan-sdk from https://vulkan.lunarg.com/sdk/home
+(optional) Download and install Vulkan SDK from https://vulkan.lunarg.com/sdk/home
 ```
 $ wget https://sdk.lunarg.com/sdk/download/1.1.114.0/mac/vulkansdk-macos-1.1.114.0.tar.gz?Human=true -O vulkansdk-macos-1.1.114.0.tar.gz
 $ tar -xf vulkansdk-macos-1.1.114.0.tar.gz
@@ -308,7 +307,8 @@ $ tar -xf vulkansdk-macos-1.1.114.0.tar.gz
 $ export VULKAN_SDK=`pwd`/vulkansdk-macos-1.1.114.0/macOS
 ```
 
-build library for iPhoneOS
+Build library for iPhoneOS:
+
 ```
 $ cd <ncnn-root-dir>
 $ mkdir build-ios
@@ -323,7 +323,8 @@ $ make -j4
 $ make install
 ```
 
-build library for iPhoneSimulator
+Build library for iPhoneSimulator:
+
 ```
 $ cd <ncnn-root-dir>
 $ mkdir build-ios-sim
@@ -332,7 +333,8 @@ $ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/ios.toolchain.cmake -DIOS_PLATFORM=
 $ make -j4
 $ make install
 ```
-package framework
+
+Package framework:
 ```
 $ cd <ncnn-root-dir>
 $ mkdir -p ncnn.framework/Versions/A/Headers
@@ -348,43 +350,47 @@ $ lipo -create \
 $ cp -r build-ios/install/include/* ncnn.framework/Versions/A/Headers/
 $ cp Info.plist ncnn.framework/Versions/A/Resources/
 
-pick ncnn.framework folder for app development
 ```
+
+Pick `ncnn.framework` folder for app development.
 
 ***
 
 ### Build for iOS on Linux with cctools-port
-you can use the pre-build ncnn.framework and openmp.framework from https://github.com/Tencent/ncnn/releases
+You can use the pre-build `ncnn.framework` and `openmp.framework` from https://github.com/Tencent/ncnn/releases
 
-setup cross-compiling environment with https://github.com/tpoechtrager/cctools-port
+Setup cross-compiling environment with https://github.com/tpoechtrager/cctools-port
 
-**you can enable the multithreading inference feature of ncnn library, if you build with cctools-port.**
+**You can enable the multithreading inference feature of ncnn library, if you build with cctools-port.**
 
 ```
 $ cd <ncnn-root-dir>
-
-change CMAKE_IOS_SDK_ROOT variable to your cctools-port target path
- in iosxc.toolchain.cmake and iossimxc.toolchain.cmake with your favourite editor
 ```
-build armv7 arm64 library
+
+Edit `iosxc.toolchain.cmake` and `iossimxc.toolchain.cmake` files, and update `CMAKE_IOS_SDK_ROOT` variable to your cctools-port target path.
+
+Build armv7 arm64 library:
+
 ```
 $ cd <ncnn-root-dir>
 $ mkdir -p build-ios
 $ cd build-ios
 $ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/iosxc.toolchain.cmake ..
-$ make
+$ make -j$(nproc)
 $ make install
 ```
-build i386 x86_64 simulator library
+
+Build i386 / x86_64 simulator library:
 ```
 $ cd <ncnn-root-dir>
 $ mkdir -p build-ios-sim
 $ cd build-ios-sim
 $ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/iossimxc.toolchain.cmake ..
-$ make
+$ make -j$(nproc)
 $ make install
 ```
-package framework
+
+Package framework:
 ```
 $ cd <ncnn-root-dir>
 $ mkdir -p ncnn.framework/Versions/A/Headers
@@ -400,30 +406,6 @@ $ lipo -create \
 $ cp -r build-ios/install/include/* ncnn.framework/Versions/A/Headers/
 $ cp Info.plist ncnn.framework/Versions/A/Resources/
 
-pick ncnn.framework folder for app development
 ```
 
-***
-
-### Build for Hisilicon platform with cross-compiling
-download and install Hisilicon SDK
-```
-# the path that toolchain should be installed in
-$ ls /opt/hisi-linux/x86-arm
-```
-```
-$ cd <ncnn-root-dir>
-$ mkdir -p build
-$ cd build
-
-# choose one cmake toolchain file depends on your target platform
-$ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/hisiv300.toolchain.cmake ..
-$ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/hisiv500.toolchain.cmake ..
-$ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/himix100.toolchain.cmake ..
-$ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/himix200.toolchain.cmake ..
-
-$ make -j4
-$ make install
-```
-
-pick build/install folder for further usage
+Pick `ncnn.framework` folder for app development.


### PR DESCRIPTION
* Merge Linux stuff into one section.
* Provide better info on dependencies
* Provide easier to use instruction for Debian / Ubuntu for native and cross-compile builds
* Capitalize Sentence and put proper punctation.
* Use backticks where appropiate
* Move Hisilicon instruction together with Arm crosscompiling
* Add information how to verify the Vulkan installation on Linux
* Change how to launch examples so it is easier (no copying needed or external resources)
* Add info about benchmark and how to test it on GPU or CPU
* Use `$(nproc)` where appropriate.
* Put some paths in quotes, in case they contain spaces or other weird characters (coma, semicolon, colon, etc).
* Remove some extremely obvious pieces that every developer usually knows.
* Use newer Vulkan SDK in instructions for Linux
* Recommend installing Vulkan stuff from distro repo first
* Use system glslangValidator by default
* Get rid of `<ncnn-root-dir>`, and just use `ncnn`. It is what git clone does. And any developer will know how to change it if they choose to do it differently.