### PR TITLE
Fixed compile warning for ios clang build. [-Wuninitialized]

### DIFF
--- a/src/layer/arm/convolution_3x3.h
+++ b/src/layer/arm/convolution_3x3.h
@@ -10952,14 +10952,14 @@ static void conv3x3s1_winograd64_neon5(const Mat& bottom_blob, Mat& top_blob, co
 
                     for (int m = 0; m + 3 < 8; m += 4)
                     {
-                        float32x4_t _output0_tm_00;
-                        float32x4_t _output0_tm_11;
-                        float32x4_t _output0_tm_22;
-                        float32x4_t _output0_tm_33;
-                        float32x4_t _output0_tm_44;
-                        float32x4_t _output0_tm_55;
-                        float32x4_t _output0_tm_66;
-                        float32x4_t _output0_tm_77;
+                        float32x4_t _output0_tm_00 = {};
+                        float32x4_t _output0_tm_11 = {};
+                        float32x4_t _output0_tm_22 = {};
+                        float32x4_t _output0_tm_33 = {};
+                        float32x4_t _output0_tm_44 = {};
+                        float32x4_t _output0_tm_55 = {};
+                        float32x4_t _output0_tm_66 = {};
+                        float32x4_t _output0_tm_77 = {};
 
                         _output0_tm_00 = vsetq_lane_f32(output0_tm0[0], _output0_tm_00, 0);
                         output0_tm0 += out0_tm.w * tiles;

--- a/src/layer/arm/convolution_3x3_int8.h
+++ b/src/layer/arm/convolution_3x3_int8.h
@@ -4135,7 +4135,9 @@ static void conv3x3s2_packed_int8_neon(const Mat& bottom_blob, Mat& top_blob, co
                     int16x8_t _r1 = vmovl_s8(_r1_s8);
                     int16x8_t _r2 = vmovl_s8(_r2_s8);
 
-                    int32x4_t _sum03, _sum47;
+                    int32x4_t _sum03 = {};
+                    int32x4_t _sum47 = {};
+
                     _sum03 = vld1q_lane_s32(outptr0, _sum03, 0); // out0
                     _sum03 = vld1q_lane_s32(outptr1, _sum03, 1); // out1
                     _sum03 = vld1q_lane_s32(outptr2, _sum03, 2); // out2

--- a/src/layer/arm/convolution_5x5.h
+++ b/src/layer/arm/convolution_5x5.h
@@ -497,13 +497,14 @@ static void conv5x5s1_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _ke
                     float32x4_t _r5 = vld1q_f32(r5);
                     _sum2 = vmlaq_f32(_sum2, _r5, _k20212223);
 
-                    float32x4_t _k_t4;
+                    float32x4_t _k_t4 = {};
+
                     _k_t4 = vsetq_lane_f32(k0[4], _k_t4, 0);
                     _k_t4 = vsetq_lane_f32(k1[4], _k_t4, 1);
                     _k_t4 = vsetq_lane_f32(k2[4], _k_t4, 2);
                     _k_t4 = vsetq_lane_f32(k3[4], _k_t4, 3);
 
-                    float32x4_t _r_t4;
+                    float32x4_t _r_t4 = {};
 
                     _r_t4 = vsetq_lane_f32(r0[4], _r_t4, 0);
                     _r_t4 = vsetq_lane_f32(r1[4], _r_t4, 1);
@@ -897,13 +898,14 @@ static void conv5x5s1_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _ke
                     float32x4_t _r4 = vld1q_f32(r4);
                     _sum = vmlaq_f32(_sum, _r4, _k20212223);
 
-                    float32x4_t _k_t4;
+                    float32x4_t _k_t4 = {};
+
                     _k_t4 = vsetq_lane_f32(k0[4], _k_t4, 0);
                     _k_t4 = vsetq_lane_f32(k1[4], _k_t4, 1);
                     _k_t4 = vsetq_lane_f32(k2[4], _k_t4, 2);
                     _k_t4 = vsetq_lane_f32(k3[4], _k_t4, 3);
 
-                    float32x4_t _r_t4;
+                    float32x4_t _r_t4 = {};
 
                     _r_t4 = vsetq_lane_f32(r0[4], _r_t4, 0);
                     _r_t4 = vsetq_lane_f32(r1[4], _r_t4, 1);

--- a/src/layer/arm/convolutiondepthwise_5x5.h
+++ b/src/layer/arm/convolutiondepthwise_5x5.h
@@ -811,13 +811,14 @@ static void convdw5x5s1_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _
                 float32x4_t _r5 = vld1q_f32(r5);
                 _sum2 = vmlaq_f32(_sum2, _r5, _k20212223);
 
-                float32x4_t _k_t4;
+                float32x4_t _k_t4 = {};
+
                 _k_t4 = vsetq_lane_f32(k0[4], _k_t4, 0);
                 _k_t4 = vsetq_lane_f32(k1[4], _k_t4, 1);
                 _k_t4 = vsetq_lane_f32(k2[4], _k_t4, 2);
                 _k_t4 = vsetq_lane_f32(k3[4], _k_t4, 3);
 
-                float32x4_t _r_t4;
+                float32x4_t _r_t4 = {};
 
                 _r_t4 = vsetq_lane_f32(r0[4], _r_t4, 0);
                 _r_t4 = vsetq_lane_f32(r1[4], _r_t4, 1);
@@ -1493,13 +1494,14 @@ static void convdw5x5s1_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _
                 float32x4_t _r4 = vld1q_f32(r4);
                 _sum = vmlaq_f32(_sum, _r4, _k20212223);
 
-                float32x4_t _k_t4;
+                float32x4_t _k_t4 = {};
+
                 _k_t4 = vsetq_lane_f32(k0[4], _k_t4, 0);
                 _k_t4 = vsetq_lane_f32(k1[4], _k_t4, 1);
                 _k_t4 = vsetq_lane_f32(k2[4], _k_t4, 2);
                 _k_t4 = vsetq_lane_f32(k3[4], _k_t4, 3);
 
-                float32x4_t _r_t4;
+                float32x4_t _r_t4 = {};
 
                 _r_t4 = vsetq_lane_f32(r0[4], _r_t4, 0);
                 _r_t4 = vsetq_lane_f32(r1[4], _r_t4, 1);


### PR DESCRIPTION
Hi, NCNN Team.

I fixed several compile warnings [-Wuninitialized] for iOS cpu/gpu build 32/64.
Could you verify my changes, pls?

https://github.com/Tencent/ncnn/runs/1293567147?check_suite_focus=true
https://github.com/Tencent/ncnn/runs/1293566755?check_suite_focus=true

/Users/runner/work/ncnn/ncnn/src/layer/arm/convolution_3x3.h:10964:73: warning: variable '_output0_tm_00' is uninitialized when used here [-Wuninitialized]
583
                        _output0_tm_00 = vsetq_lane_f32(output0_tm0[0], _output0_tm_00, 0);
584
                                                                        ^~~~~~~~~~~~~~
585
/Applications/Xcode_11.7.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/11.0.3/include/arm_neon.h:23695:22: note: expanded from macro 'vsetq_lane_f32'
586
  float32x4_t __s1 = __p1; \
587
                     ^~~~
588
/Users/runner/work/ncnn/ncnn/src/layer/arm/convolution_3x3.h:10955:25: note: variable '_output0_tm_00' is declared here
589
                        float32x4_t _output0_tm_00;
590
                        ^
591
/Users/runner/work/ncnn/ncnn/src/layer/arm/convolution_3x3.h:10973:73: warning: variable '_output0_tm_11' is uninitialized when used here [-Wuninitialized]
592
                        _output0_tm_11 = vsetq_lane_f32(output0_tm0[0], _output0_tm_11, 0);
593
                                                                        ^~~~~~~~~~~~~~
594
/Applications/Xcode_11.7.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/11.0.3/include/arm_neon.h:23695:22: note: expanded from macro 'vsetq_lane_f32'
595
  float32x4_t __s1 = __p1; \
596
                     ^~~~
597

Best regards, Proydakov Evgeny.