### PR TITLE
Fixed compile warnings for gcc linux gpu 64 build. [-Wunused-parameter]

### DIFF
--- a/src/layer/vulkan/packing_vulkan.cpp
+++ b/src/layer/vulkan/packing_vulkan.cpp
@@ -37,7 +37,6 @@ Packing_vulkan::Packing_vulkan()
 int Packing_vulkan::create_pipeline(const Option& _opt)
 {
     Option opt = _opt;
-    const Mat& shape = bottom_shapes.empty() ? Mat() : bottom_shapes[0];
     const Mat& out_shape = top_shapes.empty() ? Mat() : top_shapes[0];
 
     size_t out_elemsize;

--- a/src/layer/x86/concat_x86.cpp
+++ b/src/layer/x86/concat_x86.cpp
@@ -41,6 +41,8 @@ int Concat_x86::create_pipeline(const Option& opt)
 
         packing_pack8->create_pipeline(opt);
     }
+#else
+    (void)(opt);
 #endif // __AVX__
 
     return 0;
@@ -58,6 +60,8 @@ int Concat_x86::destroy_pipeline(const Option& opt)
             packing_pack8 = 0;
         }
     }
+#else
+    (void)(opt);
 #endif // __AVX__
 
     return 0;

--- a/src/layer/x86/innerproduct_x86.cpp
+++ b/src/layer/x86/innerproduct_x86.cpp
@@ -53,6 +53,8 @@ int InnerProduct_x86::create_pipeline(const Option& opt)
     {
         ncnn::cast_float32_to_float16(weight_data, weight_data_fp16, opt);
     }
+#else
+    (void)(opt);
 #endif // __AVX__
 
     return 0;

--- a/src/layer/x86/lstm_x86.cpp
+++ b/src/layer/x86/lstm_x86.cpp
@@ -40,6 +40,8 @@ int LSTM_x86::create_pipeline(const Option& opt)
         ncnn::cast_float32_to_float16(weight_xc_data, weight_xc_data_fp16, opt);
         ncnn::cast_float32_to_float16(weight_hc_data, weight_hc_data_fp16, opt);
     }
+#else
+    (void)(opt);
 #endif // __AVX__
 
     return 0;

--- a/src/layer/x86/padding_x86.cpp
+++ b/src/layer/x86/padding_x86.cpp
@@ -31,7 +31,7 @@ Padding_x86::Padding_x86()
 #endif // __AVX__
 }
 
-int Padding_x86::create_pipeline(const Option& opt)
+int Padding_x86::create_pipeline(const Option& /*opt*/)
 {
     return 0;
 }

--- a/src/layer/x86/reshape_x86.cpp
+++ b/src/layer/x86/reshape_x86.cpp
@@ -43,6 +43,8 @@ int Reshape_x86::create_pipeline(const Option& opt)
 
         flatten->create_pipeline(opt);
     }
+#else
+    (void)(opt);
 #endif // __AVX__
 
     return 0;

--- a/src/layer/x86/slice_x86.cpp
+++ b/src/layer/x86/slice_x86.cpp
@@ -45,6 +45,8 @@ int Slice_x86::create_pipeline(const Option& opt)
 
         packing_pack1->create_pipeline(opt);
     }
+#else
+    (void)(opt);
 #endif // __AVX__
 
     return 0;
@@ -62,6 +64,8 @@ int Slice_x86::destroy_pipeline(const Option& opt)
             packing_pack1 = 0;
         }
     }
+#else
+    (void)(opt);
 #endif // __AVX__
 
     return 0;


### PR DESCRIPTION
Hi, NCNN Team.

I fixed several compile warnings in linux gcc gpu 64 build:

https://github.com/Tencent/ncnn/runs/1248449126?check_suite_focus=true

Could you review and accept my PR, pls?

 /home/runner/work/ncnn/ncnn/src/layer/x86/concat_x86.cpp:30:47: warning: unused parameter ‘opt’ [-Wunused-parameter]
 int Concat_x86::create_pipeline(const Option& opt)
                                               ^~~
/home/runner/work/ncnn/ncnn/src/layer/x86/innerproduct_x86.cpp: In member function ‘virtual int ncnn::InnerProduct_x86::create_pipeline(const ncnn::Option&)’:
/home/runner/work/ncnn/ncnn/src/layer/x86/innerproduct_x86.cpp:39:53: warning: unused parameter ‘opt’ [-Wunused-parameter]
 int InnerProduct_x86::create_pipeline(const Option& opt)
                                                     ^~~

-------------------------------------------------------------------------------------------------------

 /home/runner/work/ncnn/ncnn/src/layer/vulkan/packing_vulkan.cpp:40:16: warning: unused variable 'shape' [-Wunused-variable]
    const Mat& shape = bottom_shapes.empty() ? Mat() : bottom_shapes[0];
               ^
[ 75%] Building CXX object src/CMakeFiles/ncnn.dir/la

Best regards, Evgeny Proydakov.