### PR TITLE
cmake: change the scope of -fno-exceptions and -fno-rtti

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -269,11 +269,11 @@ else()
 endif()
 
 if(NCNN_DISABLE_RTTI)
-    target_compile_options(ncnn PUBLIC -fno-rtti)
+    target_compile_options(ncnn PRIVATE -fno-rtti)
 endif()
 
 if(NCNN_DISABLE_EXCEPTION)
-    target_compile_options(ncnn PUBLIC -fno-exceptions)
+    target_compile_options(ncnn PRIVATE -fno-exceptions)
 endif()
 
 if(NCNN_TARGET_ARCH STREQUAL "x86")

--- a/src/datareader.h
+++ b/src/datareader.h
@@ -30,17 +30,17 @@ namespace ncnn {
 class DataReader
 {
 public:
-    virtual ~DataReader();
+    virtual ~DataReader() = 0;
 
 #if NCNN_STRING
     // parse plain param text
     // return 1 if scan success
-    virtual int scan(const char* format, void* p) const;
+    virtual int scan(const char* format, void* p) const = 0;
 #endif // NCNN_STRING
 
     // read binary param and model data
     // return bytes read
-    virtual size_t read(void* buf, size_t size) const;
+    virtual size_t read(void* buf, size_t size) const = 0;
 };
 
 #if NCNN_STDIO


### PR DESCRIPTION
ToT declares -fno-exceptions and -fno-rtti compiler options as a PUBLIC item,
but the compiler options in the public scope affects the compilation process of
the other projects doing add_executable(ncnn) or add_library(ncnn). This patch
eliminates the potential risks by changing the scope of the options above.