### PR TITLE
try add Extract interrupt

### DIFF
--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -128,7 +128,7 @@ void benchmark(const char* comment, const ncnn::Mat& _in, const ncnn::Option& op
     }
 
     double time_min = DBL_MAX;
-    double time_max = -DBL_MAX;
+    double time_max = DBL_MIN;
     double time_avg = 0;
 
     for (int i = 0; i < g_loop_count; i++)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -46,6 +46,7 @@ Net::Net()
     weight_staging_vkallocator = 0;
     pipeline_cache = 0;
 #endif // NCNN_VULKAN
+    interrupt = false;
 }
 
 Net::~Net()
@@ -1112,6 +1113,11 @@ int Net::forward_layer(int layer_index, std::vector<Mat>& blob_mats, const Optio
     const Layer* layer = layers[layer_index];
 
     //     NCNN_LOGE("forward_layer %d %s", layer_index, layer->name.c_str());
+    if (interrupt)
+    {
+        NCNN_LOGE("forward_layer interrupt exit");
+        return -1;
+    }
 
     if (layer->one_blob_only)
     {

--- a/src/net.h
+++ b/src/net.h
@@ -41,10 +41,21 @@ public:
     // clear and destroy
     ~Net();
 
+private:
+    bool interrupt;
+
+    Mutex lock;
+
 public:
     // option can be changed before loading
     Option opt;
 
+    void setInterrupt(bool _int)
+    {
+        lock.lock();
+        interrupt = _int;
+        lock.unlock();
+    }
 #if NCNN_VULKAN
     // set gpu device by index
     void set_vulkan_device(int device_index);


### PR DESCRIPTION
在benchncnn测试，可以打断。

```
thread1
{
    input..
    extract....
}

threadd2
{
    usleep(200*1000)
    net.setintterrupt
}
```

benchncnn折腾了三天的CI了，实在过不了。。。