### PR TITLE
Fixed compile warnings for gcc linux build. [-Wunused-result]

### DIFF
--- a/tests/test_squeezenet.cpp
+++ b/tests/test_squeezenet.cpp
@@ -97,6 +97,16 @@ static int check_top3(const std::vector<float>& cls_scores, float epsilon = 0.00
     return 0;
 }
 
+static void fread_or_error(void* buffer, size_t size, size_t count, FILE* fp, const char* s)
+{
+    if (count != fread(buffer, size, count, fp))
+    {
+        fprintf(stderr, "Couldn't read from file: %s\n", s);
+        fclose(fp);
+        exit(EXIT_FAILURE);
+    }
+}
+
 static std::string read_file_string(const char* filepath)
 {
     FILE* fp = fopen(filepath, "rb");
@@ -113,7 +123,7 @@ static std::string read_file_string(const char* filepath)
     std::string s;
     s.resize(len + 1); // +1 for '\0'
 
-    fread((char*)s.c_str(), 1, len, fp);
+    fread_or_error((char*)s.c_str(), 1, len, fp, filepath);
     fclose(fp);
 
     s[len] = '\0';
@@ -136,7 +146,7 @@ static ncnn::Mat read_file_content(const char* filepath)
 
     ncnn::Mat m(len, (size_t)1u, 1);
 
-    fread(m, 1, len, fp);
+    fread_or_error(m, 1, len, fp, filepath);
     fclose(fp);
 
     return m;

--- a/tools/darknet/darknet2ncnn.cpp
+++ b/tools/darknet/darknet2ncnn.cpp
@@ -34,6 +34,17 @@ void file_error(const char* s)
     exit(EXIT_FAILURE);
 }
 
+void fread_or_error(void* buffer, size_t size, size_t count, FILE* fp, const char* s)
+{
+    if (count != fread(buffer, size, count, fp))
+    {
+        fprintf(stderr, "Couldn't read from file: %s\n", s);
+        fclose(fp);
+        assert(0);
+        exit(EXIT_FAILURE);
+    }
+}
+
 void error(const char* s)
 {
     perror(s);
@@ -790,18 +801,18 @@ void load_weights(const char* filename, std::deque<Section*>& dnet)
 
     int major, minor, revision;
 
-    fread(&major, sizeof(int), 1, fp);
-    fread(&minor, sizeof(int), 1, fp);
-    fread(&revision, sizeof(int), 1, fp);
+    fread_or_error(&major, sizeof(int), 1, fp, filename);
+    fread_or_error(&minor, sizeof(int), 1, fp, filename);
+    fread_or_error(&revision, sizeof(int), 1, fp, filename);
     if ((major * 10 + minor) >= 2)
     {
         uint64_t iseen = 0;
-        fread(&iseen, sizeof(uint64_t), 1, fp);
+        fread_or_error(&iseen, sizeof(uint64_t), 1, fp, filename);
     }
     else
     {
         uint32_t iseen = 0;
-        fread(&iseen, sizeof(uint32_t), 1, fp);
+        fread_or_error(&iseen, sizeof(uint32_t), 1, fp, filename);
     }
 
     for (auto s : dnet)


### PR DESCRIPTION
Hi, NCNN Team.

I fixed several compile errors in linux gcc build:

https://github.com/Tencent/ncnn/runs/1244764065?check_suite_focus=true

Could you review and accept my PR, pls?

 /home/runner/work/ncnn/ncnn/tools/darknet/darknet2ncnn.cpp: In function ‘void load_weights(const char*, std::deque<Section*>&)’:
/home/runner/work/ncnn/ncnn/tools/darknet/darknet2ncnn.cpp:793:38: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
     fread(&major, sizeof(int), 1, fp);

/home/runner/work/ncnn/ncnn/tests/test_squeezenet.cpp:116:40: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
     fread((char*)s.c_str(), 1, len, fp);
                                        ^
/home/runner/work/ncnn/ncnn/tests/test_squeezenet.cpp: In function ‘ncnn::Mat read_file_content(const char*)’:
/home/runner/work/ncnn/ncnn/tests/test_squeezenet.cpp:139:25: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
     fread(m, 1, len, fp);
                         ^