### PR TITLE
Fix python build

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -23,7 +23,7 @@ git submodule init && git submodule update
 ```bash
 mkdir build
 cd build
-cmake -DNCNN_BUILD_PYTHON=ON ..
+cmake -DNCNN_PYTHON=ON ..
 make
 ```
 

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -622,9 +622,9 @@ PYBIND11_MODULE(ncnn, m)
 #endif // NCNN_STDIO
 
     .def("clear", &Net::clear)
-    .def("create_extractor", &Net::create_extractor)
-    .def_readwrite("blobs", &Net::blobs)
-    .def_readwrite("layers", &Net::layers);
+    .def("create_extractor", &Net::create_extractor);
+    //.def_property("blobs", &Net::mutable_blobs)
+    //.def_property("layers", &Net::mutable_layers);
 
     py::enum_<ncnn::BorderType>(m, "BorderType")
     .value("BORDER_CONSTANT", ncnn::BorderType::BORDER_CONSTANT)

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -622,7 +622,7 @@ PYBIND11_MODULE(ncnn, m)
 #endif // NCNN_STDIO
 
     .def("clear", &Net::clear)
-    .def("create_extractor", &Net::create_extractor);
+    .def("create_extractor", &Net::create_extractor)
     //.def_property("blobs", &Net::mutable_blobs)
     //.def_property("layers", &Net::mutable_layers);
 


### PR DESCRIPTION
Hi, @caishanli  && @nihui 

When I try to compile ncnn with python (i.e. pyncnn), it failed to link.

My platform: 
- MacOSX, pybind11 from https://gitee.com/mirrors/pybind11
- Python 3.7.6

I just temporarily commented out two lines of code
```c++
    //.def_property("blobs", &Net::mutable_blobs)
    //.def_property("layers", &Net::mutable_layers);
```
which, I think, should be fixed later ( but I don't know how to fix).

Also updated the documentation, `DNCNN_BUILD_PYTHON` => `DNCNN_PYTHON` according to CMakeLists.txt
