### PR TITLE
Fixed compile warning for linux gcc arm/arm82 build. [-Wcomment]

### DIFF
--- a/src/layer/arm/convolution_7x7.h
+++ b/src/layer/arm/convolution_7x7.h
@@ -255,7 +255,7 @@ static void conv7x7s1_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _ke
                         "w"(_k46474849)  // %31
                         : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v9");
                 }
-#else  // __ARM_NEON && __aarch64__ defined, but __clang__ not defined \
+#else  // __ARM_NEON && __aarch64__ defined, but __clang__ not defined
 // When compiled with gcc, gcc does not accept over 30 operands
                 for (; nn > 0; nn--)
                 {
@@ -948,7 +948,7 @@ static void conv7x7s2_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _ke
                         "w"(_k46474849)  // %31
                         : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v9");
                 }
-#else  // __ARM_NEON && __aarch64__ defined, but __clang__ not defined \
+#else  // __ARM_NEON && __aarch64__ defined, but __clang__ not defined
 // When compiled with gcc, gcc does not accept over 30 operands
                 for (; nn > 0; nn--)
                 {

--- a/src/layer/arm/deconvolution_3x3.h
+++ b/src/layer/arm/deconvolution_3x3.h
@@ -66,8 +66,7 @@ static void deconv3x3s1_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& _
                 {
                     float32x4_t _v = vld1q_f32(r0);
 
-#if 0 // bad compiler generate slow instructions :( \
-// 0
+#if 0 // bad compiler generate slow instructions :(
                     float32x4_t _out00 = vld1q_f32(outptr0 + 0);
                     _out00 = vmlaq_lane_f32(_out00, _v, vget_low_f32(_k0), 0);
 


### PR DESCRIPTION
Hi, NCNN Team.

I fixed several compile warning for linux gcc arm/arm82 build.
Could you review and accept my changes, pls?

Online example here: https://github.com/Tencent/ncnn/runs/1556709144?check_suite_focus=true

/home/runner/work/ncnn/ncnn/src/layer/arm/convolution_7x7.h:258:8: warning: multi-line comment [-Wcomment]
258 | #else // __ARM_NEON && aarch64 defined, but clang not defined 
| ^
In file included from /home/runner/work/ncnn/ncnn/src/layer/arm/convolution_arm.cpp:44:
/home/runner/work/ncnn/ncnn/src/layer/arm/convolution_7x7.h:951:8: warning: multi-line comment [-Wcomment]
951 | #else // __ARM_NEON && aarch64 defined, but clang not defined 
| ^
[ 32%] Building CXX object src/CMakeFiles/ncnn.dir/layer/arm/convolution_arm_arm82.cpp.o
In file included from /home/runner/work/ncnn/ncnn/build/src/layer/arm/convolution_arm_arm82.cpp:44:
/home/runner/work/ncnn/ncnn/src/layer/arm/convolution_7x7.h:258:8: warning: multi-line comment [-Wcomment]
258 | #else // __ARM_NEON && aarch64 defined, but clang not defined 
| ^
In file included from /home/runner/work/ncnn/ncnn/build/src/layer/arm/convolution_arm_arm82.cpp:44:
/home/runner/work/ncnn/ncnn/src/layer/arm/convolution_7x7.h:951:8: warning: multi-line comment [-Wcomment]
951 | #else // __ARM_NEON && aarch64 defined, but clang not defined 
| ^

Best regards, Proydakov Evgeny.
