### PR TITLE
Fixed compile warning in convolutiondepthwise for ios cpu 32 bit. [-Wunused-variable]

### DIFF
--- a/src/layer/arm/convolutiondepthwise_3x3_pack4.h
+++ b/src/layer/arm/convolutiondepthwise_3x3_pack4.h
@@ -14,10 +14,12 @@
 
 static void convdw3x3s1_pack4_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
 {
-    int w = bottom_blob.w;
+#if __aarch64__
+    const int w = bottom_blob.w;
+#endif
 
-    int outw = top_blob.w;
-    int outh = top_blob.h;
+    const int outw = top_blob.w;
+    const int outh = top_blob.h;
 
     const int group = bottom_blob.c;
 
@@ -33,14 +35,12 @@ static void convdw3x3s1_pack4_neon(const Mat& bottom_blob, Mat& top_blob, const 
         const float* k0 = kernel.row(g);
 
         float* outptr0 = out.row(0);
-        float* outptr1 = out.row(1);
 
         const Mat img0 = bottom_blob.channel(g);
 
         const float* r0 = img0.row(0);
         const float* r1 = img0.row(1);
         const float* r2 = img0.row(2);
-        const float* r3 = img0.row(3);
 
         float32x4_t _k00 = vld1q_f32(k0);
         float32x4_t _k01 = vld1q_f32(k0 + 4);
@@ -55,6 +55,9 @@ static void convdw3x3s1_pack4_neon(const Mat& bottom_blob, Mat& top_blob, const 
         int i = 0;
 
 #if __aarch64__
+        float* outptr1 = out.row(1);
+        const float* r3 = img0.row(3);
+
         for (; i + 1 < outh; i += 2)
         {
             int j = 0;

--- a/src/layer/arm/convolutiondepthwise_3x3_pack4_bf16s.h
+++ b/src/layer/arm/convolutiondepthwise_3x3_pack4_bf16s.h
@@ -14,10 +14,12 @@
 
 static void convdw3x3s1_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
 {
-    int w = bottom_blob.w;
+#if __aarch64__
+    const int w = bottom_blob.w;
+#endif
 
-    int outw = top_blob.w;
-    int outh = top_blob.h;
+    const int outw = top_blob.w;
+    const int outh = top_blob.h;
 
     const int group = bottom_blob.c;
 
@@ -33,14 +35,12 @@ static void convdw3x3s1_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_blob, 
         const unsigned short* k0 = kernel.row<const unsigned short>(g);
 
         unsigned short* outptr0 = out.row<unsigned short>(0);
-        unsigned short* outptr1 = out.row<unsigned short>(1);
 
         const Mat img0 = bottom_blob.channel(g);
 
         const unsigned short* r0 = img0.row<const unsigned short>(0);
         const unsigned short* r1 = img0.row<const unsigned short>(1);
         const unsigned short* r2 = img0.row<const unsigned short>(2);
-        const unsigned short* r3 = img0.row<const unsigned short>(3);
 
         float32x4_t _k00 = vcvt_f32_bf16(vld1_u16(k0));
         float32x4_t _k01 = vcvt_f32_bf16(vld1_u16(k0 + 4));
@@ -55,6 +55,9 @@ static void convdw3x3s1_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_blob, 
         int i = 0;
 
 #if __aarch64__
+        unsigned short* outptr1 = out.row<unsigned short>(1);
+        const unsigned short* r3 = img0.row<const unsigned short>(3);
+
         for (; i + 1 < outh; i += 2)
         {
             int j = 0;

--- a/src/layer/arm/convolutiondepthwise_5x5_pack4.h
+++ b/src/layer/arm/convolutiondepthwise_5x5_pack4.h
@@ -14,10 +14,12 @@
 
 static void convdw5x5s1_pack4_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
 {
-    int w = bottom_blob.w;
+#if __aarch64__
+    const int w = bottom_blob.w;
+#endif
 
-    int outw = top_blob.w;
-    int outh = top_blob.h;
+    const int outw = top_blob.w;
+    const int outh = top_blob.h;
 
     const int group = bottom_blob.c;
 
@@ -33,7 +35,6 @@ static void convdw5x5s1_pack4_neon(const Mat& bottom_blob, Mat& top_blob, const 
         const float* k0 = kernel.row(g);
 
         float* outptr0 = out.row(0);
-        float* outptr1 = out.row(1);
 
         const Mat img0 = bottom_blob.channel(g);
 
@@ -42,10 +43,13 @@ static void convdw5x5s1_pack4_neon(const Mat& bottom_blob, Mat& top_blob, const 
         const float* r2 = img0.row(2);
         const float* r3 = img0.row(3);
         const float* r4 = img0.row(4);
-        const float* r5 = img0.row(5);
 
         int i = 0;
+
 #if __aarch64__
+        float* outptr1 = out.row(1);
+        const float* r5 = img0.row(5);
+
         for (; i + 1 < outh; i += 2)
         {
             int j = 0;

--- a/src/layer/arm/convolutiondepthwise_5x5_pack4_bf16s.h
+++ b/src/layer/arm/convolutiondepthwise_5x5_pack4_bf16s.h
@@ -14,10 +14,12 @@
 
 static void convdw5x5s1_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
 {
-    int w = bottom_blob.w;
+#if __aarch64__
+    const int w = bottom_blob.w;
+#endif
 
-    int outw = top_blob.w;
-    int outh = top_blob.h;
+    const int outw = top_blob.w;
+    const int outh = top_blob.h;
 
     const int group = bottom_blob.c;
 
@@ -28,12 +30,9 @@ static void convdw5x5s1_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_blob, 
     {
         Mat out = top_blob.channel(g);
 
-        float32x4_t _bias0 = bias ? vld1q_f32((const float*)bias + g * 4) : vdupq_n_f32(0.f);
-
         const unsigned short* kptr = kernel.row<const unsigned short>(g);
 
         unsigned short* outptr0 = out.row<unsigned short>(0);
-        unsigned short* outptr1 = out.row<unsigned short>(1);
 
         const Mat img0 = bottom_blob.channel(g);
 
@@ -42,9 +41,13 @@ static void convdw5x5s1_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_blob, 
         const unsigned short* r2 = img0.row<const unsigned short>(2);
         const unsigned short* r3 = img0.row<const unsigned short>(3);
         const unsigned short* r4 = img0.row<const unsigned short>(4);
-        const unsigned short* r5 = img0.row<const unsigned short>(5);
 
 #if __aarch64__
+        unsigned short* outptr1 = out.row<unsigned short>(1);
+        const unsigned short* r5 = img0.row<const unsigned short>(5);
+
+        float32x4_t _bias0 = bias ? vld1q_f32((const float*)bias + g * 4) : vdupq_n_f32(0.f);
+
         // 4 * 25
         uint16x8_t _k00_01 = vld1q_u16(kptr);
         uint16x8_t _k02_03 = vld1q_u16(kptr + 8);


### PR DESCRIPTION
Hi, NCNN Team.

I fixed several compile warnings for clang iOS cpu 32 bit in convolutiondepthwise_3x3/convolutiondepthwise_5x5.
Could you review and accept my changes, pls?

https://github.com/Tencent/ncnn/runs/1258399492?check_suite_focus=true

In file included from /Users/evgeny.proydakov/repository/ncnn/src/layer/arm/convolutiondepthwise_arm.cpp:39:
/Users/evgeny.proydakov/repository/ncnn/src/layer/arm/convolutiondepthwise_5x5_pack4_bf16s.h:36:25: warning: unused variable 'outptr1' [-Wunused-variable]
        unsigned short* outptr1 = out.row<unsigned short>(1);
                        ^
/Users/evgeny.proydakov/repository/ncnn/src/layer/arm/convolutiondepthwise_5x5_pack4_bf16s.h:45:31: warning: unused variable 'r5' [-Wunused-variable]
        const unsigned short* r5 = img0.row<const unsigned short>(5);
                              ^
/Users/evgeny.proydakov/repository/ncnn/src/layer/arm/convolutiondepthwise_5x5_pack4_bf16s.h:31:21: warning: unused variable '_bias0' [-Wunused-variable]
        float32x4_t _bias0 = bias ? vld1q_f32((const float*)bias + g * 4) : vdupq_n_f32(0.f);
                    ^
/Users/evgeny.proydakov/repository/ncnn/src/layer/arm/convolutiondepthwise_5x5_pack4_bf16s.h:17:15: warning: unused variable 'w' [-Wunused-variable]
    const int w = bottom_blob.w;
              ^
13 warnings generated.

Best regards, Proydakov Evgeny.