### PR TITLE
support adaptive_pooling in vulkan implementation

### DIFF
--- a/src/layer/vulkan/pooling_vulkan.cpp
+++ b/src/layer/vulkan/pooling_vulkan.cpp
@@ -388,8 +388,8 @@ int Pooling_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute
         constants[9].i = top_blob.cstep;
 
         const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_global_pack8
-                                   : elempack == 4 ? pipeline_pooling_global_pack4
-                                   : pipeline_pooling_global;
+                                                 : elempack == 4 ? pipeline_pooling_global_pack4
+                                                                 : pipeline_pooling_global;
 
         cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -422,8 +422,8 @@ int Pooling_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute
         constants[9].i = top_blob.cstep;
 
         const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_adaptive_pack8
-                                   : elempack == 4 ? pipeline_pooling_adaptive_pack4
-                                   : pipeline_pooling_adaptive;
+                                                 : elempack == 4 ? pipeline_pooling_adaptive_pack4
+                                                                 : pipeline_pooling_adaptive;
 
         cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -559,8 +559,8 @@ int Pooling_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute
     constants[11].i = htailpad;
 
     const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_pack8
-                               : elempack == 4 ? pipeline_pooling_pack4
-                               : pipeline_pooling;
+                                             : elempack == 4 ? pipeline_pooling_pack4
+                                                             : pipeline_pooling;
 
     cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -598,8 +598,8 @@ int Pooling_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob,
         constants[9].i = 0; //top_blob.cstep;
 
         const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_global_pack8
-                                   : elempack == 4 ? pipeline_pooling_global_pack4
-                                   : pipeline_pooling_global;
+                                                 : elempack == 4 ? pipeline_pooling_global_pack4
+                                                                 : pipeline_pooling_global;
 
         cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -632,8 +632,8 @@ int Pooling_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob,
         constants[9].i = 0; //top_blob.cstep;
 
         const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_adaptive_pack8
-                                   : elempack == 4 ? pipeline_pooling_adaptive_pack4
-                                   : pipeline_pooling_adaptive;
+                                                 : elempack == 4 ? pipeline_pooling_adaptive_pack4
+                                                                 : pipeline_pooling_adaptive;
 
         cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -769,8 +769,8 @@ int Pooling_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob,
     constants[11].i = htailpad;
 
     const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_pack8
-                               : elempack == 4 ? pipeline_pooling_pack4
-                               : pipeline_pooling;
+                                             : elempack == 4 ? pipeline_pooling_pack4
+                                                             : pipeline_pooling;
 
     cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 

--- a/src/layer/vulkan/pooling_vulkan.cpp
+++ b/src/layer/vulkan/pooling_vulkan.cpp
@@ -33,6 +33,9 @@ Pooling_vulkan::Pooling_vulkan()
     pipeline_pooling_global = 0;
     pipeline_pooling_global_pack4 = 0;
     pipeline_pooling_global_pack8 = 0;
+    pipeline_pooling_adaptive = 0;
+    pipeline_pooling_adaptive_pack4 = 0;
+    pipeline_pooling_adaptive_pack8 = 0;
 }
 
 int Pooling_vulkan::create_pipeline(const Option& _opt)
@@ -193,6 +196,53 @@ int Pooling_vulkan::create_pipeline(const Option& _opt)
             pipeline_pooling_global_pack8->create(LayerShaderType::pooling_global_pack8, opt, specializations);
         }
     }
+    else if (adaptive_pooling)
+    {
+        std::vector<vk_specialization_type> specializations(1 + 10);
+        specializations[0].i = pooling_type;
+        specializations[1 + 0].i = shape_bordered_packed.dims;
+        specializations[1 + 1].i = shape_bordered_packed.w;
+        specializations[1 + 2].i = shape_bordered_packed.h;
+        specializations[1 + 3].i = shape_bordered_packed.c;
+        specializations[1 + 4].i = shape_bordered_packed.cstep;
+        specializations[1 + 5].i = out_shape_packed.dims;
+        specializations[1 + 6].i = out_shape_packed.w;
+        specializations[1 + 7].i = out_shape_packed.h;
+        specializations[1 + 8].i = out_shape_packed.c;
+        specializations[1 + 9].i = out_shape_packed.cstep;
+
+        Mat local_size_xyz;
+        if (out_shape_packed.dims != 0)
+        {
+            local_size_xyz.w = std::min(4, out_shape_packed.w);
+            local_size_xyz.h = std::min(4, out_shape_packed.h);
+            local_size_xyz.c = std::min(4, out_shape_packed.c);
+        }
+
+        // pack1
+        if (shape.dims == 0 || elempack == 1)
+        {
+            pipeline_pooling_adaptive = new Pipeline(vkdev);
+            pipeline_pooling_adaptive->set_optimal_local_size_xyz(local_size_xyz);
+            pipeline_pooling_adaptive->create(LayerShaderType::pooling_adaptive, opt, specializations);
+        }
+
+        // pack4
+        if (shape.dims == 0 || elempack == 4)
+        {
+            pipeline_pooling_adaptive_pack4 = new Pipeline(vkdev);
+            pipeline_pooling_adaptive_pack4->set_optimal_local_size_xyz(local_size_xyz);
+            pipeline_pooling_adaptive_pack4->create(LayerShaderType::pooling_adaptive_pack4, opt, specializations);
+        }
+
+        // pack8
+        if ((opt.use_shader_pack8 && shape.dims == 0) || elempack == 8)
+        {
+            pipeline_pooling_adaptive_pack8 = new Pipeline(vkdev);
+            pipeline_pooling_adaptive_pack8->set_optimal_local_size_xyz(local_size_xyz);
+            pipeline_pooling_adaptive_pack8->create(LayerShaderType::pooling_adaptive_pack8, opt, specializations);
+        }
+    }
     else
     {
         std::vector<vk_specialization_type> specializations(12 + 10);
@@ -252,12 +302,6 @@ int Pooling_vulkan::create_pipeline(const Option& _opt)
         }
     }
 
-    // todo support adaptive_pooling in vulkan implementation
-    if (adaptive_pooling)
-    {
-        support_vulkan = false;
-    }
-
     return 0;
 }
 
@@ -290,6 +334,15 @@ int Pooling_vulkan::destroy_pipeline(const Option& _opt)
 
     delete pipeline_pooling_global_pack8;
     pipeline_pooling_global_pack8 = 0;
+
+    delete pipeline_pooling_adaptive;
+    pipeline_pooling_adaptive = 0;
+
+    delete pipeline_pooling_adaptive_pack4;
+    pipeline_pooling_adaptive_pack4 = 0;
+
+    delete pipeline_pooling_adaptive_pack8;
+    pipeline_pooling_adaptive_pack8 = 0;
 
     return 0;
 }
@@ -337,6 +390,40 @@ int Pooling_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute
         const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_global_pack8
                                    : elempack == 4 ? pipeline_pooling_global_pack4
                                    : pipeline_pooling_global;
+
+        cmd.record_pipeline(pipeline, bindings, constants, top_blob);
+
+        return 0;
+    }
+
+    if (adaptive_pooling)
+    {
+        int outw = 1;
+        int outh = 1;
+
+        top_blob.create(outw, outh, channels, elemsize, elempack, opt.blob_vkallocator);
+        if (top_blob.empty())
+            return -100;
+
+        std::vector<VkMat> bindings(2);
+        bindings[0] = bottom_blob;
+        bindings[1] = top_blob;
+
+        std::vector<vk_constant_type> constants(10);
+        constants[0].i = bottom_blob.dims;
+        constants[1].i = bottom_blob.w;
+        constants[2].i = bottom_blob.h;
+        constants[3].i = bottom_blob.c;
+        constants[4].i = bottom_blob.cstep;
+        constants[5].i = top_blob.dims;
+        constants[6].i = top_blob.w;
+        constants[7].i = top_blob.h;
+        constants[8].i = top_blob.c;
+        constants[9].i = top_blob.cstep;
+
+        const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_adaptive_pack8
+                                                 : elempack == 4 ? pipeline_pooling_adaptive_pack4
+                                                                 : pipeline_pooling_adaptive;
 
         cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -513,6 +600,40 @@ int Pooling_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob,
         const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_global_pack8
                                    : elempack == 4 ? pipeline_pooling_global_pack4
                                    : pipeline_pooling_global;
+
+        cmd.record_pipeline(pipeline, bindings, constants, top_blob);
+
+        return 0;
+    }
+
+    if (adaptive_pooling)
+    {
+        int outw = 1;
+        int outh = 1;
+
+        top_blob.create(outw, outh, channels, elemsize, elempack, opt.blob_vkallocator);
+        if (top_blob.empty())
+            return -100;
+
+        std::vector<VkImageMat> bindings(2);
+        bindings[0] = bottom_blob;
+        bindings[1] = top_blob;
+
+        std::vector<vk_constant_type> constants(10);
+        constants[0].i = bottom_blob.dims;
+        constants[1].i = bottom_blob.w;
+        constants[2].i = bottom_blob.h;
+        constants[3].i = bottom_blob.c;
+        constants[4].i = 0; //bottom_blob.cstep;
+        constants[5].i = top_blob.dims;
+        constants[6].i = top_blob.w;
+        constants[7].i = top_blob.h;
+        constants[8].i = top_blob.c;
+        constants[9].i = 0; //top_blob.cstep;
+
+        const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_adaptive_pack8
+                                                 : elempack == 4 ? pipeline_pooling_adaptive_pack4
+                                                                 : pipeline_pooling_adaptive;
 
         cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 

--- a/src/layer/vulkan/pooling_vulkan.cpp
+++ b/src/layer/vulkan/pooling_vulkan.cpp
@@ -388,8 +388,8 @@ int Pooling_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute
         constants[9].i = top_blob.cstep;
 
         const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_global_pack8
-                                                 : elempack == 4 ? pipeline_pooling_global_pack4
-                                                                 : pipeline_pooling_global;
+                                   : elempack == 4 ? pipeline_pooling_global_pack4
+                                   : pipeline_pooling_global;
 
         cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -422,8 +422,8 @@ int Pooling_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute
         constants[9].i = top_blob.cstep;
 
         const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_adaptive_pack8
-                                                 : elempack == 4 ? pipeline_pooling_adaptive_pack4
-                                                                 : pipeline_pooling_adaptive;
+                                   : elempack == 4 ? pipeline_pooling_adaptive_pack4
+                                   : pipeline_pooling_adaptive;
 
         cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -559,8 +559,8 @@ int Pooling_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute
     constants[11].i = htailpad;
 
     const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_pack8
-                                             : elempack == 4 ? pipeline_pooling_pack4
-                                                             : pipeline_pooling;
+                               : elempack == 4 ? pipeline_pooling_pack4
+                               : pipeline_pooling;
 
     cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -598,8 +598,8 @@ int Pooling_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob,
         constants[9].i = 0; //top_blob.cstep;
 
         const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_global_pack8
-                                                 : elempack == 4 ? pipeline_pooling_global_pack4
-                                                                 : pipeline_pooling_global;
+                                   : elempack == 4 ? pipeline_pooling_global_pack4
+                                   : pipeline_pooling_global;
 
         cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -632,8 +632,8 @@ int Pooling_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob,
         constants[9].i = 0; //top_blob.cstep;
 
         const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_adaptive_pack8
-                                                 : elempack == 4 ? pipeline_pooling_adaptive_pack4
-                                                                 : pipeline_pooling_adaptive;
+                                   : elempack == 4 ? pipeline_pooling_adaptive_pack4
+                                   : pipeline_pooling_adaptive;
 
         cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -769,8 +769,8 @@ int Pooling_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob,
     constants[11].i = htailpad;
 
     const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_pack8
-                                             : elempack == 4 ? pipeline_pooling_pack4
-                                                             : pipeline_pooling;
+                               : elempack == 4 ? pipeline_pooling_pack4
+                               : pipeline_pooling;
 
     cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 

--- a/src/layer/vulkan/pooling_vulkan.cpp
+++ b/src/layer/vulkan/pooling_vulkan.cpp
@@ -398,10 +398,7 @@ int Pooling_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute
 
     if (adaptive_pooling)
     {
-        int outw = 1;
-        int outh = 1;
-
-        top_blob.create(outw, outh, channels, elemsize, elempack, opt.blob_vkallocator);
+        top_blob.create(out_w, out_h, channels, elemsize, elempack, opt.blob_vkallocator);
         if (top_blob.empty())
             return -100;
 
@@ -608,10 +605,7 @@ int Pooling_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob,
 
     if (adaptive_pooling)
     {
-        int outw = 1;
-        int outh = 1;
-
-        top_blob.create(outw, outh, channels, elemsize, elempack, opt.blob_vkallocator);
+        top_blob.create(out_w, out_h, channels, elemsize, elempack, opt.blob_vkallocator);
         if (top_blob.empty())
             return -100;
 

--- a/src/layer/vulkan/pooling_vulkan.cpp
+++ b/src/layer/vulkan/pooling_vulkan.cpp
@@ -388,8 +388,8 @@ int Pooling_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute
         constants[9].i = top_blob.cstep;
 
         const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_global_pack8
-                                   : elempack == 4 ? pipeline_pooling_global_pack4
-                                   : pipeline_pooling_global;
+                                                 : elempack == 4 ? pipeline_pooling_global_pack4
+                                                                 : pipeline_pooling_global;
 
         cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -559,8 +559,8 @@ int Pooling_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute
     constants[11].i = htailpad;
 
     const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_pack8
-                               : elempack == 4 ? pipeline_pooling_pack4
-                               : pipeline_pooling;
+                                             : elempack == 4 ? pipeline_pooling_pack4
+                                                             : pipeline_pooling;
 
     cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -598,8 +598,8 @@ int Pooling_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob,
         constants[9].i = 0; //top_blob.cstep;
 
         const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_global_pack8
-                                   : elempack == 4 ? pipeline_pooling_global_pack4
-                                   : pipeline_pooling_global;
+                                                 : elempack == 4 ? pipeline_pooling_global_pack4
+                                                                 : pipeline_pooling_global;
 
         cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 
@@ -769,8 +769,8 @@ int Pooling_vulkan::forward(const VkImageMat& bottom_blob, VkImageMat& top_blob,
     constants[11].i = htailpad;
 
     const Pipeline* pipeline = elempack == 8 ? pipeline_pooling_pack8
-                               : elempack == 4 ? pipeline_pooling_pack4
-                               : pipeline_pooling;
+                                             : elempack == 4 ? pipeline_pooling_pack4
+                                                             : pipeline_pooling;
 
     cmd.record_pipeline(pipeline, bindings, constants, top_blob);
 

--- a/src/layer/vulkan/pooling_vulkan.h
+++ b/src/layer/vulkan/pooling_vulkan.h
@@ -42,6 +42,9 @@ public:
     Pipeline* pipeline_pooling_global;
     Pipeline* pipeline_pooling_global_pack4;
     Pipeline* pipeline_pooling_global_pack8;
+    Pipeline* pipeline_pooling_adaptive;
+    Pipeline* pipeline_pooling_adaptive_pack4;
+    Pipeline* pipeline_pooling_adaptive_pack8;
 };
 
 } // namespace ncnn

--- a/src/layer/vulkan/shader/pooling_adaptive.comp
+++ b/src/layer/vulkan/shader/pooling_adaptive.comp
@@ -72,28 +72,34 @@ void main()
 
     afp res;
 
+    // calculate adaptive kernel size
+    int sx = int(floor(afp(gx * psc(w)) / afp(psc(outw))));
+    int ex = int(ceil(afp((gx + 1) * psc(w)) / afp(psc(outw))));
+    int kernel_w = ex - sx;
+    int sy = int(floor(afp(gy * psc(h)) / afp(psc(outh))));
+    int ey = int(ceil(afp((gy + 1) * psc(h)) / afp(psc(outh))));
+    int kernel_h = ey - sy;
+
     if (pooling_type == 0)
     {
         res = afp(-FLT_MAX);
 
 #if NCNN_image_shader
-        int sx = gx * 1;
-        int sy = gy * 1;
 
-        for (int y = 0; y < psc(h); y++)
+        for (int y = 0; y < kernel_h; y++)
         {
-            for (int x = 0; x < psc(w); x++)
+            for (int x = 0; x < kernel_w; x++)
             {
                 afp v = image3d_ld1(bottom_blob, ivec3(sx + x, sy + y, gz));
                 res = max(res, v);
             }
         }
 #else
-        int v_offset = gz * psc(cstep) + gy * 1 * psc(w) + gx * 1;
+        int v_offset = gz * psc(cstep) + sy * psc(w) + sx;
 
-        for (int y = 0; y < psc(h); y++)
+        for (int y = 0; y < kernel_h; y++)
         {
-            for (int x = 0; x < psc(w); x++)
+            for (int x = 0; x < kernel_w; x++)
             {
                 afp v = buffer_ld1(bottom_blob_data, v_offset + x);
                 res = max(res, v);
@@ -108,13 +114,10 @@ void main()
         res = afp(0.f);
         int area = 0;
 
-        int sx = gx * 1;
-        int sy = gy * 1;
-
 #if NCNN_image_shader
-        for (int y = 0; y < psc(h); y++)
+        for (int y = 0; y < kernel_h; y++)
         {
-            for (int x = 0; x < psc(w); x++)
+            for (int x = 0; x < kernel_w; x++)
             {
                 res += image3d_ld1(bottom_blob, ivec3(sx + x, sy + y, gz));
                 area += 1;
@@ -123,9 +126,9 @@ void main()
 #else
         int v_offset = gz * psc(cstep) + sy * psc(w) + sx;
 
-        for (int y = 0; y < psc(h); y++)
+        for (int y = 0; y < kernel_h; y++)
         {
-            for (int x = 0; x < psc(w); x++)
+            for (int x = 0; x < kernel_w; x++)
             {
                 res += buffer_ld1(bottom_blob_data, v_offset + x);
                 area += 1;

--- a/src/layer/vulkan/shader/pooling_adaptive.comp
+++ b/src/layer/vulkan/shader/pooling_adaptive.comp
@@ -1,0 +1,148 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2018 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+#if NCNN_fp16_storage
+#extension GL_EXT_shader_16bit_storage: require
+#endif
+#if NCNN_fp16_arithmetic
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#endif
+
+#define FLT_MAX 3.402823466e+38
+
+layout (constant_id = 0) const int pooling_type = 0;
+
+#define shape_constant_id_offset 1
+layout (constant_id = shape_constant_id_offset + 0) const int dims = 0;
+layout (constant_id = shape_constant_id_offset + 1) const int w = 0;
+layout (constant_id = shape_constant_id_offset + 2) const int h = 0;
+layout (constant_id = shape_constant_id_offset + 3) const int c = 0;
+layout (constant_id = shape_constant_id_offset + 4) const int cstep = 0;
+
+layout (constant_id = shape_constant_id_offset + 5) const int outdims = 0;
+layout (constant_id = shape_constant_id_offset + 6) const int outw = 0;
+layout (constant_id = shape_constant_id_offset + 7) const int outh = 0;
+layout (constant_id = shape_constant_id_offset + 8) const int outc = 0;
+layout (constant_id = shape_constant_id_offset + 9) const int outcstep = 0;
+
+#if NCNN_image_shader
+layout (binding = 0) uniform unfp sampler3D bottom_blob;
+layout (binding = 1, imfmtc1) writeonly uniform unfp image3D top_blob;
+#else
+layout (binding = 0) readonly buffer bottom_blob { sfp bottom_blob_data[]; };
+layout (binding = 1) writeonly buffer top_blob { sfp top_blob_data[]; };
+#endif
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= psc(outw) || gy >= psc(outh) || gz >= psc(outc))
+        return;
+
+    afp res;
+
+    if (pooling_type == 0)
+    {
+        res = afp(-FLT_MAX);
+
+#if NCNN_image_shader
+        int sx = gx * 1;
+        int sy = gy * 1;
+
+        for (int y = 0; y < psc(h); y++)
+        {
+            for (int x = 0; x < psc(w); x++)
+            {
+                afp v = image3d_ld1(bottom_blob, ivec3(sx + x, sy + y, gz));
+                res = max(res, v);
+            }
+        }
+#else
+        int v_offset = gz * psc(cstep) + gy * 1 * psc(w) + gx * 1;
+
+        for (int y = 0; y < psc(h); y++)
+        {
+            for (int x = 0; x < psc(w); x++)
+            {
+                afp v = buffer_ld1(bottom_blob_data, v_offset + x);
+                res = max(res, v);
+            }
+
+            v_offset += psc(w);
+        }
+#endif
+    }
+    if (pooling_type == 1)
+    {
+        res = afp(0.f);
+        int area = 0;
+
+        int sx = gx * 1;
+        int sy = gy * 1;
+
+#if NCNN_image_shader
+        for (int y = 0; y < psc(h); y++)
+        {
+            for (int x = 0; x < psc(w); x++)
+            {
+                res += image3d_ld1(bottom_blob, ivec3(sx + x, sy + y, gz));
+                area += 1;
+            }
+        }
+#else
+        int v_offset = gz * psc(cstep) + sy * psc(w) + sx;
+
+        for (int y = 0; y < psc(h); y++)
+        {
+            for (int x = 0; x < psc(w); x++)
+            {
+                res += buffer_ld1(bottom_blob_data, v_offset + x);
+                area += 1;
+            }
+
+            v_offset += psc(w);
+        }
+#endif
+
+        res /= afp(area);
+    }
+
+#if NCNN_image_shader
+    image3d_st1(top_blob, ivec3(gx, gy, gz), res);
+#else
+    const int gi = gz * psc(outcstep) + gy * psc(outw) + gx;
+
+    buffer_st1(top_blob_data, gi, res);
+#endif
+}

--- a/src/layer/vulkan/shader/pooling_adaptive_pack4.comp
+++ b/src/layer/vulkan/shader/pooling_adaptive_pack4.comp
@@ -1,0 +1,148 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+#if NCNN_fp16_storage
+#extension GL_EXT_shader_16bit_storage: require
+#endif
+#if NCNN_fp16_arithmetic
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#endif
+
+#define FLT_MAX 3.402823466e+38
+
+layout (constant_id = 0) const int pooling_type = 0;
+
+#define shape_constant_id_offset 1
+layout (constant_id = shape_constant_id_offset + 0) const int dims = 0;
+layout (constant_id = shape_constant_id_offset + 1) const int w = 0;
+layout (constant_id = shape_constant_id_offset + 2) const int h = 0;
+layout (constant_id = shape_constant_id_offset + 3) const int c = 0;
+layout (constant_id = shape_constant_id_offset + 4) const int cstep = 0;
+
+layout (constant_id = shape_constant_id_offset + 5) const int outdims = 0;
+layout (constant_id = shape_constant_id_offset + 6) const int outw = 0;
+layout (constant_id = shape_constant_id_offset + 7) const int outh = 0;
+layout (constant_id = shape_constant_id_offset + 8) const int outc = 0;
+layout (constant_id = shape_constant_id_offset + 9) const int outcstep = 0;
+
+#if NCNN_image_shader
+layout (binding = 0) uniform unfp sampler3D bottom_blob;
+layout (binding = 1, imfmtc4) writeonly uniform unfp image3D top_blob;
+#else
+layout (binding = 0) readonly buffer bottom_blob { sfpvec4 bottom_blob_data[]; };
+layout (binding = 1) writeonly buffer top_blob { sfpvec4 top_blob_data[]; };
+#endif
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= psc(outw) || gy >= psc(outh) || gz >= psc(outc))
+        return;
+
+    afpvec4 res;
+
+    if (pooling_type == 0)
+    {
+        res = afpvec4(-FLT_MAX);
+
+#if NCNN_image_shader
+        int sx = gx * 1;
+        int sy = gy * 1;
+
+        for (int y = 0; y < psc(h); y++)
+        {
+            for (int x = 0; x < psc(w); x++)
+            {
+                afpvec4 v = image3d_ld4(bottom_blob, ivec3(sx + x, sy + y, gz));
+                res = max(res, v);
+            }
+        }
+#else
+        int v_offset = gz * psc(cstep) + gy * 1 * psc(w) + gx * 1;
+
+        for (int y = 0; y < psc(h); y++)
+        {
+            for (int x = 0; x < psc(w); x++)
+            {
+                afpvec4 v = buffer_ld4(bottom_blob_data, v_offset + x);
+                res = max(res, v);
+            }
+
+            v_offset += psc(w);
+        }
+#endif
+    }
+    else if (pooling_type == 1)
+    {
+        res = afpvec4(0.f);
+        int area = 0;
+
+        int sx = gx * 1;
+        int sy = gy * 1;
+
+#if NCNN_image_shader
+        for (int y = 0; y < psc(h); y++)
+        {
+            for (int x = 0; x < psc(w); x++)
+            {
+                res += image3d_ld4(bottom_blob, ivec3(sx + x, sy + y, gz));
+                area += 1;
+            }
+        }
+#else
+        int v_offset = gz * psc(cstep) + sy * psc(w) + sx;
+
+        for (int y = 0; y < psc(h); y++)
+        {
+            for (int x = 0; x < psc(w); x++)
+            {
+                res += buffer_ld4(bottom_blob_data, v_offset + x);
+                area += 1;
+            }
+
+            v_offset += psc(w);
+        }
+#endif
+
+        res /= afp(area);
+    }
+
+#if NCNN_image_shader
+    image3d_st4(top_blob, ivec3(gx, gy, gz), res);
+#else
+    const int gi = gz * psc(outcstep) + gy * psc(outw) + gx;
+
+    buffer_st4(top_blob_data, gi, res);
+#endif
+}

--- a/src/layer/vulkan/shader/pooling_adaptive_pack4.comp
+++ b/src/layer/vulkan/shader/pooling_adaptive_pack4.comp
@@ -72,28 +72,34 @@ void main()
 
     afpvec4 res;
 
+    // calculate adaptive kernel size
+    int sx = int(floor(afp(gx * psc(w)) / afp(psc(outw))));
+    int ex = int(ceil(afp((gx + 1) * psc(w)) / afp(psc(outw))));
+    int kernel_w = ex - sx;
+    int sy = int(floor(afp(gy * psc(h)) / afp(psc(outh))));
+    int ey = int(ceil(afp((gy + 1) * psc(h)) / afp(psc(outh))));
+    int kernel_h = ey - sy;
+    
     if (pooling_type == 0)
     {
         res = afpvec4(-FLT_MAX);
 
 #if NCNN_image_shader
-        int sx = gx * 1;
-        int sy = gy * 1;
 
-        for (int y = 0; y < psc(h); y++)
+        for (int y = 0; y < kernel_h; y++)
         {
-            for (int x = 0; x < psc(w); x++)
+            for (int x = 0; x < kernel_w; x++)
             {
                 afpvec4 v = image3d_ld4(bottom_blob, ivec3(sx + x, sy + y, gz));
                 res = max(res, v);
             }
         }
 #else
-        int v_offset = gz * psc(cstep) + gy * 1 * psc(w) + gx * 1;
+        int v_offset = gz * psc(cstep) + sy * psc(w) + sx;
 
-        for (int y = 0; y < psc(h); y++)
+        for (int y = 0; y < kernel_h; y++)
         {
-            for (int x = 0; x < psc(w); x++)
+            for (int x = 0; x < kernel_w; x++)
             {
                 afpvec4 v = buffer_ld4(bottom_blob_data, v_offset + x);
                 res = max(res, v);
@@ -108,13 +114,10 @@ void main()
         res = afpvec4(0.f);
         int area = 0;
 
-        int sx = gx * 1;
-        int sy = gy * 1;
-
 #if NCNN_image_shader
-        for (int y = 0; y < psc(h); y++)
+        for (int y = 0; y < kernel_h; y++)
         {
-            for (int x = 0; x < psc(w); x++)
+            for (int x = 0; x < kernel_w; x++)
             {
                 res += image3d_ld4(bottom_blob, ivec3(sx + x, sy + y, gz));
                 area += 1;
@@ -123,9 +126,9 @@ void main()
 #else
         int v_offset = gz * psc(cstep) + sy * psc(w) + sx;
 
-        for (int y = 0; y < psc(h); y++)
+        for (int y = 0; y < kernel_h; y++)
         {
-            for (int x = 0; x < psc(w); x++)
+            for (int x = 0; x < kernel_w; x++)
             {
                 res += buffer_ld4(bottom_blob_data, v_offset + x);
                 area += 1;

--- a/src/layer/vulkan/shader/pooling_adaptive_pack8.comp
+++ b/src/layer/vulkan/shader/pooling_adaptive_pack8.comp
@@ -73,17 +73,23 @@ void main()
 
     afpvec8 res;
 
+    // calculate adaptive kernel size
+    int sx = int(floor(afp(gx * psc(w)) / afp(psc(outw))));
+    int ex = int(ceil(afp((gx + 1) * psc(w)) / afp(psc(outw))));
+    int kernel_w = ex - sx;
+    int sy = int(floor(afp(gy * psc(h)) / afp(psc(outh))));
+    int ey = int(ceil(afp((gy + 1) * psc(h)) / afp(psc(outh))));
+    int kernel_h = ey - sy;
+
     if (pooling_type == 0)
     {
         res = afpvec8(afpvec4(-FLT_MAX), afpvec4(-FLT_MAX));
 
 #if NCNN_image_shader
-        int sx = gx * 1;
-        int sy = gy * 1;
 
-        for (int y = 0; y < psc(h); y++)
+        for (int y = 0; y < kernel_h; y++)
         {
-            for (int x = 0; x < psc(w); x++)
+            for (int x = 0; x < kernel_w; x++)
             {
                 afpvec8 v = image3d_ld8(bottom_blob, ivec3(sx + x, sy + y, gz));
                 res[0] = max(res[0], v[0]);
@@ -91,11 +97,11 @@ void main()
             }
         }
 #else
-        int v_offset = gz * psc(cstep) + gy * 1 * psc(w) + gx * 1;
+        int v_offset = gz * psc(cstep) + sy * psc(w) + sx;
 
-        for (int y = 0; y < psc(h); y++)
+        for (int y = 0; y < kernel_h; y++)
         {
-            for (int x = 0; x < psc(w); x++)
+            for (int x = 0; x < kernel_w; x++)
             {
                 afpvec8 v = buffer_ld8(bottom_blob_data, v_offset + x);
                 res[0] = max(res[0], v[0]);
@@ -110,14 +116,11 @@ void main()
     {
         res = afpvec8(afpvec4(0.f), afpvec4(0.f));
         int area = 0;
-
-        int sx = gx * 1;
-        int sy = gy * 1;
-
+        
 #if NCNN_image_shader
-        for (int y = 0; y < psc(h); y++)
+        for (int y = 0; y < kernel_h; y++)
         {
-            for (int x = 0; x < psc(w); x++)
+            for (int x = 0; x < kernel_w; x++)
             {
                 afpvec8 v = image3d_ld8(bottom_blob, ivec3(sx + x, sy + y, gz));
                 res[0] += v[0];
@@ -128,9 +131,9 @@ void main()
 #else
         int v_offset = gz * psc(cstep) + sy * psc(w) + sx;
 
-        for (int y = 0; y < psc(h); y++)
+        for (int y = 0; y < kernel_h; y++)
         {
-            for (int x = 0; x < psc(w); x++)
+            for (int x = 0; x < kernel_w; x++)
             {
                 afpvec8 v = buffer_ld8(bottom_blob_data, v_offset + x);
                 res[0] += v[0];

--- a/src/layer/vulkan/shader/pooling_adaptive_pack8.comp
+++ b/src/layer/vulkan/shader/pooling_adaptive_pack8.comp
@@ -1,0 +1,156 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#version 450
+
+#if NCNN_fp16_storage
+#extension GL_EXT_shader_16bit_storage: require
+struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };
+#endif
+#if NCNN_fp16_arithmetic
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#endif
+
+#define FLT_MAX 3.402823466e+38
+
+layout (constant_id = 0) const int pooling_type = 0;
+
+#define shape_constant_id_offset 1
+layout (constant_id = shape_constant_id_offset + 0) const int dims = 0;
+layout (constant_id = shape_constant_id_offset + 1) const int w = 0;
+layout (constant_id = shape_constant_id_offset + 2) const int h = 0;
+layout (constant_id = shape_constant_id_offset + 3) const int c = 0;
+layout (constant_id = shape_constant_id_offset + 4) const int cstep = 0;
+
+layout (constant_id = shape_constant_id_offset + 5) const int outdims = 0;
+layout (constant_id = shape_constant_id_offset + 6) const int outw = 0;
+layout (constant_id = shape_constant_id_offset + 7) const int outh = 0;
+layout (constant_id = shape_constant_id_offset + 8) const int outc = 0;
+layout (constant_id = shape_constant_id_offset + 9) const int outcstep = 0;
+
+#if NCNN_image_shader
+layout (binding = 0) uniform unfp sampler3D bottom_blob;
+layout (binding = 1, imfmtc4) writeonly uniform unfp image3D top_blob;
+#else
+layout (binding = 0) readonly buffer bottom_blob { sfpvec8 bottom_blob_data[]; };
+layout (binding = 1) writeonly buffer top_blob { sfpvec8 top_blob_data[]; };
+#endif
+
+layout (push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= psc(outw) || gy >= psc(outh) || gz >= psc(outc))
+        return;
+
+    afpvec8 res;
+
+    if (pooling_type == 0)
+    {
+        res = afpvec8(afpvec4(-FLT_MAX), afpvec4(-FLT_MAX));
+
+#if NCNN_image_shader
+        int sx = gx * 1;
+        int sy = gy * 1;
+
+        for (int y = 0; y < psc(h); y++)
+        {
+            for (int x = 0; x < psc(w); x++)
+            {
+                afpvec8 v = image3d_ld8(bottom_blob, ivec3(sx + x, sy + y, gz));
+                res[0] = max(res[0], v[0]);
+                res[1] = max(res[1], v[1]);
+            }
+        }
+#else
+        int v_offset = gz * psc(cstep) + gy * 1 * psc(w) + gx * 1;
+
+        for (int y = 0; y < psc(h); y++)
+        {
+            for (int x = 0; x < psc(w); x++)
+            {
+                afpvec8 v = buffer_ld8(bottom_blob_data, v_offset + x);
+                res[0] = max(res[0], v[0]);
+                res[1] = max(res[1], v[1]);
+            }
+
+            v_offset += psc(w);
+        }
+#endif
+    }
+    else if (pooling_type == 1)
+    {
+        res = afpvec8(afpvec4(0.f), afpvec4(0.f));
+        int area = 0;
+
+        int sx = gx * 1;
+        int sy = gy * 1;
+
+#if NCNN_image_shader
+        for (int y = 0; y < psc(h); y++)
+        {
+            for (int x = 0; x < psc(w); x++)
+            {
+                afpvec8 v = image3d_ld8(bottom_blob, ivec3(sx + x, sy + y, gz));
+                res[0] += v[0];
+                res[1] += v[1];
+                area += 1;
+            }
+        }
+#else
+        int v_offset = gz * psc(cstep) + sy * psc(w) + sx;
+
+        for (int y = 0; y < psc(h); y++)
+        {
+            for (int x = 0; x < psc(w); x++)
+            {
+                afpvec8 v = buffer_ld8(bottom_blob_data, v_offset + x);
+                res[0] += v[0];
+                res[1] += v[1];
+                area += 1;
+            }
+
+            v_offset += psc(w);
+        }
+#endif
+
+        res[0] /= afp(area);
+        res[1] /= afp(area);
+    }
+
+#if NCNN_image_shader
+    image3d_st8(top_blob, ivec3(gx, gy, gz), res);
+#else
+    const int gi = gz * psc(outcstep) + gy * psc(outw) + gx;
+
+    buffer_st8(top_blob_data, gi, res);
+#endif
+}


### PR DESCRIPTION
support adaptive_pooling in vulkan implementation by adding a new shader based on the normal pooling shader but with adaptive kernel size and no padding.

Tested on my NVIDIA GTX1050 (mobile) and x86 cpu on win10 x64, the results are basically identical.