### PR TITLE
Fixed compile warning in src/allocator.cpp for linux-gcc-nostdio  [-Wunused-variable] 

### DIFF
--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -39,12 +39,14 @@ PoolAllocator::~PoolAllocator()
     if (!payouts.empty())
     {
         NCNN_LOGE("FATAL ERROR! pool allocator destroyed too early");
+#if NCNN_STDIO
         std::list<std::pair<size_t, void*> >::iterator it = payouts.begin();
         for (; it != payouts.end(); ++it)
         {
             void* ptr = it->second;
             NCNN_LOGE("%p still in use", ptr);
         }
+#endif
     }
 }
 
@@ -161,12 +163,14 @@ UnlockedPoolAllocator::~UnlockedPoolAllocator()
     if (!payouts.empty())
     {
         NCNN_LOGE("FATAL ERROR! unlocked pool allocator destroyed too early");
+#if NCNN_STDIO
         std::list<std::pair<size_t, void*> >::iterator it = payouts.begin();
         for (; it != payouts.end(); ++it)
         {
             void* ptr = it->second;
             NCNN_LOGE("%p still in use", ptr);
         }
+#endif
     }
 }
 


### PR DESCRIPTION
Hi, NCNN Team.

I fixed several compile warnings in src/allocator.cpp [-Wunused-variable] for linux-gcc-nostdio build.

You can see it here:

https://github.com/Tencent/ncnn/runs/1555424317?check_suite_focus=true

Could you review and accept my changes, pls?

/home/runner/work/ncnn/ncnn/src/allocator.cpp: In destructor ‘virtual ncnn::PoolAllocator::~PoolAllocator()’:
/home/runner/work/ncnn/ncnn/src/allocator.cpp:45:19: warning: unused variable ‘ptr’ [-Wunused-variable]
             void* ptr = it->second;
                   ^
/home/runner/work/ncnn/ncnn/src/allocator.cpp: In destructor ‘virtual ncnn::UnlockedPoolAllocator::~UnlockedPoolAllocator()’:
/home/runner/work/ncnn/ncnn/src/allocator.cpp:167:19: warning: unused variable ‘ptr’ [-Wunused-variable]
             void* ptr = it->second;

Best regards, Proydakov Evgeny.