### PR TITLE
fix darknet2ncnn.cpp warnings

### DIFF
--- a/tools/darknet/darknet2ncnn.cpp
+++ b/tools/darknet/darknet2ncnn.cpp
@@ -828,13 +828,14 @@ void load_weights(const char* filename, std::deque<Section*>& dnet)
             }
 
             if (s->layer_type == "Convolution")
-                read_to(s->weights, s->c * s->filters * s->size * s->size, fp);
+                read_to(s->weights, (size_t)(s->c) * s->filters * s->size * s->size, fp);
             else if (s->layer_type == "ConvolutionDepthWise")
                 read_to(s->weights, s->c * s->filters * s->size * s->size / s->groups, fp);
         }
     }
 
-    fclose(fp);
+    if (fp != NULL)
+        fclose(fp);
 }
 
 int count_output_blob(std::deque<Section*>& dnet)

--- a/tools/darknet/darknet2ncnn.cpp
+++ b/tools/darknet/darknet2ncnn.cpp
@@ -834,8 +834,7 @@ void load_weights(const char* filename, std::deque<Section*>& dnet)
         }
     }
 
-    if (fp != NULL)
-        fclose(fp);
+    fclose(fp);
 }
 
 int count_output_blob(std::deque<Section*>& dnet)


### PR DESCRIPTION
fix two warnings:
1.  determine if fp!=NULL before fclose
2.  wrapping (size_t) for int\*int