### PR TITLE
don't compile tools and examples when crosscompile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ option(NCNN_BUILD_TESTS "build tests" OFF)
 option(NCNN_COVERAGE "build for coverage" OFF)
 option(NCNN_BUILD_BENCHMARK "build benchmark" ON)
 
-if(ANDROID OR IOS OR NCNN_SIMPLESTL)
+if(ANDROID OR IOS OR NCNN_SIMPLESTL OR CMAKE_CROSSCOMPILING)
     option(NCNN_DISABLE_RTTI "disable rtti" ON)
     option(NCNN_BUILD_TOOLS "build tools" OFF)
     option(NCNN_BUILD_EXAMPLES "build examples" OFF)


### PR DESCRIPTION
When cross-compiling, such as arm-linux-gnueabihf,
x86 OpenCV may be wrongly found by tools & examples targets.
Turn tools and examples off when cross compiling.