### PR TITLE
fix mingw-x64 compilation for PC SIMD

### DIFF
--- a/src/layer/x86/convolution_3x3.h
+++ b/src/layer/x86/convolution_3x3.h
@@ -1079,7 +1079,7 @@ static void conv3x3s1_winograd43_sse(const Mat& bottom_blob, Mat& top_blob, cons
                     _w5 = _mm256_fmadd_ps(_d3, _5_n, _w5);
                     _w5 = _mm256_add_ps(_w5, _d5);
                     // transpose d to d_t
-#ifdef _WIN32
+#if (defined _WIN32 && !(defined __MINGW32__))
                     {
                         _t0.m256_f32[0] = _w0.m256_f32[0];
                         _t1.m256_f32[0] = _w0.m256_f32[1];


### PR DESCRIPTION
Hi Nihui

On Windows System, with CLion using MinGW-x64, compiling ncnn library with default cmake flags:
- previously, it failed
- this PR fix that failure by modifying macro determinations