### PR TITLE
Fix maybe uninitialized warnings in Vulkan reshape functions

### DIFF
--- a/src/layer/vulkan/reshape_vulkan.cpp
+++ b/src/layer/vulkan/reshape_vulkan.cpp
@@ -374,7 +374,7 @@ int Reshape_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute
     int dims = bottom_blob.dims;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
-    int out_elempack;
+    int out_elempack = 0;
 
     int total = bottom_blob.w * bottom_blob.h * bottom_blob.c * elempack;
 
@@ -697,7 +697,7 @@ int Reshape_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob,
     int dims = bottom_blob.dims;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
-    int out_elempack;
+    int out_elempack = 0;
 
     int total = bottom_blob.w * bottom_blob.h * bottom_blob.c * elempack;
 


### PR DESCRIPTION
Fix these warnings (they do look like false positives):
```
../src/layer/vulkan/reshape_vulkan.cpp: In member function ‘virtual int ncnn::Reshape_vulkan::forward(const ncnn::VkImageMat&, ncnn::VkImageMat&, ncnn::VkCompute&, const ncnn::Option&) const’:
../src/layer/vulkan/reshape_vulkan.cpp:925:13: warning: ‘out_elempack’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  925 |             if (out_elempack == 1) out_elemsize = 4u;
      |             ^~
```