### PR TITLE
Fixed compile warning for src/c_api.cpp nostring build. [-Wunused-parameter]

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -188,6 +188,7 @@ const char* ncnn_blob_get_name(ncnn_blob_t blob)
 #if NCNN_STRING
     return ((Blob*)blob)->name.c_str();
 #else
+    (void)blob;
     return "";
 #endif
 }
@@ -222,6 +223,7 @@ const char* ncnn_layer_get_name(ncnn_layer_t layer)
 #if NCNN_STRING
     return ((Layer*)layer)->name.c_str();
 #else
+    (void)layer;
     return "";
 #endif
 }
@@ -236,6 +238,7 @@ const char* ncnn_layer_get_type(ncnn_layer_t layer)
 #if NCNN_STRING
     return ((Layer*)layer)->type.c_str();
 #else
+    (void)layer;
     return "";
 #endif
 }
@@ -299,6 +302,8 @@ int ncnn_net_load_param(ncnn_net_t net, const char* path)
 #if NCNN_STDIO && NCNN_STRING
     return ((Net*)net)->load_param(path);
 #else
+    (void)path;
+    (void)net;
     return -1;
 #endif
 }
@@ -308,6 +313,8 @@ int ncnn_net_load_model(ncnn_net_t net, const char* path)
 #if NCNN_STDIO && NCNN_STRING
     return ((Net*)net)->load_model(path);
 #else
+    (void)path;
+    (void)net;
     return -1;
 #endif
 }
@@ -356,6 +363,9 @@ int ncnn_extractor_input(ncnn_extractor_t ex, const char* name, ncnn_mat_t mat)
 #if NCNN_STRING
     return ((Extractor*)ex)->input(name, *((Mat*)mat));
 #else
+    (void)ex;
+    (void)name;
+    (void)mat;
     return -1;
 #endif
 }
@@ -368,6 +378,9 @@ int ncnn_extractor_extract(ncnn_extractor_t ex, const char* name, ncnn_mat_t* ma
     *mat = (ncnn_mat_t)(new Mat(mat0));
     return ret;
 #else
+    (void)ex;
+    (void)name;
+    (void)mat;
     return -1;
 #endif
 }


### PR DESCRIPTION
Hi, NCNN Team.

I fixed compile warning in src/c_api.cpp for nostring build.

Could you review and accept my changes, pls?

You can see same warnings here:

https://github.com/Tencent/ncnn/runs/1556430685?check_suite_focus=true

/home/runner/work/ncnn/ncnn/src/c_api.cpp:186:44: warning: unused parameter ‘blob’ [-Wunused-parameter]
 const char* ncnn_blob_get_name(ncnn_blob_t blob)
                                            ^
/home/runner/work/ncnn/ncnn/src/c_api.cpp:220:46: warning: unused parameter ‘layer’ [-Wunused-parameter]
 const char* ncnn_layer_get_name(ncnn_layer_t layer)
                                              ^

Best regards, Proydakov Evgeny.
