### PR TITLE
fix: fix gnueabihf cmake toolchain neon flags

### DIFF
--- a/toolchains/arm-linux-gnueabihf.toolchain.cmake
+++ b/toolchains/arm-linux-gnueabihf.toolchain.cmake
@@ -8,8 +8,8 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
-set(CMAKE_C_FLAGS "-march=armv7-a -mfloat-abi=hard -mfpu=neon-vfpv4")
-set(CMAKE_CXX_FLAGS "-march=armv7-a -mfloat-abi=hard -mfpu=neon-vfpv4")
+set(CMAKE_C_FLAGS "-march=armv7-a -mfloat-abi=hard -mfpu=neon")
+set(CMAKE_CXX_FLAGS "-march=armv7-a -mfloat-abi=hard -mfpu=neon")
 
 # cache flags
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}" CACHE STRING "c flags")


### PR DESCRIPTION
Test platform: ZYNQ 7020, there is vfpv3 but isn't vfpv4
(Reported in QQ Group, 2020-11-02)