### PR TITLE
Silence unused parameter warning in opencv resize function

### DIFF
--- a/src/simpleocv.cpp
+++ b/src/simpleocv.cpp
@@ -82,6 +82,8 @@ void imwrite(const std::string& path, const Mat& m)
 #if NCNN_PIXEL
 void resize(const Mat& src, Mat& dst, const Size& size, float sw, float sh, int flags)
 {
+    (void)flags;
+
     int srcw = src.cols;
     int srch = src.rows;
 


### PR DESCRIPTION
Silence the unused parameter warning:
```
../src/opencv.cpp: In function ‘void cv::resize(const cv::Mat&, cv::Mat&, const cv::Size&, float, float, int)’:
../src/opencv.cpp:83:81: warning: unused parameter ‘flags’ [-Wunused-parameter]
   83 | void resize(const Mat& src, Mat& dst, const Size& size, float sw, float sh, int flags)
      |                                                                             ~~~~^~~~~
```