### PR TITLE
faster bbox calculation by background score

### DIFF
--- a/src/layer/detectionoutput.cpp
+++ b/src/layer/detectionoutput.cpp
@@ -169,6 +169,11 @@ int DetectionOutput::forward(const std::vector<Mat>& bottom_blobs, std::vector<M
     #pragma omp parallel for num_threads(opt.num_threads)
     for (int i = 0; i < num_prior; i++)
     {
+        // if score of background class is larger than confidence threshold 
+        float score = mxnet_ssd_style ? confidence[i] : confidence[i * num_class_copy];
+        if (score >= (1.0 - confidence_threshold)) {
+            continue;
+        }
         const float* loc = location_ptr + i * 4;
         const float* pb = priorbox_ptr + i * 4;
         const float* var = variance_ptr ? variance_ptr + i * 4 : variances;


### PR DESCRIPTION
For detection output layer, usually the proposals are far less than the output.
For example, if the proposals to last stage is 300, we may have < 10 output.
Among 300 proposal bboxes, most of them belong to background; only some of them are of detection target (and will go through NMS to prune redundant).

Currently the flow is:

```
1. calculate all bbox.
2. for each class c except of background:
    2.1: for each bbox b if score(c, b) > confidence_threshold, add to candidate list. other wise discard it.
    2.2: apply NMS to candidate list & select the results of this class.
3. Combine results of each class.
4. sort and keep top K.
```

**Notice that the workload of 1 can be reduced if the score of background is high enough so we know that the scores of other classes cannot exceed confidence_threshold.**
Typically for detection out layer, the score is, ex: **the output of softmax, so the sum = 1.0**; obviously, **ncnn takes this assumptions since the default value of confidence_threshold is 0.5**, as:
`confidence_threshold = pd.get(4, 0.5f);`
As the result, **once the backgroud score is > 1.0 - confidence_threshold**, no other class has the chance to exceed confidence_threshold; as the result, we can skip the calculation of bbox.

Notice that the calculation of bbox involves several addition, summation and even exp operations; hence compared to the cost of one read, one subtraction and one comparison of floating point, as well as the rejection ratio is far higher than the pass ratio (so a lot of cases will go to continue branch), we can save a lot of extra computations.
```
        float score = mxnet_ssd_style ? confidence[i] : confidence[i * num_class_copy]; // one read
        if (score >= (1.0 - confidence_threshold)) { // one addition & one comparison of floating point .
            continue;
        }
```
