### PR TITLE
fix typo in ncnn-load-model document

### DIFF
--- a/docs/how-to-use-and-FAQ/ncnn-load-model.md
+++ b/docs/how-to-use-and-FAQ/ncnn-load-model.md
@@ -7,7 +7,7 @@
 |file memory|load_param_mem(const char*)|load_param(const unsigned char*)|load_model(const unsigned char*)|
 |android asset|load_param(AAsset*)|load_param_bin(AAsset*)|load_model(AAsset*)|
 |android asset path|load_param(AAssetManager*, const char*)|load_param_bin(AAssetManager*, const char*)|load_model(AAssetManager*, const char*)|
-|custom IO reader|load_param(const DataReader&)|load_param_bin(const DataReader&)|load_mocel(const DataReader&)|
+|custom IO reader|load_param(const DataReader&)|load_param_bin(const DataReader&)|load_model(const DataReader&)|
 
 ### points to note
 


### PR DESCRIPTION
Hi, Nihui

This PR fix typo in [ncnn-load-model](https://github.com/Tencent/ncnn/wiki/ncnn-load-model) document page, as pointed out in this PR https://github.com/Tencent/ncnn/issues/2594 