### PR TITLE
Ncnn xadd merge fix riscv build err

### DIFF
--- a/src/allocator.h
+++ b/src/allocator.h
@@ -98,6 +98,11 @@ static inline void fastFree(void* ptr)
     }
 }
 
+
+#if defined NCNN_THREADS && defined __riscv && !defined __riscv_atomic
+#define NCNN_XADD
+#endif
+
 #if defined NCNN_THREADS && defined __INTEL_COMPILER && !(defined WIN32 || defined _WIN32)
 // atomic increment on the linux version of the Intel(tm) compiler
 #define NCNN_XADD(addr, delta) (int)_InterlockedExchangeAdd(const_cast<void*>(reinterpret_cast<volatile void*>(addr)), delta)
@@ -128,6 +133,9 @@ static inline void fastFree(void* ptr)
 #endif
 #endif
 
+#if defined NCNN_THREADS && defined __riscv && !defined __riscv_atomic
+#undef NCNN_XADD
+#endif
 #ifndef NCNN_XADD
 static inline int NCNN_XADD(int* addr, int delta)
 {
@@ -136,6 +144,7 @@ static inline int NCNN_XADD(int* addr, int delta)
     return tmp;
 }
 #endif
+
 /*
 #if NCNN_THREADS
 // exchange-add operation for atomic operations on reference counters

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -103,7 +103,7 @@ static inline void fastFree(void* ptr)
 #define NCNN_XADD
 #endif
 
-#if defined NCNN_THREADS && defined __INTEL_COMPILER && !(defined WIN32 || defined _WIN32)
+#if defined NCNN_THREADS  && !(defined NCNN_XADD) && defined __INTEL_COMPILER && !(defined WIN32 || defined _WIN32)
 // atomic increment on the linux version of the Intel(tm) compiler
 #define NCNN_XADD(addr, delta) (int)_InterlockedExchangeAdd(const_cast<void*>(reinterpret_cast<volatile void*>(addr)), delta)
 #endif


### PR DESCRIPTION
ios vk err：
Undefined symbols for architecture arm64e:
  "_vkAllocateCommandBuffers", referenced from:
      ncnn::VkCompute::init() in libncnn.a(command.cpp.o)
      ncnn::VkTransfer::init() in libncnn.a(command.cpp.o)

mac test err
The following tests FAILED:
	  5 - test_squeezenet (Failed)
	 38 - test_pooling (Failed)