### PR TITLE
feat: add denormal options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,10 +228,6 @@ if(NCNN_VULKAN)
     endif()
 endif()
 
-if(UNIX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-endif()
-
 add_subdirectory(src)
 if(NCNN_BUILD_BENCHMARK)
     add_subdirectory(benchmark)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,10 @@ if(NCNN_VULKAN)
     endif()
 endif()
 
+if(UNIX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+endif()
+
 add_subdirectory(src)
 if(NCNN_BUILD_BENCHMARK)
     add_subdirectory(benchmark)

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -71,6 +71,10 @@
 #endif
 #endif
 
+#if defined(__SSE3__)
+#include <immintrin.h>
+#endif
+
 namespace ncnn {
 
 #if defined __ANDROID__ || defined __linux__
@@ -845,6 +849,51 @@ void set_kmp_blocktime(int time_ms)
 #else
     (void)time_ms;
 #endif
+}
+
+static int g_flush_denormals = 0;
+
+int get_flush_denormals()
+{
+    return g_flush_denormals;
+}
+
+int set_flush_denormals(int flush_denormals)
+{
+    if (flush_denormals < 0 || flush_denormals > 3)
+    {
+        NCNN_LOGE("denormals_zero %d not supported", flush_denormals);
+        return -1;
+    }
+#if defined(__SSE3__)
+    if (flush_denormals == 0)
+    {
+        _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_OFF);
+        _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
+    }
+    else if (flush_denormals == 1)
+    {
+        _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
+        _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
+    }
+    else if (flush_denormals == 2)
+    {
+        _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_OFF);
+        _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+    }
+    else if (flush_denormals == 3)
+    {
+        _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
+        _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+    }
+
+    g_flush_denormals = flush_denormals;
+
+    return 0;
+#else
+    return 0;
+#endif
+
 }
 
 } // namespace ncnn

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -851,11 +851,15 @@ void set_kmp_blocktime(int time_ms)
 #endif
 }
 
-static int g_flush_denormals = 0;
+static ncnn::ThreadLocalStorage tls_flush_denormals;
 
 int get_flush_denormals()
 {
-    return g_flush_denormals;
+#if defined(__SSE3__)
+    return (int)reinterpret_cast<size_t>(tls_flush_denormals.get());
+#else
+    return 0;
+#endif
 }
 
 int set_flush_denormals(int flush_denormals)
@@ -887,13 +891,11 @@ int set_flush_denormals(int flush_denormals)
         _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
     }
 
-    g_flush_denormals = flush_denormals;
-
+    tls_flush_denormals.set(reinterpret_cast<void*>((size_t)flush_denormals));
     return 0;
 #else
     return 0;
 #endif
-
 }
 
 } // namespace ncnn

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -89,6 +89,15 @@ NCNN_EXPORT int get_omp_thread_num();
 NCNN_EXPORT int get_kmp_blocktime();
 NCNN_EXPORT void set_kmp_blocktime(int time_ms);
 
+// need to flush denormals on Intel Chipset.
+// Other architectures such as ARM can be added as needed.
+// 0 = DAZ OFF, FTZ OFF
+// 1 = DAZ ON , FTZ OFF
+// 2 = DAZ OFF, FTZ ON
+// 3 = DAZ ON,  FTZ ON
+NCNN_EXPORT int get_flush_denormals();
+NCNN_EXPORT int set_flush_denormals(int flush_denormals);
+
 } // namespace ncnn
 
 #endif // NCNN_CPU_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2385,6 +2385,9 @@ int Extractor::extract(int blob_index, Mat& feat, int type)
     int old_blocktime = get_kmp_blocktime();
     set_kmp_blocktime(d->opt.openmp_blocktime);
 
+    int old_flush_denormals = get_flush_denormals();
+    set_flush_denormals(d->opt.flush_denormals);
+
     int ret = 0;
 
     if (d->blob_mats[blob_index].dims == 0)
@@ -2516,6 +2519,7 @@ int Extractor::extract(int blob_index, Mat& feat, int type)
     // clang-format on
 
     set_kmp_blocktime(old_blocktime);
+    set_flush_denormals(old_flush_denormals);
 
     return ret;
 }

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -61,6 +61,8 @@ Option::Option()
     use_tensor_storage = false;
 
     use_weight_fp16_storage = false;
+
+    flush_denormals = 3;
 }
 
 } // namespace ncnn

--- a/src/option.h
+++ b/src/option.h
@@ -121,6 +121,14 @@ public:
     // TODO drop this option
     bool use_weight_fp16_storage;
 
+    // enable DAZ(Denormals-Are-Zero) and FTZ(Flush-To-Zero)
+    // default value is 3
+    // 0 = DAZ OFF, FTZ OFF
+    // 1 = DAZ ON , FTZ OFF
+    // 2 = DAZ OFF, FTZ ON
+    // 3 = DAZ ON,  FTZ ON
+    int flush_denormals;
+
     bool use_reserved_0;
     bool use_reserved_1;
     bool use_reserved_2;


### PR DESCRIPTION
Flush-To-Zero(FTZ) and Denormals-Are-Zero(DAZ) are modes that bypass IEEE754 methods of dealing with denormal floating-point numbers on x86_64 and some x86 CPUs. [[link]](https://en.wikipedia.org/wiki/Denormal_number#Disabling_denormal_floats_at_the_code_level)
refer : https://github.com/pytorch/pytorch/blob/22a34bcf4e5eaa348f0117c414c3dd760ec64b13/caffe2/core/init_denormals.cc

I haven't found a function in ARM chipset that does the following:
If someone finds it, please add it.

The following is the result of testing with a model with denormal number.
|                    | before | after |
|:------------------:|:------:|:-----:|
| custom mobilenetv2 |  28ms  |  8ms  |