### PR TITLE
Fixed compile warnings for gcc linux build. [-Wunused-parameter]  [-Wunused-but-set-variable]

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -163,6 +163,7 @@ int ncnn_option_get_use_vulkan_compute(ncnn_option_t opt)
 #if NCNN_VULKAN
     return ((Option*)opt)->use_vulkan_compute;
 #else
+    (void)opt;
     return 0;
 #endif
 }

--- a/src/layer/interp.cpp
+++ b/src/layer/interp.cpp
@@ -408,7 +408,6 @@ int Interp::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) co
 {
     int w = bottom_blob.w;
     int h = bottom_blob.h;
-    int channels = bottom_blob.c;
 
     int outh = output_height;
     int outw = output_width;
@@ -416,7 +415,6 @@ int Interp::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) co
     {
         h = 1;
         w = 1;
-        channels = bottom_blob.w;
     }
     if (outh == 0 || outw == 0)
     {


### PR DESCRIPTION
Hi, NCNN Team.

I fixed 2 small compile warnings for gcc linux build:

https://github.com/Tencent/ncnn/runs/1239480361?check_suite_focus=true

Could you verify and accept my PR, pls?

 /home/runner/work/ncnn/ncnn/src/c_api.cpp:161:54: warning: unused parameter ‘opt’ [-Wunused-parameter]
 int ncnn_option_get_use_vulkan_compute(ncnn_option_t opt)
                                                      ^~~

 /home/runner/work/ncnn/ncnn/src/layer/interp.cpp: In member function ‘virtual int ncnn::Interp::forward(const ncnn::Mat&, ncnn::Mat&, const ncnn::Option&) const’:
/home/runner/work/ncnn/ncnn/src/layer/interp.cpp:411:9: warning: variable ‘channels’ set but not used [-Wunused-but-set-variable]
     int channels = bottom_blob.c;
         ^~~~~~~~