### PR TITLE
fix avg pooling accumulation overflow in vulkan using fp16 arithmetic

### DIFF
--- a/src/layer/vulkan/shader/pooling.comp
+++ b/src/layer/vulkan/shader/pooling.comp
@@ -119,7 +119,7 @@ void main()
     }
     if (pooling_type == 1 && avgpool_count_include_pad == 0)
     {
-        res = afp(0.f);
+        float res_fp32 = 0.f;  // force accumulation in fp32
         int area = 0;
 
         int sx = gx * stride_w;
@@ -142,7 +142,7 @@ void main()
                 if (sx + x >= psc(w) - pad_right - p.wtailpad)
                     break;
 
-                res += image3d_ld1(bottom_blob, ivec3(sx + x, sy + y, gz));
+                res_fp32 += texelFetch(bottom_blob, ivec3(sx + x, sy + y, gz), 0).r;
                 area += 1;
             }
         }
@@ -170,7 +170,7 @@ void main()
                 if (sx + x >= psc(w) - pad_right - p.wtailpad)
                     break;
 
-                res += buffer_ld1(bottom_blob_data, v_offset + x);
+                res_fp32 += bottom_blob_data[v_offset + x];
                 area += 1;
             }
 
@@ -178,11 +178,12 @@ void main()
         }
 #endif
 
-        res /= afp(area);
+        res_fp32 /= float(area);
+        res = afp(res_fp32);  // cast to fp16 if possible
     }
     if (pooling_type == 1 && avgpool_count_include_pad == 1)
     {
-        res = afp(0.f);
+        float res_fp32 = 0.f;  // force accumulation in fp32
 
 #if NCNN_image_shader
         int sx = gx * stride_w;
@@ -192,7 +193,7 @@ void main()
         {
             for (int x = 0; x < kernel_w; x++)
             {
-                res += image3d_ld1(bottom_blob, ivec3(sx + x, sy + y, gz));
+                res_fp32 += texelFetch(bottom_blob, ivec3(sx + x, sy + y, gz), 0).r;
             }
         }
 #else
@@ -202,14 +203,15 @@ void main()
         {
             for (int x = 0; x < kernel_w; x++)
             {
-                res += buffer_ld1(bottom_blob_data, v_offset + x);
+                res_fp32 += bottom_blob_data[v_offset + x];
             }
 
             v_offset += psc(w);
         }
 #endif
 
-        res /= afp(kernel_w * kernel_h);
+        res_fp32 /= float(kernel_w * kernel_h);
+        res = afp(res_fp32);  // cast to fp16 if possible
     }
 
 #if NCNN_image_shader

--- a/src/layer/vulkan/shader/pooling_adaptive.comp
+++ b/src/layer/vulkan/shader/pooling_adaptive.comp
@@ -111,7 +111,7 @@ void main()
     }
     if (pooling_type == 1)
     {
-        res = afp(0.f);
+        float res_fp32 = 0.f;  // force accumulation in fp32
         int area = 0;
 
 #if NCNN_image_shader
@@ -119,7 +119,7 @@ void main()
         {
             for (int x = 0; x < kernel_w; x++)
             {
-                res += image3d_ld1(bottom_blob, ivec3(sx + x, sy + y, gz));
+                res_fp32 += texelFetch(bottom_blob, ivec3(sx + x, sy + y, gz), 0).r;
                 area += 1;
             }
         }
@@ -130,7 +130,7 @@ void main()
         {
             for (int x = 0; x < kernel_w; x++)
             {
-                res += buffer_ld1(bottom_blob_data, v_offset + x);
+                res_fp32 += bottom_blob_data[v_offset + x];
                 area += 1;
             }
 
@@ -138,7 +138,8 @@ void main()
         }
 #endif
 
-        res /= afp(area);
+        res_fp32 /= float(area);
+        res = afp(res_fp32);  // cast to fp16 if possible
     }
 
 #if NCNN_image_shader

--- a/src/layer/vulkan/shader/pooling_adaptive_pack4.comp
+++ b/src/layer/vulkan/shader/pooling_adaptive_pack4.comp
@@ -111,7 +111,7 @@ void main()
     }
     else if (pooling_type == 1)
     {
-        res = afpvec4(0.f);
+        vec4 res_fp32 = vec4(0.f);  // force accumulation in fp32
         int area = 0;
 
 #if NCNN_image_shader
@@ -119,7 +119,7 @@ void main()
         {
             for (int x = 0; x < kernel_w; x++)
             {
-                res += image3d_ld4(bottom_blob, ivec3(sx + x, sy + y, gz));
+                res_fp32 += texelFetch(bottom_blob, ivec3(sx + x, sy + y, gz), 0);
                 area += 1;
             }
         }
@@ -130,7 +130,7 @@ void main()
         {
             for (int x = 0; x < kernel_w; x++)
             {
-                res += buffer_ld4(bottom_blob_data, v_offset + x);
+                res_fp32 += bottom_blob_data[v_offset + x];
                 area += 1;
             }
 
@@ -138,7 +138,8 @@ void main()
         }
 #endif
 
-        res /= afp(area);
+        res_fp32 /= float(area);
+        res = afpvec4(res_fp32);  // cast to fp16 if possible
     }
 
 #if NCNN_image_shader

--- a/src/layer/vulkan/shader/pooling_adaptive_pack8.comp
+++ b/src/layer/vulkan/shader/pooling_adaptive_pack8.comp
@@ -114,7 +114,7 @@ void main()
     }
     else if (pooling_type == 1)
     {
-        res = afpvec8(afpvec4(0.f), afpvec4(0.f));
+        mat2x4 res_fp32 = mat2x4(vec4(0.f), vec4(0.f));  // force accumulation in fp32
         int area = 0;
         
 #if NCNN_image_shader
@@ -122,9 +122,9 @@ void main()
         {
             for (int x = 0; x < kernel_w; x++)
             {
-                afpvec8 v = image3d_ld8(bottom_blob, ivec3(sx + x, sy + y, gz));
-                res[0] += v[0];
-                res[1] += v[1];
+                mat2x4 v = mat2x4(texelFetch(bottom_blob, ivec3((sx + x)*2, sy + y, gz), 0), texelFetch(bottom_blob, ivec3((sx + x)*2+1, sy + y, gz), 0));
+                res_fp32[0] += v[0];
+                res_fp32[1] += v[1];
                 area += 1;
             }
         }
@@ -135,9 +135,8 @@ void main()
         {
             for (int x = 0; x < kernel_w; x++)
             {
-                afpvec8 v = buffer_ld8(bottom_blob_data, v_offset + x);
-                res[0] += v[0];
-                res[1] += v[1];
+                res_fp32[0] += bottom_blob_data[v_offset + x][0];
+                res_fp32[1] += bottom_blob_data[v_offset + x][1];
                 area += 1;
             }
 
@@ -145,8 +144,9 @@ void main()
         }
 #endif
 
-        res[0] /= afp(area);
-        res[1] /= afp(area);
+        res_fp32[0] /= float(area);
+        res_fp32[1] /= float(area);
+        res = afpvec8(res_fp32);  // cast to fp16 if possible
     }
 
 #if NCNN_image_shader

--- a/src/layer/vulkan/shader/pooling_global.comp
+++ b/src/layer/vulkan/shader/pooling_global.comp
@@ -98,24 +98,25 @@ void main()
     }
     if (pooling_type == 1)
     {
-        res = afp(0.f);
+        float res_fp32 = 0.f;  // force accumulation in fp32
 
 #if NCNN_image_shader
         for (int y = 0; y < psc(h); y++)
         {
             for (int x = 0; x < psc(w); x++)
             {
-                res += image3d_ld1(bottom_blob, ivec3(x, y, gx));
+                res_fp32 += texelFetch(bottom_blob, ivec3(x, y, gx), 0).r;
             }
         }
 #else
         for (int i = 0; i < size; i++)
         {
-            res += buffer_ld1(bottom_blob_data, v_offset + i);
+            res_fp32 += bottom_blob_data[v_offset + i];
         }
 #endif
 
-        res /= afp(size);
+        res_fp32 /= float(size);
+        res = afp(res_fp32);  // cast to fp16 if possible
     }
 
 #if NCNN_image_shader

--- a/src/layer/vulkan/shader/pooling_global_pack4.comp
+++ b/src/layer/vulkan/shader/pooling_global_pack4.comp
@@ -98,24 +98,25 @@ void main()
     }
     if (pooling_type == 1)
     {
-        res = afpvec4(0.f);
+        vec4 res_fp32 = vec4(0.f);  // force accumulation in fp32
 
 #if NCNN_image_shader
         for (int y = 0; y < psc(h); y++)
         {
             for (int x = 0; x < psc(w); x++)
             {
-                res += image3d_ld4(bottom_blob, ivec3(x, y, gx));
+                res_fp32 += texelFetch(bottom_blob, ivec3(x, y, gx), 0);
             }
         }
 #else
         for (int i = 0; i < size; i++)
         {
-            res += buffer_ld4(bottom_blob_data, v_offset + i);
+            res_fp32 += bottom_blob_data[v_offset + i];
         }
 #endif
 
-        res /= afp(size);
+        res_fp32 /= float(size);
+        res = afpvec4(res_fp32);  // cast to fp16 if possible
     }
 
 #if NCNN_image_shader

--- a/src/layer/vulkan/shader/pooling_global_pack8.comp
+++ b/src/layer/vulkan/shader/pooling_global_pack8.comp
@@ -101,30 +101,30 @@ void main()
     }
     if (pooling_type == 1)
     {
-        res = afpvec8(afpvec4(0.f), afpvec4(0.f));
+        mat2x4 res_fp32 = mat2x4(vec4(0.f), vec4(0.f));  // force accumulation in fp32
 
 #if NCNN_image_shader
         for (int y = 0; y < psc(h); y++)
         {
             for (int x = 0; x < psc(w); x++)
             {
-                afpvec8 v = image3d_ld8(bottom_blob, ivec3(x, y, gx));
-                res[0] += v[0];
-                res[1] += v[1];
+                mat2x4 v = mat2x4(texelFetch(bottom_blob, ivec3(x*2, y, gx), 0), texelFetch(bottom_blob, ivec3(x*2+1, y, gx), 0));
+                res_fp32[0] += v[0];
+                res_fp32[1] += v[1];
             }
         }
 #else
         for (int i = 0; i < size; i++)
         {
-            afpvec8 v = buffer_ld8(bottom_blob_data, v_offset + i);
-            res[0] += v[0];
-            res[1] += v[1];
+            res_fp32[0] += bottom_blob_data[v_offset + i][0];
+            res_fp32[1] += bottom_blob_data[v_offset + i][1];
         }
 #endif
 
-        afp area = afp(size);
-        res[0] /= area;
-        res[1] /= area;
+        float area = float(size);
+        res_fp32[0] /= float(area);
+        res_fp32[1] /= float(area);
+        res = afpvec8(res_fp32);  // cast to fp16 if possible
     }
 
 #if NCNN_image_shader

--- a/src/layer/vulkan/shader/pooling_pack4.comp
+++ b/src/layer/vulkan/shader/pooling_pack4.comp
@@ -119,7 +119,7 @@ void main()
     }
     else if (pooling_type == 1 && avgpool_count_include_pad == 0)
     {
-        res = afpvec4(0.f);
+        vec4 res_fp32 = vec4(0.f);  // force accumulation in fp32
         int area = 0;
 
         int sx = gx * stride_w;
@@ -142,7 +142,7 @@ void main()
                 if (sx + x >= psc(w) - pad_right - p.wtailpad)
                     break;
 
-                res += image3d_ld4(bottom_blob, ivec3(sx + x, sy + y, gz));
+                res_fp32 += texelFetch(bottom_blob, ivec3(sx + x, sy + y, gz), 0);
                 area += 1;
             }
         }
@@ -170,7 +170,7 @@ void main()
                 if (sx + x >= psc(w) - pad_right - p.wtailpad)
                     break;
 
-                res += buffer_ld4(bottom_blob_data, v_offset + x);
+                res_fp32 += bottom_blob_data[v_offset + x];
                 area += 1;
             }
 
@@ -178,11 +178,12 @@ void main()
         }
 #endif
 
-        res /= afp(area);
+        res_fp32 /= float(area);
+        res = afpvec4(res_fp32);  // cast to fp16 if possible
     }
     else if (pooling_type == 1 && avgpool_count_include_pad == 1)
     {
-        res = afpvec4(0.f);
+        vec4 res_fp32 = vec4(0.f);  // force accumulation in fp32
 
 #if NCNN_image_shader
         int sx = gx * stride_w;
@@ -192,7 +193,7 @@ void main()
         {
             for (int x = 0; x < kernel_w; x++)
             {
-                res += image3d_ld4(bottom_blob, ivec3(sx + x, sy + y, gz));
+                res_fp32 += texelFetch(bottom_blob, ivec3(sx + x, sy + y, gz), 0);
             }
         }
 #else
@@ -202,14 +203,15 @@ void main()
         {
             for (int x = 0; x < kernel_w; x++)
             {
-                res += buffer_ld4(bottom_blob_data, v_offset + x);
+                res_fp32 += bottom_blob_data[v_offset + x];
             }
 
             v_offset += psc(w);
         }
 #endif
 
-        res /= afp(kernel_w * kernel_h);
+        res_fp32 /= float(kernel_w * kernel_h);
+        res = afpvec4(res_fp32);  // cast to fp16 if possible
     }
 
 #if NCNN_image_shader

--- a/src/layer/vulkan/shader/pooling_pack8.comp
+++ b/src/layer/vulkan/shader/pooling_pack8.comp
@@ -122,7 +122,7 @@ void main()
     }
     else if (pooling_type == 1 && avgpool_count_include_pad == 0)
     {
-        res = afpvec8(afpvec4(0.f), afpvec4(0.f));
+        mat2x4 res_fp32 = mat2x4(vec4(0.f), vec4(0.f));  // force accumulation in fp32
         int area = 0;
 
         int sx = gx * stride_w;
@@ -145,9 +145,9 @@ void main()
                 if (sx + x >= psc(w) - pad_right - p.wtailpad)
                     break;
 
-                afpvec8 v = image3d_ld8(bottom_blob, ivec3(sx + x, sy + y, gz));
-                res[0] += v[0];
-                res[1] += v[1];
+                mat2x4 v = mat2x4(texelFetch(bottom_blob, ivec3((sx + x)*2, sy + y, gz), 0), texelFetch(bottom_blob, ivec3((sx + x)*2+1, sy + y, gz), 0));
+                res_fp32[0] += v[0];
+                res_fp32[1] += v[1];
                 area += 1;
             }
         }
@@ -175,9 +175,8 @@ void main()
                 if (sx + x >= psc(w) - pad_right - p.wtailpad)
                     break;
 
-                afpvec8 v = buffer_ld8(bottom_blob_data, v_offset + x);
-                res[0] += v[0];
-                res[1] += v[1];
+                res_fp32[0] += bottom_blob_data[v_offset + x][0];
+                res_fp32[1] += bottom_blob_data[v_offset + x][1];
                 area += 1;
             }
 
@@ -185,12 +184,13 @@ void main()
         }
 #endif
 
-        res[0] /= afp(area);
-        res[1] /= afp(area);
+        res_fp32[0] /= float(area);
+        res_fp32[1] /= float(area);
+        res = afpvec8(res_fp32);  // cast to fp16 if possible
     }
     else if (pooling_type == 1 && avgpool_count_include_pad == 1)
     {
-        res = afpvec8(afpvec4(0.f), afpvec4(0.f));
+        mat2x4 res_fp32 = mat2x4(vec4(0.f), vec4(0.f));  // force accumulation in fp32
 
 #if NCNN_image_shader
         int sx = gx * stride_w;
@@ -200,9 +200,9 @@ void main()
         {
             for (int x = 0; x < kernel_w; x++)
             {
-                afpvec8 v = image3d_ld8(bottom_blob, ivec3(sx + x, sy + y, gz));
-                res[0] += v[0];
-                res[1] += v[1];
+                mat2x4 v = mat2x4(texelFetch(bottom_blob, ivec3((sx + x)*2, sy + y, gz), 0), texelFetch(bottom_blob, ivec3((sx + x)*2+1, sy + y, gz), 0));
+                res_fp32[0] += v[0];
+                res_fp32[1] += v[1];
             }
         }
 #else
@@ -212,18 +212,18 @@ void main()
         {
             for (int x = 0; x < kernel_w; x++)
             {
-                afpvec8 v = buffer_ld8(bottom_blob_data, v_offset + x);
-                res[0] += v[0];
-                res[1] += v[1];
+                res_fp32[0] += bottom_blob_data[v_offset + x][0];
+                res_fp32[1] += bottom_blob_data[v_offset + x][1];
             }
 
             v_offset += psc(w);
         }
 #endif
 
-        afp area = afp(kernel_w * kernel_h);
-        res[0] /= area;
-        res[1] /= area;
+        float area = float(kernel_w * kernel_h);
+        res_fp32[0] /= area;
+        res_fp32[1] /= area;
+        res = afpvec8(res_fp32);  // cast to fp16 if possible
     }
 
 #if NCNN_image_shader


### PR DESCRIPTION
The current implementation use fp16 variable to perform accumulation in avg pooling, 

for example,
```
res = afp(0.f); // res will be a fp16 variable in fp16 mode
for (...)
    res += buffer_ld1(bottom_blob_data, v_offset + x); // res keeps getting larger
```
So there is a protenial risk of data overflow considering `res` keeps getting larger over time.

Assuming there is a feature map with a larger kernel size 256x256, and the feature map has value over `1.0` on each data, the sum will be over `65536`, causing fp16 overflow, then you get the wrong result of pooling.

I also confirmed that when disabling all the fp16 options in vulkan, the result is correct and when running in vulkan on older devices which don't support fp16 arithmetic like gtx1050, the result is also right.

Now I perform accumulation on a temporary fp32 variable and cast to fp16 in the end. Though it may be a little bit slower but it can make sure the result is accurate. It's tested on rtx2080ti and intel u630, the result is correct in both fp16 and fp32 modes.