### PR TITLE
Fixed compile warning for clang linux onnx2ncnn.cpp [-Wformat]

### DIFF
--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -3775,7 +3775,7 @@ int main(int argc, char** argv)
                 }
                 else if (attr.type() == 2)
                 {
-                    fprintf(stderr, "  # %s=%lld\n", attr.name().c_str(), attr.i());
+                    fprintf(stderr, "  # %s=%lld\n", attr.name().c_str(), (long long)attr.i());
                 }
                 else if (attr.type() == 3)
                 {


### PR DESCRIPTION
Hello, NCNN Team.

Last time I raised PR for onnx2ncnn.cpp MacOS clang compilation: https://github.com/Tencent/ncnn/pull/2175
It fixed problem under MacOS, but started a new on Linux:

https://github.com/Tencent/ncnn/runs/1230453068?check_suite_focus=true

I created new fix for linux & macOS. Next time I will check the logs of other platforms more carefully.

Could you review my PR one more time, pls?

/home/runner/work/ncnn/ncnn/tools/onnx/onnx2ncnn.cpp:3778:75: warning: format specifies type 'long long' but the argument has type '::google::protobuf::int64' (aka 'long') [-Wformat]
                    fprintf(stderr, "  # %s=%lld\n", attr.name().c_str(), attr.i());
                                            ~~~~                          ^~~~~~~~
                                            %ld
1 warning generated.

../tools/onnx/onnx2ncnn.cpp:3774:74: warning: format specifies type 'long' but the argument has type '::google::protobuf::int64' (aka 'long long') [-Wformat]
                    fprintf(stderr, "  # %s=%ld\n", attr.name().c_str(), attr.i());
                                            ~~~                          ^~~~~~~~
                                            %lld
1 warnings generated.
