### PR TITLE
Support Allwinner V831

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -120,6 +120,14 @@ make -j4
 make install
 popd
 
+##### linux of v831 toolchain with neon and openmp
+mkdir -p build-v831-linux
+pushd build-v831-linux
+cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/v831.toolchain.cmake ..
+make -j4
+make install
+popd
+
 ##### linux for aarch64-linux-gnu toolchain
 mkdir -p build-aarch64-linux-gnu
 pushd build-aarch64-linux-gnu

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -512,7 +512,7 @@ static int set_sched_affinity(const CpuSet& thread_affinity_mask)
 #if defined(__GLIBC__) || defined(__OHOS__)
     pid_t pid = syscall(SYS_gettid);
 #else
-#ifdef PI3
+#if defined(PI3) || (defined(__MUSL__) && __MUSL_MINOR__ <= 14)
     pid_t pid = getpid();
 #else
     pid_t pid = gettid();

--- a/toolchains/v831.toolchain.cmake
+++ b/toolchains/v831.toolchain.cmake
@@ -1,0 +1,19 @@
+# set cross-compiled system type, it's better not use the type which cmake cannot recognized.
+SET ( CMAKE_SYSTEM_NAME Linux )
+SET ( CMAKE_SYSTEM_PROCESSOR arm )
+# when hislicon SDK was installed, toolchain was installed in the path as below: 
+SET ( CMAKE_C_COMPILER "/opt/v831-toolchain/bin/arm-openwrt-linux-gcc" )
+SET ( CMAKE_CXX_COMPILER "/opt/v831-toolchain/bin/arm-openwrt-linux-g++" )
+SET ( CMAKE_FIND_ROOT_PATH "/opt/v831-toolchain" )
+
+# set searching rules for cross-compiler
+SET ( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER )
+SET ( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
+SET ( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )
+
+# set ${CMAKE_C_FLAGS} and ${CMAKE_CXX_FLAGS}flag for cross-compiled process
+SET ( CMAKE_CXX_FLAGS "-march=armv7-a -mfloat-abi=hard -mfpu=neon ${CMAKE_CXX_FLAGS}" )
+
+# cache flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}" CACHE STRING "c flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" CACHE STRING "c++ flags")


### PR DESCRIPTION
- Add v831 support to build script
- Use `getpid` instead of `gettid` due to v831 toolchain
- Add v831 toolchain file