### PR TITLE
get_little_cpu_count() and get_big_cpu_count()

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -378,6 +378,16 @@ int get_cpu_count()
     return g_cpucount;
 }
 
+int get_little_cpu_count()
+{
+    return ncnn::get_cpu_thread_affinity_mask(1).num_enabled();
+}
+
+int get_big_cpu_count()
+{
+    return ncnn::get_cpu_thread_affinity_mask(2).num_enabled();
+}
+
 #if defined __ANDROID__ || defined __linux__
 static int get_max_freq_khz(int cpuid)
 {

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -380,12 +380,12 @@ int get_cpu_count()
 
 int get_little_cpu_count()
 {
-    return ncnn::get_cpu_thread_affinity_mask(1).num_enabled();
+    return get_cpu_thread_affinity_mask(1).num_enabled();
 }
 
 int get_big_cpu_count()
 {
-    return ncnn::get_cpu_thread_affinity_mask(2).num_enabled();
+    return get_cpu_thread_affinity_mask(2).num_enabled();
 }
 
 #if defined __ANDROID__ || defined __linux__

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -52,6 +52,8 @@ int cpu_support_x86_avx2();
 
 // cpu info
 int get_cpu_count();
+int get_little_cpu_count();
+int get_big_cpu_count();
 
 // bind all threads on little clusters if powersave enabled
 // affacts HMP arch cpu like ARM big.LITTLE


### PR DESCRIPTION
As recommended in QQ Contributor Group, created two functions:

- `get_little_cpu_count()`
- `get_big_cpu_count()`

