### PR TITLE
[WIP] modularize convert tools

### DIFF
--- a/tools/mxnet/CMakeLists.txt
+++ b/tools/mxnet/CMakeLists.txt
@@ -1,5 +1,8 @@
 
-add_executable(mxnet2ncnn mxnet2ncnn.cpp)
+add_library(libmxnet2ncnn mxnet2ncnn.cpp mxnet2ncnn.h)
+target_include_directories(libmxnet2ncnn PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+add_executable(mxnet2ncnn mxnet2ncnn_exe.cpp)
+target_link_libraries(mxnet2ncnn libmxnet2ncnn)
 
 # add all mxnet2ncnn tool to a virtual project group
-set_property(TARGET mxnet2ncnn PROPERTY FOLDER "tools/converter")
+set_property(TARGET mxnet2ncnn libmxnet2ncnn PROPERTY FOLDER "tools/converter")

--- a/tools/mxnet/mxnet2ncnn.cpp
+++ b/tools/mxnet/mxnet2ncnn.cpp
@@ -350,14 +350,8 @@ static void parse_input_list(const char* s, std::vector<int>& inputs, std::vecto
     }
 }
 
-static bool read_mxnet_json(const char* jsonpath, std::vector<MXNetNode>& nodes)
+static bool read_mxnet_json(FILE* fp, std::vector<MXNetNode>& nodes)
 {
-    FILE* fp = fopen(jsonpath, "rb");
-    if (!fp)
-    {
-        fprintf(stderr, "fopen %s failed\n", jsonpath);
-        return false;
-    }
 
     int internal_unknown = 0;
     int internal_underscore = 0;
@@ -368,7 +362,7 @@ static bool read_mxnet_json(const char* jsonpath, std::vector<MXNetNode>& nodes)
     char* s = fgets(line, 1024, fp);
     if (!s)
     {
-        fprintf(stderr, "fgets %s failed\n", jsonpath);
+        fprintf(stderr, "fgets mxnet json failed\n");
         return false;
     }
 
@@ -593,15 +587,8 @@ static bool read_mxnet_json(const char* jsonpath, std::vector<MXNetNode>& nodes)
     return true;
 }
 
-static bool read_mxnet_param(const char* parampath, std::vector<MXNetParam>& params)
+static bool read_mxnet_param(FILE* fp, std::vector<MXNetParam>& params)
 {
-    FILE* fp = fopen(parampath, "rb");
-    if (!fp)
-    {
-        fprintf(stderr, "fopen %s failed\n", parampath);
-        return false;
-    }
-
     size_t nread;
     uint64_t header;
     uint64_t reserved;
@@ -967,21 +954,12 @@ static void fuse_hardsigmoid_hardswish(std::vector<MXNetNode>& nodes, std::vecto
     }
 }
 
-int main(int argc, char** argv)
-{
-    const char* jsonpath = argv[1];
-    const char* parampath = argv[2];
-    const char* ncnn_prototxt = argc >= 5 ? argv[3] : "ncnn.param";
-    const char* ncnn_modelbin = argc >= 5 ? argv[4] : "ncnn.bin";
-
+void convert(FILE* mxnet_json, FILE* mxnet_param, FILE* pp, FILE* bp) {
     std::vector<MXNetNode> nodes;
     std::vector<MXNetParam> params;
 
-    read_mxnet_json(jsonpath, nodes);
-    read_mxnet_param(parampath, params);
-
-    FILE* pp = fopen(ncnn_prototxt, "wb");
-    FILE* bp = fopen(ncnn_modelbin, "wb");
+    read_mxnet_json(mxnet_json, nodes);
+    read_mxnet_param(mxnet_param, params);
 
     // magic
     fprintf(pp, "7767517\n");
@@ -2744,9 +2722,4 @@ int main(int argc, char** argv)
             }
         }
     }
-
-    fclose(pp);
-    fclose(bp);
-
-    return 0;
 }

--- a/tools/mxnet/mxnet2ncnn.h
+++ b/tools/mxnet/mxnet2ncnn.h
@@ -1,0 +1,8 @@
+#ifndef TOOLS_MXNET_MXNET2NCNN_H
+#define TOOLS_MXNET_MXNET2NCNN_H
+
+#include <stdio.h>
+
+void convert(FILE* mxnet_json, FILE* mxnet_param, FILE* pp, FILE* bp);
+
+#endif

--- a/tools/mxnet/mxnet2ncnn_exe.cpp
+++ b/tools/mxnet/mxnet2ncnn_exe.cpp
@@ -1,0 +1,32 @@
+#include "mxnet2ncnn.h"
+
+int main(int argc, char** argv)
+{
+    const char* jsonpath = argv[1];
+    const char* parampath = argv[2];
+    const char* ncnn_prototxt = argc >= 5 ? argv[3] : "ncnn.param";
+    const char* ncnn_modelbin = argc >= 5 ? argv[4] : "ncnn.bin";
+
+    FILE* mxnet_json = fopen(jsonpath, "rb");
+    if (!mxnet_json)
+    {
+        fprintf(stderr, "fopen %s failed\n", jsonpath);
+    }
+
+    FILE* mxnet_param = fopen(parampath, "rb");
+    if (!mxnet_param)
+    {
+        fprintf(stderr, "fopen %s failed\n", parampath);
+    }
+
+    FILE* pp = fopen(ncnn_prototxt, "wb");
+    FILE* bp = fopen(ncnn_modelbin, "wb");
+
+    convert(mxnet_json, mxnet_param, pp, bp);
+
+    fclose(pp);
+    fclose(bp);
+
+    return 0;
+}
+

--- a/tools/onnx/CMakeLists.txt
+++ b/tools/onnx/CMakeLists.txt
@@ -3,15 +3,19 @@ find_package(Protobuf)
 
 if(PROTOBUF_FOUND)
     protobuf_generate_cpp(ONNX_PROTO_SRCS ONNX_PROTO_HDRS onnx.proto)
-    add_executable(onnx2ncnn onnx2ncnn.cpp ${ONNX_PROTO_SRCS} ${ONNX_PROTO_HDRS})
-    target_include_directories(onnx2ncnn
-        PRIVATE
+    add_library(libonnx2ncnn onnx2ncnn.cpp ${ONNX_PROTO_SRCS} ${ONNX_PROTO_HDRS})
+    target_include_directories(libonnx2ncnn
+        PUBLIC
             ${PROTOBUF_INCLUDE_DIR}
-            ${CMAKE_CURRENT_BINARY_DIR})
-    target_link_libraries(onnx2ncnn PRIVATE ${PROTOBUF_LIBRARIES})
+            ${CMAKE_CURRENT_BINARY_DIR}
+            ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(libonnx2ncnn PRIVATE ${PROTOBUF_LIBRARIES})
+
+    add_executable(onnx2ncnn onnx2ncnn_exe.cpp)
+    target_link_libraries(onnx2ncnn libonnx2ncnn)
 
     # add all onnx2ncnn tool to a virtual project group
-    set_property(TARGET onnx2ncnn PROPERTY FOLDER "tools/converter")
+    set_property(TARGET libonnx2ncnn onnx2ncnn PROPERTY FOLDER "tools/converter")
 else()
     message(WARNING "Protobuf not found, onnx model convert tool won't be built")
 endif()

--- a/tools/onnx/onnx2ncnn.h
+++ b/tools/onnx/onnx2ncnn.h
@@ -1,0 +1,9 @@
+#ifndef TOOLS_ONNX_ONNX2NCNN_H
+#define TOOLS_ONNX_ONNX2NCNN_H
+
+#include "onnx.pb.h"
+
+#include <stdio.h>
+void convert(onnx::ModelProto model, FILE* pp, FILE* bp);
+
+#endif

--- a/tools/onnx/onnx2ncnn_exe.cpp
+++ b/tools/onnx/onnx2ncnn_exe.cpp
@@ -1,0 +1,59 @@
+#include <fstream>
+
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+
+#include "onnx2ncnn.h"
+
+static bool read_proto_from_binary(const char* filepath, onnx::ModelProto* message)
+{
+    std::ifstream fs(filepath, std::ifstream::in | std::ifstream::binary);
+    if (!fs.is_open())
+    {
+        fprintf(stderr, "open failed %s\n", filepath);
+        return false;
+    }
+
+    google::protobuf::io::IstreamInputStream input(&fs);
+    google::protobuf::io::CodedInputStream codedstr(&input);
+
+#if GOOGLE_PROTOBUF_VERSION >= 3011000
+    codedstr.SetTotalBytesLimit(INT_MAX);
+#else
+    codedstr.SetTotalBytesLimit(INT_MAX, INT_MAX / 2);
+#endif
+
+    bool success = message->ParseFromCodedStream(&codedstr);
+
+    fs.close();
+
+    return success;
+}
+
+int main(int argc, char** argv)
+{
+    const char* onnxpb = argv[1];
+    const char* ncnn_prototxt = argc >= 4 ? argv[2] : "ncnn.param";
+    const char* ncnn_modelbin = argc >= 4 ? argv[3] : "ncnn.bin";
+
+    onnx::ModelProto model;
+
+    // load
+    bool s1 = read_proto_from_binary(onnxpb, &model);
+    if (!s1)
+    {
+        fprintf(stderr, "read_proto_from_binary failed\n");
+        return -1;
+    }
+
+    FILE* pp = fopen(ncnn_prototxt, "wb");
+    FILE* bp = fopen(ncnn_modelbin, "wb");
+
+    convert(model, pp, bp);
+
+    fclose(pp);
+    fclose(bp);
+
+    return 0;
+}
+


### PR DESCRIPTION
I separated the conversion part and the file reading/writing part of the conversion tools. It helps projects like [convertmodel.com](https://convertmodel.com) integrate ncnn conversion tools smoothly.

It is a work-in-progress. Only mxnet2ncnn and onnx2ncnn are modularized for now. Any advice are welcomed ;)