### PR TITLE
workaround bugihfa cannot access fp16 element by vector index

### DIFF
--- a/src/layer/vulkan/permute_vulkan.cpp
+++ b/src/layer/vulkan/permute_vulkan.cpp
@@ -85,18 +85,19 @@ int Permute_vulkan::create_pipeline(const Option& _opt)
         opt.use_image_storage = false;
     }
 
-    std::vector<vk_specialization_type> specializations(1 + 10);
+    std::vector<vk_specialization_type> specializations(2 + 10);
     specializations[0].i = order_type;
-    specializations[1 + 0].i = shape_packed.dims;
-    specializations[1 + 1].i = shape_packed.w;
-    specializations[1 + 2].i = shape_packed.h;
-    specializations[1 + 3].i = shape_packed.c;
-    specializations[1 + 4].i = shape_packed.cstep;
-    specializations[1 + 5].i = out_shape_packed.dims;
-    specializations[1 + 6].i = out_shape_packed.w;
-    specializations[1 + 7].i = out_shape_packed.h;
-    specializations[1 + 8].i = out_shape_packed.c;
-    specializations[1 + 9].i = out_shape_packed.cstep;
+    specializations[1].i = vkdev->info.bug_implicit_fp16_arithmetic();
+    specializations[2 + 0].i = shape_packed.dims;
+    specializations[2 + 1].i = shape_packed.w;
+    specializations[2 + 2].i = shape_packed.h;
+    specializations[2 + 3].i = shape_packed.c;
+    specializations[2 + 4].i = shape_packed.cstep;
+    specializations[2 + 5].i = out_shape_packed.dims;
+    specializations[2 + 6].i = out_shape_packed.w;
+    specializations[2 + 7].i = out_shape_packed.h;
+    specializations[2 + 8].i = out_shape_packed.c;
+    specializations[2 + 9].i = out_shape_packed.cstep;
 
     Mat local_size_xyz_bottom; // pack4to1 and pack8to1
     if (shape_packed.dims == 2)

--- a/src/layer/vulkan/shader/permute.comp
+++ b/src/layer/vulkan/shader/permute.comp
@@ -22,8 +22,9 @@
 #endif
 
 layout (constant_id = 0) const int order_type = 0;
+layout (constant_id = 1) const int bugihfa = 0;
 
-#define shape_constant_id_offset 1
+#define shape_constant_id_offset 2
 layout (constant_id = shape_constant_id_offset + 0) const int dims = 0;
 layout (constant_id = shape_constant_id_offset + 1) const int w = 0;
 layout (constant_id = shape_constant_id_offset + 2) const int h = 0;

--- a/src/layer/vulkan/shader/permute_pack1to4.comp
+++ b/src/layer/vulkan/shader/permute_pack1to4.comp
@@ -22,8 +22,9 @@
 #endif
 
 layout (constant_id = 0) const int order_type = 0;
+layout (constant_id = 1) const int bugihfa = 0;
 
-#define shape_constant_id_offset 1
+#define shape_constant_id_offset 2
 layout (constant_id = shape_constant_id_offset + 0) const int dims = 0;
 layout (constant_id = shape_constant_id_offset + 1) const int w = 0;
 layout (constant_id = shape_constant_id_offset + 2) const int h = 0;

--- a/src/layer/vulkan/shader/permute_pack1to8.comp
+++ b/src/layer/vulkan/shader/permute_pack1to8.comp
@@ -23,8 +23,9 @@ struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };
 #endif
 
 layout (constant_id = 0) const int order_type = 0;
+layout (constant_id = 1) const int bugihfa = 0;
 
-#define shape_constant_id_offset 1
+#define shape_constant_id_offset 2
 layout (constant_id = shape_constant_id_offset + 0) const int dims = 0;
 layout (constant_id = shape_constant_id_offset + 1) const int w = 0;
 layout (constant_id = shape_constant_id_offset + 2) const int h = 0;

--- a/src/layer/vulkan/shader/permute_pack4.comp
+++ b/src/layer/vulkan/shader/permute_pack4.comp
@@ -22,8 +22,9 @@
 #endif
 
 layout (constant_id = 0) const int order_type = 0;
+layout (constant_id = 1) const int bugihfa = 0;
 
-#define shape_constant_id_offset 1
+#define shape_constant_id_offset 2
 layout (constant_id = shape_constant_id_offset + 0) const int dims = 0;
 layout (constant_id = shape_constant_id_offset + 1) const int w = 0;
 layout (constant_id = shape_constant_id_offset + 2) const int h = 0;
@@ -100,7 +101,33 @@ void main()
 
         ivec4 lane4 = y4 % 4;
 
-        afpvec4 v = afpvec4(vr[lane4.r], vg[lane4.g], vb[lane4.b], va[lane4.a]);
+        afpvec4 v;
+
+#if NCNN_fp16_arithmetic
+        if (bugihfa == 1)
+        {
+            if (lane4.r == 0) v.r = vr.r;
+            if (lane4.r == 1) v.r = vr.g;
+            if (lane4.r == 2) v.r = vr.b;
+            if (lane4.r == 3) v.r = vr.a;
+            if (lane4.g == 0) v.g = vg.r;
+            if (lane4.g == 1) v.g = vg.g;
+            if (lane4.g == 2) v.g = vg.b;
+            if (lane4.g == 3) v.g = vg.a;
+            if (lane4.b == 0) v.b = vb.r;
+            if (lane4.b == 1) v.b = vb.g;
+            if (lane4.b == 2) v.b = vb.b;
+            if (lane4.b == 3) v.b = vb.a;
+            if (lane4.a == 0) v.a = va.r;
+            if (lane4.a == 1) v.a = va.g;
+            if (lane4.a == 2) v.a = va.b;
+            if (lane4.a == 3) v.a = va.a;
+        }
+        else
+#endif
+        {
+            v = afpvec4(vr[lane4.r], vg[lane4.g], vb[lane4.b], va[lane4.a]);
+        }
 
         image3d_st4(top_blob_3d, ivec3(gx, gy, 0), v);
     }
@@ -154,7 +181,33 @@ void main()
 
         ivec4 lane4 = z4 % 4;
 
-        afpvec4 v = afpvec4(vr[lane4.r], vg[lane4.g], vb[lane4.b], va[lane4.a]);
+        afpvec4 v;
+        
+#if NCNN_fp16_arithmetic
+        if (bugihfa == 1)
+        {
+            if (lane4.r == 0) v.r = vr.r;
+            if (lane4.r == 1) v.r = vr.g;
+            if (lane4.r == 2) v.r = vr.b;
+            if (lane4.r == 3) v.r = vr.a;
+            if (lane4.g == 0) v.g = vg.r;
+            if (lane4.g == 1) v.g = vg.g;
+            if (lane4.g == 2) v.g = vg.b;
+            if (lane4.g == 3) v.g = vg.a;
+            if (lane4.b == 0) v.b = vb.r;
+            if (lane4.b == 1) v.b = vb.g;
+            if (lane4.b == 2) v.b = vb.b;
+            if (lane4.b == 3) v.b = vb.a;
+            if (lane4.a == 0) v.a = va.r;
+            if (lane4.a == 1) v.a = va.g;
+            if (lane4.a == 2) v.a = va.b;
+            if (lane4.a == 3) v.a = va.a;
+        }
+        else
+#endif
+        {
+            v = afpvec4(vr[lane4.r], vg[lane4.g], vb[lane4.b], va[lane4.a]);
+        }
 
         image3d_st4(top_blob_3d, ivec3(gx, gy, gz), v);
     }

--- a/src/layer/vulkan/shader/permute_pack4to1.comp
+++ b/src/layer/vulkan/shader/permute_pack4to1.comp
@@ -22,8 +22,9 @@
 #endif
 
 layout (constant_id = 0) const int order_type = 0;
+layout (constant_id = 1) const int bugihfa = 0;
 
-#define shape_constant_id_offset 1
+#define shape_constant_id_offset 2
 layout (constant_id = shape_constant_id_offset + 0) const int dims = 0;
 layout (constant_id = shape_constant_id_offset + 1) const int w = 0;
 layout (constant_id = shape_constant_id_offset + 2) const int h = 0;

--- a/src/layer/vulkan/shader/permute_pack4to8.comp
+++ b/src/layer/vulkan/shader/permute_pack4to8.comp
@@ -23,8 +23,9 @@ struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };
 #endif
 
 layout (constant_id = 0) const int order_type = 0;
+layout (constant_id = 1) const int bugihfa = 0;
 
-#define shape_constant_id_offset 1
+#define shape_constant_id_offset 2
 layout (constant_id = shape_constant_id_offset + 0) const int dims = 0;
 layout (constant_id = shape_constant_id_offset + 1) const int w = 0;
 layout (constant_id = shape_constant_id_offset + 2) const int h = 0;

--- a/src/layer/vulkan/shader/permute_pack8.comp
+++ b/src/layer/vulkan/shader/permute_pack8.comp
@@ -23,8 +23,9 @@ struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };
 #endif
 
 layout (constant_id = 0) const int order_type = 0;
+layout (constant_id = 1) const int bugihfa = 0;
 
-#define shape_constant_id_offset 1
+#define shape_constant_id_offset 2
 layout (constant_id = shape_constant_id_offset + 0) const int dims = 0;
 layout (constant_id = shape_constant_id_offset + 1) const int w = 0;
 layout (constant_id = shape_constant_id_offset + 2) const int h = 0;

--- a/src/layer/vulkan/shader/permute_pack8to1.comp
+++ b/src/layer/vulkan/shader/permute_pack8to1.comp
@@ -23,8 +23,9 @@ struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };
 #endif
 
 layout (constant_id = 0) const int order_type = 0;
+layout (constant_id = 1) const int bugihfa = 0;
 
-#define shape_constant_id_offset 1
+#define shape_constant_id_offset 2
 layout (constant_id = shape_constant_id_offset + 0) const int dims = 0;
 layout (constant_id = shape_constant_id_offset + 1) const int w = 0;
 layout (constant_id = shape_constant_id_offset + 2) const int h = 0;

--- a/src/layer/vulkan/shader/permute_pack8to4.comp
+++ b/src/layer/vulkan/shader/permute_pack8to4.comp
@@ -22,8 +22,9 @@
 #endif
 
 layout (constant_id = 0) const int order_type = 0;
+layout (constant_id = 1) const int bugihfa = 0;
 
-#define shape_constant_id_offset 1
+#define shape_constant_id_offset 2
 layout (constant_id = shape_constant_id_offset + 0) const int dims = 0;
 layout (constant_id = shape_constant_id_offset + 1) const int w = 0;
 layout (constant_id = shape_constant_id_offset + 2) const int h = 0;


### PR DESCRIPTION
Hi Nihui

This PR fix permute layer vulkan implementation by adding bugihfa related stuffs, as workaround for QCOM driver bug when acceccing vec4 element by dynamically calculated index.