### PR TITLE
Fixed compile warning for x86 layer. [-Wunused-variable]

### DIFF
--- a/src/layer/x86/batchnorm_x86.cpp
+++ b/src/layer/x86/batchnorm_x86.cpp
@@ -29,9 +29,10 @@ BatchNorm_x86::BatchNorm_x86()
 int BatchNorm_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
 {
     int dims = bottom_top_blob.dims;
-    int elempack = bottom_top_blob.elempack;
 
 #if __AVX__
+    int elempack = bottom_top_blob.elempack;
+
     if (elempack == 8)
     {
         if (dims == 1)

--- a/src/layer/x86/clip_x86.cpp
+++ b/src/layer/x86/clip_x86.cpp
@@ -32,9 +32,10 @@ int Clip_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
     int h = bottom_top_blob.h;
     int channels = bottom_top_blob.c;
     int size = w * h;
-    int elempack = bottom_top_blob.elempack;
 
 #if __AVX__
+    int elempack = bottom_top_blob.elempack;
+
     if (elempack == 8)
     {
         #pragma omp parallel for num_threads(opt.num_threads)

--- a/src/layer/x86/concat_x86.cpp
+++ b/src/layer/x86/concat_x86.cpp
@@ -65,9 +65,9 @@ int Concat_x86::destroy_pipeline(const Option& opt)
 
 int Concat_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt) const
 {
+#if __AVX__
     int dims = bottom_blobs[0].dims;
 
-#if __AVX__
     if (opt.use_packing_layout)
     {
         if (dims == 1) // axis == 0

--- a/src/layer/x86/relu_x86.cpp
+++ b/src/layer/x86/relu_x86.cpp
@@ -33,9 +33,10 @@ int ReLU_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
     int h = bottom_top_blob.h;
     int channels = bottom_top_blob.c;
     int size = w * h;
-    int elempack = bottom_top_blob.elempack;
 
 #if __AVX__
+    int elempack = bottom_top_blob.elempack;
+
     if (elempack == 8)
     {
         if (slope == 0.f)
@@ -59,7 +60,6 @@ int ReLU_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
             for (int q = 0; q < channels; q++)
             {
                 float* ptr = bottom_top_blob.channel(q);
-                __m256 _zero = _mm256_set1_ps(0.f);
                 for (int i = 0; i < size; i++)
                 {
                     __m256 _p = _mm256_loadu_ps(ptr);


### PR DESCRIPTION
Hello, NCNN Team.

I observe compiler warnings when building x86 layers.
I have the desire and time to correct these warnings.
I have prepared the first PR with fixing the build of four files.
Could you review and accept my PR, pls?

These warnings are reproduced in Travis CI:

https://github.com/Tencent/ncnn/runs/1230452598?check_suite_focus=true
https://github.com/Tencent/ncnn/runs/1230453068?check_suite_focus=true

[20/208] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/batchnorm_x86.cpp.o
../src/layer/x86/batchnorm_x86.cpp:32:9: warning: unused variable 'elempack' [-Wunused-variable]
    int elempack = bottom_top_blob.elempack;
        ^
1 warning generated.

[89/272] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/concat_x86.cpp.o
../src/layer/x86/concat_x86.cpp:68:9: warning: unused variable 'dims' [-Wunused-variable]
    int dims = bottom_blobs[0].dims;
        ^
1 warning generated.

[137/272] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/relu_x86_avx2.cpp.o
src/layer/x86/relu_x86_avx2.cpp:62:24: warning: unused variable '_zero' [-Wunused-variable]
                __m256 _zero = _mm256_set1_ps(0.f);
                       ^
1 warning generated.

[2/24] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/relu_x86.cpp.o
../src/layer/x86/relu_x86.cpp:36:9: warning: unused variable 'elempack' [-Wunused-variable]
    int elempack = bottom_top_blob.elempack;
        ^
1 warning generated.

[179/272] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/clip_x86.cpp.o
../src/layer/x86/clip_x86.cpp:35:9: warning: unused variable 'elempack' [-Wunused-variable]
    int elempack = bottom_top_blob.elempack;
        ^
1 warning generated.