### PR TITLE
Fixed compile warning for x86 layer with reason: [-Wunused-variable]

### DIFF
--- a/src/layer/x86/binaryop_x86.cpp
+++ b/src/layer/x86/binaryop_x86.cpp
@@ -658,12 +658,12 @@ struct binary_op_rdiv_pack8
 
 int BinaryOp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt) const
 {
+#if __AVX__
     const Mat& bottom_blob = bottom_blobs[0];
     const Mat& bottom_blob1 = bottom_blobs[1];
 
     Mat& top_blob = top_blobs[0];
 
-#if __AVX__
     int elempack = bottom_blob.elempack;
     int elempack1 = bottom_blob1.elempack;
 

--- a/src/layer/x86/convolution_1x1_pack8.h
+++ b/src/layer/x86/convolution_1x1_pack8.h
@@ -197,8 +197,6 @@ static void conv1x1s1_sgemm_pack8_avx(const Mat& bottom_blob, Mat& top_blob, con
     int h = bottom_blob.h;
     int inch = bottom_blob.c;
     int outch = top_blob.c;
-    int outw = top_blob.w;
-    int outh = top_blob.h;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 

--- a/src/layer/x86/convolution_1x1_pack8_fp16.h
+++ b/src/layer/x86/convolution_1x1_pack8_fp16.h
@@ -196,8 +196,6 @@ static void conv1x1s1_sgemm_fp16_pack8_avx(const Mat& bottom_blob, Mat& top_blob
     int h = bottom_blob.h;
     int inch = bottom_blob.c;
     int outch = top_blob.c;
-    int outw = top_blob.w;
-    int outh = top_blob.h;
 
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;

--- a/src/layer/x86/convolution_3x3_pack8to1.h
+++ b/src/layer/x86/convolution_3x3_pack8to1.h
@@ -21,7 +21,6 @@ static void conv3x3s1_pack8to1_avx(const Mat& bottom_blob, Mat& top_blob, const 
 
     const float* bias = _bias;
 
-    int nn_outch = 0;
     int remain_outch_start = 0;
 
     #pragma omp parallel for num_threads(opt.num_threads)

--- a/src/layer/x86/convolution_x86.cpp
+++ b/src/layer/x86/convolution_x86.cpp
@@ -168,12 +168,12 @@ int Convolution_x86::create_pipeline(const Option& opt)
         return 0;
     }
 
-    const int maxk = kernel_w * kernel_h;
-
     int elempack = (support_packing && opt.use_packing_layout && num_input % 8 == 0) ? 8 : 1;
     int out_elempack = (support_packing && opt.use_packing_layout && num_output % 8 == 0) ? 8 : 1;
 
 #if __AVX__
+    const int maxk = kernel_w * kernel_h;
+
     // pack8
     if (elempack == 8 && out_elempack == 8)
     {

--- a/src/layer/x86/convolutiondepthwise_3x3_pack8.h
+++ b/src/layer/x86/convolutiondepthwise_3x3_pack8.h
@@ -14,8 +14,6 @@
 
 static void convdw3x3s1_pack8_avx(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
 {
-    int w = bottom_blob.w;
-
     int outw = top_blob.w;
     int outh = top_blob.h;
 
@@ -33,7 +31,6 @@ static void convdw3x3s1_pack8_avx(const Mat& bottom_blob, Mat& top_blob, const M
         const float* k0 = kernel.row(g);
 
         float* outptr0 = out.row(0);
-        float* outptr1 = out.row(1);
 
         const Mat img0 = bottom_blob.channel(g);
 
@@ -386,7 +383,6 @@ static void convdw3x3s2_pack8_avx(const Mat& bottom_blob, Mat& top_blob, const M
         const float* k0 = kernel.row(g);
 
         float* outptr0 = out.row(0);
-        float* outptr1 = out.row(1);
 
         const Mat img0 = bottom_blob.channel(g);
 

--- a/src/layer/x86/convolutiondepthwise_3x3_pack8_fp16.h
+++ b/src/layer/x86/convolutiondepthwise_3x3_pack8_fp16.h
@@ -14,8 +14,6 @@
 
 static void convdw3x3s1_fp16_pack8_avx(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
 {
-    int w = bottom_blob.w;
-
     int outw = top_blob.w;
     int outh = top_blob.h;
 
@@ -33,7 +31,6 @@ static void convdw3x3s1_fp16_pack8_avx(const Mat& bottom_blob, Mat& top_blob, co
         const unsigned short* k0 = (const unsigned short*)kernel.row(g);
 
         float* outptr0 = out.row(0);
-        float* outptr1 = out.row(1);
 
         const Mat img0 = bottom_blob.channel(g);
 
@@ -386,7 +383,6 @@ static void convdw3x3s2_fp16_pack8_avx(const Mat& bottom_blob, Mat& top_blob, co
         const unsigned short* k0 = (const unsigned short*)kernel.row(g);
 
         float* outptr0 = out.row(0);
-        float* outptr1 = out.row(1);
 
         const Mat img0 = bottom_blob.channel(g);
 

--- a/src/layer/x86/convolutiondepthwise_5x5_pack8.h
+++ b/src/layer/x86/convolutiondepthwise_5x5_pack8.h
@@ -14,8 +14,6 @@
 
 static void convdw5x5s1_pack8_avx(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
 {
-    int w = bottom_blob.w;
-
     int outw = top_blob.w;
     int outh = top_blob.h;
 
@@ -32,7 +30,6 @@ static void convdw5x5s1_pack8_avx(const Mat& bottom_blob, Mat& top_blob, const M
         const float* k0 = kernel.row(g);
 
         float* outptr0 = out.row(0);
-        float* outptr1 = out.row(1);
 
         const Mat img0 = bottom_blob.channel(g);
 
@@ -187,7 +184,6 @@ static void convdw5x5s2_pack8_avx(const Mat& bottom_blob, Mat& top_blob, const M
         const float* k0 = kernel.row(g);
 
         float* outptr0 = out.row(0);
-        float* outptr1 = out.row(1);
 
         const Mat img0 = bottom_blob.channel(g);
 

--- a/src/layer/x86/convolutiondepthwise_x86.cpp
+++ b/src/layer/x86/convolutiondepthwise_x86.cpp
@@ -112,8 +112,9 @@ int ConvolutionDepthWise_x86::create_pipeline(const Option& opt)
     group_ops.clear();
     if (channels == group && group == num_output)
     {
-        int elempack = (support_packing && opt.use_packing_layout && channels % 8 == 0) ? 8 : 1;
 #if __AVX__
+        int elempack = (support_packing && opt.use_packing_layout && channels % 8 == 0) ? 8 : 1;
+
         // pack8
         if (elempack == 8)
         {

--- a/src/layer/x86/crop_x86.cpp
+++ b/src/layer/x86/crop_x86.cpp
@@ -55,14 +55,15 @@ static void crop_pack8_avx(const Mat& src, Mat& dst, int top, int left)
 
 int Crop_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const
 {
+    int elempack = bottom_blob.elempack;
+
+#if __AVX__
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int channels = bottom_blob.c;
     int dims = bottom_blob.dims;
     size_t elemsize = bottom_blob.elemsize;
-    int elempack = bottom_blob.elempack;
 
-#if __AVX__
     if (elempack == 8)
     {
         int _woffset, _hoffset, _coffset;
@@ -172,18 +173,18 @@ int Crop_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& to
     const Mat& bottom_blob = bottom_blobs[0];
     const Mat& reference_blob = bottom_blobs[1];
 
+    int elempack = bottom_blob.elempack;
+
+    int ref_elempack = reference_blob.elempack;
+
+#if __AVX__
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int channels = bottom_blob.c;
     int dims = bottom_blob.dims;
     size_t elemsize = bottom_blob.elemsize;
-    int elempack = bottom_blob.elempack;
-
-    int ref_elempack = reference_blob.elempack;
-
     Mat& top_blob = top_blobs[0];
 
-#if __AVX__
     if (elempack == 8)
     {
         int _woffset, _hoffset, _coffset;

--- a/src/layer/x86/dropout_x86.cpp
+++ b/src/layer/x86/dropout_x86.cpp
@@ -34,10 +34,10 @@ int Dropout_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
         return 0;
     }
 
+#if __AVX__
     int dims = bottom_top_blob.dims;
     int elempack = bottom_top_blob.elempack;
 
-#if __AVX__
     if (elempack == 8)
     {
         int w = bottom_top_blob.w;

--- a/src/layer/x86/hardsigmoid_x86.cpp
+++ b/src/layer/x86/hardsigmoid_x86.cpp
@@ -33,9 +33,10 @@ int HardSigmoid_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) co
     int h = bottom_top_blob.h;
     int channels = bottom_top_blob.c;
     int size = w * h;
-    int elempack = bottom_top_blob.elempack;
 
 #if __AVX__
+    int elempack = bottom_top_blob.elempack;
+
     if (elempack == 8)
     {
         #pragma omp parallel for num_threads(opt.num_threads)

--- a/src/layer/x86/hardswish_x86.cpp
+++ b/src/layer/x86/hardswish_x86.cpp
@@ -33,9 +33,10 @@ int HardSwish_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) cons
     int h = bottom_top_blob.h;
     int channels = bottom_top_blob.c;
     int size = w * h;
-    int elempack = bottom_top_blob.elempack;
 
 #if __AVX__
+    int elempack = bottom_top_blob.elempack;
+
     if (elempack == 8)
     {
         #pragma omp parallel for num_threads(opt.num_threads)

--- a/src/layer/x86/innerproduct_x86.cpp
+++ b/src/layer/x86/innerproduct_x86.cpp
@@ -78,13 +78,14 @@ int InnerProduct_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Optio
         return InnerProduct::forward(bottom_blob, top_blob, opt);
     }
 
+#if __AVX__
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int channels = bottom_blob.c;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
     int size = w * h;
-#if __AVX__
+
     if (elempack == 8)
     {
         // flatten
@@ -363,7 +364,6 @@ int InnerProduct_x86::forward_fp16(const Mat& bottom_blob, Mat& top_blob, const 
     int h = bottom_blob.h;
     int channels = bottom_blob.c;
     size_t elemsize = bottom_blob.elemsize;
-    int elempack = bottom_blob.elempack;
     int size = w * h;
     top_blob.create(num_output, elemsize, opt.blob_allocator);
     if (top_blob.empty())

--- a/src/layer/x86/mish_x86.cpp
+++ b/src/layer/x86/mish_x86.cpp
@@ -34,8 +34,10 @@ int Mish_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
     int h = bottom_top_blob.h;
     int channels = bottom_top_blob.c;
     int size = w * h;
-    int elempack = bottom_top_blob.elempack;
+
 #if __AVX__
+    int elempack = bottom_top_blob.elempack;
+
     if (elempack == 8)
     {
         #pragma omp parallel for num_threads(opt.num_threads)

--- a/src/layer/x86/packing_x86.cpp
+++ b/src/layer/x86/packing_x86.cpp
@@ -29,7 +29,6 @@ int Packing_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& op
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
-    bool elemtype_is_bf16 = (elemsize == 2u && elempack == 1) || (elemsize == 16u && elempack == 8);
     bool elemtype_is_fp32 = (elemsize == 4u && elempack == 1) || (elemsize == 32u && elempack == 8);
     if (use_padding)
     {

--- a/src/layer/x86/padding_x86.cpp
+++ b/src/layer/x86/padding_x86.cpp
@@ -49,17 +49,18 @@ int Padding_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& op
         return 0;
     }
 
+    Mat bottom_blob_unpacked = bottom_blob;
+
+#if __AVX__
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int channels = bottom_blob.c;
     int dims = bottom_blob.dims;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
-    Mat bottom_blob_unpacked = bottom_blob;
-
-#if __AVX__
     int out_elempack = elempack;
     int outc = channels;
+
     //Check if channel padding is being applied.
     if (front != 0 || behind != 0)
     {
@@ -157,6 +158,7 @@ int Padding_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& op
         return 0;
     }
 #endif // __AVX__
+
     return Padding::forward(bottom_blob_unpacked, top_blob, opt);
 }
 

--- a/src/layer/x86/pooling_x86.cpp
+++ b/src/layer/x86/pooling_x86.cpp
@@ -42,13 +42,13 @@ int Pooling_x86::forward(const Mat& bottom_blob, Mat& top_blob,
     // max value in NxN window
     // avg value in NxN window
 
+#if __AVX__
+    int elempack = bottom_blob.elempack;
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int channels = bottom_blob.c;
     size_t elemsize = bottom_blob.elemsize;
-    int elempack = bottom_blob.elempack;
 
-#if __AVX__
     //     NCNN_LOGE("Pooling     input %d x %d  pad = %d %d %d %d  ksize=%d %d  stride=%d %d", w, h, pad_left, pad_right, pad_top, pad_bottom, kernel_w, kernel_h, stride_w, stride_h);
     if (elempack == 8)
     {
@@ -290,14 +290,16 @@ int Pooling_x86::forward(const Mat& bottom_blob, Mat& top_blob,
         return Pooling::forward(bottom_blob, top_blob, opt);
     }
 
-    const int kernel_size = kernel_w;
     const int stride = stride_w;
 
     if (pooling_type != PoolMethod_MAX || stride != 2 || global_pooling == 1)
     {
         return Pooling::forward(bottom_blob, top_blob, opt);
     }
+
 #if __AVX__
+    const int kernel_size = kernel_w;
+
     if (kernel_size != 2)
     {
         return Pooling::forward(bottom_blob, top_blob, opt);

--- a/src/layer/x86/prelu_x86.cpp
+++ b/src/layer/x86/prelu_x86.cpp
@@ -30,9 +30,10 @@ PReLU_x86::PReLU_x86()
 int PReLU_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
 {
     int dims = bottom_top_blob.dims;
-    int elempack = bottom_top_blob.elempack;
 
 #if __AVX__
+    int elempack = bottom_top_blob.elempack;
+
     if (elempack == 8)
     {
         if (dims == 1)

--- a/src/layer/x86/scale_x86.cpp
+++ b/src/layer/x86/scale_x86.cpp
@@ -33,9 +33,10 @@ int Scale_x86::forward_inplace(std::vector<Mat>& bottom_top_blobs, const Option&
     const Mat& scale_blob = bottom_top_blobs[1];
 
     int dims = bottom_top_blob.dims;
-    int elempack = bottom_top_blob.elempack;
 
 #if __AVX__
+    int elempack = bottom_top_blob.elempack;
+
     if (elempack == 8)
     {
         if (dims == 1)

--- a/src/layer/x86/sigmoid_x86.cpp
+++ b/src/layer/x86/sigmoid_x86.cpp
@@ -35,8 +35,10 @@ int Sigmoid_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
     int h = bottom_top_blob.h;
     int channels = bottom_top_blob.c;
     int size = w * h;
-    int elempack = bottom_top_blob.elempack;
+
 #if __AVX__
+    int elempack = bottom_top_blob.elempack;
+
     if (elempack == 8)
     {
         #pragma omp parallel for num_threads(opt.num_threads)

--- a/src/layer/x86/slice_x86.cpp
+++ b/src/layer/x86/slice_x86.cpp
@@ -69,13 +69,13 @@ int Slice_x86::destroy_pipeline(const Option& opt)
 
 int Slice_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt) const
 {
+#if __AVX__
     const Mat& bottom_blob = bottom_blobs[0];
     int dims = bottom_blob.dims;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
     const int* slices_ptr = slices;
 
-#if __AVX__
     if (opt.use_packing_layout)
     {
         if (dims == 1) // axis == 0

--- a/src/layer/x86/swish_x86.cpp
+++ b/src/layer/x86/swish_x86.cpp
@@ -34,9 +34,10 @@ int Swish_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
     int h = bottom_top_blob.h;
     int channels = bottom_top_blob.c;
     int size = w * h;
-    int elempack = bottom_top_blob.elempack;
 
 #if __AVX__
+    int elempack = bottom_top_blob.elempack;
+
     if (elempack == 8)
     {
         #pragma omp parallel for num_threads(opt.num_threads)

--- a/src/layer/x86/tanh_x86.cpp
+++ b/src/layer/x86/tanh_x86.cpp
@@ -34,9 +34,10 @@ int TanH_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
     int h = bottom_top_blob.h;
     int channels = bottom_top_blob.c;
     int size = w * h;
-    int elempack = bottom_top_blob.elempack;
 
 #if __AVX__
+    int elempack = bottom_top_blob.elempack;
+
     if (elempack == 8)
     {
         #pragma omp parallel for num_threads(opt.num_threads)

--- a/src/layer/x86/yolov3detectionoutput_x86.cpp
+++ b/src/layer/x86/yolov3detectionoutput_x86.cpp
@@ -106,9 +106,9 @@ int Yolov3DetectionOutput_x86::forward(const std::vector<Mat>& bottom_blobs, std
                     float class_score = -FLT_MAX;
                     float* ptr = ((float*)scores.data) + i * w + j;
                     float* end = ptr + num_class * cs;
-                    float* end8 = ptr + (num_class & -8) * cs;
                     int q = 0;
 #if __AVX__
+                    float* end8 = ptr + (num_class & -8) * cs;
                     unsigned long index;
 
                     for (; ptr < end8; ptr += 8 * cs, q += 8)


### PR DESCRIPTION
Hello, NCNN Team.

This pull request is a logical continuation: https://github.com/Tencent/ncnn/pull/2184

I fixed all [-Wunused-variable] compile warnings under MacOS clang.

[140/350] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/dropout_x86.cpp.o
../src/layer/x86/dropout_x86.cpp:38:9: warning: unused variable 'elempack' [-Wunused-variable]
    int elempack = bottom_top_blob.elempack;
        ^
../src/layer/x86/dropout_x86.cpp:37:9: warning: unused variable 'dims' [-Wunused-variable]
    int dims = bottom_top_blob.dims;
        ^
2 warnings generated.

[115/350] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/innerproduct_x86.cpp.o
../src/layer/x86/innerproduct_x86.cpp:83:9: warning: unused variable 'channels' [-Wunused-variable]
    int channels = bottom_blob.c;
        ^
../src/layer/x86/innerproduct_x86.cpp:85:9: warning: unused variable 'elempack' [-Wunused-variable]
    int elempack = bottom_blob.elempack;
        ^
../src/layer/x86/innerproduct_x86.cpp:84:12: warning: unused variable 'elemsize' [-Wunused-variable]
    size_t elemsize = bottom_blob.elemsize;
           ^
../src/layer/x86/innerproduct_x86.cpp:86:9: warning: unused variable 'size' [-Wunused-variable]
    int size = w * h;
        ^
4 warnings generated.

[212/220] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/swish_x86.cpp.o
../src/layer/x86/swish_x86.cpp:37:9: warning: unused variable 'elempack' [-Wunused-variable]
    int elempack = bottom_top_blob.elempack;
        ^
1 warning generated.

------

[123/220] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/innerproduct_x86_avx2.cpp.o
src/layer/x86/innerproduct_x86_avx2.cpp:367:9: warning: unused variable 'elempack' [-Wunused-variable]
    int elempack = bottom_blob.elempack;
        ^
1 warning generated.
[126/220] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/prelu_x86.cpp.o
../src/layer/x86/prelu_x86.cpp:33:9: warning: unused variable 'elempack' [-Wunused-variable]
    int elempack = bottom_top_blob.elempack;
        ^
1 warning generated.
[136/220] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/scale_x86.cpp.o
../src/layer/x86/scale_x86.cpp:36:9: warning: unused variable 'elempack' [-Wunused-variable]
    int elempack = bottom_top_blob.elempack;
        ^
1 warning generated.
[138/220] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/convolution_x86.cpp.o
../src/layer/x86/convolution_x86.cpp:171:15: warning: unused variable 'maxk' [-Wunused-variable]
    const int maxk = kernel_w * kernel_h;
              ^
1 warning generated.
[139/220] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/sigmoid_x86.cpp.o
../src/layer/x86/sigmoid_x86.cpp:38:9: warning: unused variable 'elempack' [-Wunused-variable]
    int elempack = bottom_top_blob.elempack;
        ^
1 warning generated.

ETC