### PR TITLE
fix src/net.cpp missing-field-initializers warning

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -96,9 +96,9 @@ int Net::register_custom_layer(int index, layer_creator_func creator, layer_dest
     if ((int)custom_layer_registry.size() <= custom_index)
     {
 #if NCNN_STRING
-        struct layer_registry_entry dummy = {"", 0};
+        struct layer_registry_entry dummy = {"", 0, 0};
 #else
-        struct layer_registry_entry dummy = {0};
+        struct layer_registry_entry dummy = {0, 0};
 #endif // NCNN_STRING
         custom_layer_registry.resize(custom_index + 1, dummy);
     }


### PR DESCRIPTION
Hi Nihui

On my local MacOSX machine, cross compiling for android arm64 platform, ndk-r21b, gives this warning:
```
[1/3] Building CXX object src/CMakeFiles/ncnn.dir/net.cpp.o
../../src/net.cpp:99:51: warning: missing field 'destroyer' initializer [-Wmissing-field-initializers]
        struct layer_registry_entry dummy = {"", 0};
```

This PR try to remove that warning.