### PR TITLE
Fixed compile warning in 'eltwise_vulkan.cpp'. [-Wunused-variable]

### DIFF
--- a/src/layer/vulkan/eltwise_vulkan.cpp
+++ b/src/layer/vulkan/eltwise_vulkan.cpp
@@ -149,9 +149,6 @@ int Eltwise_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<
     const VkMat& bottom_blob = bottom_blobs[0];
     const VkMat& bottom_blob1 = bottom_blobs[1];
 
-    int w = bottom_blob.w;
-    int h = bottom_blob.h;
-    int channels = bottom_blob.c;
     int elempack = bottom_blob.elempack;
 
     VkMat& top_blob = top_blobs[0];
@@ -210,9 +207,6 @@ int Eltwise_vulkan::forward(const std::vector<VkImageMat>& bottom_blobs, std::ve
     const VkImageMat& bottom_blob = bottom_blobs[0];
     const VkImageMat& bottom_blob1 = bottom_blobs[1];
 
-    int w = bottom_blob.w;
-    int h = bottom_blob.h;
-    int channels = bottom_blob.c;
     int elempack = bottom_blob.elempack;
 
     VkImageMat& top_blob = top_blobs[0];


### PR DESCRIPTION
Hi, NCNN Team.

I fixed several compile warning in eltwise_vulkan.cpp.
Could you review and accept my changes, pls?

https://github.com/Tencent/ncnn/runs/1732549148?check_suite_focus=true

[ 60%] Building CXX object src/CMakeFiles/ncnn.dir/layer/vulkan/eltwise_vulkan.cpp.o
/home/runner/work/ncnn/ncnn/src/layer/vulkan/eltwise_vulkan.cpp: In member function ‘virtual int ncnn::Eltwise_vulkan::forward(const std::vector<ncnn::VkMat>&, std::vector<ncnn::VkMat>&, ncnn::VkCompute&, const ncnn::Option&) const’:
/home/runner/work/ncnn/ncnn/src/layer/vulkan/eltwise_vulkan.cpp:152:9: warning: unused variable ‘w’ [-Wunused-variable]
     int w = bottom_blob.w;
         ^
/home/runner/work/ncnn/ncnn/src/layer/vulkan/eltwise_vulkan.cpp:153:9: warning: unused variable ‘h’ [-Wunused-variable]
     int h = bottom_blob.h;
         ^
/home/runner/work/ncnn/ncnn/src/layer/vulkan/eltwise_vulkan.cpp:154:9: warning: unused variable ‘channels’ [-Wunused-variable]
     int channels = bottom_blob.c;
         ^~~~~~~~
        
Best regards, Evgeny Proydakov.