### PR TITLE
fix(cmake): fix can't build on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ if(NOT CMAKE_VERSION VERSION_LESS "3.15")
     cmake_policy(SET CMP0091 NEW)
 endif()
 
+if(POLICY CMP0025)
+    # reference from https://cmake.org/cmake/help/latest/policy/CMP0025.html
+    cmake_policy(SET CMP0025 NEW)
+endif()
+
 project(ncnn)
 
 if(MSVC AND NOT CMAKE_VERSION VERSION_LESS "3.15")


### PR DESCRIPTION
Hello
When I tried to build ncnn, cmake generation failed in the following environment.
So, I made a patch to fix this.

reference from : https://cmake.org/cmake/help/latest/policy/CMP0025.html
```
(base) ☁  ncnn [fix-cmake] clang --version
clang version 11.0.0
Target: x86_64-apple-darwin19.6.0
Thread model: posix
InstalledDir: /usr/local/opt/llvm/bin
```
```
(base) ☁  ncnn [fix-cmake] cmake --version
cmake version 3.19.1

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```
```
/Applications/CLion.app/Contents/bin/cmake/mac/bin/cmake -DCMAKE_BUILD_TYPE=Debug -G "CodeBlocks - Unix Makefiles" /Users/soo/soo-works/soo-contribute/ncnn
-- CMAKE_INSTALL_PREFIX = /Users/soo/soo-works/soo-contribute/ncnn/cmake-build-debug/install
-- NCNN_VERSION_STRING = 1.0.21.02.03
-- The C compiler identification is Clang 11.0.0
-- The CXX compiler identification is Clang 11.0.0
-- Check for working C compiler: /usr/local/opt/llvm/bin/clang
-- Check for working C compiler: /usr/local/opt/llvm/bin/clang - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/local/opt/llvm/bin/clang++
-- Check for working CXX compiler: /usr/local/opt/llvm/bin/clang++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Target arch: x86
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- Found OpenMP_C: -fopenmp=libomp (found version "5.0") 
-- Found OpenMP_CXX: -fopenmp=libomp (found version "5.0") 
-- Found OpenMP: TRUE (found version "5.0")  
-- OpenCV library: /usr/local/Cellar/opencv/4.5.1_2
--     version: 4.5.1
--     libraries: opencv_core;opencv_highgui;opencv_imgproc;opencv_imgcodecs;opencv_videoio
--     include path: /usr/local/Cellar/opencv/4.5.1_2/include/opencv4
-- Found Protobuf: /usr/local/lib/libprotobuf.dylib (found version "3.14.0") 
-- Configuring done
CMake Error in examples/CMakeLists.txt:
  No known features for CXX compiler

  "Clang"

  version 11.0.0.


CMake Generate step failed.  Build files cannot be regenerated correctly.

[Failed to reload]

```