### PR TITLE
Fixed compile warnings for clang ios gpu. [-Wunused-variable]

### DIFF
--- a/src/layer/arm/convolution_3x3_pack4_fp16s.h
+++ b/src/layer/arm/convolution_3x3_pack4_fp16s.h
@@ -239,7 +239,7 @@ static void conv3x3s1_winograd64_pack4_fp16sa_neon(const Mat& bottom_blob, Mat& 
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int inch = bottom_blob.c;
-    size_t elemsize = bottom_blob.elemsize;
+    //size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
     int outw = top_blob.w;

--- a/src/layer/arm/convolution_3x3_pack4to1_bf16s.h
+++ b/src/layer/arm/convolution_3x3_pack4to1_bf16s.h
@@ -17,7 +17,7 @@ static void conv3x3s1_winograd64_pack4to1_bf16s_neon(const Mat& bottom_blob, Mat
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int inch = bottom_blob.c;
-    size_t elemsize = bottom_blob.elemsize;
+    //size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
     int outw = top_blob.w;

--- a/src/layer/arm/convolution_3x3_pack8to1_fp16s.h
+++ b/src/layer/arm/convolution_3x3_pack8to1_fp16s.h
@@ -133,7 +133,7 @@ static void conv3x3s1_winograd64_pack8to1_fp16sa_neon(const Mat& bottom_blob, Ma
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int inch = bottom_blob.c;
-    size_t elemsize = bottom_blob.elemsize;
+    //size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
     int outw = top_blob.w;

--- a/src/layer/arm/convolution_3x3_pack8to4_fp16s.h
+++ b/src/layer/arm/convolution_3x3_pack8to4_fp16s.h
@@ -139,7 +139,7 @@ static void conv3x3s1_winograd64_pack8to4_fp16sa_neon(const Mat& bottom_blob, Ma
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int inch = bottom_blob.c;
-    size_t elemsize = bottom_blob.elemsize;
+    //size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
     int outw = top_blob.w;

--- a/src/layer/arm/interp_arm.cpp
+++ b/src/layer/arm/interp_arm.cpp
@@ -78,7 +78,6 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
     int h = bottom_blob.h;
     int w = bottom_blob.w;
     int channels = bottom_blob.c;
-    int dims = bottom_blob.dims;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
@@ -271,7 +270,6 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
     int h = bottom_blob.h;
     int w = bottom_blob.w;
     int channels = bottom_blob.c;
-    int dims = bottom_blob.dims;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
@@ -461,7 +459,6 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
     int h = bottom_blob.h;
     int w = bottom_blob.w;
     int channels = bottom_blob.c;
-    int dims = bottom_blob.dims;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
@@ -737,7 +734,6 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
     int h = bottom_blob.h;
     int w = bottom_blob.w;
     int channels = bottom_blob.c;
-    int dims = bottom_blob.dims;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 


### PR DESCRIPTION
Hi, NCNN Team.

I fixed several compile warnings for iOS clang GPU:

https://github.com/Tencent/ncnn/runs/1248447863?check_suite_focus=true

Could you review and accept my PR, pls ?

/Users/evgeny.proydakov/repository/ncnn/src/layer/arm/interp_arm.cpp:81:9: warning: unused variable 'dims' [-Wunused-variable]
    int dims = bottom_blob.dims;
        ^
/Users/evgeny.proydakov/repository/ncnn/src/layer/arm/interp_arm.cpp:274:9: warning: unused variable 'dims' [-Wunused-variable]
    int dims = bottom_blob.dims;
        ^
/Users/evgeny.proydakov/repository/ncnn/src/layer/arm/interp_arm.cpp:464:9: warning: unused variable 'dims' [-Wunused-variable]
    int dims = bottom_blob.dims;
        ^
/Users/evgeny.proydakov/repository/ncnn/src/layer/arm/interp_arm.cpp:740:9: warning: unused variable 'dims' [-Wunused-variable]
    int dims = bottom_blob.dims;
        ^
4 warnings generated.