### PR TITLE
A single approach was used to suppress the msvc C4996 compiler warning [_CRT_SECURE_NO_WARNINGS]

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,3 +1,9 @@
+
+if(MSVC)
+    # warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
+    add_definitions(/wd4996)
+endif()
+
 add_executable(benchncnn benchncnn.cpp)
 target_link_libraries(benchncnn PRIVATE ncnn)
 

--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -12,10 +12,6 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-#ifdef _WIN32
-#define _CRT_SECURE_NO_WARNINGS
-#endif
-
 #include <float.h>
 #include <stdio.h>
 #include <string.h>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,9 @@
 
+if(MSVC)
+    # warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
+    add_definitions(/wd4996)
+endif()
+
 macro(ncnn_add_test name)
     add_executable(test_${name} test_${name}.cpp)
     target_link_libraries(test_${name} PRIVATE ncnn)


### PR DESCRIPTION
Hi, NCNN Team.

I fixed C4996 msvc compile warning & used single approach from tools/CMakeLists.txt to solve this problem for tools/tests/bechmark folders.

Could you review and accept my PR, pls?

https://travis-ci.com/github/Tencent/ncnn/jobs/398749674

C:\Users\travis\build\Tencent\ncnn\tests\test_squeezenet.cpp(112): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [C:\Users\travis\build\Tencent\ncnn\build\tests\test_squeezenet.vcxproj]

Best regards, Evgeny Proydakov.