### PR TITLE
Fixed compile warnings for ios clang cpu 32bit. [-Wunused-variable]

### DIFF
--- a/src/layer/arm/convolution_1x1_pack4.h
+++ b/src/layer/arm/convolution_1x1_pack4.h
@@ -403,10 +403,10 @@ static void conv1x1s1_sgemm_pack4_neon(const Mat& bottom_blob, Mat& top_blob, co
         }
     }
 
-    int nn_outch = 0;
     int remain_outch_start = 0;
 
 #if __ARM_NEON && __aarch64__
+    int nn_outch = 0;
     nn_outch = outch >> 1;
     remain_outch_start = nn_outch << 1;
 

--- a/src/layer/arm/convolution_1x1_pack4_bf16s.h
+++ b/src/layer/arm/convolution_1x1_pack4_bf16s.h
@@ -400,10 +400,10 @@ static void conv1x1s1_sgemm_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_bl
         }
     }
 
-    int nn_outch = 0;
     int remain_outch_start = 0;
 
 #if __ARM_NEON && __aarch64__
+    int nn_outch = 0;
     nn_outch = outch >> 1;
     remain_outch_start = nn_outch << 1;
 

--- a/src/layer/arm/convolution_3x3_pack1to4.h
+++ b/src/layer/arm/convolution_3x3_pack1to4.h
@@ -21,10 +21,10 @@ static void conv3x3s1_pack1to4_neon(const Mat& bottom_blob, Mat& top_blob, const
 
     const float* bias = _bias;
 
-    int nn_outch = 0;
     int remain_outch_start = 0;
 
 #if __ARM_NEON && __aarch64__
+    int nn_outch = 0;
     nn_outch = outch >> 1;
     remain_outch_start = nn_outch << 1;
 
@@ -907,10 +907,10 @@ static void conv3x3s2_pack1to4_neon(const Mat& bottom_blob, Mat& top_blob, const
 
     const float* bias = _bias;
 
-    int nn_outch = 0;
     int remain_outch_start = 0;
 
 #if __ARM_NEON && __aarch64__
+    int nn_outch = 0;
     nn_outch = outch >> 1;
     remain_outch_start = nn_outch << 1;
 

--- a/src/layer/arm/convolution_3x3_pack1to4_bf16s.h
+++ b/src/layer/arm/convolution_3x3_pack1to4_bf16s.h
@@ -27,10 +27,10 @@ static void conv3x3s1_pack1to4_bf16s_neon(const Mat& bottom_blob, Mat& top_blob,
 
     const float* bias = _bias;
 
-    int nn_outch = 0;
     int remain_outch_start = 0;
 
 #if __ARM_NEON && __aarch64__
+    int nn_outch = 0;
     nn_outch = outch >> 1;
     remain_outch_start = nn_outch << 1;
 
@@ -1970,10 +1970,10 @@ static void conv3x3s2_pack1to4_bf16s_neon(const Mat& bottom_blob, Mat& top_blob,
 
     const float* bias = _bias;
 
-    int nn_outch = 0;
     int remain_outch_start = 0;
 
 #if __ARM_NEON && __aarch64__
+    int nn_outch = 0;
     nn_outch = outch >> 1;
     remain_outch_start = nn_outch << 1;
 

--- a/src/layer/arm/convolution_3x3_pack4.h
+++ b/src/layer/arm/convolution_3x3_pack4.h
@@ -735,10 +735,10 @@ static void conv3x3s1_winograd64_pack4_neon(const Mat& bottom_blob, Mat& top_blo
 
         top_blob_tm.create(tiles, 64, outch, elemsize, elempack, opt.workspace_allocator);
 
-        int nn_outch = 0;
         int remain_outch_start = 0;
 
 #if __ARM_NEON && __aarch64__
+        int nn_outch = 0;
         nn_outch = outch >> 1;
         remain_outch_start = nn_outch << 1;
 

--- a/src/layer/arm/convolution_3x3_pack4_bf16s.h
+++ b/src/layer/arm/convolution_3x3_pack4_bf16s.h
@@ -504,10 +504,10 @@ static void conv3x3s1_winograd64_pack4_bf16s_neon(const Mat& bottom_blob, Mat& t
 
         top_blob_tm.create(tiles, 64, outch, 4u * elempack, elempack, opt.workspace_allocator);
 
-        int nn_outch = 0;
         int remain_outch_start = 0;
 
 #if __ARM_NEON && __aarch64__
+        int nn_outch = 0;
         nn_outch = outch >> 1;
         remain_outch_start = nn_outch << 1;
 

--- a/src/layer/arm/convolution_3x3_pack4to1.h
+++ b/src/layer/arm/convolution_3x3_pack4to1.h
@@ -2303,10 +2303,10 @@ static void conv3x3s1_pack4to1_neon(const Mat& bottom_blob, Mat& top_blob, const
 
     const float* bias = _bias;
 
-    int nn_outch = 0;
     int remain_outch_start = 0;
 
 #if __ARM_NEON && __aarch64__
+    int nn_outch = 0;
     nn_outch = outch >> 1;
     remain_outch_start = nn_outch << 1;
 


### PR DESCRIPTION
Hi, NCNN Team.

I fixed several compile warnings for iOS clang CPU 32bit:

Could you review and accept my PR?

https://github.com/Tencent/ncnn/runs/1253637205?check_suite_focus=true

/Users/runner/work/ncnn/ncnn/src/layer/arm/convolution_1x1_pack4.h:406:9: warning: unused variable 'nn_outch' [-Wunused-variable]
    int nn_outch = 0;
        ^
In file included from /Users/runner/work/ncnn/ncnn/src/layer/arm/convolution_arm.cpp:48:
/Users/runner/work/ncnn/ncnn/src/layer/arm/convolution_1x1_pack4_bf16s.h:403:9: warning: unused variable 'nn_outch' [-Wunused-variable]
    int nn_outch = 0;
        ^
In file included from /Users/runner/work/ncnn/ncnn/src/layer/arm/convolution_arm.cpp:51:
/Users/runner/work/ncnn/ncnn/src/layer/arm/convolution_3x3_pack1to4.h:24:9: warning: unused variable 'nn_outch' [-Wunused-variable]
    int nn_outch = 0;
        ^

Best regards, Proydakov Evgeny.