### PR TITLE
change abs() to fabs() for float args on ARM

### DIFF
--- a/src/layer/arm/unaryop_arm.cpp
+++ b/src/layer/arm/unaryop_arm.cpp
@@ -768,7 +768,7 @@ struct unary_op_abs_fp16s
 {
     __fp16 operator()(const __fp16& x) const
     {
-        return (__fp16)abs(x);
+        return (__fp16)fabs(x);
     }
 };
 
@@ -1127,7 +1127,7 @@ struct unary_op_abs
 {
     float operator()(const float& x) const
     {
-        return abs(x);
+        return fabs(x);
     }
 };
 


### PR DESCRIPTION
For compatiblity for old compilers such as ndk-r16b.
`fabs()` keeps result stable.

ref: https://github.com/Tencent/ncnn/issues/2372