### PR TITLE
Fixed compile warning in src/cpu.cpp for ios 32/64 bit compilation. [-Wunused-variable]

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -730,9 +730,10 @@ int set_cpu_thread_affinity(const CpuSet& thread_affinity_mask)
 
     return 0;
 #elif __APPLE__
-    int num_threads = thread_affinity_mask.num_enabled();
 
 #ifdef _OPENMP
+    int num_threads = thread_affinity_mask.num_enabled();
+
     // set affinity for each thread
     set_omp_num_threads(num_threads);
     std::vector<int> ssarets(num_threads, 0);


### PR DESCRIPTION
Hi, NCNN Team.

I fixed compile warning for IOS 32/64 build in src/cpu.cpp

Could you review and accept my changes, pls?

/Users/evgeny.proydakov/repository/ncnn/src/cpu.cpp:733:9: warning: unused variable 'num_threads' [-Wunused-variable]
    int num_threads = thread_affinity_mask.num_enabled();
        ^
1 warning generated.
/Users/evgeny.proydakov/repository/ncnn/src/cpu.cpp:733:9: warning: unused variable 'num_threads' [-Wunused-variable]
    int num_threads = thread_affinity_mask.num_enabled();
        ^
1 warning generated.
/Users/evgeny.proydakov/repository/ncnn/src/cpu.cpp:733:9: warning: unused variable 'num_threads' [-Wunused-variable]
    int num_threads = thread_affinity_mask.num_enabled();
        ^
1 warning generated.
/Users/evgeny.proydakov/repository/ncnn/src/cpu.cpp:733:9: warning: unused variable 'num_threads' [-Wunused-variable]
    int num_threads = thread_affinity_mask.num_enabled();
        ^
1 warning generated.

Best regards, Proydakov Evgeny.