### PR TITLE
Fixed compile warnings for gcc linux gpu 64 build. [-Wunused-parameter] [-Wunused-variable]

### DIFF
--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -1612,7 +1612,7 @@ void VkStagingAllocator::fastFree(VkBufferMemory* ptr)
     buffer_budgets.push_back(ptr);
 }
 
-VkImageMemory* VkStagingAllocator::fastMalloc(int dims, int w, int h, int c, size_t elemsize, int elempack)
+VkImageMemory* VkStagingAllocator::fastMalloc(int dims, int w, int h, int c, size_t elemsize, int /* elempack */)
 {
     // staging image is mainly used for storing small piece of dynamic parameters
     // we allocate host memory as a fake image, it's simple and good

--- a/src/layer/vulkan/interp_vulkan.cpp
+++ b/src/layer/vulkan/interp_vulkan.cpp
@@ -263,7 +263,6 @@ int Interp_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute&
 {
     int w = bottom_blob.w;
     int h = bottom_blob.h;
-    int channels = bottom_blob.c;
 
     int outh = output_height;
     int outw = output_width;
@@ -294,7 +293,6 @@ int Interp_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob, 
 {
     int w = bottom_blob.w;
     int h = bottom_blob.h;
-    int channels = bottom_blob.c;
 
     int outh = output_height;
     int outw = output_width;

--- a/src/layer/vulkan/lrn_vulkan.cpp
+++ b/src/layer/vulkan/lrn_vulkan.cpp
@@ -245,7 +245,6 @@ int LRN_vulkan::forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Op
     int w = bottom_top_blob.w;
     int h = bottom_top_blob.h;
     int channels = bottom_top_blob.c;
-    size_t elemsize = bottom_top_blob.elemsize;
     int elempack = bottom_top_blob.elempack;
 
     VkMat square_workspace;
@@ -342,7 +341,6 @@ int LRN_vulkan::forward_inplace(VkImageMat& bottom_top_blob, VkCompute& cmd, con
     int w = bottom_top_blob.w;
     int h = bottom_top_blob.h;
     int channels = bottom_top_blob.c;
-    size_t elemsize = bottom_top_blob.elemsize;
     int elempack = bottom_top_blob.elempack;
 
     VkImageMat square_workspace;


### PR DESCRIPTION
Hi, NCNN Team.

I fixed several compile warnings in linux gcc gpu 64 build:

https://github.com/Tencent/ncnn/runs/1247837319?check_suite_focus=true

Could you review and accept my PR, pls?

/home/runner/work/ncnn/ncnn/src/allocator.cpp: In member function ‘virtual ncnn::VkImageMemory* ncnn::VkStagingAllocator::fastMalloc(int, int, int, int, size_t, int)’:
/home/runner/work/ncnn/ncnn/src/allocator.cpp:1615:99: warning: unused parameter ‘elempack’ [-Wunused-parameter]
 VkImageMemory* VkStagingAllocator::fastMalloc(int dims, int w, int h, int c, size_t elemsize, int elempack)
              
/home/runner/work/ncnn/ncnn/src/layer/vulkan/interp_vulkan.cpp: In member function ‘virtual int ncnn::Interp_vulkan::forward(const ncnn::VkMat&, ncnn::VkMat&, ncnn::VkCompute&, const ncnn::Option&) const’:
/home/runner/work/ncnn/ncnn/src/layer/vulkan/interp_vulkan.cpp:266:9: warning: unused variable ‘channels’ [-Wunused-variable]
     int channels = bottom_blob.c;
         ^~~~~~~~
/home/runner/work/ncnn/ncnn/src/layer/vulkan/interp_vulkan.cpp: In member function ‘virtual int ncnn::Interp_vulkan::forward(const ncnn::VkImageMat&, ncnn::VkImageMat&, ncnn::VkCompute&, const ncnn::Option&) const’:
/home/runner/work/ncnn/ncnn/src/layer/vulkan/interp_vulkan.cpp:297:9: warning: unused variable ‘channels’ [-Wunused-variable]
     int channels = bottom_blob.c;
         ^~~~~~~~
/home/runner/work/ncnn/ncnn/src/layer/vulkan/lrn_vulkan.cpp: In member function ‘virtual int ncnn::LRN_vulkan::forward_inplace(ncnn::VkMat&, ncnn::VkCompute&, const ncnn::Option&) const’:
/home/runner/work/ncnn/ncnn/src/layer/vulkan/lrn_vulkan.cpp:248:12: warning: unused variable ‘elemsize’ [-Wunused-variable]
     size_t elemsize = bottom_top_blob.elemsize;
            ^~~~~~~~
/home/runner/work/ncnn/ncnn/src/layer/vulkan/lrn_vulkan.cpp: In member function ‘virtual int ncnn::LRN_vulkan::forward_inplace(ncnn::VkImageMat&, ncnn::VkCompute&, const ncnn::Option&) const’:
/home/runner/work/ncnn/ncnn/src/layer/vulkan/lrn_vulkan.cpp:345:12: warning: unused variable ‘elemsize’ [-Wunused-variable]
     size_t elemsize = bottom_top_blob.elemsize;
            ^~~~~~~~

Best regards, Evgeny Proydakov.