### PR TITLE
[WIP] arm neon optimization for cortex-a53

### DIFF
--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -40,7 +40,7 @@ public:
 PoolAllocator::PoolAllocator()
     : Allocator(), d(new PoolAllocatorPrivate)
 {
-    d->size_compare_ratio = 192; // 0.75f * 256
+    d->size_compare_ratio = 128; // 0.5f * 256
 }
 
 PoolAllocator::~PoolAllocator()
@@ -185,7 +185,7 @@ public:
 UnlockedPoolAllocator::UnlockedPoolAllocator()
     : Allocator(), d(new UnlockedPoolAllocatorPrivate)
 {
-    d->size_compare_ratio = 192; // 0.75f * 256
+    d->size_compare_ratio = 0; // 0.0f * 256
 }
 
 UnlockedPoolAllocator::~UnlockedPoolAllocator()

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -64,6 +64,10 @@ static inline size_t alignSize(size_t sz, int n)
 
 static inline void* fastMalloc(size_t size)
 {
+    // some kernel code may over-preload data in loops
+    // allocate more space to keep safe  --- nihui
+    size += 64;
+
 #if _MSC_VER
     return _aligned_malloc(size, MALLOC_ALIGN);
 #elif (defined(__unix__) || defined(__APPLE__)) && _POSIX_C_SOURCE >= 200112L || (__ANDROID__ && __ANDROID_API__ >= 17)
@@ -164,7 +168,7 @@ public:
     ~PoolAllocator();
 
     // ratio range 0 ~ 1
-    // default cr = 0.75
+    // default cr = 0.5
     void set_size_compare_ratio(float scr);
 
     // release all budgets immediately
@@ -189,7 +193,7 @@ public:
     ~UnlockedPoolAllocator();
 
     // ratio range 0 ~ 1
-    // default cr = 0.75
+    // default cr = 0.0
     void set_size_compare_ratio(float scr);
 
     // release all budgets immediately

--- a/src/layer/arm/convolution_1x1_pack4_a53.h
+++ b/src/layer/arm/convolution_1x1_pack4_a53.h
@@ -1,0 +1,65 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+static void conv1x1s1_sgemm_pack4_neon_a53(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
+{
+    int w = bottom_blob.w;
+    int h = bottom_blob.h;
+    const int size = w * h;
+
+    Mat bottom_im2col = bottom_blob;
+    bottom_im2col.w = size;
+    bottom_im2col.h = 1;
+
+    im2col_sgemm_pack4_neon_a53(bottom_im2col, top_blob, kernel, _bias, opt);
+}
+
+static void conv1x1s2_pack4_neon_a53(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
+{
+    int w = bottom_blob.w;
+    int channels = bottom_blob.c;
+    size_t elemsize = bottom_blob.elemsize;
+    int elempack = bottom_blob.elempack;
+
+    int outw = top_blob.w;
+    int outh = top_blob.h;
+
+    const int tailstep = (w - 2 * outw + w) * 4;
+
+    Mat bottom_blob_shrinked;
+    bottom_blob_shrinked.create(outw, outh, channels, elemsize, elempack, opt.workspace_allocator);
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int p = 0; p < channels; p++)
+    {
+        const float* r0 = bottom_blob.channel(p);
+        float* outptr = bottom_blob_shrinked.channel(p);
+
+        for (int i = 0; i < outh; i++)
+        {
+            for (int j = 0; j < outw; j++)
+            {
+                float32x4_t _v = vld1q_f32(r0);
+                vst1q_f32(outptr, _v);
+
+                r0 += 8;
+                outptr += 4;
+            }
+
+            r0 += tailstep;
+        }
+    }
+
+    conv1x1s1_sgemm_pack4_neon_a53(bottom_blob_shrinked, top_blob, kernel, _bias, opt);
+}

--- a/src/layer/arm/convolution_3x3_pack4_a53.h
+++ b/src/layer/arm/convolution_3x3_pack4_a53.h
@@ -1363,11 +1363,11 @@ static void conv3x3s1_winograd42_pack4_neon_a53(const Mat& bottom_blob, Mat& top
     // BEGIN transform input
     Mat bottom_blob_tm;
     {
-        const int tiles = (outw / 6) * (outh / 6);
+        const int tiles = (outw / 4) * (outh / 4);
 
-        bottom_blob_tm.create(tiles, 64, inch, elemsize, elempack, opt.workspace_allocator);
+        bottom_blob_tm.create(tiles, 36, inch, elemsize, elempack, opt.workspace_allocator);
 
-        convolution_winograd_f63_transform_input_pack4_neon(bottom_blob_bordered, bottom_blob_tm, opt);
+        convolution_winograd_f43_transform_input_pack4_neon(bottom_blob_bordered, bottom_blob_tm, opt);
     }
     bottom_blob_bordered = Mat();
     // END transform input
@@ -2655,7 +2655,7 @@ static void conv3x3s1_winograd42_pack4_neon_a53(const Mat& bottom_blob, Mat& top
             top_blob_bordered.create(outw, outh, outch, elemsize, elempack, opt.workspace_allocator);
         }
 
-        convolution_winograd_f63_transform_output_pack4_neon(top_blob_tm, top_blob_bordered, bias, opt);
+        convolution_winograd_f43_transform_output_pack4_neon(top_blob_tm, top_blob_bordered, bias, opt);
     }
     // END transform output
 

--- a/src/layer/arm/convolution_3x3_pack4_a53.h
+++ b/src/layer/arm/convolution_3x3_pack4_a53.h
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making ncnn available.
 //
-// Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
 //
 // Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at
@@ -12,239 +12,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-static void conv3x3s1_winograd64_transform_kernel_pack4_neon(const Mat& kernel, Mat& kernel_tm_pack4, int inch, int outch)
-{
-    // winograd63 transform kernel
-    Mat kernel_tm;
-    kernel_tm.create(8 * 8, inch, outch);
-
-    const float ktm[8][3] = {
-        {1.0f, 0.0f, 0.0f},
-        {-2.0f / 9, -2.0f / 9, -2.0f / 9},
-        {-2.0f / 9, 2.0f / 9, -2.0f / 9},
-        {1.0f / 90, 1.0f / 45, 2.0f / 45},
-        {1.0f / 90, -1.0f / 45, 2.0f / 45},
-        {1.0f / 45, 1.0f / 90, 1.0f / 180},
-        {1.0f / 45, -1.0f / 90, 1.0f / 180},
-        {0.0f, 0.0f, 1.0f}
-    };
-
-    #pragma omp parallel for
-    for (int p = 0; p < outch; p++)
-    {
-        for (int q = 0; q < inch; q++)
-        {
-            const float* kernel0 = (const float*)kernel + p * inch * 9 + q * 9;
-            float* kernel_tm0 = kernel_tm.channel(p).row(q);
-
-            // transform kernel, transposed
-            const float* k0 = kernel0;
-            const float* k1 = kernel0 + 3;
-            const float* k2 = kernel0 + 6;
-
-            // h
-            float tmp[8][3];
-            for (int i = 0; i < 8; i++)
-            {
-                tmp[i][0] = k0[0] * ktm[i][0] + k0[1] * ktm[i][1] + k0[2] * ktm[i][2];
-                tmp[i][1] = k1[0] * ktm[i][0] + k1[1] * ktm[i][1] + k1[2] * ktm[i][2];
-                tmp[i][2] = k2[0] * ktm[i][0] + k2[1] * ktm[i][1] + k2[2] * ktm[i][2];
-            }
-
-            // v
-            for (int j = 0; j < 8; j++)
-            {
-                float* tmpp = &tmp[j][0];
-
-                for (int i = 0; i < 8; i++)
-                {
-                    kernel_tm0[j * 8 + i] = tmpp[0] * ktm[i][0] + tmpp[1] * ktm[i][1] + tmpp[2] * ktm[i][2];
-                }
-            }
-        }
-    }
-
-    // interleave
-    // src = 64-inch-outch
-    // dst = 4b-4a-inch/4a-64-outch/4b;
-#if __aarch64__
-    kernel_tm_pack4.create(2 * inch / 4, 64, (outch / 4) / 2 + (outch / 4) % 2, (size_t)4u * 16, 16);
-#else
-    kernel_tm_pack4.create(inch / 4, 64, outch / 4, (size_t)4u * 16, 16);
-#endif
-
-    int q = 0;
-#if __aarch64__
-    for (; q + 7 < outch; q += 8)
-    {
-        const Mat k0 = kernel_tm.channel(q);
-        const Mat k1 = kernel_tm.channel(q + 1);
-        const Mat k2 = kernel_tm.channel(q + 2);
-        const Mat k3 = kernel_tm.channel(q + 3);
-        const Mat k4 = kernel_tm.channel(q + 4);
-        const Mat k5 = kernel_tm.channel(q + 5);
-        const Mat k6 = kernel_tm.channel(q + 6);
-        const Mat k7 = kernel_tm.channel(q + 7);
-
-        Mat g0 = kernel_tm_pack4.channel(q / 8);
-
-        for (int k = 0; k < 64; k++)
-        {
-            float* g00 = g0.row(k);
-
-            for (int p = 0; p + 3 < inch; p += 4)
-            {
-                const float* k00 = k0.row(p);
-                const float* k01 = k0.row(p + 1);
-                const float* k02 = k0.row(p + 2);
-                const float* k03 = k0.row(p + 3);
-
-                const float* k10 = k1.row(p);
-                const float* k11 = k1.row(p + 1);
-                const float* k12 = k1.row(p + 2);
-                const float* k13 = k1.row(p + 3);
-
-                const float* k20 = k2.row(p);
-                const float* k21 = k2.row(p + 1);
-                const float* k22 = k2.row(p + 2);
-                const float* k23 = k2.row(p + 3);
-
-                const float* k30 = k3.row(p);
-                const float* k31 = k3.row(p + 1);
-                const float* k32 = k3.row(p + 2);
-                const float* k33 = k3.row(p + 3);
-
-                const float* k40 = k4.row(p);
-                const float* k41 = k4.row(p + 1);
-                const float* k42 = k4.row(p + 2);
-                const float* k43 = k4.row(p + 3);
-
-                const float* k50 = k5.row(p);
-                const float* k51 = k5.row(p + 1);
-                const float* k52 = k5.row(p + 2);
-                const float* k53 = k5.row(p + 3);
-
-                const float* k60 = k6.row(p);
-                const float* k61 = k6.row(p + 1);
-                const float* k62 = k6.row(p + 2);
-                const float* k63 = k6.row(p + 3);
-
-                const float* k70 = k7.row(p);
-                const float* k71 = k7.row(p + 1);
-                const float* k72 = k7.row(p + 2);
-                const float* k73 = k7.row(p + 3);
-
-                g00[0] = k00[k];
-                g00[1] = k10[k];
-                g00[2] = k20[k];
-                g00[3] = k30[k];
-
-                g00[4] = k40[k];
-                g00[5] = k50[k];
-                g00[6] = k60[k];
-                g00[7] = k70[k];
-
-                g00[8] = k01[k];
-                g00[9] = k11[k];
-                g00[10] = k21[k];
-                g00[11] = k31[k];
-
-                g00[12] = k41[k];
-                g00[13] = k51[k];
-                g00[14] = k61[k];
-                g00[15] = k71[k];
-
-                g00[16] = k02[k];
-                g00[17] = k12[k];
-                g00[18] = k22[k];
-                g00[19] = k32[k];
-
-                g00[20] = k42[k];
-                g00[21] = k52[k];
-                g00[22] = k62[k];
-                g00[23] = k72[k];
-
-                g00[24] = k03[k];
-                g00[25] = k13[k];
-                g00[26] = k23[k];
-                g00[27] = k33[k];
-
-                g00[28] = k43[k];
-                g00[29] = k53[k];
-                g00[30] = k63[k];
-                g00[31] = k73[k];
-
-                g00 += 32;
-            }
-        }
-    }
-#endif // __aarch64__
-    for (; q + 3 < outch; q += 4)
-    {
-        const Mat k0 = kernel_tm.channel(q);
-        const Mat k1 = kernel_tm.channel(q + 1);
-        const Mat k2 = kernel_tm.channel(q + 2);
-        const Mat k3 = kernel_tm.channel(q + 3);
-
-#if __aarch64__
-        Mat g0 = kernel_tm_pack4.channel(q / 8 + (q % 8) / 4);
-#else
-        Mat g0 = kernel_tm_pack4.channel(q / 4);
-#endif
-
-        for (int k = 0; k < 64; k++)
-        {
-            float* g00 = g0.row(k);
-
-            for (int p = 0; p + 3 < inch; p += 4)
-            {
-                const float* k00 = k0.row(p);
-                const float* k01 = k0.row(p + 1);
-                const float* k02 = k0.row(p + 2);
-                const float* k03 = k0.row(p + 3);
-
-                const float* k10 = k1.row(p);
-                const float* k11 = k1.row(p + 1);
-                const float* k12 = k1.row(p + 2);
-                const float* k13 = k1.row(p + 3);
-
-                const float* k20 = k2.row(p);
-                const float* k21 = k2.row(p + 1);
-                const float* k22 = k2.row(p + 2);
-                const float* k23 = k2.row(p + 3);
-
-                const float* k30 = k3.row(p);
-                const float* k31 = k3.row(p + 1);
-                const float* k32 = k3.row(p + 2);
-                const float* k33 = k3.row(p + 3);
-
-                g00[0] = k00[k];
-                g00[1] = k10[k];
-                g00[2] = k20[k];
-                g00[3] = k30[k];
-
-                g00[4] = k01[k];
-                g00[5] = k11[k];
-                g00[6] = k21[k];
-                g00[7] = k31[k];
-
-                g00[8] = k02[k];
-                g00[9] = k12[k];
-                g00[10] = k22[k];
-                g00[11] = k32[k];
-
-                g00[12] = k03[k];
-                g00[13] = k13[k];
-                g00[14] = k23[k];
-                g00[15] = k33[k];
-
-                g00 += 16;
-            }
-        }
-    }
-}
-
-static void conv3x3s1_winograd64_pack4_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel_tm, const Mat& bias, const Option& opt)
+static void conv3x3s1_winograd64_pack4_neon_a53(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel_tm, const Mat& bias, const Option& opt)
 {
     int w = bottom_blob.w;
     int h = bottom_blob.h;
@@ -596,134 +364,336 @@ static void conv3x3s1_winograd64_pack4_neon(const Mat& bottom_blob, Mat& top_blo
                         "eor    v30.16b, v30.16b, v30.16b   \n"
                         "eor    v31.16b, v31.16b, v31.16b   \n"
 
+                        // preload
+
+                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "prfm   pldl1keep, [%3, #128]             \n"
+
+                        "ld1    {v6.4s}, [%4], #16          \n"
+
+                        "ld1    {v0.4s, v1.4s, v2.4s}, [%3], #48 \n"
+
+                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "prfm   pldl1keep, [%3, #256]             \n"
+
                         "0:                                 \n"
 
-                        "prfm   pldl1keep, [%3, #512]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%3], #64 \n"
+                        //v
+                        "ldr    d7, [%4]                    \n"
 
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v4.4s, v5.4s, v6.4s, v7.4s}, [%4], #64   \n" // w0011_01
+                        "fmla   v8.4s, v6.4s, v0.s[0]       \n"
+                        "ldr    x23, [%4, #8]               \n"
+                        "fmla   v9.4s, v6.4s, v0.s[1]       \n"
+                        "add    %4, %4, #16                 \n"
+                        "fmla   v10.4s, v6.4s, v0.s[2]      \n"
 
-                        "fmla   v8.4s, v4.4s, v0.s[0]       \n"
-                        "fmla   v9.4s, v4.4s, v0.s[1]       \n"
-                        "fmla   v10.4s, v4.4s, v0.s[2]      \n"
-                        "fmla   v11.4s, v4.4s, v0.s[3]      \n"
-                        "fmla   v12.4s, v4.4s, v1.s[0]      \n"
-                        "fmla   v13.4s, v4.4s, v1.s[1]      \n"
-                        "fmla   v14.4s, v4.4s, v1.s[2]      \n"
-                        "fmla   v15.4s, v4.4s, v1.s[3]      \n"
-                        "fmla   v16.4s, v4.4s, v2.s[0]      \n"
-                        "fmla   v17.4s, v4.4s, v2.s[1]      \n"
-                        "fmla   v18.4s, v4.4s, v2.s[2]      \n"
-                        "fmla   v19.4s, v4.4s, v2.s[3]      \n"
+                        //v
+                        "ldr    d3, [%3]                    \n"
+                        "ins    v7.d[1], x23                \n"
 
-                        "fmla   v20.4s, v5.4s, v0.s[0]      \n"
-                        "fmla   v21.4s, v5.4s, v0.s[1]      \n"
-                        "fmla   v22.4s, v5.4s, v0.s[2]      \n"
-                        "fmla   v23.4s, v5.4s, v0.s[3]      \n"
-                        "fmla   v24.4s, v5.4s, v1.s[0]      \n"
-                        "fmla   v25.4s, v5.4s, v1.s[1]      \n"
-                        "fmla   v26.4s, v5.4s, v1.s[2]      \n"
-                        "fmla   v27.4s, v5.4s, v1.s[3]      \n"
-                        "fmla   v28.4s, v5.4s, v2.s[0]      \n"
-                        "fmla   v29.4s, v5.4s, v2.s[1]      \n"
-                        "fmla   v30.4s, v5.4s, v2.s[2]      \n"
-                        "fmla   v31.4s, v5.4s, v2.s[3]      \n"
+                        "fmla   v11.4s, v6.4s, v0.s[3]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v12.4s, v6.4s, v1.s[0]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v13.4s, v6.4s, v1.s[1]      \n"
+
+                        //v
+                        "ldr    d4, [%3]                    \n"
+                        "ins    v3.d[1], x23                \n"
+
+                        "fmla   v14.4s, v6.4s, v1.s[2]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v15.4s, v6.4s, v1.s[3]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v16.4s, v6.4s, v2.s[0]      \n"
+
+                        //v
+                        "ldr    d5, [%3]                    \n"
+                        "ins    v4.d[1], x23                \n"
+
+                        "fmla   v17.4s, v6.4s, v2.s[1]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v18.4s, v6.4s, v2.s[2]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v19.4s, v6.4s, v2.s[3]      \n"
+
+                        //v
+                        "ldr    d6, [%4]                    \n"
+                        "ins    v5.d[1], x23                \n"
+
+                        "fmla   v20.4s, v7.4s, v0.s[0]      \n"
+                        "ldr    x23, [%4, #8]               \n"
+                        "fmla   v21.4s, v7.4s, v0.s[1]      \n"
+                        "add    %4, %4, #16                 \n"
+                        "fmla   v22.4s, v7.4s, v0.s[2]      \n"
+
+                        //v
+                        "ins    v6.d[1], x23                \n"
+                        "nop                                \n"
+
+                        "fmla   v23.4s, v7.4s, v0.s[3]      \n"
+                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "fmla   v24.4s, v7.4s, v1.s[0]      \n"
+                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "fmla   v25.4s, v7.4s, v1.s[1]      \n"
+
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
+
+                        "fmla   v26.4s, v7.4s, v1.s[2]      \n"
+                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "fmla   v27.4s, v7.4s, v1.s[3]      \n"
+                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "fmla   v28.4s, v7.4s, v2.s[0]      \n"
+
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
+
+                        "fmla   v29.4s, v7.4s, v2.s[1]      \n"
+                        "fmla   v30.4s, v7.4s, v2.s[2]      \n"
+                        "fmla   v31.4s, v7.4s, v2.s[3]      \n"
+
+                        //v
+                        "ldr    d7, [%4]                    \n"
 
                         "fmla   v8.4s, v6.4s, v3.s[0]       \n"
+                        "ldr    x23, [%4, #8]               \n"
                         "fmla   v9.4s, v6.4s, v3.s[1]       \n"
+                        "add    %4, %4, #16                 \n"
                         "fmla   v10.4s, v6.4s, v3.s[2]      \n"
+
+                        //v
+                        "ldr    d0, [%3]                    \n"
+                        "ins    v7.d[1], x23                \n"
+
                         "fmla   v11.4s, v6.4s, v3.s[3]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v12.4s, v6.4s, v4.s[0]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v13.4s, v6.4s, v4.s[1]      \n"
+
+                        //v
+                        "ldr    d1, [%3]                    \n"
+                        "ins    v0.d[1], x23                \n"
+
+                        "fmla   v14.4s, v6.4s, v4.s[2]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v15.4s, v6.4s, v4.s[3]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v16.4s, v6.4s, v5.s[0]      \n"
+
+                        //v
+                        "ldr    d2, [%3]                    \n"
+                        "ins    v1.d[1], x23                \n"
+
+                        "fmla   v17.4s, v6.4s, v5.s[1]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v18.4s, v6.4s, v5.s[2]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v19.4s, v6.4s, v5.s[3]      \n"
+
+                        //v
+                        "ldr    d6, [%4]                    \n"
+                        "ins    v2.d[1], x23                \n"
 
                         "fmla   v20.4s, v7.4s, v3.s[0]      \n"
+                        "ldr    x23, [%4, #8]               \n"
                         "fmla   v21.4s, v7.4s, v3.s[1]      \n"
+                        "add    %4, %4, #16                 \n"
                         "fmla   v22.4s, v7.4s, v3.s[2]      \n"
+
+                        //v
+                        "ins    v6.d[1], x23                \n"
+                        "nop                                \n"
+
                         "fmla   v23.4s, v7.4s, v3.s[3]      \n"
+                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "fmla   v24.4s, v7.4s, v4.s[0]      \n"
+                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "fmla   v25.4s, v7.4s, v4.s[1]      \n"
 
-                        "prfm   pldl1keep, [%3, #512]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%3], #64 \n"
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
 
-                        "fmla   v12.4s, v6.4s, v0.s[0]      \n"
-                        "fmla   v13.4s, v6.4s, v0.s[1]      \n"
-                        "fmla   v14.4s, v6.4s, v0.s[2]      \n"
-                        "fmla   v15.4s, v6.4s, v0.s[3]      \n"
-                        "fmla   v16.4s, v6.4s, v1.s[0]      \n"
-                        "fmla   v17.4s, v6.4s, v1.s[1]      \n"
-                        "fmla   v18.4s, v6.4s, v1.s[2]      \n"
-                        "fmla   v19.4s, v6.4s, v1.s[3]      \n"
+                        "fmla   v26.4s, v7.4s, v4.s[2]      \n"
+                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "fmla   v27.4s, v7.4s, v4.s[3]      \n"
+                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "fmla   v28.4s, v7.4s, v5.s[0]      \n"
 
-                        "fmla   v24.4s, v7.4s, v0.s[0]      \n"
-                        "fmla   v25.4s, v7.4s, v0.s[1]      \n"
-                        "fmla   v26.4s, v7.4s, v0.s[2]      \n"
-                        "fmla   v27.4s, v7.4s, v0.s[3]      \n"
-                        "fmla   v28.4s, v7.4s, v1.s[0]      \n"
-                        "fmla   v29.4s, v7.4s, v1.s[1]      \n"
-                        "fmla   v30.4s, v7.4s, v1.s[2]      \n"
-                        "fmla   v31.4s, v7.4s, v1.s[3]      \n"
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
 
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v4.4s, v5.4s, v6.4s, v7.4s}, [%4], #64   \n" // w2233_01
+                        "fmla   v29.4s, v7.4s, v5.s[1]      \n"
+                        "fmla   v30.4s, v7.4s, v5.s[2]      \n"
+                        "fmla   v31.4s, v7.4s, v5.s[3]      \n"
 
-                        "fmla   v8.4s, v4.4s, v2.s[0]       \n"
-                        "fmla   v9.4s, v4.4s, v2.s[1]       \n"
-                        "fmla   v10.4s, v4.4s, v2.s[2]      \n"
-                        "fmla   v11.4s, v4.4s, v2.s[3]      \n"
-                        "fmla   v12.4s, v4.4s, v3.s[0]      \n"
-                        "fmla   v13.4s, v4.4s, v3.s[1]      \n"
-                        "fmla   v14.4s, v4.4s, v3.s[2]      \n"
-                        "fmla   v15.4s, v4.4s, v3.s[3]      \n"
+                        //v
+                        "ldr    d7, [%4]                    \n"
 
-                        "fmla   v20.4s, v5.4s, v2.s[0]      \n"
-                        "fmla   v21.4s, v5.4s, v2.s[1]      \n"
-                        "fmla   v22.4s, v5.4s, v2.s[2]      \n"
-                        "fmla   v23.4s, v5.4s, v2.s[3]      \n"
-                        "fmla   v24.4s, v5.4s, v3.s[0]      \n"
-                        "fmla   v25.4s, v5.4s, v3.s[1]      \n"
-                        "fmla   v26.4s, v5.4s, v3.s[2]      \n"
-                        "fmla   v27.4s, v5.4s, v3.s[3]      \n"
+                        "fmla   v8.4s, v6.4s, v0.s[0]       \n"
+                        "ldr    x23, [%4, #8]               \n"
+                        "fmla   v9.4s, v6.4s, v0.s[1]       \n"
+                        "add    %4, %4, #16                 \n"
+                        "fmla   v10.4s, v6.4s, v0.s[2]      \n"
 
-                        "prfm   pldl1keep, [%3, #512]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%3], #64 \n"
+                        //v
+                        "ldr    d3, [%3]                    \n"
+                        "ins    v7.d[1], x23                \n"
 
-                        "fmla   v16.4s, v4.4s, v0.s[0]      \n"
-                        "fmla   v17.4s, v4.4s, v0.s[1]      \n"
-                        "fmla   v18.4s, v4.4s, v0.s[2]      \n"
-                        "fmla   v19.4s, v4.4s, v0.s[3]      \n"
+                        "fmla   v11.4s, v6.4s, v0.s[3]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v12.4s, v6.4s, v1.s[0]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v13.4s, v6.4s, v1.s[1]      \n"
 
-                        "fmla   v28.4s, v5.4s, v0.s[0]      \n"
-                        "fmla   v29.4s, v5.4s, v0.s[1]      \n"
-                        "fmla   v30.4s, v5.4s, v0.s[2]      \n"
-                        "fmla   v31.4s, v5.4s, v0.s[3]      \n"
+                        //v
+                        "ldr    d4, [%3]                    \n"
+                        "ins    v3.d[1], x23                \n"
 
-                        "fmla   v8.4s, v6.4s, v1.s[0]       \n"
-                        "fmla   v9.4s, v6.4s, v1.s[1]       \n"
-                        "fmla   v10.4s, v6.4s, v1.s[2]      \n"
-                        "fmla   v11.4s, v6.4s, v1.s[3]      \n"
-                        "fmla   v12.4s, v6.4s, v2.s[0]      \n"
-                        "fmla   v13.4s, v6.4s, v2.s[1]      \n"
-                        "fmla   v14.4s, v6.4s, v2.s[2]      \n"
-                        "fmla   v15.4s, v6.4s, v2.s[3]      \n"
-                        "fmla   v16.4s, v6.4s, v3.s[0]      \n"
-                        "fmla   v17.4s, v6.4s, v3.s[1]      \n"
-                        "fmla   v18.4s, v6.4s, v3.s[2]      \n"
-                        "fmla   v19.4s, v6.4s, v3.s[3]      \n"
+                        "fmla   v14.4s, v6.4s, v1.s[2]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v15.4s, v6.4s, v1.s[3]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v16.4s, v6.4s, v2.s[0]      \n"
+
+                        //v
+                        "ldr    d5, [%3]                    \n"
+                        "ins    v4.d[1], x23                \n"
+
+                        "fmla   v17.4s, v6.4s, v2.s[1]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v18.4s, v6.4s, v2.s[2]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v19.4s, v6.4s, v2.s[3]      \n"
+
+                        //v
+                        "ldr    d6, [%4]                    \n"
+                        "ins    v5.d[1], x23                \n"
+
+                        "fmla   v20.4s, v7.4s, v0.s[0]      \n"
+                        "ldr    x23, [%4, #8]               \n"
+                        "fmla   v21.4s, v7.4s, v0.s[1]      \n"
+                        "add    %4, %4, #16                 \n"
+                        "fmla   v22.4s, v7.4s, v0.s[2]      \n"
+
+                        //v
+                        "ins    v6.d[1], x23                \n"
+                        "nop                                \n"
+
+                        "fmla   v23.4s, v7.4s, v0.s[3]      \n"
+                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "fmla   v24.4s, v7.4s, v1.s[0]      \n"
+                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "fmla   v25.4s, v7.4s, v1.s[1]      \n"
+
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
+
+                        "fmla   v26.4s, v7.4s, v1.s[2]      \n"
+                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "fmla   v27.4s, v7.4s, v1.s[3]      \n"
+                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "fmla   v28.4s, v7.4s, v2.s[0]      \n"
+
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
+
+                        "fmla   v29.4s, v7.4s, v2.s[1]      \n"
+                        "fmla   v30.4s, v7.4s, v2.s[2]      \n"
+                        "fmla   v31.4s, v7.4s, v2.s[3]      \n"
+
+                        //v
+                        "ldr    d7, [%4]                    \n"
+
+                        "fmla   v8.4s, v6.4s, v3.s[0]       \n"
+                        "ldr    x23, [%4, #8]               \n"
+                        "fmla   v9.4s, v6.4s, v3.s[1]       \n"
+                        "add    %4, %4, #16                 \n"
+                        "fmla   v10.4s, v6.4s, v3.s[2]      \n"
+
+                        //v
+                        "ldr    d0, [%3]                    \n"
+                        "ins    v7.d[1], x23                \n"
+
+                        "fmla   v11.4s, v6.4s, v3.s[3]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v12.4s, v6.4s, v4.s[0]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v13.4s, v6.4s, v4.s[1]      \n"
+
+                        //v
+                        "ldr    d1, [%3]                    \n"
+                        "ins    v0.d[1], x23                \n"
+
+                        "fmla   v14.4s, v6.4s, v4.s[2]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v15.4s, v6.4s, v4.s[3]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v16.4s, v6.4s, v5.s[0]      \n"
+
+                        //v
+                        "ldr    d2, [%3]                    \n"
+                        "ins    v1.d[1], x23                \n"
+
+                        "fmla   v17.4s, v6.4s, v5.s[1]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v18.4s, v6.4s, v5.s[2]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v19.4s, v6.4s, v5.s[3]      \n"
+
+                        //v
+                        "ldr    d6, [%4]                    \n"
+                        "ins    v2.d[1], x23                \n"
+
+                        "fmla   v20.4s, v7.4s, v3.s[0]      \n"
+                        "ldr    x23, [%4, #8]               \n"
+                        "fmla   v21.4s, v7.4s, v3.s[1]      \n"
+                        "add    %4, %4, #16                 \n"
+                        "fmla   v22.4s, v7.4s, v3.s[2]      \n"
+
+                        //v
+                        "ins    v6.d[1], x23                \n"
+                        "nop                                \n"
+
+                        "fmla   v23.4s, v7.4s, v3.s[3]      \n"
+                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "fmla   v24.4s, v7.4s, v4.s[0]      \n"
+                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "fmla   v25.4s, v7.4s, v4.s[1]      \n"
+
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
+
+                        "fmla   v26.4s, v7.4s, v4.s[2]      \n"
+                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "fmla   v27.4s, v7.4s, v4.s[3]      \n"
+                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "fmla   v28.4s, v7.4s, v5.s[0]      \n"
+
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
+
+                        "fmla   v29.4s, v7.4s, v5.s[1]      \n"
+                        "fmla   v30.4s, v7.4s, v5.s[2]      \n"
+                        "fmla   v31.4s, v7.4s, v5.s[3]      \n"
 
                         "subs   %w0, %w0, #1                \n"
 
-                        "fmla   v20.4s, v7.4s, v1.s[0]      \n"
-                        "fmla   v21.4s, v7.4s, v1.s[1]      \n"
-                        "fmla   v22.4s, v7.4s, v1.s[2]      \n"
-                        "fmla   v23.4s, v7.4s, v1.s[3]      \n"
-                        "fmla   v24.4s, v7.4s, v2.s[0]      \n"
-                        "fmla   v25.4s, v7.4s, v2.s[1]      \n"
-                        "fmla   v26.4s, v7.4s, v2.s[2]      \n"
-                        "fmla   v27.4s, v7.4s, v2.s[3]      \n"
-                        "fmla   v28.4s, v7.4s, v3.s[0]      \n"
-                        "fmla   v29.4s, v7.4s, v3.s[1]      \n"
-                        "fmla   v30.4s, v7.4s, v3.s[2]      \n"
-                        "fmla   v31.4s, v7.4s, v3.s[3]      \n"
+                        // preload
 
                         "bne    0b                          \n"
+
+                        "sub    %4, %4, #16                 \n"
+                        "sub    %3, %3, #48                 \n"
 
                         "st1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%1], #64 \n"
                         "st1    {v20.4s, v21.4s, v22.4s, v23.4s}, [%2], #64 \n"
@@ -742,7 +712,7 @@ static void conv3x3s1_winograd64_pack4_neon(const Mat& bottom_blob, Mat& top_blo
                         "2"(output1_tm),
                         "3"(r0),
                         "4"(k01)
-                        : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31");
+                        : "cc", "memory", "x23", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31");
                 }
                 for (; i + 7 < tiles; i += 8)
                 {
@@ -1688,236 +1658,7 @@ static void conv3x3s1_winograd64_pack4_neon(const Mat& bottom_blob, Mat& top_blo
     copy_cut_border(top_blob_bordered, top_blob, 0, top_blob_bordered.h - top_blob.h, 0, top_blob_bordered.w - top_blob.w, opt);
 }
 
-static void conv3x3s1_winograd42_transform_kernel_pack4_neon(const Mat& kernel, Mat& kernel_tm_pack4, int inch, int outch)
-{
-    // winograd43 transform kernel
-    Mat kernel_tm(6 * 6, inch, outch);
-
-    const float ktm[6][3] = {
-        {1.0f / 4, 0.0f, 0.0f},
-        {-1.0f / 6, -1.0f / 6, -1.0f / 6},
-        {-1.0f / 6, 1.0f / 6, -1.0f / 6},
-        {1.0f / 24, 1.0f / 12, 1.0f / 6},
-        {1.0f / 24, -1.0f / 12, 1.0f / 6},
-        {0.0f, 0.0f, 1.0f}
-    };
-
-    #pragma omp parallel for
-    for (int p = 0; p < outch; p++)
-    {
-        for (int q = 0; q < inch; q++)
-        {
-            const float* kernel0 = (const float*)kernel + p * inch * 9 + q * 9;
-            float* kernel_tm0 = kernel_tm.channel(p).row(q);
-
-            // transform kernel
-            const float* k0 = kernel0;
-            const float* k1 = kernel0 + 3;
-            const float* k2 = kernel0 + 6;
-
-            // h
-            float tmp[6][3];
-            for (int i = 0; i < 6; i++)
-            {
-                tmp[i][0] = k0[0] * ktm[i][0] + k0[1] * ktm[i][1] + k0[2] * ktm[i][2];
-                tmp[i][1] = k1[0] * ktm[i][0] + k1[1] * ktm[i][1] + k1[2] * ktm[i][2];
-                tmp[i][2] = k2[0] * ktm[i][0] + k2[1] * ktm[i][1] + k2[2] * ktm[i][2];
-            }
-
-            // U
-            for (int j = 0; j < 6; j++)
-            {
-                float* tmpp = &tmp[j][0];
-
-                for (int i = 0; i < 6; i++)
-                {
-                    kernel_tm0[j * 6 + i] = tmpp[0] * ktm[i][0] + tmpp[1] * ktm[i][1] + tmpp[2] * ktm[i][2];
-                }
-            }
-        }
-    }
-
-    // interleave
-    // src = 36-inch-outch
-    // dst = 4b-4a-inch/4a-36-outch/4b;
-#if __aarch64__
-    kernel_tm_pack4.create(2 * inch / 4, 36, (outch / 4) / 2 + (outch / 4) % 2, (size_t)4u * 16, 16);
-#else
-    kernel_tm_pack4.create(inch / 4, 36, outch / 4, (size_t)4u * 16, 16);
-#endif
-
-    int q = 0;
-#if __aarch64__
-    for (; q + 7 < outch; q += 8)
-    {
-        const Mat k0 = kernel_tm.channel(q);
-        const Mat k1 = kernel_tm.channel(q + 1);
-        const Mat k2 = kernel_tm.channel(q + 2);
-        const Mat k3 = kernel_tm.channel(q + 3);
-        const Mat k4 = kernel_tm.channel(q + 4);
-        const Mat k5 = kernel_tm.channel(q + 5);
-        const Mat k6 = kernel_tm.channel(q + 6);
-        const Mat k7 = kernel_tm.channel(q + 7);
-
-        Mat g0 = kernel_tm_pack4.channel(q / 8);
-
-        for (int k = 0; k < 36; k++)
-        {
-            float* g00 = g0.row(k);
-
-            for (int p = 0; p + 3 < inch; p += 4)
-            {
-                const float* k00 = k0.row(p);
-                const float* k01 = k0.row(p + 1);
-                const float* k02 = k0.row(p + 2);
-                const float* k03 = k0.row(p + 3);
-
-                const float* k10 = k1.row(p);
-                const float* k11 = k1.row(p + 1);
-                const float* k12 = k1.row(p + 2);
-                const float* k13 = k1.row(p + 3);
-
-                const float* k20 = k2.row(p);
-                const float* k21 = k2.row(p + 1);
-                const float* k22 = k2.row(p + 2);
-                const float* k23 = k2.row(p + 3);
-
-                const float* k30 = k3.row(p);
-                const float* k31 = k3.row(p + 1);
-                const float* k32 = k3.row(p + 2);
-                const float* k33 = k3.row(p + 3);
-
-                const float* k40 = k4.row(p);
-                const float* k41 = k4.row(p + 1);
-                const float* k42 = k4.row(p + 2);
-                const float* k43 = k4.row(p + 3);
-
-                const float* k50 = k5.row(p);
-                const float* k51 = k5.row(p + 1);
-                const float* k52 = k5.row(p + 2);
-                const float* k53 = k5.row(p + 3);
-
-                const float* k60 = k6.row(p);
-                const float* k61 = k6.row(p + 1);
-                const float* k62 = k6.row(p + 2);
-                const float* k63 = k6.row(p + 3);
-
-                const float* k70 = k7.row(p);
-                const float* k71 = k7.row(p + 1);
-                const float* k72 = k7.row(p + 2);
-                const float* k73 = k7.row(p + 3);
-
-                g00[0] = k00[k];
-                g00[1] = k10[k];
-                g00[2] = k20[k];
-                g00[3] = k30[k];
-
-                g00[4] = k40[k];
-                g00[5] = k50[k];
-                g00[6] = k60[k];
-                g00[7] = k70[k];
-
-                g00[8] = k01[k];
-                g00[9] = k11[k];
-                g00[10] = k21[k];
-                g00[11] = k31[k];
-
-                g00[12] = k41[k];
-                g00[13] = k51[k];
-                g00[14] = k61[k];
-                g00[15] = k71[k];
-
-                g00[16] = k02[k];
-                g00[17] = k12[k];
-                g00[18] = k22[k];
-                g00[19] = k32[k];
-
-                g00[20] = k42[k];
-                g00[21] = k52[k];
-                g00[22] = k62[k];
-                g00[23] = k72[k];
-
-                g00[24] = k03[k];
-                g00[25] = k13[k];
-                g00[26] = k23[k];
-                g00[27] = k33[k];
-
-                g00[28] = k43[k];
-                g00[29] = k53[k];
-                g00[30] = k63[k];
-                g00[31] = k73[k];
-
-                g00 += 32;
-            }
-        }
-    }
-#endif // __aarch64__
-    for (; q + 3 < outch; q += 4)
-    {
-        const Mat k0 = kernel_tm.channel(q);
-        const Mat k1 = kernel_tm.channel(q + 1);
-        const Mat k2 = kernel_tm.channel(q + 2);
-        const Mat k3 = kernel_tm.channel(q + 3);
-
-#if __aarch64__
-        Mat g0 = kernel_tm_pack4.channel(q / 8 + (q % 8) / 4);
-#else
-        Mat g0 = kernel_tm_pack4.channel(q / 4);
-#endif
-
-        for (int k = 0; k < 36; k++)
-        {
-            float* g00 = g0.row(k);
-
-            for (int p = 0; p + 3 < inch; p += 4)
-            {
-                const float* k00 = k0.row(p);
-                const float* k01 = k0.row(p + 1);
-                const float* k02 = k0.row(p + 2);
-                const float* k03 = k0.row(p + 3);
-
-                const float* k10 = k1.row(p);
-                const float* k11 = k1.row(p + 1);
-                const float* k12 = k1.row(p + 2);
-                const float* k13 = k1.row(p + 3);
-
-                const float* k20 = k2.row(p);
-                const float* k21 = k2.row(p + 1);
-                const float* k22 = k2.row(p + 2);
-                const float* k23 = k2.row(p + 3);
-
-                const float* k30 = k3.row(p);
-                const float* k31 = k3.row(p + 1);
-                const float* k32 = k3.row(p + 2);
-                const float* k33 = k3.row(p + 3);
-
-                g00[0] = k00[k];
-                g00[1] = k10[k];
-                g00[2] = k20[k];
-                g00[3] = k30[k];
-
-                g00[4] = k01[k];
-                g00[5] = k11[k];
-                g00[6] = k21[k];
-                g00[7] = k31[k];
-
-                g00[8] = k02[k];
-                g00[9] = k12[k];
-                g00[10] = k22[k];
-                g00[11] = k32[k];
-
-                g00[12] = k03[k];
-                g00[13] = k13[k];
-                g00[14] = k23[k];
-                g00[15] = k33[k];
-
-                g00 += 16;
-            }
-        }
-    }
-}
-
-static void conv3x3s1_winograd42_pack4_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel_tm, const Mat& bias, const Option& opt)
+static void conv3x3s1_winograd42_pack4_neon_a53(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel_tm, const Mat& bias, const Option& opt)
 {
     int w = bottom_blob.w;
     int h = bottom_blob.h;
@@ -1942,11 +1683,11 @@ static void conv3x3s1_winograd42_pack4_neon(const Mat& bottom_blob, Mat& top_blo
     // BEGIN transform input
     Mat bottom_blob_tm;
     {
-        const int tiles = (outw / 4) * (outh / 4);
+        const int tiles = (outw / 6) * (outh / 6);
 
-        bottom_blob_tm.create(tiles, 36, inch, elemsize, elempack, opt.workspace_allocator);
+        bottom_blob_tm.create(tiles, 64, inch, elemsize, elempack, opt.workspace_allocator);
 
-        convolution_winograd_f43_transform_input_pack4_neon(bottom_blob_bordered, bottom_blob_tm, opt);
+        convolution_winograd_f63_transform_input_pack4_neon(bottom_blob_bordered, bottom_blob_tm, opt);
     }
     bottom_blob_bordered = Mat();
     // END transform input
@@ -2269,134 +2010,336 @@ static void conv3x3s1_winograd42_pack4_neon(const Mat& bottom_blob, Mat& top_blo
                         "eor    v30.16b, v30.16b, v30.16b   \n"
                         "eor    v31.16b, v31.16b, v31.16b   \n"
 
+                        // preload
+
+                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "prfm   pldl1keep, [%3, #128]             \n"
+
+                        "ld1    {v6.4s}, [%4], #16          \n"
+
+                        "ld1    {v0.4s, v1.4s, v2.4s}, [%3], #48 \n"
+
+                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "prfm   pldl1keep, [%3, #256]             \n"
+
                         "0:                                 \n"
 
-                        "prfm   pldl1keep, [%3, #512]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%3], #64 \n"
+                        //v
+                        "ldr    d7, [%4]                    \n"
 
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v4.4s, v5.4s, v6.4s, v7.4s}, [%4], #64   \n" // w0011_01
+                        "fmla   v8.4s, v6.4s, v0.s[0]       \n"
+                        "ldr    x23, [%4, #8]               \n"
+                        "fmla   v9.4s, v6.4s, v0.s[1]       \n"
+                        "add    %4, %4, #16                 \n"
+                        "fmla   v10.4s, v6.4s, v0.s[2]      \n"
 
-                        "fmla   v8.4s, v4.4s, v0.s[0]       \n"
-                        "fmla   v9.4s, v4.4s, v0.s[1]       \n"
-                        "fmla   v10.4s, v4.4s, v0.s[2]      \n"
-                        "fmla   v11.4s, v4.4s, v0.s[3]      \n"
-                        "fmla   v12.4s, v4.4s, v1.s[0]      \n"
-                        "fmla   v13.4s, v4.4s, v1.s[1]      \n"
-                        "fmla   v14.4s, v4.4s, v1.s[2]      \n"
-                        "fmla   v15.4s, v4.4s, v1.s[3]      \n"
-                        "fmla   v16.4s, v4.4s, v2.s[0]      \n"
-                        "fmla   v17.4s, v4.4s, v2.s[1]      \n"
-                        "fmla   v18.4s, v4.4s, v2.s[2]      \n"
-                        "fmla   v19.4s, v4.4s, v2.s[3]      \n"
+                        //v
+                        "ldr    d3, [%3]                    \n"
+                        "ins    v7.d[1], x23                \n"
 
-                        "fmla   v20.4s, v5.4s, v0.s[0]      \n"
-                        "fmla   v21.4s, v5.4s, v0.s[1]      \n"
-                        "fmla   v22.4s, v5.4s, v0.s[2]      \n"
-                        "fmla   v23.4s, v5.4s, v0.s[3]      \n"
-                        "fmla   v24.4s, v5.4s, v1.s[0]      \n"
-                        "fmla   v25.4s, v5.4s, v1.s[1]      \n"
-                        "fmla   v26.4s, v5.4s, v1.s[2]      \n"
-                        "fmla   v27.4s, v5.4s, v1.s[3]      \n"
-                        "fmla   v28.4s, v5.4s, v2.s[0]      \n"
-                        "fmla   v29.4s, v5.4s, v2.s[1]      \n"
-                        "fmla   v30.4s, v5.4s, v2.s[2]      \n"
-                        "fmla   v31.4s, v5.4s, v2.s[3]      \n"
+                        "fmla   v11.4s, v6.4s, v0.s[3]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v12.4s, v6.4s, v1.s[0]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v13.4s, v6.4s, v1.s[1]      \n"
+
+                        //v
+                        "ldr    d4, [%3]                    \n"
+                        "ins    v3.d[1], x23                \n"
+
+                        "fmla   v14.4s, v6.4s, v1.s[2]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v15.4s, v6.4s, v1.s[3]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v16.4s, v6.4s, v2.s[0]      \n"
+
+                        //v
+                        "ldr    d5, [%3]                    \n"
+                        "ins    v4.d[1], x23                \n"
+
+                        "fmla   v17.4s, v6.4s, v2.s[1]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v18.4s, v6.4s, v2.s[2]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v19.4s, v6.4s, v2.s[3]      \n"
+
+                        //v
+                        "ldr    d6, [%4]                    \n"
+                        "ins    v5.d[1], x23                \n"
+
+                        "fmla   v20.4s, v7.4s, v0.s[0]      \n"
+                        "ldr    x23, [%4, #8]               \n"
+                        "fmla   v21.4s, v7.4s, v0.s[1]      \n"
+                        "add    %4, %4, #16                 \n"
+                        "fmla   v22.4s, v7.4s, v0.s[2]      \n"
+
+                        //v
+                        "ins    v6.d[1], x23                \n"
+                        "nop                                \n"
+
+                        "fmla   v23.4s, v7.4s, v0.s[3]      \n"
+                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "fmla   v24.4s, v7.4s, v1.s[0]      \n"
+                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "fmla   v25.4s, v7.4s, v1.s[1]      \n"
+
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
+
+                        "fmla   v26.4s, v7.4s, v1.s[2]      \n"
+                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "fmla   v27.4s, v7.4s, v1.s[3]      \n"
+                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "fmla   v28.4s, v7.4s, v2.s[0]      \n"
+
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
+
+                        "fmla   v29.4s, v7.4s, v2.s[1]      \n"
+                        "fmla   v30.4s, v7.4s, v2.s[2]      \n"
+                        "fmla   v31.4s, v7.4s, v2.s[3]      \n"
+
+                        //v
+                        "ldr    d7, [%4]                    \n"
 
                         "fmla   v8.4s, v6.4s, v3.s[0]       \n"
+                        "ldr    x23, [%4, #8]               \n"
                         "fmla   v9.4s, v6.4s, v3.s[1]       \n"
+                        "add    %4, %4, #16                 \n"
                         "fmla   v10.4s, v6.4s, v3.s[2]      \n"
+
+                        //v
+                        "ldr    d0, [%3]                    \n"
+                        "ins    v7.d[1], x23                \n"
+
                         "fmla   v11.4s, v6.4s, v3.s[3]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v12.4s, v6.4s, v4.s[0]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v13.4s, v6.4s, v4.s[1]      \n"
+
+                        //v
+                        "ldr    d1, [%3]                    \n"
+                        "ins    v0.d[1], x23                \n"
+
+                        "fmla   v14.4s, v6.4s, v4.s[2]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v15.4s, v6.4s, v4.s[3]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v16.4s, v6.4s, v5.s[0]      \n"
+
+                        //v
+                        "ldr    d2, [%3]                    \n"
+                        "ins    v1.d[1], x23                \n"
+
+                        "fmla   v17.4s, v6.4s, v5.s[1]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v18.4s, v6.4s, v5.s[2]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v19.4s, v6.4s, v5.s[3]      \n"
+
+                        //v
+                        "ldr    d6, [%4]                    \n"
+                        "ins    v2.d[1], x23                \n"
 
                         "fmla   v20.4s, v7.4s, v3.s[0]      \n"
+                        "ldr    x23, [%4, #8]               \n"
                         "fmla   v21.4s, v7.4s, v3.s[1]      \n"
+                        "add    %4, %4, #16                 \n"
                         "fmla   v22.4s, v7.4s, v3.s[2]      \n"
+
+                        //v
+                        "ins    v6.d[1], x23                \n"
+                        "nop                                \n"
+
                         "fmla   v23.4s, v7.4s, v3.s[3]      \n"
+                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "fmla   v24.4s, v7.4s, v4.s[0]      \n"
+                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "fmla   v25.4s, v7.4s, v4.s[1]      \n"
 
-                        "prfm   pldl1keep, [%3, #512]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%3], #64 \n"
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
 
-                        "fmla   v12.4s, v6.4s, v0.s[0]      \n"
-                        "fmla   v13.4s, v6.4s, v0.s[1]      \n"
-                        "fmla   v14.4s, v6.4s, v0.s[2]      \n"
-                        "fmla   v15.4s, v6.4s, v0.s[3]      \n"
-                        "fmla   v16.4s, v6.4s, v1.s[0]      \n"
-                        "fmla   v17.4s, v6.4s, v1.s[1]      \n"
-                        "fmla   v18.4s, v6.4s, v1.s[2]      \n"
-                        "fmla   v19.4s, v6.4s, v1.s[3]      \n"
+                        "fmla   v26.4s, v7.4s, v4.s[2]      \n"
+                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "fmla   v27.4s, v7.4s, v4.s[3]      \n"
+                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "fmla   v28.4s, v7.4s, v5.s[0]      \n"
 
-                        "fmla   v24.4s, v7.4s, v0.s[0]      \n"
-                        "fmla   v25.4s, v7.4s, v0.s[1]      \n"
-                        "fmla   v26.4s, v7.4s, v0.s[2]      \n"
-                        "fmla   v27.4s, v7.4s, v0.s[3]      \n"
-                        "fmla   v28.4s, v7.4s, v1.s[0]      \n"
-                        "fmla   v29.4s, v7.4s, v1.s[1]      \n"
-                        "fmla   v30.4s, v7.4s, v1.s[2]      \n"
-                        "fmla   v31.4s, v7.4s, v1.s[3]      \n"
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
 
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v4.4s, v5.4s, v6.4s, v7.4s}, [%4], #64   \n" // w2233_01
+                        "fmla   v29.4s, v7.4s, v5.s[1]      \n"
+                        "fmla   v30.4s, v7.4s, v5.s[2]      \n"
+                        "fmla   v31.4s, v7.4s, v5.s[3]      \n"
 
-                        "fmla   v8.4s, v4.4s, v2.s[0]       \n"
-                        "fmla   v9.4s, v4.4s, v2.s[1]       \n"
-                        "fmla   v10.4s, v4.4s, v2.s[2]      \n"
-                        "fmla   v11.4s, v4.4s, v2.s[3]      \n"
-                        "fmla   v12.4s, v4.4s, v3.s[0]      \n"
-                        "fmla   v13.4s, v4.4s, v3.s[1]      \n"
-                        "fmla   v14.4s, v4.4s, v3.s[2]      \n"
-                        "fmla   v15.4s, v4.4s, v3.s[3]      \n"
+                        //v
+                        "ldr    d7, [%4]                    \n"
 
-                        "fmla   v20.4s, v5.4s, v2.s[0]      \n"
-                        "fmla   v21.4s, v5.4s, v2.s[1]      \n"
-                        "fmla   v22.4s, v5.4s, v2.s[2]      \n"
-                        "fmla   v23.4s, v5.4s, v2.s[3]      \n"
-                        "fmla   v24.4s, v5.4s, v3.s[0]      \n"
-                        "fmla   v25.4s, v5.4s, v3.s[1]      \n"
-                        "fmla   v26.4s, v5.4s, v3.s[2]      \n"
-                        "fmla   v27.4s, v5.4s, v3.s[3]      \n"
+                        "fmla   v8.4s, v6.4s, v0.s[0]       \n"
+                        "ldr    x23, [%4, #8]               \n"
+                        "fmla   v9.4s, v6.4s, v0.s[1]       \n"
+                        "add    %4, %4, #16                 \n"
+                        "fmla   v10.4s, v6.4s, v0.s[2]      \n"
 
-                        "prfm   pldl1keep, [%3, #512]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%3], #64 \n"
+                        //v
+                        "ldr    d3, [%3]                    \n"
+                        "ins    v7.d[1], x23                \n"
 
-                        "fmla   v16.4s, v4.4s, v0.s[0]      \n"
-                        "fmla   v17.4s, v4.4s, v0.s[1]      \n"
-                        "fmla   v18.4s, v4.4s, v0.s[2]      \n"
-                        "fmla   v19.4s, v4.4s, v0.s[3]      \n"
+                        "fmla   v11.4s, v6.4s, v0.s[3]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v12.4s, v6.4s, v1.s[0]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v13.4s, v6.4s, v1.s[1]      \n"
 
-                        "fmla   v28.4s, v5.4s, v0.s[0]      \n"
-                        "fmla   v29.4s, v5.4s, v0.s[1]      \n"
-                        "fmla   v30.4s, v5.4s, v0.s[2]      \n"
-                        "fmla   v31.4s, v5.4s, v0.s[3]      \n"
+                        //v
+                        "ldr    d4, [%3]                    \n"
+                        "ins    v3.d[1], x23                \n"
 
-                        "fmla   v8.4s, v6.4s, v1.s[0]       \n"
-                        "fmla   v9.4s, v6.4s, v1.s[1]       \n"
-                        "fmla   v10.4s, v6.4s, v1.s[2]      \n"
-                        "fmla   v11.4s, v6.4s, v1.s[3]      \n"
-                        "fmla   v12.4s, v6.4s, v2.s[0]      \n"
-                        "fmla   v13.4s, v6.4s, v2.s[1]      \n"
-                        "fmla   v14.4s, v6.4s, v2.s[2]      \n"
-                        "fmla   v15.4s, v6.4s, v2.s[3]      \n"
-                        "fmla   v16.4s, v6.4s, v3.s[0]      \n"
-                        "fmla   v17.4s, v6.4s, v3.s[1]      \n"
-                        "fmla   v18.4s, v6.4s, v3.s[2]      \n"
-                        "fmla   v19.4s, v6.4s, v3.s[3]      \n"
+                        "fmla   v14.4s, v6.4s, v1.s[2]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v15.4s, v6.4s, v1.s[3]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v16.4s, v6.4s, v2.s[0]      \n"
+
+                        //v
+                        "ldr    d5, [%3]                    \n"
+                        "ins    v4.d[1], x23                \n"
+
+                        "fmla   v17.4s, v6.4s, v2.s[1]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v18.4s, v6.4s, v2.s[2]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v19.4s, v6.4s, v2.s[3]      \n"
+
+                        //v
+                        "ldr    d6, [%4]                    \n"
+                        "ins    v5.d[1], x23                \n"
+
+                        "fmla   v20.4s, v7.4s, v0.s[0]      \n"
+                        "ldr    x23, [%4, #8]               \n"
+                        "fmla   v21.4s, v7.4s, v0.s[1]      \n"
+                        "add    %4, %4, #16                 \n"
+                        "fmla   v22.4s, v7.4s, v0.s[2]      \n"
+
+                        //v
+                        "ins    v6.d[1], x23                \n"
+                        "nop                                \n"
+
+                        "fmla   v23.4s, v7.4s, v0.s[3]      \n"
+                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "fmla   v24.4s, v7.4s, v1.s[0]      \n"
+                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "fmla   v25.4s, v7.4s, v1.s[1]      \n"
+
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
+
+                        "fmla   v26.4s, v7.4s, v1.s[2]      \n"
+                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "fmla   v27.4s, v7.4s, v1.s[3]      \n"
+                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "fmla   v28.4s, v7.4s, v2.s[0]      \n"
+
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
+
+                        "fmla   v29.4s, v7.4s, v2.s[1]      \n"
+                        "fmla   v30.4s, v7.4s, v2.s[2]      \n"
+                        "fmla   v31.4s, v7.4s, v2.s[3]      \n"
+
+                        //v
+                        "ldr    d7, [%4]                    \n"
+
+                        "fmla   v8.4s, v6.4s, v3.s[0]       \n"
+                        "ldr    x23, [%4, #8]               \n"
+                        "fmla   v9.4s, v6.4s, v3.s[1]       \n"
+                        "add    %4, %4, #16                 \n"
+                        "fmla   v10.4s, v6.4s, v3.s[2]      \n"
+
+                        //v
+                        "ldr    d0, [%3]                    \n"
+                        "ins    v7.d[1], x23                \n"
+
+                        "fmla   v11.4s, v6.4s, v3.s[3]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v12.4s, v6.4s, v4.s[0]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v13.4s, v6.4s, v4.s[1]      \n"
+
+                        //v
+                        "ldr    d1, [%3]                    \n"
+                        "ins    v0.d[1], x23                \n"
+
+                        "fmla   v14.4s, v6.4s, v4.s[2]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v15.4s, v6.4s, v4.s[3]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v16.4s, v6.4s, v5.s[0]      \n"
+
+                        //v
+                        "ldr    d2, [%3]                    \n"
+                        "ins    v1.d[1], x23                \n"
+
+                        "fmla   v17.4s, v6.4s, v5.s[1]      \n"
+                        "ldr    x23, [%3, #8]               \n"
+                        "fmla   v18.4s, v6.4s, v5.s[2]      \n"
+                        "add    %3, %3, #16                 \n"
+                        "fmla   v19.4s, v6.4s, v5.s[3]      \n"
+
+                        //v
+                        "ldr    d6, [%4]                    \n"
+                        "ins    v2.d[1], x23                \n"
+
+                        "fmla   v20.4s, v7.4s, v3.s[0]      \n"
+                        "ldr    x23, [%4, #8]               \n"
+                        "fmla   v21.4s, v7.4s, v3.s[1]      \n"
+                        "add    %4, %4, #16                 \n"
+                        "fmla   v22.4s, v7.4s, v3.s[2]      \n"
+
+                        //v
+                        "ins    v6.d[1], x23                \n"
+                        "nop                                \n"
+
+                        "fmla   v23.4s, v7.4s, v3.s[3]      \n"
+                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "fmla   v24.4s, v7.4s, v4.s[0]      \n"
+                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "fmla   v25.4s, v7.4s, v4.s[1]      \n"
+
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
+
+                        "fmla   v26.4s, v7.4s, v4.s[2]      \n"
+                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "fmla   v27.4s, v7.4s, v4.s[3]      \n"
+                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "fmla   v28.4s, v7.4s, v5.s[0]      \n"
+
+                        //v
+                        "nop                                \n"
+                        "nop                                \n"
+
+                        "fmla   v29.4s, v7.4s, v5.s[1]      \n"
+                        "fmla   v30.4s, v7.4s, v5.s[2]      \n"
+                        "fmla   v31.4s, v7.4s, v5.s[3]      \n"
 
                         "subs   %w0, %w0, #1                \n"
 
-                        "fmla   v20.4s, v7.4s, v1.s[0]      \n"
-                        "fmla   v21.4s, v7.4s, v1.s[1]      \n"
-                        "fmla   v22.4s, v7.4s, v1.s[2]      \n"
-                        "fmla   v23.4s, v7.4s, v1.s[3]      \n"
-                        "fmla   v24.4s, v7.4s, v2.s[0]      \n"
-                        "fmla   v25.4s, v7.4s, v2.s[1]      \n"
-                        "fmla   v26.4s, v7.4s, v2.s[2]      \n"
-                        "fmla   v27.4s, v7.4s, v2.s[3]      \n"
-                        "fmla   v28.4s, v7.4s, v3.s[0]      \n"
-                        "fmla   v29.4s, v7.4s, v3.s[1]      \n"
-                        "fmla   v30.4s, v7.4s, v3.s[2]      \n"
-                        "fmla   v31.4s, v7.4s, v3.s[3]      \n"
+                        // preload
 
                         "bne    0b                          \n"
+
+                        "sub    %4, %4, #16                 \n"
+                        "sub    %3, %3, #48                 \n"
 
                         "st1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%1], #64 \n"
                         "st1    {v20.4s, v21.4s, v22.4s, v23.4s}, [%2], #64 \n"
@@ -2415,7 +2358,7 @@ static void conv3x3s1_winograd42_pack4_neon(const Mat& bottom_blob, Mat& top_blo
                         "2"(output1_tm),
                         "3"(r0),
                         "4"(k01)
-                        : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31");
+                        : "cc", "memory", "x23", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31");
                 }
                 for (; i + 7 < tiles; i += 8)
                 {
@@ -3353,7 +3296,7 @@ static void conv3x3s1_winograd42_pack4_neon(const Mat& bottom_blob, Mat& top_blo
             top_blob_bordered.create(outw, outh, outch, elemsize, elempack, opt.workspace_allocator);
         }
 
-        convolution_winograd_f43_transform_output_pack4_neon(top_blob_tm, top_blob_bordered, bias, opt);
+        convolution_winograd_f63_transform_output_pack4_neon(top_blob_tm, top_blob_bordered, bias, opt);
     }
     // END transform output
 
@@ -3361,1066 +3304,7 @@ static void conv3x3s1_winograd42_pack4_neon(const Mat& bottom_blob, Mat& top_blo
     copy_cut_border(top_blob_bordered, top_blob, 0, top_blob_bordered.h - top_blob.h, 0, top_blob_bordered.w - top_blob.w, opt);
 }
 
-static void conv3x3s2_pack4_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
-{
-    int w = bottom_blob.w;
-    int inch = bottom_blob.c;
-    int outw = top_blob.w;
-    int outh = top_blob.h;
-    int outch = top_blob.c;
-
-    const int tailstep = (w - 2 * outw + w) * 4;
-
-    const float* bias = _bias;
-
-    #pragma omp parallel for num_threads(opt.num_threads)
-    for (int p = 0; p < outch; p++)
-    {
-        Mat out0 = top_blob.channel(p);
-
-        float32x4_t _bias0 = bias ? vld1q_f32((const float*)bias + p * 4) : vdupq_n_f32(0.f);
-        out0.fill(_bias0);
-
-        for (int q = 0; q < inch; q++)
-        {
-            float* outptr0 = out0.row(0);
-
-            const Mat img0 = bottom_blob.channel(q);
-
-            const float* r0 = img0.row(0);
-            const float* r1 = img0.row(1);
-            const float* r2 = img0.row(2);
-
-            const float* kptr = (const float*)kernel.channel(p).row(q);
-
-            int i = 0;
-            for (; i < outh; i++)
-            {
-                int j = 0;
-                for (; j + 3 < outw; j += 4)
-                {
-#if __aarch64__
-                    asm volatile(
-                        "prfm   pldl1keep, [%0, #512]       \n"
-                        "ld1    {v20.4s, v21.4s, v22.4s, v23.4s}, [%0] \n" // sum0 sum1 sum2 sum3
-
-                        "prfm   pldl1keep, [%1, #512]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%1], #64 \n" // r00 r01 r02 r03
-
-                        "prfm   pldl1keep, [%1, #512]       \n"
-                        "ld1    {v4.4s, v5.4s, v6.4s, v7.4s}, [%1], #64 \n" // r04 r05 r06 r07
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4], #64 \n"
-
-                        "fmla   v20.4s, v16.4s, v0.s[0]     \n"
-                        "fmla   v21.4s, v16.4s, v2.s[0]     \n"
-                        "fmla   v22.4s, v16.4s, v4.s[0]     \n"
-                        "fmla   v23.4s, v16.4s, v6.s[0]     \n"
-                        "fmla   v20.4s, v17.4s, v0.s[1]     \n"
-                        "fmla   v21.4s, v17.4s, v2.s[1]     \n"
-                        "fmla   v22.4s, v17.4s, v4.s[1]     \n"
-                        "fmla   v23.4s, v17.4s, v6.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%4], #64 \n"
-
-                        "fmla   v20.4s, v18.4s, v0.s[2]     \n"
-                        "fmla   v21.4s, v18.4s, v2.s[2]     \n"
-                        "fmla   v22.4s, v18.4s, v4.s[2]     \n"
-                        "fmla   v23.4s, v18.4s, v6.s[2]     \n"
-                        "fmla   v20.4s, v19.4s, v0.s[3]     \n"
-                        "fmla   v21.4s, v19.4s, v2.s[3]     \n"
-                        "fmla   v22.4s, v19.4s, v4.s[3]     \n"
-                        "fmla   v23.4s, v19.4s, v6.s[3]     \n"
-
-                        "prfm   pldl1keep, [%1, #128]       \n"
-                        "ld1    {v28.4s}, [%1]              \n" // r08
-
-                        "fmla   v20.4s, v24.4s, v1.s[0]     \n"
-                        "fmla   v21.4s, v24.4s, v3.s[0]     \n"
-                        "fmla   v22.4s, v24.4s, v5.s[0]     \n"
-                        "fmla   v23.4s, v24.4s, v7.s[0]     \n"
-                        "fmla   v20.4s, v25.4s, v1.s[1]     \n"
-                        "fmla   v21.4s, v25.4s, v3.s[1]     \n"
-                        "fmla   v22.4s, v25.4s, v5.s[1]     \n"
-                        "fmla   v23.4s, v25.4s, v7.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4], #64 \n"
-
-                        "fmla   v20.4s, v26.4s, v1.s[2]     \n"
-                        "fmla   v21.4s, v26.4s, v3.s[2]     \n"
-                        "fmla   v22.4s, v26.4s, v5.s[2]     \n"
-                        "fmla   v23.4s, v26.4s, v7.s[2]     \n"
-                        "fmla   v20.4s, v27.4s, v1.s[3]     \n"
-                        "fmla   v21.4s, v27.4s, v3.s[3]     \n"
-                        "fmla   v22.4s, v27.4s, v5.s[3]     \n"
-                        "fmla   v23.4s, v27.4s, v7.s[3]     \n"
-
-                        "prfm   pldl1keep, [%2, #512]       \n"
-                        "ld1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%2], #64 \n" // r10 r11 r12 r13
-
-                        "fmla   v20.4s, v16.4s, v2.s[0]     \n"
-                        "fmla   v21.4s, v16.4s, v4.s[0]     \n"
-                        "fmla   v22.4s, v16.4s, v6.s[0]     \n"
-                        "fmla   v23.4s, v16.4s, v28.s[0]    \n"
-                        "fmla   v20.4s, v17.4s, v2.s[1]     \n"
-                        "fmla   v21.4s, v17.4s, v4.s[1]     \n"
-                        "fmla   v22.4s, v17.4s, v6.s[1]     \n"
-                        "fmla   v23.4s, v17.4s, v28.s[1]    \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%4], #64 \n"
-
-                        "fmla   v20.4s, v18.4s, v2.s[2]     \n"
-                        "fmla   v21.4s, v18.4s, v4.s[2]     \n"
-                        "fmla   v22.4s, v18.4s, v6.s[2]     \n"
-                        "fmla   v23.4s, v18.4s, v28.s[2]    \n"
-                        "fmla   v20.4s, v19.4s, v2.s[3]     \n"
-                        "fmla   v21.4s, v19.4s, v4.s[3]     \n"
-                        "fmla   v22.4s, v19.4s, v6.s[3]     \n"
-                        "fmla   v23.4s, v19.4s, v28.s[3]    \n"
-
-                        "prfm   pldl1keep, [%2, #512]       \n"
-                        "ld1    {v12.4s, v13.4s, v14.4s, v15.4s}, [%2], #64 \n" // r14 r15 r16 r17
-
-                        "fmla   v20.4s, v24.4s, v8.s[0]     \n"
-                        "fmla   v21.4s, v24.4s, v10.s[0]    \n"
-                        "fmla   v22.4s, v24.4s, v12.s[0]    \n"
-                        "fmla   v23.4s, v24.4s, v14.s[0]    \n"
-                        "fmla   v20.4s, v25.4s, v8.s[1]     \n"
-                        "fmla   v21.4s, v25.4s, v10.s[1]    \n"
-                        "fmla   v22.4s, v25.4s, v12.s[1]    \n"
-                        "fmla   v23.4s, v25.4s, v14.s[1]    \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4], #64 \n"
-
-                        "fmla   v20.4s, v26.4s, v8.s[2]     \n"
-                        "fmla   v21.4s, v26.4s, v10.s[2]    \n"
-                        "fmla   v22.4s, v26.4s, v12.s[2]    \n"
-                        "fmla   v23.4s, v26.4s, v14.s[2]    \n"
-                        "fmla   v20.4s, v27.4s, v8.s[3]     \n"
-                        "fmla   v21.4s, v27.4s, v10.s[3]    \n"
-                        "fmla   v22.4s, v27.4s, v12.s[3]    \n"
-                        "fmla   v23.4s, v27.4s, v14.s[3]    \n"
-
-                        "prfm   pldl1keep, [%2, #128]       \n"
-                        "ld1    {v28.4s}, [%2]              \n" // r18
-
-                        "fmla   v20.4s, v16.4s, v9.s[0]     \n"
-                        "fmla   v21.4s, v16.4s, v11.s[0]    \n"
-                        "fmla   v22.4s, v16.4s, v13.s[0]    \n"
-                        "fmla   v23.4s, v16.4s, v15.s[0]    \n"
-                        "fmla   v20.4s, v17.4s, v9.s[1]     \n"
-                        "fmla   v21.4s, v17.4s, v11.s[1]    \n"
-                        "fmla   v22.4s, v17.4s, v13.s[1]    \n"
-                        "fmla   v23.4s, v17.4s, v15.s[1]    \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%4], #64 \n"
-
-                        "fmla   v20.4s, v18.4s, v9.s[2]     \n"
-                        "fmla   v21.4s, v18.4s, v11.s[2]    \n"
-                        "fmla   v22.4s, v18.4s, v13.s[2]    \n"
-                        "fmla   v23.4s, v18.4s, v15.s[2]    \n"
-                        "fmla   v20.4s, v19.4s, v9.s[3]     \n"
-                        "fmla   v21.4s, v19.4s, v11.s[3]    \n"
-                        "fmla   v22.4s, v19.4s, v13.s[3]    \n"
-                        "fmla   v23.4s, v19.4s, v15.s[3]    \n"
-
-                        "prfm   pldl1keep, [%3, #512]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%3], #64 \n" // r20 r21 r22 r23
-
-                        "fmla   v20.4s, v24.4s, v10.s[0]    \n"
-                        "fmla   v21.4s, v24.4s, v12.s[0]    \n"
-                        "fmla   v22.4s, v24.4s, v14.s[0]    \n"
-                        "fmla   v23.4s, v24.4s, v28.s[0]    \n"
-                        "fmla   v20.4s, v25.4s, v10.s[1]    \n"
-                        "fmla   v21.4s, v25.4s, v12.s[1]    \n"
-                        "fmla   v22.4s, v25.4s, v14.s[1]    \n"
-                        "fmla   v23.4s, v25.4s, v28.s[1]    \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4], #64 \n"
-
-                        "fmla   v20.4s, v26.4s, v10.s[2]    \n"
-                        "fmla   v21.4s, v26.4s, v12.s[2]    \n"
-                        "fmla   v22.4s, v26.4s, v14.s[2]    \n"
-                        "fmla   v23.4s, v26.4s, v28.s[2]    \n"
-                        "fmla   v20.4s, v27.4s, v10.s[3]    \n"
-                        "fmla   v21.4s, v27.4s, v12.s[3]    \n"
-                        "fmla   v22.4s, v27.4s, v14.s[3]    \n"
-                        "fmla   v23.4s, v27.4s, v28.s[3]    \n"
-
-                        "prfm   pldl1keep, [%3, #512]       \n"
-                        "ld1    {v4.4s, v5.4s, v6.4s, v7.4s}, [%3], #64 \n" // r24 r25 r26 r27
-
-                        "fmla   v20.4s, v16.4s, v0.s[0]     \n"
-                        "fmla   v21.4s, v16.4s, v2.s[0]     \n"
-                        "fmla   v22.4s, v16.4s, v4.s[0]     \n"
-                        "fmla   v23.4s, v16.4s, v6.s[0]     \n"
-                        "fmla   v20.4s, v17.4s, v0.s[1]     \n"
-                        "fmla   v21.4s, v17.4s, v2.s[1]     \n"
-                        "fmla   v22.4s, v17.4s, v4.s[1]     \n"
-                        "fmla   v23.4s, v17.4s, v6.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%4], #64 \n"
-
-                        "fmla   v20.4s, v18.4s, v0.s[2]     \n"
-                        "fmla   v21.4s, v18.4s, v2.s[2]     \n"
-                        "fmla   v22.4s, v18.4s, v4.s[2]     \n"
-                        "fmla   v23.4s, v18.4s, v6.s[2]     \n"
-                        "fmla   v20.4s, v19.4s, v0.s[3]     \n"
-                        "fmla   v21.4s, v19.4s, v2.s[3]     \n"
-                        "fmla   v22.4s, v19.4s, v4.s[3]     \n"
-                        "fmla   v23.4s, v19.4s, v6.s[3]     \n"
-
-                        "prfm   pldl1keep, [%3, #128]       \n"
-                        "ld1    {v28.4s}, [%3]              \n" // r28
-
-                        "fmla   v20.4s, v24.4s, v1.s[0]     \n"
-                        "fmla   v21.4s, v24.4s, v3.s[0]     \n"
-                        "fmla   v22.4s, v24.4s, v5.s[0]     \n"
-                        "fmla   v23.4s, v24.4s, v7.s[0]     \n"
-                        "fmla   v20.4s, v25.4s, v1.s[1]     \n"
-                        "fmla   v21.4s, v25.4s, v3.s[1]     \n"
-                        "fmla   v22.4s, v25.4s, v5.s[1]     \n"
-                        "fmla   v23.4s, v25.4s, v7.s[1]     \n"
-
-                        //                         "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4] \n"
-
-                        "fmla   v20.4s, v26.4s, v1.s[2]     \n"
-                        "fmla   v21.4s, v26.4s, v3.s[2]     \n"
-                        "fmla   v22.4s, v26.4s, v5.s[2]     \n"
-                        "fmla   v23.4s, v26.4s, v7.s[2]     \n"
-                        "fmla   v20.4s, v27.4s, v1.s[3]     \n"
-                        "fmla   v21.4s, v27.4s, v3.s[3]     \n"
-                        "fmla   v22.4s, v27.4s, v5.s[3]     \n"
-                        "fmla   v23.4s, v27.4s, v7.s[3]     \n"
-
-                        "fmla   v20.4s, v16.4s, v2.s[0]     \n"
-                        "fmla   v21.4s, v16.4s, v4.s[0]     \n"
-                        "fmla   v22.4s, v16.4s, v6.s[0]     \n"
-                        "fmla   v23.4s, v16.4s, v28.s[0]    \n"
-                        "fmla   v20.4s, v17.4s, v2.s[1]     \n"
-                        "fmla   v21.4s, v17.4s, v4.s[1]     \n"
-                        "fmla   v22.4s, v17.4s, v6.s[1]     \n"
-                        "fmla   v23.4s, v17.4s, v28.s[1]    \n"
-                        "fmla   v20.4s, v18.4s, v2.s[2]     \n"
-                        "fmla   v21.4s, v18.4s, v4.s[2]     \n"
-                        "fmla   v22.4s, v18.4s, v6.s[2]     \n"
-                        "fmla   v23.4s, v18.4s, v28.s[2]    \n"
-                        "fmla   v20.4s, v19.4s, v2.s[3]     \n"
-                        "fmla   v21.4s, v19.4s, v4.s[3]     \n"
-                        "fmla   v22.4s, v19.4s, v6.s[3]     \n"
-                        "fmla   v23.4s, v19.4s, v28.s[3]    \n"
-
-                        "sub    %4, %4, #512                \n" // kptr -= 8 * 16;
-
-                        "st1    {v20.4s, v21.4s, v22.4s, v23.4s}, [%0], #64 \n"
-
-                        : "=r"(outptr0), // %0
-                        "=r"(r0),      // %1
-                        "=r"(r1),      // %2
-                        "=r"(r2),      // %3
-                        "=r"(kptr)     // %4
-                        : "0"(outptr0),
-                        "1"(r0),
-                        "2"(r1),
-                        "3"(r2),
-                        "4"(kptr)
-                        : "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28");
-#else  // __aarch64__
-                    asm volatile(
-                        "pld        [%0, #512]          \n"
-                        "vldm       %0, {d24-d31}       \n" // sum0 sum1 sum2 sum3
-
-                        "pld        [%1, #512]          \n"
-                        "vldm       %1!, {d0-d7}        \n" // r00 r01 r02 r03
-
-                        "pld        [%1, #512]          \n"
-                        "vldm       %1!, {d8-d15}       \n" // r04 r05 r06 r07
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q12, q8, d0[0]      \n"
-                        "vmla.f32   q13, q8, d4[0]      \n"
-                        "vmla.f32   q14, q8, d8[0]      \n"
-                        "vmla.f32   q15, q8, d12[0]     \n"
-                        "vmla.f32   q12, q9, d0[1]      \n"
-                        "vmla.f32   q13, q9, d4[1]      \n"
-                        "vmla.f32   q14, q9, d8[1]      \n"
-                        "vmla.f32   q15, q9, d12[1]     \n"
-                        "vmla.f32   q12, q10, d1[0]     \n"
-                        "vmla.f32   q13, q10, d5[0]     \n"
-                        "vmla.f32   q14, q10, d9[0]     \n"
-                        "vmla.f32   q15, q10, d13[0]    \n"
-                        "vmla.f32   q12, q11, d1[1]     \n"
-                        "vmla.f32   q13, q11, d5[1]     \n"
-                        "vmla.f32   q14, q11, d9[1]     \n"
-                        "vmla.f32   q15, q11, d13[1]    \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "pld        [%1, #128]          \n"
-                        "vld1.f32   {d0-d1}, [%1 :128]  \n" // r08
-
-                        "vmla.f32   q12, q8, d2[0]      \n"
-                        "vmla.f32   q13, q8, d6[0]      \n"
-                        "vmla.f32   q14, q8, d10[0]     \n"
-                        "vmla.f32   q15, q8, d14[0]     \n"
-                        "vmla.f32   q12, q9, d2[1]      \n"
-                        "vmla.f32   q13, q9, d6[1]      \n"
-                        "vmla.f32   q14, q9, d10[1]     \n"
-                        "vmla.f32   q15, q9, d14[1]     \n"
-                        "vmla.f32   q12, q10, d3[0]     \n"
-                        "vmla.f32   q13, q10, d7[0]     \n"
-                        "vmla.f32   q14, q10, d11[0]    \n"
-                        "vmla.f32   q15, q10, d15[0]    \n"
-                        "vmla.f32   q12, q11, d3[1]     \n"
-                        "vmla.f32   q13, q11, d7[1]     \n"
-                        "vmla.f32   q14, q11, d11[1]    \n"
-                        "vmla.f32   q15, q11, d15[1]    \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q12, q8, d4[0]      \n"
-                        "vmla.f32   q13, q8, d8[0]      \n"
-                        "vmla.f32   q14, q8, d12[0]     \n"
-                        "vmla.f32   q15, q8, d0[0]      \n"
-                        "vmla.f32   q12, q9, d4[1]      \n"
-                        "vmla.f32   q13, q9, d8[1]      \n"
-                        "vmla.f32   q14, q9, d12[1]     \n"
-                        "vmla.f32   q15, q9, d0[1]      \n"
-                        "vmla.f32   q12, q10, d5[0]     \n"
-                        "vmla.f32   q13, q10, d9[0]     \n"
-                        "vmla.f32   q14, q10, d13[0]    \n"
-                        "vmla.f32   q15, q10, d1[0]     \n"
-                        "vmla.f32   q12, q11, d5[1]     \n"
-                        "vmla.f32   q13, q11, d9[1]     \n"
-                        "vmla.f32   q14, q11, d13[1]    \n"
-                        "vmla.f32   q15, q11, d1[1]     \n"
-
-                        "pld        [%2, #512]          \n"
-                        "vldm       %2!, {d8-d15}       \n" // r10 r11 r12 r13
-
-                        "pld        [%2, #512]          \n"
-                        "vldm       %2!, {d0-d7}        \n" // r14 r15 r16 r17
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q12, q8, d8[0]      \n"
-                        "vmla.f32   q13, q8, d12[0]     \n"
-                        "vmla.f32   q14, q8, d0[0]      \n"
-                        "vmla.f32   q15, q8, d4[0]      \n"
-                        "vmla.f32   q12, q9, d8[1]      \n"
-                        "vmla.f32   q13, q9, d12[1]     \n"
-                        "vmla.f32   q14, q9, d0[1]      \n"
-                        "vmla.f32   q15, q9, d4[1]      \n"
-                        "vmla.f32   q12, q10, d9[0]     \n"
-                        "vmla.f32   q13, q10, d13[0]    \n"
-                        "vmla.f32   q14, q10, d1[0]     \n"
-                        "vmla.f32   q15, q10, d5[0]     \n"
-                        "vmla.f32   q12, q11, d9[1]     \n"
-                        "vmla.f32   q13, q11, d13[1]    \n"
-                        "vmla.f32   q14, q11, d1[1]     \n"
-                        "vmla.f32   q15, q11, d5[1]     \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "pld        [%2, #128]          \n"
-                        "vld1.f32   {d8-d9}, [%2 :128]  \n" // r18
-
-                        "vmla.f32   q12, q8, d10[0]     \n"
-                        "vmla.f32   q13, q8, d14[0]     \n"
-                        "vmla.f32   q14, q8, d2[0]      \n"
-                        "vmla.f32   q15, q8, d6[0]      \n"
-                        "vmla.f32   q12, q9, d10[1]     \n"
-                        "vmla.f32   q13, q9, d14[1]     \n"
-                        "vmla.f32   q14, q9, d2[1]      \n"
-                        "vmla.f32   q15, q9, d6[1]      \n"
-                        "vmla.f32   q12, q10, d11[0]    \n"
-                        "vmla.f32   q13, q10, d15[0]    \n"
-                        "vmla.f32   q14, q10, d3[0]     \n"
-                        "vmla.f32   q15, q10, d7[0]     \n"
-                        "vmla.f32   q12, q11, d11[1]    \n"
-                        "vmla.f32   q13, q11, d15[1]    \n"
-                        "vmla.f32   q14, q11, d3[1]     \n"
-                        "vmla.f32   q15, q11, d7[1]     \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q12, q8, d12[0]     \n"
-                        "vmla.f32   q13, q8, d0[0]      \n"
-                        "vmla.f32   q14, q8, d4[0]      \n"
-                        "vmla.f32   q15, q8, d8[0]      \n"
-                        "vmla.f32   q12, q9, d12[1]     \n"
-                        "vmla.f32   q13, q9, d0[1]      \n"
-                        "vmla.f32   q14, q9, d4[1]      \n"
-                        "vmla.f32   q15, q9, d8[1]      \n"
-                        "vmla.f32   q12, q10, d13[0]    \n"
-                        "vmla.f32   q13, q10, d1[0]     \n"
-                        "vmla.f32   q14, q10, d5[0]     \n"
-                        "vmla.f32   q15, q10, d9[0]     \n"
-                        "vmla.f32   q12, q11, d13[1]    \n"
-                        "vmla.f32   q13, q11, d1[1]     \n"
-                        "vmla.f32   q14, q11, d5[1]     \n"
-                        "vmla.f32   q15, q11, d9[1]     \n"
-
-                        "pld        [%3, #512]          \n"
-                        "vldm       %3!, {d0-d7}        \n" // r20 r21 r22 r23
-
-                        "pld        [%3, #512]          \n"
-                        "vldm       %3!, {d8-d15}       \n" // r24 r25 r26 r27
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q12, q8, d0[0]      \n"
-                        "vmla.f32   q13, q8, d4[0]      \n"
-                        "vmla.f32   q14, q8, d8[0]      \n"
-                        "vmla.f32   q15, q8, d12[0]     \n"
-                        "vmla.f32   q12, q9, d0[1]      \n"
-                        "vmla.f32   q13, q9, d4[1]      \n"
-                        "vmla.f32   q14, q9, d8[1]      \n"
-                        "vmla.f32   q15, q9, d12[1]     \n"
-                        "vmla.f32   q12, q10, d1[0]     \n"
-                        "vmla.f32   q13, q10, d5[0]     \n"
-                        "vmla.f32   q14, q10, d9[0]     \n"
-                        "vmla.f32   q15, q10, d13[0]    \n"
-                        "vmla.f32   q12, q11, d1[1]     \n"
-                        "vmla.f32   q13, q11, d5[1]     \n"
-                        "vmla.f32   q14, q11, d9[1]     \n"
-                        "vmla.f32   q15, q11, d13[1]    \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "pld        [%3, #128]          \n"
-                        "vld1.f32   {d0-d1}, [%3 :128]  \n" // r28
-
-                        "vmla.f32   q12, q8, d2[0]      \n"
-                        "vmla.f32   q13, q8, d6[0]      \n"
-                        "vmla.f32   q14, q8, d10[0]     \n"
-                        "vmla.f32   q15, q8, d14[0]     \n"
-                        "vmla.f32   q12, q9, d2[1]      \n"
-                        "vmla.f32   q13, q9, d6[1]      \n"
-                        "vmla.f32   q14, q9, d10[1]     \n"
-                        "vmla.f32   q15, q9, d14[1]     \n"
-                        "vmla.f32   q12, q10, d3[0]     \n"
-                        "vmla.f32   q13, q10, d7[0]     \n"
-                        "vmla.f32   q14, q10, d11[0]    \n"
-                        "vmla.f32   q15, q10, d15[0]    \n"
-                        "vmla.f32   q12, q11, d3[1]     \n"
-                        "vmla.f32   q13, q11, d7[1]     \n"
-                        "vmla.f32   q14, q11, d11[1]    \n"
-                        "vmla.f32   q15, q11, d15[1]    \n"
-
-                        //                         "pld        [%4, #512]          \n"
-                        "vldm       %4, {d16-d23}       \n"
-
-                        "vmla.f32   q12, q8, d4[0]      \n"
-                        "vmla.f32   q13, q8, d8[0]      \n"
-                        "vmla.f32   q14, q8, d12[0]     \n"
-                        "vmla.f32   q15, q8, d0[0]      \n"
-                        "vmla.f32   q12, q9, d4[1]      \n"
-                        "vmla.f32   q13, q9, d8[1]      \n"
-                        "vmla.f32   q14, q9, d12[1]     \n"
-                        "vmla.f32   q15, q9, d0[1]      \n"
-                        "vmla.f32   q12, q10, d5[0]     \n"
-                        "vmla.f32   q13, q10, d9[0]     \n"
-                        "vmla.f32   q14, q10, d13[0]    \n"
-                        "vmla.f32   q15, q10, d1[0]     \n"
-                        "vmla.f32   q12, q11, d5[1]     \n"
-                        "vmla.f32   q13, q11, d9[1]     \n"
-                        "vmla.f32   q14, q11, d13[1]    \n"
-                        "vmla.f32   q15, q11, d1[1]     \n"
-
-                        "sub        %4, %4, #512        \n" // kptr -= 8 * 16;
-
-                        "vstm       %0!, {d24-d31}      \n"
-
-                        : "=r"(outptr0), // %0
-                        "=r"(r0),      // %1
-                        "=r"(r1),      // %2
-                        "=r"(r2),      // %3
-                        "=r"(kptr)     // %4
-                        : "0"(outptr0),
-                        "1"(r0),
-                        "2"(r1),
-                        "3"(r2),
-                        "4"(kptr)
-                        : "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15");
-#endif // __aarch64__
-                }
-                for (; j + 1 < outw; j += 2)
-                {
-#if __aarch64__
-                    asm volatile(
-                        "prfm   pldl1keep, [%0, #256]       \n"
-                        "ld1    {v20.4s, v21.4s}, [%0]      \n" // sum0 sum1
-
-                        "prfm   pldl1keep, [%1, #512]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%1], #64 \n" // r00 r01 r02 r03
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4], #64 \n"
-
-                        "fmul   v22.4s, v16.4s, v0.s[0]     \n"
-                        "fmul   v23.4s, v16.4s, v2.s[0]     \n"
-                        "fmla   v20.4s, v17.4s, v0.s[1]     \n"
-                        "fmla   v21.4s, v17.4s, v2.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%4], #64 \n"
-
-                        "fmla   v22.4s, v18.4s, v0.s[2]     \n"
-                        "fmla   v23.4s, v18.4s, v2.s[2]     \n"
-                        "fmla   v20.4s, v19.4s, v0.s[3]     \n"
-                        "fmla   v21.4s, v19.4s, v2.s[3]     \n"
-
-                        "prfm   pldl1keep, [%1, #128]       \n"
-                        "ld1    {v4.4s}, [%1]               \n" // r04
-
-                        "fmla   v22.4s, v24.4s, v1.s[0]     \n"
-                        "fmla   v23.4s, v24.4s, v3.s[0]     \n"
-                        "fmla   v20.4s, v25.4s, v1.s[1]     \n"
-                        "fmla   v21.4s, v25.4s, v3.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4], #64 \n"
-
-                        "fmla   v22.4s, v26.4s, v1.s[2]     \n"
-                        "fmla   v23.4s, v26.4s, v3.s[2]     \n"
-                        "fmla   v20.4s, v27.4s, v1.s[3]     \n"
-                        "fmla   v21.4s, v27.4s, v3.s[3]     \n"
-
-                        "fmla   v22.4s, v16.4s, v2.s[0]     \n"
-                        "fmla   v23.4s, v16.4s, v4.s[0]     \n"
-                        "fmla   v20.4s, v17.4s, v2.s[1]     \n"
-                        "fmla   v21.4s, v17.4s, v4.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%4], #64 \n"
-
-                        "fmla   v22.4s, v18.4s, v2.s[2]     \n"
-                        "fmla   v23.4s, v18.4s, v4.s[2]     \n"
-                        "fmla   v20.4s, v19.4s, v2.s[3]     \n"
-                        "fmla   v21.4s, v19.4s, v4.s[3]     \n"
-
-                        "prfm   pldl1keep, [%2, #512]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%2], #64 \n" // r10 r11 r12 r13
-
-                        "fmla   v22.4s, v24.4s, v0.s[0]     \n"
-                        "fmla   v23.4s, v24.4s, v2.s[0]     \n"
-                        "fmla   v20.4s, v25.4s, v0.s[1]     \n"
-                        "fmla   v21.4s, v25.4s, v2.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4], #64 \n"
-
-                        "fmla   v22.4s, v26.4s, v0.s[2]     \n"
-                        "fmla   v23.4s, v26.4s, v2.s[2]     \n"
-                        "fmla   v20.4s, v27.4s, v0.s[3]     \n"
-                        "fmla   v21.4s, v27.4s, v2.s[3]     \n"
-
-                        "prfm   pldl1keep, [%2, #128]       \n"
-                        "ld1    {v4.4s}, [%2]               \n" // r14
-
-                        "fmla   v22.4s, v16.4s, v1.s[0]     \n"
-                        "fmla   v23.4s, v16.4s, v3.s[0]     \n"
-                        "fmla   v20.4s, v17.4s, v1.s[1]     \n"
-                        "fmla   v21.4s, v17.4s, v3.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%4], #64 \n"
-
-                        "fmla   v22.4s, v18.4s, v1.s[2]     \n"
-                        "fmla   v23.4s, v18.4s, v3.s[2]     \n"
-                        "fmla   v20.4s, v19.4s, v1.s[3]     \n"
-                        "fmla   v21.4s, v19.4s, v3.s[3]     \n"
-
-                        "fmla   v22.4s, v24.4s, v2.s[0]     \n"
-                        "fmla   v23.4s, v24.4s, v4.s[0]     \n"
-                        "fmla   v20.4s, v25.4s, v2.s[1]     \n"
-                        "fmla   v21.4s, v25.4s, v4.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4], #64 \n"
-
-                        "fmla   v22.4s, v26.4s, v2.s[2]     \n"
-                        "fmla   v23.4s, v26.4s, v4.s[2]     \n"
-                        "fmla   v20.4s, v27.4s, v2.s[3]     \n"
-                        "fmla   v21.4s, v27.4s, v4.s[3]     \n"
-
-                        "prfm   pldl1keep, [%3, #512]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%3], #64 \n" // r20 r21 r22 r23
-
-                        "fmla   v22.4s, v16.4s, v0.s[0]     \n"
-                        "fmla   v23.4s, v16.4s, v2.s[0]     \n"
-                        "fmla   v20.4s, v17.4s, v0.s[1]     \n"
-                        "fmla   v21.4s, v17.4s, v2.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%4], #64 \n"
-
-                        "fmla   v22.4s, v18.4s, v0.s[2]     \n"
-                        "fmla   v23.4s, v18.4s, v2.s[2]     \n"
-                        "fmla   v20.4s, v19.4s, v0.s[3]     \n"
-                        "fmla   v21.4s, v19.4s, v2.s[3]     \n"
-
-                        "prfm   pldl1keep, [%3, #128]       \n"
-                        "ld1    {v4.4s}, [%3]               \n" // r24
-
-                        "fmla   v22.4s, v24.4s, v1.s[0]     \n"
-                        "fmla   v23.4s, v24.4s, v3.s[0]     \n"
-                        "fmla   v20.4s, v25.4s, v1.s[1]     \n"
-                        "fmla   v21.4s, v25.4s, v3.s[1]     \n"
-
-                        //                         "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4] \n"
-
-                        "fmla   v22.4s, v26.4s, v1.s[2]     \n"
-                        "fmla   v23.4s, v26.4s, v3.s[2]     \n"
-                        "fmla   v20.4s, v27.4s, v1.s[3]     \n"
-                        "fmla   v21.4s, v27.4s, v3.s[3]     \n"
-
-                        "fmla   v22.4s, v16.4s, v2.s[0]     \n"
-                        "fmla   v23.4s, v16.4s, v4.s[0]     \n"
-                        "fmla   v20.4s, v17.4s, v2.s[1]     \n"
-                        "fmla   v21.4s, v17.4s, v4.s[1]     \n"
-                        "fmla   v22.4s, v18.4s, v2.s[2]     \n"
-                        "fmla   v23.4s, v18.4s, v4.s[2]     \n"
-                        "fmla   v20.4s, v19.4s, v2.s[3]     \n"
-                        "fmla   v21.4s, v19.4s, v4.s[3]     \n"
-
-                        "fadd   v20.4s, v20.4s, v22.4s      \n"
-                        "fadd   v21.4s, v21.4s, v23.4s      \n"
-
-                        "sub    %4, %4, #512                \n" // kptr -= 8 * 16;
-
-                        "st1    {v20.4s, v21.4s}, [%0], #32 \n"
-
-                        : "=r"(outptr0), // %0
-                        "=r"(r0),      // %1
-                        "=r"(r1),      // %2
-                        "=r"(r2),      // %3
-                        "=r"(kptr)     // %4
-                        : "0"(outptr0),
-                        "1"(r0),
-                        "2"(r1),
-                        "3"(r2),
-                        "4"(kptr)
-                        : "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27");
-#else  // __aarch64__
-                    asm volatile(
-                        "pld        [%0, #256]          \n"
-                        "vld1.f32   {d24-d27}, [%0 :128] \n" // sum0 sum1
-
-                        "pld        [%1, #512]          \n"
-                        "vldm       %1!, {d0-d7}        \n" // r00 r01 r02 r03
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmul.f32   q14, q8, d0[0]      \n"
-                        "vmul.f32   q15, q8, d4[0]      \n"
-                        "vmla.f32   q12, q9, d0[1]      \n"
-                        "vmla.f32   q13, q9, d4[1]      \n"
-                        "vmla.f32   q14, q10, d1[0]     \n"
-                        "vmla.f32   q15, q10, d5[0]     \n"
-                        "vmla.f32   q12, q11, d1[1]     \n"
-                        "vmla.f32   q13, q11, d5[1]     \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "pld        [%1, #128]          \n"
-                        "vld1.f32   {d8-d9}, [%1 :128]  \n" // r04
-
-                        "vmla.f32   q14, q8, d2[0]      \n"
-                        "vmla.f32   q15, q8, d6[0]      \n"
-                        "vmla.f32   q12, q9, d2[1]      \n"
-                        "vmla.f32   q13, q9, d6[1]      \n"
-                        "vmla.f32   q14, q10, d3[0]     \n"
-                        "vmla.f32   q15, q10, d7[0]     \n"
-                        "vmla.f32   q12, q11, d3[1]     \n"
-                        "vmla.f32   q13, q11, d7[1]     \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q14, q8, d4[0]      \n"
-                        "vmla.f32   q15, q8, d8[0]      \n"
-                        "vmla.f32   q12, q9, d4[1]      \n"
-                        "vmla.f32   q13, q9, d8[1]      \n"
-                        "vmla.f32   q14, q10, d5[0]     \n"
-                        "vmla.f32   q15, q10, d9[0]     \n"
-                        "vmla.f32   q12, q11, d5[1]     \n"
-                        "vmla.f32   q13, q11, d9[1]     \n"
-
-                        "pld        [%2, #512]          \n"
-                        "vldm       %2!, {d0-d7}        \n" // r10 r11 r12 r13
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q14, q8, d0[0]      \n"
-                        "vmla.f32   q15, q8, d4[0]      \n"
-                        "vmla.f32   q12, q9, d0[1]      \n"
-                        "vmla.f32   q13, q9, d4[1]      \n"
-                        "vmla.f32   q14, q10, d1[0]     \n"
-                        "vmla.f32   q15, q10, d5[0]     \n"
-                        "vmla.f32   q12, q11, d1[1]     \n"
-                        "vmla.f32   q13, q11, d5[1]     \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "pld        [%2, #128]          \n"
-                        "vld1.f32   {d8-d9}, [%2 :128]  \n" // r14
-
-                        "vmla.f32   q14, q8, d2[0]      \n"
-                        "vmla.f32   q15, q8, d6[0]      \n"
-                        "vmla.f32   q12, q9, d2[1]      \n"
-                        "vmla.f32   q13, q9, d6[1]      \n"
-                        "vmla.f32   q14, q10, d3[0]     \n"
-                        "vmla.f32   q15, q10, d7[0]     \n"
-                        "vmla.f32   q12, q11, d3[1]     \n"
-                        "vmla.f32   q13, q11, d7[1]     \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q14, q8, d4[0]      \n"
-                        "vmla.f32   q15, q8, d8[0]      \n"
-                        "vmla.f32   q12, q9, d4[1]      \n"
-                        "vmla.f32   q13, q9, d8[1]      \n"
-                        "vmla.f32   q14, q10, d5[0]     \n"
-                        "vmla.f32   q15, q10, d9[0]     \n"
-                        "vmla.f32   q12, q11, d5[1]     \n"
-                        "vmla.f32   q13, q11, d9[1]     \n"
-
-                        "pld        [%3, #512]          \n"
-                        "vldm       %3!, {d0-d7}        \n" // r20 r21 r22 r23
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q14, q8, d0[0]      \n"
-                        "vmla.f32   q15, q8, d4[0]      \n"
-                        "vmla.f32   q12, q9, d0[1]      \n"
-                        "vmla.f32   q13, q9, d4[1]      \n"
-                        "vmla.f32   q14, q10, d1[0]     \n"
-                        "vmla.f32   q15, q10, d5[0]     \n"
-                        "vmla.f32   q12, q11, d1[1]     \n"
-                        "vmla.f32   q13, q11, d5[1]     \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "pld        [%3, #128]          \n"
-                        "vld1.f32   {d8-d9}, [%3 :128]  \n" // r24
-
-                        "vmla.f32   q14, q8, d2[0]      \n"
-                        "vmla.f32   q15, q8, d6[0]      \n"
-                        "vmla.f32   q12, q9, d2[1]      \n"
-                        "vmla.f32   q13, q9, d6[1]      \n"
-                        "vmla.f32   q14, q10, d3[0]     \n"
-                        "vmla.f32   q15, q10, d7[0]     \n"
-                        "vmla.f32   q12, q11, d3[1]     \n"
-                        "vmla.f32   q13, q11, d7[1]     \n"
-
-                        //                         "pld        [%4, #512]          \n"
-                        "vldm       %4, {d16-d23}       \n"
-
-                        "vmla.f32   q14, q8, d4[0]      \n"
-                        "vmla.f32   q15, q8, d8[0]      \n"
-                        "vmla.f32   q12, q9, d4[1]      \n"
-                        "vmla.f32   q13, q9, d8[1]      \n"
-                        "vmla.f32   q14, q10, d5[0]     \n"
-                        "vmla.f32   q15, q10, d9[0]     \n"
-                        "vmla.f32   q12, q11, d5[1]     \n"
-                        "vmla.f32   q13, q11, d9[1]     \n"
-
-                        "vadd.f32   q12, q12, q14       \n"
-                        "vadd.f32   q13, q13, q15       \n"
-
-                        "sub        %4, %4, #512        \n" // kptr -= 8 * 16;
-
-                        "vst1.f32   {d24-d27}, [%0 :128]! \n"
-
-                        : "=r"(outptr0), // %0
-                        "=r"(r0),      // %1
-                        "=r"(r1),      // %2
-                        "=r"(r2),      // %3
-                        "=r"(kptr)     // %4
-                        : "0"(outptr0),
-                        "1"(r0),
-                        "2"(r1),
-                        "3"(r2),
-                        "4"(kptr)
-                        : "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15");
-#endif // __aarch64__
-                }
-                for (; j < outw; j++)
-                {
-#if __aarch64__
-                    asm volatile(
-                        "prfm   pldl1keep, [%0, #128]       \n"
-                        "ld1    {v20.4s}, [%0]              \n" // sum0
-
-                        "prfm   pldl1keep, [%1, #384]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s}, [%1] \n" // r00 r01 r02
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4], #64 \n"
-
-                        "fmul   v21.4s, v16.4s, v0.s[0]     \n"
-                        "fmul   v22.4s, v17.4s, v0.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%4], #64 \n"
-
-                        "fmul   v23.4s, v18.4s, v0.s[2]     \n"
-                        "fmla   v20.4s, v19.4s, v0.s[3]     \n"
-
-                        "fmla   v21.4s, v24.4s, v1.s[0]     \n"
-                        "fmla   v22.4s, v25.4s, v1.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4], #64 \n"
-
-                        "fmla   v23.4s, v26.4s, v1.s[2]     \n"
-                        "fmla   v20.4s, v27.4s, v1.s[3]     \n"
-
-                        "prfm   pldl1keep, [%2, #384]       \n"
-                        "ld1    {v3.4s, v4.4s, v5.4s}, [%2] \n" // r10 r11 r12
-
-                        "fmla   v21.4s, v16.4s, v2.s[0]     \n"
-                        "fmla   v22.4s, v17.4s, v2.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%4], #64 \n"
-
-                        "fmla   v23.4s, v18.4s, v2.s[2]     \n"
-                        "fmla   v20.4s, v19.4s, v2.s[3]     \n"
-
-                        "fmla   v21.4s, v24.4s, v3.s[0]     \n"
-                        "fmla   v22.4s, v25.4s, v3.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4], #64 \n"
-
-                        "fmla   v23.4s, v26.4s, v3.s[2]     \n"
-                        "fmla   v20.4s, v27.4s, v3.s[3]     \n"
-
-                        "fmla   v21.4s, v16.4s, v4.s[0]     \n"
-                        "fmla   v22.4s, v17.4s, v4.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%4], #64 \n"
-
-                        "fmla   v23.4s, v18.4s, v4.s[2]     \n"
-                        "fmla   v20.4s, v19.4s, v4.s[3]     \n"
-
-                        "prfm   pldl1keep, [%3, #384]       \n"
-                        "ld1    {v0.4s, v1.4s, v2.4s}, [%3] \n" // r20 r21 r22
-
-                        "fmla   v21.4s, v24.4s, v5.s[0]     \n"
-                        "fmla   v22.4s, v25.4s, v5.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4], #64 \n"
-
-                        "fmla   v23.4s, v26.4s, v5.s[2]     \n"
-                        "fmla   v20.4s, v27.4s, v5.s[3]     \n"
-
-                        "fmla   v21.4s, v16.4s, v0.s[0]     \n"
-                        "fmla   v22.4s, v17.4s, v0.s[1]     \n"
-
-                        "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%4], #64 \n"
-
-                        "fmla   v23.4s, v18.4s, v0.s[2]     \n"
-                        "fmla   v20.4s, v19.4s, v0.s[3]     \n"
-
-                        "fmla   v21.4s, v24.4s, v1.s[0]     \n"
-                        "fmla   v22.4s, v25.4s, v1.s[1]     \n"
-
-                        //                         "prfm   pldl1keep, [%4, #512]       \n"
-                        "ld1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%4] \n"
-
-                        "fmla   v23.4s, v26.4s, v1.s[2]     \n"
-                        "fmla   v20.4s, v27.4s, v1.s[3]     \n"
-
-                        "fmla   v21.4s, v16.4s, v2.s[0]     \n"
-                        "fmla   v22.4s, v17.4s, v2.s[1]     \n"
-                        "fmla   v23.4s, v18.4s, v2.s[2]     \n"
-                        "fmla   v20.4s, v19.4s, v2.s[3]     \n"
-
-                        "add    %1, %1, #32                 \n"
-
-                        "fadd   v22.4s, v21.4s, v22.4s      \n"
-
-                        "add    %2, %2, #32                 \n"
-
-                        "fadd   v23.4s, v23.4s, v22.4s      \n"
-
-                        "add    %3, %3, #32                 \n"
-
-                        "fadd   v20.4s, v20.4s, v23.4s      \n"
-
-                        "sub    %4, %4, #512                \n" // kptr -= 8 * 16;
-
-                        "st1    {v20.4s}, [%0], #16         \n"
-
-                        : "=r"(outptr0), // %0
-                        "=r"(r0),      // %1
-                        "=r"(r1),      // %2
-                        "=r"(r2),      // %3
-                        "=r"(kptr)     // %4
-                        : "0"(outptr0),
-                        "1"(r0),
-                        "2"(r1),
-                        "3"(r2),
-                        "4"(kptr)
-                        : "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27");
-#else  // __aarch64__
-                    asm volatile(
-                        "pld        [%0, #128]          \n"
-                        "vld1.f32   {d24-d25}, [%0 :128] \n" // sum0
-
-                        "pld        [%1, #384]          \n"
-                        "vldm       %1, {d0-d5}         \n" // r00 r01 r02
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmul.f32   q13, q8, d0[0]      \n"
-                        "vmul.f32   q14, q9, d0[1]      \n"
-                        "vmul.f32   q15, q10, d1[0]     \n"
-                        "vmla.f32   q12, q11, d1[1]     \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q13, q8, d2[0]      \n"
-                        "vmla.f32   q14, q9, d2[1]      \n"
-                        "vmla.f32   q15, q10, d3[0]     \n"
-                        "vmla.f32   q12, q11, d3[1]     \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q13, q8, d4[0]      \n"
-                        "vmla.f32   q14, q9, d4[1]      \n"
-                        "vmla.f32   q15, q10, d5[0]     \n"
-                        "vmla.f32   q12, q11, d5[1]     \n"
-
-                        "pld        [%2, #384]          \n"
-                        "vldm       %2, {d0-d5}         \n" // r10 r11 r12
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q13, q8, d0[0]      \n"
-                        "vmla.f32   q14, q9, d0[1]      \n"
-                        "vmla.f32   q15, q10, d1[0]     \n"
-                        "vmla.f32   q12, q11, d1[1]     \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q13, q8, d2[0]      \n"
-                        "vmla.f32   q14, q9, d2[1]      \n"
-                        "vmla.f32   q15, q10, d3[0]     \n"
-                        "vmla.f32   q12, q11, d3[1]     \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q13, q8, d4[0]      \n"
-                        "vmla.f32   q14, q9, d4[1]      \n"
-                        "vmla.f32   q15, q10, d5[0]     \n"
-                        "vmla.f32   q12, q11, d5[1]     \n"
-
-                        "pld        [%3, #384]          \n"
-                        "vldm       %3, {d0-d5}         \n" // r20 r21 r22
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q13, q8, d0[0]      \n"
-                        "vmla.f32   q14, q9, d0[1]      \n"
-                        "vmla.f32   q15, q10, d1[0]     \n"
-                        "vmla.f32   q12, q11, d1[1]     \n"
-
-                        "pld        [%4, #512]          \n"
-                        "vldm       %4!, {d16-d23}      \n"
-
-                        "vmla.f32   q13, q8, d2[0]      \n"
-                        "vmla.f32   q14, q9, d2[1]      \n"
-                        "vmla.f32   q15, q10, d3[0]     \n"
-                        "vmla.f32   q12, q11, d3[1]     \n"
-
-                        //                         "pld        [%4, #512]          \n"
-                        "vldm       %4, {d16-d23}       \n"
-
-                        "vmla.f32   q13, q8, d4[0]      \n"
-                        "vmla.f32   q14, q9, d4[1]      \n"
-                        "vmla.f32   q15, q10, d5[0]     \n"
-                        "vmla.f32   q12, q11, d5[1]     \n"
-
-                        "vadd.f32   q14, q14, q13       \n"
-
-                        "add        %1, %1, #32         \n"
-
-                        "vadd.f32   q15, q15, q14       \n"
-
-                        "add        %2, %2, #32         \n"
-
-                        "vadd.f32   q12, q12, q15       \n"
-
-                        "add        %3, %3, #32         \n"
-
-                        "sub        %4, %4, #512        \n" // kptr -= 8 * 16;
-
-                        "vst1.f32   {d24-d25}, [%0 :128]! \n"
-
-                        : "=r"(outptr0), // %0
-                        "=r"(r0),      // %1
-                        "=r"(r1),      // %2
-                        "=r"(r2),      // %3
-                        "=r"(kptr)     // %4
-                        : "0"(outptr0),
-                        "1"(r0),
-                        "2"(r1),
-                        "3"(r2),
-                        "4"(kptr)
-                        : "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15");
-#endif // __aarch64__
-                }
-
-                r0 += tailstep;
-                r1 += tailstep;
-                r2 += tailstep;
-            }
-        }
-    }
-}
-
-static void conv3x3s2_im2col_sgemm_pack4_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
+static void conv3x3s2_im2col_sgemm_pack4_neon_a53(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
 {
     int w = bottom_blob.w;
     int inch = bottom_blob.c;
@@ -4558,5 +3442,5 @@ static void conv3x3s2_im2col_sgemm_pack4_neon(const Mat& bottom_blob, Mat& top_b
         }
     }
 
-    im2col_sgemm_pack4_neon(bottom_im2col, top_blob, kernel, _bias, opt);
+    im2col_sgemm_pack4_neon_a53(bottom_im2col, top_blob, kernel, _bias, opt);
 }

--- a/src/layer/arm/convolution_3x3_pack4_a53.h
+++ b/src/layer/arm/convolution_3x3_pack4_a53.h
@@ -274,15 +274,15 @@ static void conv3x3s1_winograd64_pack4_neon_a53(const Mat& bottom_blob, Mat& top
 
                         // preload
 
-                        "prfm   pldl1keep, [%4, #128]             \n"
-                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "prfm   pldl1keep, [%4, #128]       \n"
+                        "prfm   pldl1keep, [%3, #128]       \n"
 
                         "ld1    {v6.4s}, [%4], #16          \n"
 
                         "ld1    {v0.4s, v1.4s, v2.4s}, [%3], #48 \n"
 
-                        "prfm   pldl1keep, [%4, #256]             \n"
-                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "prfm   pldl1keep, [%4, #256]       \n"
+                        "prfm   pldl1keep, [%3, #256]       \n"
 
                         "0:                                 \n"
 
@@ -340,9 +340,9 @@ static void conv3x3s1_winograd64_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v23.4s, v7.4s, v0.s[3]      \n"
-                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "prfm   pldl1keep, [%4, #128]       \n"
                         "fmla   v24.4s, v7.4s, v1.s[0]      \n"
-                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "prfm   pldl1keep, [%3, #128]       \n"
                         "fmla   v25.4s, v7.4s, v1.s[1]      \n"
 
                         //v
@@ -350,9 +350,9 @@ static void conv3x3s1_winograd64_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v26.4s, v7.4s, v1.s[2]      \n"
-                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "prfm   pldl1keep, [%4, #256]       \n"
                         "fmla   v27.4s, v7.4s, v1.s[3]      \n"
-                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "prfm   pldl1keep, [%3, #256]       \n"
                         "fmla   v28.4s, v7.4s, v2.s[0]      \n"
 
                         //v
@@ -417,9 +417,9 @@ static void conv3x3s1_winograd64_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v23.4s, v7.4s, v3.s[3]      \n"
-                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "prfm   pldl1keep, [%4, #128]       \n"
                         "fmla   v24.4s, v7.4s, v4.s[0]      \n"
-                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "prfm   pldl1keep, [%3, #128]       \n"
                         "fmla   v25.4s, v7.4s, v4.s[1]      \n"
 
                         //v
@@ -427,9 +427,9 @@ static void conv3x3s1_winograd64_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v26.4s, v7.4s, v4.s[2]      \n"
-                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "prfm   pldl1keep, [%4, #256]       \n"
                         "fmla   v27.4s, v7.4s, v4.s[3]      \n"
-                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "prfm   pldl1keep, [%3, #256]       \n"
                         "fmla   v28.4s, v7.4s, v5.s[0]      \n"
 
                         //v
@@ -494,9 +494,9 @@ static void conv3x3s1_winograd64_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v23.4s, v7.4s, v0.s[3]      \n"
-                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "prfm   pldl1keep, [%4, #128]       \n"
                         "fmla   v24.4s, v7.4s, v1.s[0]      \n"
-                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "prfm   pldl1keep, [%3, #128]       \n"
                         "fmla   v25.4s, v7.4s, v1.s[1]      \n"
 
                         //v
@@ -504,9 +504,9 @@ static void conv3x3s1_winograd64_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v26.4s, v7.4s, v1.s[2]      \n"
-                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "prfm   pldl1keep, [%4, #256]       \n"
                         "fmla   v27.4s, v7.4s, v1.s[3]      \n"
-                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "prfm   pldl1keep, [%3, #256]       \n"
                         "fmla   v28.4s, v7.4s, v2.s[0]      \n"
 
                         //v
@@ -571,9 +571,9 @@ static void conv3x3s1_winograd64_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v23.4s, v7.4s, v3.s[3]      \n"
-                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "prfm   pldl1keep, [%4, #128]       \n"
                         "fmla   v24.4s, v7.4s, v4.s[0]      \n"
-                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "prfm   pldl1keep, [%3, #128]       \n"
                         "fmla   v25.4s, v7.4s, v4.s[1]      \n"
 
                         //v
@@ -581,9 +581,9 @@ static void conv3x3s1_winograd64_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v26.4s, v7.4s, v4.s[2]      \n"
-                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "prfm   pldl1keep, [%4, #256]       \n"
                         "fmla   v27.4s, v7.4s, v4.s[3]      \n"
-                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "prfm   pldl1keep, [%3, #256]       \n"
                         "fmla   v28.4s, v7.4s, v5.s[0]      \n"
 
                         //v
@@ -1599,15 +1599,15 @@ static void conv3x3s1_winograd42_pack4_neon_a53(const Mat& bottom_blob, Mat& top
 
                         // preload
 
-                        "prfm   pldl1keep, [%4, #128]             \n"
-                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "prfm   pldl1keep, [%4, #128]       \n"
+                        "prfm   pldl1keep, [%3, #128]       \n"
 
                         "ld1    {v6.4s}, [%4], #16          \n"
 
                         "ld1    {v0.4s, v1.4s, v2.4s}, [%3], #48 \n"
 
-                        "prfm   pldl1keep, [%4, #256]             \n"
-                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "prfm   pldl1keep, [%4, #256]       \n"
+                        "prfm   pldl1keep, [%3, #256]       \n"
 
                         "0:                                 \n"
 
@@ -1665,9 +1665,9 @@ static void conv3x3s1_winograd42_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v23.4s, v7.4s, v0.s[3]      \n"
-                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "prfm   pldl1keep, [%4, #128]       \n"
                         "fmla   v24.4s, v7.4s, v1.s[0]      \n"
-                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "prfm   pldl1keep, [%3, #128]       \n"
                         "fmla   v25.4s, v7.4s, v1.s[1]      \n"
 
                         //v
@@ -1675,9 +1675,9 @@ static void conv3x3s1_winograd42_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v26.4s, v7.4s, v1.s[2]      \n"
-                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "prfm   pldl1keep, [%4, #256]       \n"
                         "fmla   v27.4s, v7.4s, v1.s[3]      \n"
-                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "prfm   pldl1keep, [%3, #256]       \n"
                         "fmla   v28.4s, v7.4s, v2.s[0]      \n"
 
                         //v
@@ -1742,9 +1742,9 @@ static void conv3x3s1_winograd42_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v23.4s, v7.4s, v3.s[3]      \n"
-                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "prfm   pldl1keep, [%4, #128]       \n"
                         "fmla   v24.4s, v7.4s, v4.s[0]      \n"
-                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "prfm   pldl1keep, [%3, #128]       \n"
                         "fmla   v25.4s, v7.4s, v4.s[1]      \n"
 
                         //v
@@ -1752,9 +1752,9 @@ static void conv3x3s1_winograd42_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v26.4s, v7.4s, v4.s[2]      \n"
-                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "prfm   pldl1keep, [%4, #256]       \n"
                         "fmla   v27.4s, v7.4s, v4.s[3]      \n"
-                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "prfm   pldl1keep, [%3, #256]       \n"
                         "fmla   v28.4s, v7.4s, v5.s[0]      \n"
 
                         //v
@@ -1819,9 +1819,9 @@ static void conv3x3s1_winograd42_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v23.4s, v7.4s, v0.s[3]      \n"
-                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "prfm   pldl1keep, [%4, #128]       \n"
                         "fmla   v24.4s, v7.4s, v1.s[0]      \n"
-                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "prfm   pldl1keep, [%3, #128]       \n"
                         "fmla   v25.4s, v7.4s, v1.s[1]      \n"
 
                         //v
@@ -1829,9 +1829,9 @@ static void conv3x3s1_winograd42_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v26.4s, v7.4s, v1.s[2]      \n"
-                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "prfm   pldl1keep, [%4, #256]       \n"
                         "fmla   v27.4s, v7.4s, v1.s[3]      \n"
-                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "prfm   pldl1keep, [%3, #256]       \n"
                         "fmla   v28.4s, v7.4s, v2.s[0]      \n"
 
                         //v
@@ -1896,9 +1896,9 @@ static void conv3x3s1_winograd42_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v23.4s, v7.4s, v3.s[3]      \n"
-                        "prfm   pldl1keep, [%4, #128]             \n"
+                        "prfm   pldl1keep, [%4, #128]       \n"
                         "fmla   v24.4s, v7.4s, v4.s[0]      \n"
-                        "prfm   pldl1keep, [%3, #128]             \n"
+                        "prfm   pldl1keep, [%3, #128]       \n"
                         "fmla   v25.4s, v7.4s, v4.s[1]      \n"
 
                         //v
@@ -1906,9 +1906,9 @@ static void conv3x3s1_winograd42_pack4_neon_a53(const Mat& bottom_blob, Mat& top
                         "nop                                \n"
 
                         "fmla   v26.4s, v7.4s, v4.s[2]      \n"
-                        "prfm   pldl1keep, [%4, #256]             \n"
+                        "prfm   pldl1keep, [%4, #256]       \n"
                         "fmla   v27.4s, v7.4s, v4.s[3]      \n"
-                        "prfm   pldl1keep, [%3, #256]             \n"
+                        "prfm   pldl1keep, [%3, #256]       \n"
                         "fmla   v28.4s, v7.4s, v5.s[0]      \n"
 
                         //v

--- a/src/layer/arm/convolution_arm.cpp
+++ b/src/layer/arm/convolution_arm.cpp
@@ -486,7 +486,7 @@ int Convolution_arm::forward(const Mat& bottom_blob, Mat& top_blob, const Option
         if (kernel_w == 1 && kernel_h == 1 && dilation_w == 1 && dilation_h == 1 && stride_w == 1 && stride_h == 1)
         {
 #if __aarch64__
-            if (opt.use_a53_optimzed_kernel)
+            if (opt.use_a53_optimized_kernel)
             {
                 conv1x1s1_sgemm_pack4_neon_a53(bottom_blob_bordered, top_blob, weight_data_pack4, bias_data, opt);
             }
@@ -504,7 +504,7 @@ int Convolution_arm::forward(const Mat& bottom_blob, Mat& top_blob, const Option
         else if (kernel_w == 1 && kernel_h == 1 && dilation_w == 1 && dilation_h == 1 && stride_w == 2 && stride_h == 2)
         {
 #if __aarch64__
-            if (opt.use_a53_optimzed_kernel)
+            if (opt.use_a53_optimized_kernel)
             {
                 conv1x1s2_pack4_neon_a53(bottom_blob_bordered, top_blob, weight_data_pack4, bias_data, opt);
             }
@@ -525,7 +525,7 @@ int Convolution_arm::forward(const Mat& bottom_blob, Mat& top_blob, const Option
             if ((w <= 10 || (w >= 15 && w <= 18) || w == 21 || w == 22) && (h <= 10 || (h >= 15 && h <= 18) || h == 21 || h == 22))
             {
 #if __aarch64__
-                if (opt.use_a53_optimzed_kernel)
+                if (opt.use_a53_optimized_kernel)
                 {
                     conv3x3s1_winograd42_pack4_neon_a53(bottom_blob_bordered, top_blob, weight_3x3_winograd42_data_pack4, bias_data, opt);
                 }
@@ -538,7 +538,7 @@ int Convolution_arm::forward(const Mat& bottom_blob, Mat& top_blob, const Option
             else
             {
 #if __aarch64__
-                if (opt.use_a53_optimzed_kernel)
+                if (opt.use_a53_optimized_kernel)
                 {
                     conv3x3s1_winograd64_pack4_neon_a53(bottom_blob_bordered, top_blob, weight_data_pack4, bias_data, opt);
                 }
@@ -565,7 +565,7 @@ int Convolution_arm::forward(const Mat& bottom_blob, Mat& top_blob, const Option
             if (opt.use_sgemm_convolution && prefer_sgemm)
             {
 #if __aarch64__
-                if (opt.use_a53_optimzed_kernel)
+                if (opt.use_a53_optimized_kernel)
                 {
                     conv3x3s2_im2col_sgemm_pack4_neon_a53(bottom_blob_bordered, top_blob, weight_sgemm_data_pack4, bias_data, opt);
                 }
@@ -600,7 +600,7 @@ int Convolution_arm::forward(const Mat& bottom_blob, Mat& top_blob, const Option
             if (opt.use_sgemm_convolution && prefer_sgemm)
             {
 #if __aarch64__
-                if (opt.use_a53_optimzed_kernel)
+                if (opt.use_a53_optimized_kernel)
                 {
                     convolution_im2col_sgemm_pack4_neon_a53(bottom_blob_bordered, top_blob, weight_sgemm_data_pack4, bias_data, kernel_w, kernel_h, dilation_w, dilation_h, stride_w, stride_h, opt);
                 }
@@ -629,7 +629,7 @@ int Convolution_arm::forward(const Mat& bottom_blob, Mat& top_blob, const Option
             if (opt.use_sgemm_convolution && prefer_sgemm)
             {
 #if __aarch64__
-                if (opt.use_a53_optimzed_kernel)
+                if (opt.use_a53_optimized_kernel)
                 {
                     convolution_im2col_sgemm_pack4_neon_a53(bottom_blob_bordered, top_blob, weight_sgemm_data_pack4, bias_data, kernel_w, kernel_h, dilation_w, dilation_h, stride_w, stride_h, opt);
                 }
@@ -652,7 +652,7 @@ int Convolution_arm::forward(const Mat& bottom_blob, Mat& top_blob, const Option
         else if (opt.use_sgemm_convolution && prefer_sgemm)
         {
 #if __aarch64__
-            if (opt.use_a53_optimzed_kernel)
+            if (opt.use_a53_optimized_kernel)
             {
                 convolution_im2col_sgemm_pack4_neon_a53(bottom_blob_bordered, top_blob, weight_sgemm_data_pack4, bias_data, kernel_w, kernel_h, dilation_w, dilation_h, stride_w, stride_h, opt);
             }

--- a/src/layer/arm/convolution_sgemm_pack4_a53.h
+++ b/src/layer/arm/convolution_sgemm_pack4_a53.h
@@ -262,15 +262,15 @@ static void im2col_sgemm_pack4_neon_a53(const Mat& bottom_im2col, Mat& top_blob,
 
                 // preload
 
-                "prfm   pldl1keep, [%4, #128]             \n"
-                "prfm   pldl1keep, [%3, #128]             \n"
+                "prfm   pldl1keep, [%4, #128]       \n"
+                "prfm   pldl1keep, [%3, #128]       \n"
 
                 "ld1    {v6.4s}, [%4], #16          \n"
 
                 "ld1    {v0.4s, v1.4s, v2.4s}, [%3], #48 \n"
 
-                "prfm   pldl1keep, [%4, #256]             \n"
-                "prfm   pldl1keep, [%3, #256]             \n"
+                "prfm   pldl1keep, [%4, #256]       \n"
+                "prfm   pldl1keep, [%3, #256]       \n"
 
                 "0:                                 \n"
 
@@ -328,9 +328,9 @@ static void im2col_sgemm_pack4_neon_a53(const Mat& bottom_im2col, Mat& top_blob,
                 "nop                                \n"
 
                 "fmla   v23.4s, v7.4s, v0.s[3]      \n"
-                "prfm   pldl1keep, [%4, #128]             \n"
+                "prfm   pldl1keep, [%4, #128]       \n"
                 "fmla   v24.4s, v7.4s, v1.s[0]      \n"
-                "prfm   pldl1keep, [%3, #128]             \n"
+                "prfm   pldl1keep, [%3, #128]       \n"
                 "fmla   v25.4s, v7.4s, v1.s[1]      \n"
 
                 //v
@@ -338,9 +338,9 @@ static void im2col_sgemm_pack4_neon_a53(const Mat& bottom_im2col, Mat& top_blob,
                 "nop                                \n"
 
                 "fmla   v26.4s, v7.4s, v1.s[2]      \n"
-                "prfm   pldl1keep, [%4, #256]             \n"
+                "prfm   pldl1keep, [%4, #256]       \n"
                 "fmla   v27.4s, v7.4s, v1.s[3]      \n"
-                "prfm   pldl1keep, [%3, #256]             \n"
+                "prfm   pldl1keep, [%3, #256]       \n"
                 "fmla   v28.4s, v7.4s, v2.s[0]      \n"
 
                 //v
@@ -405,9 +405,9 @@ static void im2col_sgemm_pack4_neon_a53(const Mat& bottom_im2col, Mat& top_blob,
                 "nop                                \n"
 
                 "fmla   v23.4s, v7.4s, v3.s[3]      \n"
-                "prfm   pldl1keep, [%4, #128]             \n"
+                "prfm   pldl1keep, [%4, #128]       \n"
                 "fmla   v24.4s, v7.4s, v4.s[0]      \n"
-                "prfm   pldl1keep, [%3, #128]             \n"
+                "prfm   pldl1keep, [%3, #128]       \n"
                 "fmla   v25.4s, v7.4s, v4.s[1]      \n"
 
                 //v
@@ -415,9 +415,9 @@ static void im2col_sgemm_pack4_neon_a53(const Mat& bottom_im2col, Mat& top_blob,
                 "nop                                \n"
 
                 "fmla   v26.4s, v7.4s, v4.s[2]      \n"
-                "prfm   pldl1keep, [%4, #256]             \n"
+                "prfm   pldl1keep, [%4, #256]       \n"
                 "fmla   v27.4s, v7.4s, v4.s[3]      \n"
-                "prfm   pldl1keep, [%3, #256]             \n"
+                "prfm   pldl1keep, [%3, #256]       \n"
                 "fmla   v28.4s, v7.4s, v5.s[0]      \n"
 
                 //v
@@ -482,9 +482,9 @@ static void im2col_sgemm_pack4_neon_a53(const Mat& bottom_im2col, Mat& top_blob,
                 "nop                                \n"
 
                 "fmla   v23.4s, v7.4s, v0.s[3]      \n"
-                "prfm   pldl1keep, [%4, #128]             \n"
+                "prfm   pldl1keep, [%4, #128]       \n"
                 "fmla   v24.4s, v7.4s, v1.s[0]      \n"
-                "prfm   pldl1keep, [%3, #128]             \n"
+                "prfm   pldl1keep, [%3, #128]       \n"
                 "fmla   v25.4s, v7.4s, v1.s[1]      \n"
 
                 //v
@@ -492,9 +492,9 @@ static void im2col_sgemm_pack4_neon_a53(const Mat& bottom_im2col, Mat& top_blob,
                 "nop                                \n"
 
                 "fmla   v26.4s, v7.4s, v1.s[2]      \n"
-                "prfm   pldl1keep, [%4, #256]             \n"
+                "prfm   pldl1keep, [%4, #256]       \n"
                 "fmla   v27.4s, v7.4s, v1.s[3]      \n"
-                "prfm   pldl1keep, [%3, #256]             \n"
+                "prfm   pldl1keep, [%3, #256]       \n"
                 "fmla   v28.4s, v7.4s, v2.s[0]      \n"
 
                 //v
@@ -559,9 +559,9 @@ static void im2col_sgemm_pack4_neon_a53(const Mat& bottom_im2col, Mat& top_blob,
                 "nop                                \n"
 
                 "fmla   v23.4s, v7.4s, v3.s[3]      \n"
-                "prfm   pldl1keep, [%4, #128]             \n"
+                "prfm   pldl1keep, [%4, #128]       \n"
                 "fmla   v24.4s, v7.4s, v4.s[0]      \n"
-                "prfm   pldl1keep, [%3, #128]             \n"
+                "prfm   pldl1keep, [%3, #128]       \n"
                 "fmla   v25.4s, v7.4s, v4.s[1]      \n"
 
                 //v
@@ -569,9 +569,9 @@ static void im2col_sgemm_pack4_neon_a53(const Mat& bottom_im2col, Mat& top_blob,
                 "nop                                \n"
 
                 "fmla   v26.4s, v7.4s, v4.s[2]      \n"
-                "prfm   pldl1keep, [%4, #256]             \n"
+                "prfm   pldl1keep, [%4, #256]       \n"
                 "fmla   v27.4s, v7.4s, v4.s[3]      \n"
-                "prfm   pldl1keep, [%3, #256]             \n"
+                "prfm   pldl1keep, [%3, #256]       \n"
                 "fmla   v28.4s, v7.4s, v5.s[0]      \n"
 
                 //v

--- a/src/layer/arm/convolution_sgemm_pack4_a53.h
+++ b/src/layer/arm/convolution_sgemm_pack4_a53.h
@@ -1,0 +1,1713 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+static void im2col_sgemm_pack4_neon_a53(const Mat& bottom_im2col, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
+{
+    // Mat bottom_im2col(size, maxk, inch, 16u, 4, opt.workspace_allocator);
+
+    const int size = bottom_im2col.w;
+    const int maxk = bottom_im2col.h;
+    const int inch = bottom_im2col.c;
+
+    const int outch = top_blob.c;
+
+    const float* bias = _bias;
+
+    // permute
+    Mat tmp;
+#if __aarch64__
+    if (size >= 12)
+        tmp.create(12 * maxk, inch, size / 12 + (size % 12) / 8 + (size % 12 % 8) / 4 + (size % 12 % 4) / 2 + size % 12 % 2, 16u, 4, opt.workspace_allocator);
+    else if (size >= 8)
+        tmp.create(8 * maxk, inch, size / 8 + (size % 8) / 4 + (size % 4) / 2 + size % 2, 16u, 4, opt.workspace_allocator);
+    else if (size >= 4)
+        tmp.create(4 * maxk, inch, size / 4 + (size % 4) / 2 + size % 2, 16u, 4, opt.workspace_allocator);
+    else if (size >= 2)
+        tmp.create(2 * maxk, inch, size / 2 + size % 2, 16u, 4, opt.workspace_allocator);
+    else
+        tmp.create(maxk, inch, size, 16u, 4, opt.workspace_allocator);
+#else
+    if (size >= 8)
+        tmp.create(8 * maxk, inch, size / 8 + (size % 8) / 4 + (size % 4) / 2 + size % 2, 16u, 4, opt.workspace_allocator);
+    else if (size >= 4)
+        tmp.create(4 * maxk, inch, size / 4 + (size % 4) / 2 + size % 2, 16u, 4, opt.workspace_allocator);
+    else if (size >= 2)
+        tmp.create(2 * maxk, inch, size / 2 + size % 2, 16u, 4, opt.workspace_allocator);
+    else
+        tmp.create(maxk, inch, size, 16u, 4, opt.workspace_allocator);
+#endif
+    {
+#if __aarch64__
+        int nn_size = size / 12;
+        int remain_size_start = 0;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int ii = 0; ii < nn_size; ii++)
+        {
+            int i = remain_size_start + ii * 12;
+
+            float* tmpptr = tmp.channel(i / 12);
+
+            for (int q = 0; q < inch; q++)
+            {
+                const float* img0 = (const float*)bottom_im2col.channel(q) + i * 4;
+
+                for (int k = 0; k < maxk; k++)
+                {
+                    asm volatile(
+                        "prfm   pldl1keep, [%0, #512]       \n"
+                        "ld4    {v0.4s, v1.4s, v2.4s, v3.4s}, [%0], #64 \n"
+                        "prfm   pldl1keep, [%0, #512]       \n"
+                        "ld4    {v4.4s, v5.4s, v6.4s, v7.4s}, [%0], #64 \n"
+                        "prfm   pldl1keep, [%0, #512]       \n"
+                        "ld4    {v8.4s, v9.4s, v10.4s, v11.4s}, [%0] \n"
+                        "st1    {v0.4s}, [%1], #16          \n"
+                        "st1    {v4.4s}, [%1], #16          \n"
+                        "st1    {v8.4s}, [%1], #16          \n"
+                        "sub    %0, %0, #128                \n"
+                        "st1    {v1.4s}, [%1], #16          \n"
+                        "st1    {v5.4s}, [%1], #16          \n"
+                        "st1    {v9.4s}, [%1], #16          \n"
+                        "st1    {v2.4s}, [%1], #16          \n"
+                        "st1    {v6.4s}, [%1], #16          \n"
+                        "st1    {v10.4s}, [%1], #16         \n"
+                        "st1    {v3.4s}, [%1], #16          \n"
+                        "st1    {v7.4s}, [%1], #16          \n"
+                        "st1    {v11.4s}, [%1], #16         \n"
+                        : "=r"(img0),  // %0
+                        "=r"(tmpptr) // %1
+                        : "0"(img0),
+                        "1"(tmpptr)
+                        : "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11");
+                    img0 += size * 4;
+                }
+            }
+        }
+
+        remain_size_start += nn_size * 12;
+        nn_size = (size - remain_size_start) >> 3;
+#else
+        int nn_size = size >> 3;
+        int remain_size_start = 0;
+#endif
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int ii = 0; ii < nn_size; ii++)
+        {
+            int i = remain_size_start + ii * 8;
+
+#if __aarch64__
+            float* tmpptr = tmp.channel(i / 12 + (i % 12) / 8);
+#else
+            float* tmpptr = tmp.channel(i / 8);
+#endif
+
+            for (int q = 0; q < inch; q++)
+            {
+                const float* img0 = (const float*)bottom_im2col.channel(q) + i * 4;
+
+                for (int k = 0; k < maxk; k++)
+                {
+#if __aarch64__
+                    asm volatile(
+                        "prfm   pldl1keep, [%0, #512]       \n"
+                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%0], #64 \n"
+                        "prfm   pldl1keep, [%0, #512]       \n"
+                        "ld1    {v4.4s, v5.4s, v6.4s, v7.4s}, [%0] \n"
+                        "st1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%1], #64 \n"
+                        "sub    %0, %0, #64                 \n"
+                        "st1    {v4.4s, v5.4s, v6.4s, v7.4s}, [%1], #64 \n"
+                        : "=r"(img0),  // %0
+                        "=r"(tmpptr) // %1
+                        : "0"(img0),
+                        "1"(tmpptr)
+                        : "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7");
+#else
+                    asm volatile(
+                        "pld        [%0, #512]          \n"
+                        "vldm       %0!, {d0-d7}        \n"
+                        "pld        [%0, #512]          \n"
+                        "vldm       %0, {d16-d23}       \n"
+
+                        // transpose 8x4
+                        "vtrn.32    q0, q1              \n"
+                        "vtrn.32    q2, q3              \n"
+                        "vtrn.32    q8, q9              \n"
+                        "vtrn.32    q10, q11            \n"
+                        "vswp       d1, d4              \n"
+                        "vswp       d3, d6              \n"
+                        "vswp       d17, d20            \n"
+                        "vswp       d19, d22            \n"
+                        "vswp       q1, q8              \n"
+                        "vswp       q3, q10             \n"
+
+                        "vst1.f32   {d0-d3}, [%1 :128]! \n"
+                        "vst1.f32   {d16-d19}, [%1 :128]! \n"
+                        "sub        %0, %0, #64         \n"
+                        "vst1.f32   {d4-d7}, [%1 :128]! \n"
+                        "vst1.f32   {d20-d23}, [%1 :128]! \n"
+                        : "=r"(img0),  // %0
+                        "=r"(tmpptr) // %1
+                        : "0"(img0),
+                        "1"(tmpptr)
+                        : "memory", "q0", "q1", "q2", "q3", "q8", "q9", "q10", "q11");
+#endif // __aarch64__
+                    img0 += size * 4;
+                }
+            }
+        }
+
+        remain_size_start += nn_size << 3;
+        nn_size = (size - remain_size_start) >> 2;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int ii = 0; ii < nn_size; ii++)
+        {
+            int i = remain_size_start + ii * 4;
+
+#if __aarch64__
+            float* tmpptr = tmp.channel(i / 12 + (i % 12) / 8 + (i % 12 % 8) / 4);
+#else
+            float* tmpptr = tmp.channel(i / 8 + (i % 8) / 4);
+#endif
+
+            for (int q = 0; q < inch; q++)
+            {
+                const float* img0 = (const float*)bottom_im2col.channel(q) + i * 4;
+
+                for (int k = 0; k < maxk; k++)
+                {
+#if __aarch64__
+                    asm volatile(
+                        "prfm   pldl1keep, [%0, #512]       \n"
+                        "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%0] \n"
+                        "st1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%1], #64 \n"
+                        : "=r"(img0),  // %0
+                        "=r"(tmpptr) // %1
+                        : "0"(img0),
+                        "1"(tmpptr)
+                        : "memory", "v0", "v1", "v2", "v3");
+#else
+                    asm volatile(
+                        "pld        [%0, #512]          \n"
+                        "vldm       %0, {d0-d7}         \n"
+                        "vstm       %1!, {d0-d7}        \n"
+                        : "=r"(img0),  // %0
+                        "=r"(tmpptr) // %1
+                        : "0"(img0),
+                        "1"(tmpptr)
+                        : "memory", "q0", "q1", "q2", "q3");
+#endif // __aarch64__
+                    img0 += size * 4;
+                }
+            }
+        }
+
+        remain_size_start += nn_size << 2;
+        nn_size = (size - remain_size_start) >> 1;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int ii = 0; ii < nn_size; ii++)
+        {
+            int i = remain_size_start + ii * 2;
+
+#if __aarch64__
+            float* tmpptr = tmp.channel(i / 12 + (i % 12) / 8 + (i % 12 % 8) / 4 + (i % 12 % 4) / 2);
+#else
+            float* tmpptr = tmp.channel(i / 8 + (i % 8) / 4 + (i % 4) / 2);
+#endif
+
+            for (int q = 0; q < inch; q++)
+            {
+                const float* img0 = (const float*)bottom_im2col.channel(q) + i * 4;
+
+                for (int k = 0; k < maxk; k++)
+                {
+#if __aarch64__
+                    asm volatile(
+                        "prfm   pldl1keep, [%0, #256]       \n"
+                        "ld1    {v0.4s, v1.4s}, [%0]        \n"
+                        "st1    {v0.4s, v1.4s}, [%1], #32   \n"
+                        : "=r"(img0),  // %0
+                        "=r"(tmpptr) // %1
+                        : "0"(img0),
+                        "1"(tmpptr)
+                        : "memory", "v0", "v1");
+#else
+                    asm volatile(
+                        "pld        [%0, #256]          \n"
+                        "vld1.f32   {d0-d3}, [%0 :128]  \n"
+                        "vst1.f32   {d0-d3}, [%1 :128]! \n"
+                        : "=r"(img0),  // %0
+                        "=r"(tmpptr) // %1
+                        : "0"(img0),
+                        "1"(tmpptr)
+                        : "memory", "q0", "q1");
+#endif // __aarch64__
+                    img0 += size * 4;
+                }
+            }
+        }
+
+        remain_size_start += nn_size << 1;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int i = remain_size_start; i < size; i++)
+        {
+#if __aarch64__
+            float* tmpptr = tmp.channel(i / 12 + (i % 12) / 8 + (i % 12 % 8) / 4 + (i % 12 % 4) / 2 + i % 12 % 2);
+#else
+            float* tmpptr = tmp.channel(i / 8 + (i % 8) / 4 + (i % 4) / 2 + i % 2);
+#endif
+
+            for (int q = 0; q < inch; q++)
+            {
+                const float* img0 = (const float*)bottom_im2col.channel(q) + i * 4;
+
+                for (int k = 0; k < maxk; k++)
+                {
+#if __aarch64__
+                    asm volatile(
+                        "prfm   pldl1keep, [%0, #128]       \n"
+                        "ld1    {v0.4s}, [%0]               \n"
+                        "st1    {v0.4s}, [%1], #16          \n"
+                        : "=r"(img0),  // %0
+                        "=r"(tmpptr) // %1
+                        : "0"(img0),
+                        "1"(tmpptr)
+                        : "memory", "v0");
+#else
+                    asm volatile(
+                        "pld        [%0, #128]          \n"
+                        "vld1.f32   {d0-d1}, [%0 :128]  \n"
+                        "vst1.f32   {d0-d1}, [%1 :128]! \n"
+                        : "=r"(img0),  // %0
+                        "=r"(tmpptr) // %1
+                        : "0"(img0),
+                        "1"(tmpptr)
+                        : "memory", "q0");
+#endif // __aarch64__
+                    img0 += size * 4;
+                }
+            }
+        }
+    }
+
+    int remain_outch_start = 0;
+
+#if __aarch64__
+    int nn_outch = outch >> 1;
+    remain_outch_start = nn_outch << 1;
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int pp = 0; pp < nn_outch; pp++)
+    {
+        int p = pp * 2;
+
+        float* outptr0 = top_blob.channel(p);
+        float* outptr1 = top_blob.channel(p + 1);
+
+        const float zeros[8] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+        const float* biasptr = bias ? bias + p * 4 : zeros;
+
+        int i = 0;
+        for (; i + 11 < size; i += 12)
+        {
+            const float* tmpptr = tmp.channel(i / 12);
+            const float* kptr0 = kernel.channel(p / 2);
+
+            int nn = inch * maxk; // inch always > 0
+
+            asm volatile(
+                "ld1    {v0.4s, v1.4s}, [%10]       \n"
+                "mov    v8.16b, v0.16b              \n"
+                "mov    v9.16b, v0.16b              \n"
+                "mov    v10.16b, v0.16b             \n"
+                "mov    v11.16b, v0.16b             \n"
+                "mov    v12.16b, v0.16b             \n"
+                "mov    v13.16b, v0.16b             \n"
+                "mov    v14.16b, v0.16b             \n"
+                "mov    v15.16b, v0.16b             \n"
+                "mov    v16.16b, v0.16b             \n"
+                "mov    v17.16b, v0.16b             \n"
+                "mov    v18.16b, v0.16b             \n"
+                "mov    v19.16b, v0.16b             \n"
+                "mov    v20.16b, v1.16b             \n"
+                "mov    v21.16b, v1.16b             \n"
+                "mov    v22.16b, v1.16b             \n"
+                "mov    v23.16b, v1.16b             \n"
+                "mov    v24.16b, v1.16b             \n"
+                "mov    v25.16b, v1.16b             \n"
+                "mov    v26.16b, v1.16b             \n"
+                "mov    v27.16b, v1.16b             \n"
+                "mov    v28.16b, v1.16b             \n"
+                "mov    v29.16b, v1.16b             \n"
+                "mov    v30.16b, v1.16b             \n"
+                "mov    v31.16b, v1.16b             \n"
+
+                // preload
+
+                "prfm   pldl1keep, [%4, #128]             \n"
+                "prfm   pldl1keep, [%3, #128]             \n"
+
+                "ld1    {v6.4s}, [%4], #16          \n"
+
+                "ld1    {v0.4s, v1.4s, v2.4s}, [%3], #48 \n"
+
+                "prfm   pldl1keep, [%4, #256]             \n"
+                "prfm   pldl1keep, [%3, #256]             \n"
+
+                "0:                                 \n"
+
+                //v
+                "ldr    d7, [%4]                    \n"
+
+                "fmla   v8.4s, v6.4s, v0.s[0]       \n"
+                "ldr    x23, [%4, #8]               \n"
+                "fmla   v9.4s, v6.4s, v0.s[1]       \n"
+                "add    %4, %4, #16                 \n"
+                "fmla   v10.4s, v6.4s, v0.s[2]      \n"
+
+                //v
+                "ldr    d3, [%3]                    \n"
+                "ins    v7.d[1], x23                \n"
+
+                "fmla   v11.4s, v6.4s, v0.s[3]      \n"
+                "ldr    x23, [%3, #8]               \n"
+                "fmla   v12.4s, v6.4s, v1.s[0]      \n"
+                "add    %3, %3, #16                 \n"
+                "fmla   v13.4s, v6.4s, v1.s[1]      \n"
+
+                //v
+                "ldr    d4, [%3]                    \n"
+                "ins    v3.d[1], x23                \n"
+
+                "fmla   v14.4s, v6.4s, v1.s[2]      \n"
+                "ldr    x23, [%3, #8]               \n"
+                "fmla   v15.4s, v6.4s, v1.s[3]      \n"
+                "add    %3, %3, #16                 \n"
+                "fmla   v16.4s, v6.4s, v2.s[0]      \n"
+
+                //v
+                "ldr    d5, [%3]                    \n"
+                "ins    v4.d[1], x23                \n"
+
+                "fmla   v17.4s, v6.4s, v2.s[1]      \n"
+                "ldr    x23, [%3, #8]               \n"
+                "fmla   v18.4s, v6.4s, v2.s[2]      \n"
+                "add    %3, %3, #16                 \n"
+                "fmla   v19.4s, v6.4s, v2.s[3]      \n"
+
+                //v
+                "ldr    d6, [%4]                    \n"
+                "ins    v5.d[1], x23                \n"
+
+                "fmla   v20.4s, v7.4s, v0.s[0]      \n"
+                "ldr    x23, [%4, #8]               \n"
+                "fmla   v21.4s, v7.4s, v0.s[1]      \n"
+                "add    %4, %4, #16                 \n"
+                "fmla   v22.4s, v7.4s, v0.s[2]      \n"
+
+                //v
+                "ins    v6.d[1], x23                \n"
+                "nop                                \n"
+
+                "fmla   v23.4s, v7.4s, v0.s[3]      \n"
+                "prfm   pldl1keep, [%4, #128]             \n"
+                "fmla   v24.4s, v7.4s, v1.s[0]      \n"
+                "prfm   pldl1keep, [%3, #128]             \n"
+                "fmla   v25.4s, v7.4s, v1.s[1]      \n"
+
+                //v
+                "nop                                \n"
+                "nop                                \n"
+
+                "fmla   v26.4s, v7.4s, v1.s[2]      \n"
+                "prfm   pldl1keep, [%4, #256]             \n"
+                "fmla   v27.4s, v7.4s, v1.s[3]      \n"
+                "prfm   pldl1keep, [%3, #256]             \n"
+                "fmla   v28.4s, v7.4s, v2.s[0]      \n"
+
+                //v
+                "nop                                \n"
+                "nop                                \n"
+
+                "fmla   v29.4s, v7.4s, v2.s[1]      \n"
+                "fmla   v30.4s, v7.4s, v2.s[2]      \n"
+                "fmla   v31.4s, v7.4s, v2.s[3]      \n"
+
+                //v
+                "ldr    d7, [%4]                    \n"
+
+                "fmla   v8.4s, v6.4s, v3.s[0]       \n"
+                "ldr    x23, [%4, #8]               \n"
+                "fmla   v9.4s, v6.4s, v3.s[1]       \n"
+                "add    %4, %4, #16                 \n"
+                "fmla   v10.4s, v6.4s, v3.s[2]      \n"
+
+                //v
+                "ldr    d0, [%3]                    \n"
+                "ins    v7.d[1], x23                \n"
+
+                "fmla   v11.4s, v6.4s, v3.s[3]      \n"
+                "ldr    x23, [%3, #8]               \n"
+                "fmla   v12.4s, v6.4s, v4.s[0]      \n"
+                "add    %3, %3, #16                 \n"
+                "fmla   v13.4s, v6.4s, v4.s[1]      \n"
+
+                //v
+                "ldr    d1, [%3]                    \n"
+                "ins    v0.d[1], x23                \n"
+
+                "fmla   v14.4s, v6.4s, v4.s[2]      \n"
+                "ldr    x23, [%3, #8]               \n"
+                "fmla   v15.4s, v6.4s, v4.s[3]      \n"
+                "add    %3, %3, #16                 \n"
+                "fmla   v16.4s, v6.4s, v5.s[0]      \n"
+
+                //v
+                "ldr    d2, [%3]                    \n"
+                "ins    v1.d[1], x23                \n"
+
+                "fmla   v17.4s, v6.4s, v5.s[1]      \n"
+                "ldr    x23, [%3, #8]               \n"
+                "fmla   v18.4s, v6.4s, v5.s[2]      \n"
+                "add    %3, %3, #16                 \n"
+                "fmla   v19.4s, v6.4s, v5.s[3]      \n"
+
+                //v
+                "ldr    d6, [%4]                    \n"
+                "ins    v2.d[1], x23                \n"
+
+                "fmla   v20.4s, v7.4s, v3.s[0]      \n"
+                "ldr    x23, [%4, #8]               \n"
+                "fmla   v21.4s, v7.4s, v3.s[1]      \n"
+                "add    %4, %4, #16                 \n"
+                "fmla   v22.4s, v7.4s, v3.s[2]      \n"
+
+                //v
+                "ins    v6.d[1], x23                \n"
+                "nop                                \n"
+
+                "fmla   v23.4s, v7.4s, v3.s[3]      \n"
+                "prfm   pldl1keep, [%4, #128]             \n"
+                "fmla   v24.4s, v7.4s, v4.s[0]      \n"
+                "prfm   pldl1keep, [%3, #128]             \n"
+                "fmla   v25.4s, v7.4s, v4.s[1]      \n"
+
+                //v
+                "nop                                \n"
+                "nop                                \n"
+
+                "fmla   v26.4s, v7.4s, v4.s[2]      \n"
+                "prfm   pldl1keep, [%4, #256]             \n"
+                "fmla   v27.4s, v7.4s, v4.s[3]      \n"
+                "prfm   pldl1keep, [%3, #256]             \n"
+                "fmla   v28.4s, v7.4s, v5.s[0]      \n"
+
+                //v
+                "nop                                \n"
+                "nop                                \n"
+
+                "fmla   v29.4s, v7.4s, v5.s[1]      \n"
+                "fmla   v30.4s, v7.4s, v5.s[2]      \n"
+                "fmla   v31.4s, v7.4s, v5.s[3]      \n"
+
+                //v
+                "ldr    d7, [%4]                    \n"
+
+                "fmla   v8.4s, v6.4s, v0.s[0]       \n"
+                "ldr    x23, [%4, #8]               \n"
+                "fmla   v9.4s, v6.4s, v0.s[1]       \n"
+                "add    %4, %4, #16                 \n"
+                "fmla   v10.4s, v6.4s, v0.s[2]      \n"
+
+                //v
+                "ldr    d3, [%3]                    \n"
+                "ins    v7.d[1], x23                \n"
+
+                "fmla   v11.4s, v6.4s, v0.s[3]      \n"
+                "ldr    x23, [%3, #8]               \n"
+                "fmla   v12.4s, v6.4s, v1.s[0]      \n"
+                "add    %3, %3, #16                 \n"
+                "fmla   v13.4s, v6.4s, v1.s[1]      \n"
+
+                //v
+                "ldr    d4, [%3]                    \n"
+                "ins    v3.d[1], x23                \n"
+
+                "fmla   v14.4s, v6.4s, v1.s[2]      \n"
+                "ldr    x23, [%3, #8]               \n"
+                "fmla   v15.4s, v6.4s, v1.s[3]      \n"
+                "add    %3, %3, #16                 \n"
+                "fmla   v16.4s, v6.4s, v2.s[0]      \n"
+
+                //v
+                "ldr    d5, [%3]                    \n"
+                "ins    v4.d[1], x23                \n"
+
+                "fmla   v17.4s, v6.4s, v2.s[1]      \n"
+                "ldr    x23, [%3, #8]               \n"
+                "fmla   v18.4s, v6.4s, v2.s[2]      \n"
+                "add    %3, %3, #16                 \n"
+                "fmla   v19.4s, v6.4s, v2.s[3]      \n"
+
+                //v
+                "ldr    d6, [%4]                    \n"
+                "ins    v5.d[1], x23                \n"
+
+                "fmla   v20.4s, v7.4s, v0.s[0]      \n"
+                "ldr    x23, [%4, #8]               \n"
+                "fmla   v21.4s, v7.4s, v0.s[1]      \n"
+                "add    %4, %4, #16                 \n"
+                "fmla   v22.4s, v7.4s, v0.s[2]      \n"
+
+                //v
+                "ins    v6.d[1], x23                \n"
+                "nop                                \n"
+
+                "fmla   v23.4s, v7.4s, v0.s[3]      \n"
+                "prfm   pldl1keep, [%4, #128]             \n"
+                "fmla   v24.4s, v7.4s, v1.s[0]      \n"
+                "prfm   pldl1keep, [%3, #128]             \n"
+                "fmla   v25.4s, v7.4s, v1.s[1]      \n"
+
+                //v
+                "nop                                \n"
+                "nop                                \n"
+
+                "fmla   v26.4s, v7.4s, v1.s[2]      \n"
+                "prfm   pldl1keep, [%4, #256]             \n"
+                "fmla   v27.4s, v7.4s, v1.s[3]      \n"
+                "prfm   pldl1keep, [%3, #256]             \n"
+                "fmla   v28.4s, v7.4s, v2.s[0]      \n"
+
+                //v
+                "nop                                \n"
+                "nop                                \n"
+
+                "fmla   v29.4s, v7.4s, v2.s[1]      \n"
+                "fmla   v30.4s, v7.4s, v2.s[2]      \n"
+                "fmla   v31.4s, v7.4s, v2.s[3]      \n"
+
+                //v
+                "ldr    d7, [%4]                    \n"
+
+                "fmla   v8.4s, v6.4s, v3.s[0]       \n"
+                "ldr    x23, [%4, #8]               \n"
+                "fmla   v9.4s, v6.4s, v3.s[1]       \n"
+                "add    %4, %4, #16                 \n"
+                "fmla   v10.4s, v6.4s, v3.s[2]      \n"
+
+                //v
+                "ldr    d0, [%3]                    \n"
+                "ins    v7.d[1], x23                \n"
+
+                "fmla   v11.4s, v6.4s, v3.s[3]      \n"
+                "ldr    x23, [%3, #8]               \n"
+                "fmla   v12.4s, v6.4s, v4.s[0]      \n"
+                "add    %3, %3, #16                 \n"
+                "fmla   v13.4s, v6.4s, v4.s[1]      \n"
+
+                //v
+                "ldr    d1, [%3]                    \n"
+                "ins    v0.d[1], x23                \n"
+
+                "fmla   v14.4s, v6.4s, v4.s[2]      \n"
+                "ldr    x23, [%3, #8]               \n"
+                "fmla   v15.4s, v6.4s, v4.s[3]      \n"
+                "add    %3, %3, #16                 \n"
+                "fmla   v16.4s, v6.4s, v5.s[0]      \n"
+
+                //v
+                "ldr    d2, [%3]                    \n"
+                "ins    v1.d[1], x23                \n"
+
+                "fmla   v17.4s, v6.4s, v5.s[1]      \n"
+                "ldr    x23, [%3, #8]               \n"
+                "fmla   v18.4s, v6.4s, v5.s[2]      \n"
+                "add    %3, %3, #16                 \n"
+                "fmla   v19.4s, v6.4s, v5.s[3]      \n"
+
+                //v
+                "ldr    d6, [%4]                    \n"
+                "ins    v2.d[1], x23                \n"
+
+                "fmla   v20.4s, v7.4s, v3.s[0]      \n"
+                "ldr    x23, [%4, #8]               \n"
+                "fmla   v21.4s, v7.4s, v3.s[1]      \n"
+                "add    %4, %4, #16                 \n"
+                "fmla   v22.4s, v7.4s, v3.s[2]      \n"
+
+                //v
+                "ins    v6.d[1], x23                \n"
+                "nop                                \n"
+
+                "fmla   v23.4s, v7.4s, v3.s[3]      \n"
+                "prfm   pldl1keep, [%4, #128]             \n"
+                "fmla   v24.4s, v7.4s, v4.s[0]      \n"
+                "prfm   pldl1keep, [%3, #128]             \n"
+                "fmla   v25.4s, v7.4s, v4.s[1]      \n"
+
+                //v
+                "nop                                \n"
+                "nop                                \n"
+
+                "fmla   v26.4s, v7.4s, v4.s[2]      \n"
+                "prfm   pldl1keep, [%4, #256]             \n"
+                "fmla   v27.4s, v7.4s, v4.s[3]      \n"
+                "prfm   pldl1keep, [%3, #256]             \n"
+                "fmla   v28.4s, v7.4s, v5.s[0]      \n"
+
+                //v
+                "nop                                \n"
+                "nop                                \n"
+
+                "fmla   v29.4s, v7.4s, v5.s[1]      \n"
+                "fmla   v30.4s, v7.4s, v5.s[2]      \n"
+                "fmla   v31.4s, v7.4s, v5.s[3]      \n"
+
+                "subs   %w0, %w0, #1                \n"
+
+                // preload
+
+                "bne    0b                          \n"
+
+                "sub    %4, %4, #16                 \n"
+                "sub    %3, %3, #48                 \n"
+
+                "st1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%1], #64 \n"
+                "st1    {v20.4s, v21.4s, v22.4s, v23.4s}, [%2], #64 \n"
+                "st1    {v12.4s, v13.4s, v14.4s, v15.4s}, [%1], #64 \n"
+                "st1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%2], #64 \n"
+                "st1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%1], #64 \n"
+                "st1    {v28.4s, v29.4s, v30.4s, v31.4s}, [%2], #64 \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(outptr1), // %2
+                "=r"(tmpptr),  // %3
+                "=r"(kptr0)    // %4
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(outptr1),
+                "3"(tmpptr),
+                "4"(kptr0),
+                "r"(biasptr) // %10
+                : "cc", "memory", "x23", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31");
+        }
+        for (; i + 7 < size; i += 8)
+        {
+            const float* tmpptr = tmp.channel(i / 12 + (i % 12) / 8);
+            const float* kptr0 = kernel.channel(p / 2);
+
+            int nn = inch * maxk; // inch always > 0
+
+            asm volatile(
+                "ld1    {v0.4s, v1.4s}, [%10]       \n"
+                "mov    v16.16b, v0.16b             \n"
+                "mov    v17.16b, v0.16b             \n"
+                "mov    v18.16b, v0.16b             \n"
+                "mov    v19.16b, v0.16b             \n"
+                "mov    v20.16b, v0.16b             \n"
+                "mov    v21.16b, v0.16b             \n"
+                "mov    v22.16b, v0.16b             \n"
+                "mov    v23.16b, v0.16b             \n"
+                "mov    v24.16b, v1.16b             \n"
+                "mov    v25.16b, v1.16b             \n"
+                "mov    v26.16b, v1.16b             \n"
+                "mov    v27.16b, v1.16b             \n"
+                "mov    v28.16b, v1.16b             \n"
+                "mov    v29.16b, v1.16b             \n"
+                "mov    v30.16b, v1.16b             \n"
+                "mov    v31.16b, v1.16b             \n"
+
+                "0:                                 \n"
+
+                "prfm   pldl1keep, [%3, #512]       \n"
+                "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%3], #64 \n" // r0 r1 r2 r3
+
+                "prfm   pldl1keep, [%4, #512]       \n"
+                "ld1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%4], #64 \n" // w0011_01
+
+                "fmla   v16.4s, v8.4s, v0.s[0]      \n"
+                "fmla   v17.4s, v8.4s, v1.s[0]      \n"
+                "fmla   v18.4s, v8.4s, v2.s[0]      \n"
+                "fmla   v19.4s, v8.4s, v3.s[0]      \n"
+
+                "prfm   pldl1keep, [%3, #512]       \n"
+                "ld1    {v4.4s, v5.4s, v6.4s, v7.4s}, [%3], #64 \n" // r4 r5 r6 r7
+
+                "fmla   v20.4s, v8.4s, v4.s[0]      \n"
+                "fmla   v21.4s, v8.4s, v5.s[0]      \n"
+                "fmla   v22.4s, v8.4s, v6.s[0]      \n"
+                "fmla   v23.4s, v8.4s, v7.s[0]      \n"
+
+                "fmla   v24.4s, v9.4s, v0.s[0]      \n"
+                "fmla   v25.4s, v9.4s, v1.s[0]      \n"
+                "fmla   v26.4s, v9.4s, v2.s[0]      \n"
+                "fmla   v27.4s, v9.4s, v3.s[0]      \n"
+                "fmla   v28.4s, v9.4s, v4.s[0]      \n"
+                "fmla   v29.4s, v9.4s, v5.s[0]      \n"
+                "fmla   v30.4s, v9.4s, v6.s[0]      \n"
+                "fmla   v31.4s, v9.4s, v7.s[0]      \n"
+
+                "fmla   v16.4s, v10.4s, v0.s[1]     \n"
+                "fmla   v17.4s, v10.4s, v1.s[1]     \n"
+                "fmla   v18.4s, v10.4s, v2.s[1]     \n"
+                "fmla   v19.4s, v10.4s, v3.s[1]     \n"
+                "fmla   v20.4s, v10.4s, v4.s[1]     \n"
+                "fmla   v21.4s, v10.4s, v5.s[1]     \n"
+                "fmla   v22.4s, v10.4s, v6.s[1]     \n"
+                "fmla   v23.4s, v10.4s, v7.s[1]     \n"
+
+                "fmla   v24.4s, v11.4s, v0.s[1]     \n"
+                "fmla   v25.4s, v11.4s, v1.s[1]     \n"
+                "fmla   v26.4s, v11.4s, v2.s[1]     \n"
+                "fmla   v27.4s, v11.4s, v3.s[1]     \n"
+                "fmla   v28.4s, v11.4s, v4.s[1]     \n"
+                "fmla   v29.4s, v11.4s, v5.s[1]     \n"
+                "fmla   v30.4s, v11.4s, v6.s[1]     \n"
+                "fmla   v31.4s, v11.4s, v7.s[1]     \n"
+
+                "prfm   pldl1keep, [%4, #512]       \n"
+                "ld1    {v12.4s, v13.4s, v14.4s, v15.4s}, [%4], #64 \n" // w2233_01
+
+                "fmla   v16.4s, v12.4s, v0.s[2]     \n"
+                "fmla   v17.4s, v12.4s, v1.s[2]     \n"
+                "fmla   v18.4s, v12.4s, v2.s[2]     \n"
+                "fmla   v19.4s, v12.4s, v3.s[2]     \n"
+                "fmla   v20.4s, v12.4s, v4.s[2]     \n"
+                "fmla   v21.4s, v12.4s, v5.s[2]     \n"
+                "fmla   v22.4s, v12.4s, v6.s[2]     \n"
+                "fmla   v23.4s, v12.4s, v7.s[2]     \n"
+
+                "fmla   v24.4s, v13.4s, v0.s[2]     \n"
+                "fmla   v25.4s, v13.4s, v1.s[2]     \n"
+                "fmla   v26.4s, v13.4s, v2.s[2]     \n"
+                "fmla   v27.4s, v13.4s, v3.s[2]     \n"
+                "fmla   v28.4s, v13.4s, v4.s[2]     \n"
+                "fmla   v29.4s, v13.4s, v5.s[2]     \n"
+                "fmla   v30.4s, v13.4s, v6.s[2]     \n"
+                "fmla   v31.4s, v13.4s, v7.s[2]     \n"
+
+                "fmla   v16.4s, v14.4s, v0.s[3]     \n"
+                "fmla   v17.4s, v14.4s, v1.s[3]     \n"
+                "fmla   v18.4s, v14.4s, v2.s[3]     \n"
+                "fmla   v19.4s, v14.4s, v3.s[3]     \n"
+                "fmla   v20.4s, v14.4s, v4.s[3]     \n"
+                "fmla   v21.4s, v14.4s, v5.s[3]     \n"
+                "fmla   v22.4s, v14.4s, v6.s[3]     \n"
+                "fmla   v23.4s, v14.4s, v7.s[3]     \n"
+
+                "subs   %w0, %w0, #1                \n"
+
+                "fmla   v24.4s, v15.4s, v0.s[3]     \n"
+                "fmla   v25.4s, v15.4s, v1.s[3]     \n"
+                "fmla   v26.4s, v15.4s, v2.s[3]     \n"
+                "fmla   v27.4s, v15.4s, v3.s[3]     \n"
+                "fmla   v28.4s, v15.4s, v4.s[3]     \n"
+                "fmla   v29.4s, v15.4s, v5.s[3]     \n"
+                "fmla   v30.4s, v15.4s, v6.s[3]     \n"
+                "fmla   v31.4s, v15.4s, v7.s[3]     \n"
+
+                "bne    0b                          \n"
+
+                "st1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%1], #64 \n"
+                "st1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%2], #64 \n"
+                "st1    {v20.4s, v21.4s, v22.4s, v23.4s}, [%1], #64 \n"
+                "st1    {v28.4s, v29.4s, v30.4s, v31.4s}, [%2], #64 \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(outptr1), // %2
+                "=r"(tmpptr),  // %3
+                "=r"(kptr0)    // %4
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(outptr1),
+                "3"(tmpptr),
+                "4"(kptr0),
+                "r"(biasptr) // %10
+                : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31");
+        }
+        for (; i + 3 < size; i += 4)
+        {
+            const float* tmpptr = tmp.channel(i / 12 + (i % 12) / 8 + (i % 12 % 8) / 4);
+            const float* kptr0 = kernel.channel(p / 2);
+
+            int nn = inch * maxk; // inch always > 0
+
+            asm volatile(
+                "ld1    {v0.4s, v1.4s}, [%10]       \n"
+                "mov    v16.16b, v0.16b             \n"
+                "mov    v17.16b, v0.16b             \n"
+                "mov    v18.16b, v0.16b             \n"
+                "mov    v19.16b, v0.16b             \n"
+                "mov    v20.16b, v1.16b             \n"
+                "mov    v21.16b, v1.16b             \n"
+                "mov    v22.16b, v1.16b             \n"
+                "mov    v23.16b, v1.16b             \n"
+
+                "0:                                 \n"
+
+                "prfm   pldl1keep, [%3, #512]       \n"
+                "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%3], #64 \n" // r0 r1 r2 r3
+
+                "prfm   pldl1keep, [%4, #512]       \n"
+                "ld1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%4], #64 \n" // w0011_01
+
+                "fmla   v16.4s, v8.4s, v0.s[0]      \n"
+                "fmla   v17.4s, v8.4s, v1.s[0]      \n"
+                "fmla   v18.4s, v8.4s, v2.s[0]      \n"
+                "fmla   v19.4s, v8.4s, v3.s[0]      \n"
+
+                "fmla   v20.4s, v9.4s, v0.s[0]      \n"
+                "fmla   v21.4s, v9.4s, v1.s[0]      \n"
+                "fmla   v22.4s, v9.4s, v2.s[0]      \n"
+                "fmla   v23.4s, v9.4s, v3.s[0]      \n"
+
+                "prfm   pldl1keep, [%4, #512]       \n"
+                "ld1    {v12.4s, v13.4s, v14.4s, v15.4s}, [%4], #64 \n" // w2233_01
+
+                "fmla   v16.4s, v10.4s, v0.s[1]     \n"
+                "fmla   v17.4s, v10.4s, v1.s[1]     \n"
+                "fmla   v18.4s, v10.4s, v2.s[1]     \n"
+                "fmla   v19.4s, v10.4s, v3.s[1]     \n"
+
+                "fmla   v20.4s, v11.4s, v0.s[1]     \n"
+                "fmla   v21.4s, v11.4s, v1.s[1]     \n"
+                "fmla   v22.4s, v11.4s, v2.s[1]     \n"
+                "fmla   v23.4s, v11.4s, v3.s[1]     \n"
+
+                "fmla   v16.4s, v12.4s, v0.s[2]     \n"
+                "fmla   v17.4s, v12.4s, v1.s[2]     \n"
+                "fmla   v18.4s, v12.4s, v2.s[2]     \n"
+                "fmla   v19.4s, v12.4s, v3.s[2]     \n"
+
+                "fmla   v20.4s, v13.4s, v0.s[2]     \n"
+                "fmla   v21.4s, v13.4s, v1.s[2]     \n"
+                "fmla   v22.4s, v13.4s, v2.s[2]     \n"
+                "fmla   v23.4s, v13.4s, v3.s[2]     \n"
+
+                "subs   %w0, %w0, #1                \n"
+
+                "fmla   v16.4s, v14.4s, v0.s[3]     \n"
+                "fmla   v17.4s, v14.4s, v1.s[3]     \n"
+                "fmla   v18.4s, v14.4s, v2.s[3]     \n"
+                "fmla   v19.4s, v14.4s, v3.s[3]     \n"
+
+                "fmla   v20.4s, v15.4s, v0.s[3]     \n"
+                "fmla   v21.4s, v15.4s, v1.s[3]     \n"
+                "fmla   v22.4s, v15.4s, v2.s[3]     \n"
+                "fmla   v23.4s, v15.4s, v3.s[3]     \n"
+
+                "bne    0b                          \n"
+
+                "st1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%1], #64 \n"
+                "st1    {v20.4s, v21.4s, v22.4s, v23.4s}, [%2], #64 \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(outptr1), // %2
+                "=r"(tmpptr),  // %3
+                "=r"(kptr0)    // %4
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(outptr1),
+                "3"(tmpptr),
+                "4"(kptr0),
+                "r"(biasptr) // %10
+                : "cc", "memory", "v0", "v1", "v2", "v3", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23");
+        }
+        for (; i + 1 < size; i += 2)
+        {
+            const float* tmpptr = tmp.channel(i / 12 + (i % 12) / 8 + (i % 12 % 8) / 4 + (i % 12 % 4) / 2);
+            const float* kptr0 = kernel.channel(p / 2);
+
+            int nn = inch * maxk; // inch always > 0
+
+            asm volatile(
+                "ld1    {v0.4s, v1.4s}, [%10]       \n"
+                "mov    v16.16b, v0.16b             \n"
+                "mov    v17.16b, v0.16b             \n"
+                "mov    v18.16b, v1.16b             \n"
+                "mov    v19.16b, v1.16b             \n"
+
+                "0:                                 \n"
+
+                "prfm   pldl1keep, [%3, #256]       \n"
+                "ld1    {v0.4s, v1.4s}, [%3], #32   \n" // r0 r1
+
+                "prfm   pldl1keep, [%4, #512]       \n"
+                "ld1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%4], #64 \n" // w0011_01
+
+                "fmla   v16.4s, v8.4s, v0.s[0]      \n"
+                "fmla   v17.4s, v8.4s, v1.s[0]      \n"
+                "fmla   v18.4s, v9.4s, v0.s[0]     \n"
+                "fmla   v19.4s, v9.4s, v1.s[0]     \n"
+
+                "prfm   pldl1keep, [%4, #512]       \n"
+                "ld1    {v12.4s, v13.4s, v14.4s, v15.4s}, [%4], #64 \n" // w2233_01
+
+                "fmla   v16.4s, v10.4s, v0.s[1]      \n"
+                "fmla   v17.4s, v10.4s, v1.s[1]      \n"
+                "fmla   v18.4s, v11.4s, v0.s[1]     \n"
+                "fmla   v19.4s, v11.4s, v1.s[1]     \n"
+
+                "fmla   v16.4s, v12.4s, v0.s[2]     \n"
+                "fmla   v17.4s, v12.4s, v1.s[2]     \n"
+                "fmla   v18.4s, v13.4s, v0.s[2]     \n"
+                "fmla   v19.4s, v13.4s, v1.s[2]     \n"
+
+                "subs   %w0, %w0, #1                \n"
+
+                "fmla   v16.4s, v14.4s, v0.s[3]     \n"
+                "fmla   v17.4s, v14.4s, v1.s[3]     \n"
+                "fmla   v18.4s, v15.4s, v0.s[3]     \n"
+                "fmla   v19.4s, v15.4s, v1.s[3]     \n"
+
+                "bne    0b                          \n"
+
+                "st1    {v16.4s, v17.4s}, [%1], #32 \n"
+                "st1    {v18.4s, v19.4s}, [%2], #32 \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(outptr1), // %2
+                "=r"(tmpptr),  // %3
+                "=r"(kptr0)    // %4
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(outptr1),
+                "3"(tmpptr),
+                "4"(kptr0),
+                "r"(biasptr) // %10
+                : "cc", "memory", "v0", "v1", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19");
+        }
+        for (; i < size; i++)
+        {
+            const float* tmpptr = tmp.channel(i / 12 + (i % 12) / 8 + (i % 12 % 8) / 4 + (i % 12 % 4) / 2 + i % 12 % 2);
+            const float* kptr0 = kernel.channel(p / 2);
+
+            int nn = inch * maxk; // inch always > 0
+
+            asm volatile(
+                "ld1    {v16.4s, v17.4s}, [%10]     \n"
+
+                "0:                                 \n"
+
+                "prfm   pldl1keep, [%3, #128]       \n"
+                "ld1    {v0.4s}, [%3], #16          \n" // r0
+
+                "prfm   pldl1keep, [%4, #512]       \n"
+                "ld1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%4], #64 \n" // w0011_01
+
+                "fmla   v16.4s, v8.4s, v0.s[0]      \n"
+                "fmla   v17.4s, v9.4s, v0.s[0]      \n"
+
+                "prfm   pldl1keep, [%4, #512]       \n"
+                "ld1    {v12.4s, v13.4s, v14.4s, v15.4s}, [%4], #64 \n" // w2233_01
+
+                "fmla   v16.4s, v10.4s, v0.s[1]     \n"
+                "fmla   v17.4s, v11.4s, v0.s[1]     \n"
+
+                "fmla   v16.4s, v12.4s, v0.s[2]     \n"
+                "fmla   v17.4s, v13.4s, v0.s[2]     \n"
+
+                "subs   %w0, %w0, #1                \n"
+
+                "fmla   v16.4s, v14.4s, v0.s[3]     \n"
+                "fmla   v17.4s, v15.4s, v0.s[3]     \n"
+
+                "bne    0b                          \n"
+
+                "st1    {v16.4s}, [%1], #16         \n"
+                "st1    {v17.4s}, [%2], #16         \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(outptr1), // %2
+                "=r"(tmpptr),  // %3
+                "=r"(kptr0)    // %4
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(outptr1),
+                "3"(tmpptr),
+                "4"(kptr0),
+                "r"(biasptr) // %10
+                : "cc", "memory", "v0", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17");
+        }
+    }
+#endif // __aarch64__
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int p = remain_outch_start; p < outch; p++)
+    {
+        float* outptr0 = top_blob.channel(p);
+
+        const float zeros[4] = {0.f, 0.f, 0.f, 0.f};
+        const float* biasptr = bias ? bias + p * 4 : zeros;
+
+        int i = 0;
+#if __aarch64__
+        for (; i + 11 < size; i += 12)
+        {
+            const float* tmpptr = tmp.channel(i / 12);
+            const float* kptr0 = kernel.channel(p / 2 + p % 2);
+
+            int nn = inch * maxk; // inch always > 0
+
+            asm volatile(
+                "ld1    {v0.4s}, [%8]               \n"
+                "mov    v8.16b, v0.16b              \n"
+                "mov    v9.16b, v0.16b              \n"
+                "mov    v10.16b, v0.16b             \n"
+                "mov    v11.16b, v0.16b             \n"
+                "mov    v12.16b, v0.16b             \n"
+                "mov    v13.16b, v0.16b             \n"
+                "mov    v14.16b, v0.16b             \n"
+                "mov    v15.16b, v0.16b             \n"
+                "mov    v16.16b, v0.16b             \n"
+                "mov    v17.16b, v0.16b             \n"
+                "mov    v18.16b, v0.16b             \n"
+                "mov    v19.16b, v0.16b             \n"
+
+                "0:                                 \n"
+
+                "prfm   pldl1keep, [%2, #512]       \n"
+                "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%2], #64 \n"
+
+                "prfm   pldl1keep, [%3, #512]       \n"
+                "ld1    {v4.4s, v5.4s, v6.4s, v7.4s}, [%3], #64 \n" // w0123_0
+
+                "fmla   v8.4s, v4.4s, v0.s[0]       \n"
+                "fmla   v9.4s, v4.4s, v0.s[1]       \n"
+                "fmla   v10.4s, v4.4s, v0.s[2]      \n"
+                "fmla   v11.4s, v4.4s, v0.s[3]      \n"
+                "fmla   v12.4s, v4.4s, v1.s[0]      \n"
+                "fmla   v13.4s, v4.4s, v1.s[1]      \n"
+                "fmla   v14.4s, v4.4s, v1.s[2]      \n"
+                "fmla   v15.4s, v4.4s, v1.s[3]      \n"
+                "fmla   v16.4s, v4.4s, v2.s[0]      \n"
+                "fmla   v17.4s, v4.4s, v2.s[1]      \n"
+                "fmla   v18.4s, v4.4s, v2.s[2]      \n"
+                "fmla   v19.4s, v4.4s, v2.s[3]      \n"
+
+                "prfm   pldl1keep, [%2, #512]       \n"
+                "ld1    {v20.4s, v21.4s, v22.4s, v23.4s}, [%2], #64 \n"
+
+                "fmla   v8.4s, v5.4s, v3.s[0]       \n"
+                "fmla   v9.4s, v5.4s, v3.s[1]       \n"
+                "fmla   v10.4s, v5.4s, v3.s[2]      \n"
+                "fmla   v11.4s, v5.4s, v3.s[3]      \n"
+                "fmla   v12.4s, v5.4s, v20.s[0]     \n"
+                "fmla   v13.4s, v5.4s, v20.s[1]     \n"
+                "fmla   v14.4s, v5.4s, v20.s[2]     \n"
+                "fmla   v15.4s, v5.4s, v20.s[3]     \n"
+                "fmla   v16.4s, v5.4s, v21.s[0]     \n"
+                "fmla   v17.4s, v5.4s, v21.s[1]     \n"
+                "fmla   v18.4s, v5.4s, v21.s[2]     \n"
+                "fmla   v19.4s, v5.4s, v21.s[3]     \n"
+
+                "prfm   pldl1keep, [%2, #512]       \n"
+                "ld1    {v24.4s, v25.4s, v26.4s, v27.4s}, [%2], #64 \n"
+
+                "fmla   v8.4s, v6.4s, v22.s[0]      \n"
+                "fmla   v9.4s, v6.4s, v22.s[1]      \n"
+                "fmla   v10.4s, v6.4s, v22.s[2]     \n"
+                "fmla   v11.4s, v6.4s, v22.s[3]     \n"
+                "fmla   v12.4s, v6.4s, v23.s[0]     \n"
+                "fmla   v13.4s, v6.4s, v23.s[1]     \n"
+                "fmla   v14.4s, v6.4s, v23.s[2]     \n"
+                "fmla   v15.4s, v6.4s, v23.s[3]     \n"
+                "fmla   v16.4s, v6.4s, v24.s[0]     \n"
+                "fmla   v17.4s, v6.4s, v24.s[1]     \n"
+                "fmla   v18.4s, v6.4s, v24.s[2]     \n"
+                "fmla   v19.4s, v6.4s, v24.s[3]     \n"
+
+                "subs   %w0, %w0, #1                \n"
+
+                "fmla   v8.4s, v7.4s, v25.s[0]      \n"
+                "fmla   v9.4s, v7.4s, v25.s[1]      \n"
+                "fmla   v10.4s, v7.4s, v25.s[2]     \n"
+                "fmla   v11.4s, v7.4s, v25.s[3]     \n"
+                "fmla   v12.4s, v7.4s, v26.s[0]     \n"
+                "fmla   v13.4s, v7.4s, v26.s[1]     \n"
+                "fmla   v14.4s, v7.4s, v26.s[2]     \n"
+                "fmla   v15.4s, v7.4s, v26.s[3]     \n"
+                "fmla   v16.4s, v7.4s, v27.s[0]     \n"
+                "fmla   v17.4s, v7.4s, v27.s[1]     \n"
+                "fmla   v18.4s, v7.4s, v27.s[2]     \n"
+                "fmla   v19.4s, v7.4s, v27.s[3]     \n"
+
+                "bne    0b                          \n"
+
+                "st1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%1], #64 \n"
+                "st1    {v12.4s, v13.4s, v14.4s, v15.4s}, [%1], #64 \n"
+                "st1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%1], #64 \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(tmpptr),  // %2
+                "=r"(kptr0)    // %3
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(tmpptr),
+                "3"(kptr0),
+                "r"(biasptr) // %8
+                : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27");
+        }
+#endif // __aarch64__
+        for (; i + 7 < size; i += 8)
+        {
+#if __aarch64__
+            const float* tmpptr = tmp.channel(i / 12 + (i % 12) / 8);
+            const float* kptr0 = kernel.channel(p / 2 + p % 2);
+#else
+            const float* tmpptr = tmp.channel(i / 8);
+            const float* kptr0 = kernel.channel(p);
+#endif
+
+            int nn = inch * maxk; // inch always > 0
+
+#if __aarch64__
+            asm volatile(
+                "ld1    {v0.4s}, [%8]               \n"
+                "mov    v16.16b, v0.16b             \n"
+                "mov    v17.16b, v0.16b             \n"
+                "mov    v18.16b, v0.16b             \n"
+                "mov    v19.16b, v0.16b             \n"
+                "mov    v20.16b, v0.16b             \n"
+                "mov    v21.16b, v0.16b             \n"
+                "mov    v22.16b, v0.16b             \n"
+                "mov    v23.16b, v0.16b             \n"
+
+                "0:                                 \n"
+
+                "prfm   pldl1keep, [%2, #512]       \n"
+                "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%2], #64 \n" // r0 r1 r2 r3
+
+                "prfm   pldl1keep, [%3, #512]       \n"
+                "ld1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%3], #64 \n" // w0123
+
+                "fmla   v16.4s, v8.4s, v0.s[0]      \n"
+                "fmla   v17.4s, v8.4s, v1.s[0]      \n"
+                "fmla   v18.4s, v8.4s, v2.s[0]      \n"
+                "fmla   v19.4s, v8.4s, v3.s[0]      \n"
+
+                "prfm   pldl1keep, [%2, #512]       \n"
+                "ld1    {v4.4s, v5.4s, v6.4s, v7.4s}, [%2], #64 \n" // r4 r5 r6 r7
+
+                "fmla   v20.4s, v8.4s, v4.s[0]      \n"
+                "fmla   v21.4s, v8.4s, v5.s[0]      \n"
+                "fmla   v22.4s, v8.4s, v6.s[0]      \n"
+                "fmla   v23.4s, v8.4s, v7.s[0]      \n"
+
+                "fmla   v16.4s, v9.4s, v0.s[1]      \n"
+                "fmla   v17.4s, v9.4s, v1.s[1]      \n"
+                "fmla   v18.4s, v9.4s, v2.s[1]      \n"
+                "fmla   v19.4s, v9.4s, v3.s[1]      \n"
+                "fmla   v20.4s, v9.4s, v4.s[1]      \n"
+                "fmla   v21.4s, v9.4s, v5.s[1]      \n"
+                "fmla   v22.4s, v9.4s, v6.s[1]      \n"
+                "fmla   v23.4s, v9.4s, v7.s[1]      \n"
+
+                "fmla   v16.4s, v10.4s, v0.s[2]     \n"
+                "fmla   v17.4s, v10.4s, v1.s[2]     \n"
+                "fmla   v18.4s, v10.4s, v2.s[2]     \n"
+                "fmla   v19.4s, v10.4s, v3.s[2]     \n"
+                "fmla   v20.4s, v10.4s, v4.s[2]     \n"
+                "fmla   v21.4s, v10.4s, v5.s[2]     \n"
+                "fmla   v22.4s, v10.4s, v6.s[2]     \n"
+                "fmla   v23.4s, v10.4s, v7.s[2]     \n"
+
+                "subs   %w0, %w0, #1                \n"
+
+                "fmla   v16.4s, v11.4s, v0.s[3]     \n"
+                "fmla   v17.4s, v11.4s, v1.s[3]     \n"
+                "fmla   v18.4s, v11.4s, v2.s[3]     \n"
+                "fmla   v19.4s, v11.4s, v3.s[3]     \n"
+                "fmla   v20.4s, v11.4s, v4.s[3]     \n"
+                "fmla   v21.4s, v11.4s, v5.s[3]     \n"
+                "fmla   v22.4s, v11.4s, v6.s[3]     \n"
+                "fmla   v23.4s, v11.4s, v7.s[3]     \n"
+
+                "bne    0b                          \n"
+
+                "st1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%1], #64 \n"
+                "st1    {v20.4s, v21.4s, v22.4s, v23.4s}, [%1], #64 \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(tmpptr),  // %2
+                "=r"(kptr0)    // %3
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(tmpptr),
+                "3"(kptr0),
+                "r"(biasptr) // %8
+                : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23");
+#else
+            asm volatile(
+                "vld1.f32   {d0-d1}, [%8]   \n"
+                "vmov       q8, q0          \n"
+                "vmov       q9, q0          \n"
+                "vmov       q10, q0         \n"
+                "vmov       q11, q0         \n"
+                "vmov       q12, q0         \n"
+                "vmov       q13, q0         \n"
+                "vmov       q14, q0         \n"
+                "vmov       q15, q0         \n"
+
+                "0:                         \n"
+
+                "pld        [%2, #512]      \n"
+                "vldm       %2!, {d0-d7}    \n"
+
+                "pld        [%3, #512]      \n"
+                "vldm       %3!, {d8-d15}   \n"
+
+                "vmla.f32   q8, q4, d0[0]   \n"
+                "vmla.f32   q9, q4, d0[1]   \n"
+                "vmla.f32   q10, q4, d1[0]  \n"
+                "vmla.f32   q11, q4, d1[1]  \n"
+                "vmla.f32   q12, q4, d2[0]  \n"
+                "vmla.f32   q13, q4, d2[1]  \n"
+                "vmla.f32   q14, q4, d3[0]  \n"
+                "vmla.f32   q15, q4, d3[1]  \n"
+
+                "vmla.f32   q8, q5, d4[0]   \n"
+                "vmla.f32   q9, q5, d4[1]   \n"
+                "vmla.f32   q10, q5, d5[0]  \n"
+                "vmla.f32   q11, q5, d5[1]  \n"
+                "vmla.f32   q12, q5, d6[0]  \n"
+                "vmla.f32   q13, q5, d6[1]  \n"
+                "vmla.f32   q14, q5, d7[0]  \n"
+                "vmla.f32   q15, q5, d7[1]  \n"
+
+                "pld        [%2, #512]      \n"
+                "vldm       %2!, {d0-d7}    \n"
+
+                "vmla.f32   q8, q6, d0[0]   \n"
+                "vmla.f32   q9, q6, d0[1]   \n"
+                "vmla.f32   q10, q6, d1[0]  \n"
+                "vmla.f32   q11, q6, d1[1]  \n"
+                "vmla.f32   q12, q6, d2[0]  \n"
+                "vmla.f32   q13, q6, d2[1]  \n"
+                "vmla.f32   q14, q6, d3[0]  \n"
+                "vmla.f32   q15, q6, d3[1]  \n"
+
+                "subs       %0, %0, #1      \n"
+
+                "vmla.f32   q8, q7, d4[0]   \n"
+                "vmla.f32   q9, q7, d4[1]   \n"
+                "vmla.f32   q10, q7, d5[0]  \n"
+                "vmla.f32   q11, q7, d5[1]  \n"
+                "vmla.f32   q12, q7, d6[0]  \n"
+                "vmla.f32   q13, q7, d6[1]  \n"
+                "vmla.f32   q14, q7, d7[0]  \n"
+                "vmla.f32   q15, q7, d7[1]  \n"
+
+                "bne        0b              \n"
+
+                "vstm       %1!, {d16-d23}  \n"
+                "vstm       %1!, {d24-d31}  \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(tmpptr),  // %2
+                "=r"(kptr0)    // %3
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(tmpptr),
+                "3"(kptr0),
+                "r"(biasptr) // %8
+                : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15");
+#endif
+        }
+        for (; i + 3 < size; i += 4)
+        {
+#if __aarch64__
+            const float* tmpptr = tmp.channel(i / 12 + (i % 12) / 8 + (i % 12 % 8) / 4);
+            const float* kptr0 = kernel.channel(p / 2 + p % 2);
+#else
+            const float* tmpptr = tmp.channel(i / 8 + (i % 8) / 4);
+            const float* kptr0 = kernel.channel(p);
+#endif
+
+            int nn = inch * maxk; // inch always > 0
+
+#if __aarch64__
+            asm volatile(
+                "ld1    {v0.4s}, [%8]               \n"
+                "mov    v16.16b, v0.16b             \n"
+                "mov    v17.16b, v0.16b             \n"
+                "mov    v18.16b, v0.16b             \n"
+                "mov    v19.16b, v0.16b             \n"
+
+                "0:                                 \n"
+
+                "prfm   pldl1keep, [%2, #512]       \n"
+                "ld1    {v0.4s, v1.4s, v2.4s, v3.4s}, [%2], #64 \n" // r0 r1 r2 r3
+
+                "prfm   pldl1keep, [%3, #512]       \n"
+                "ld1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%3], #64 \n" // w0123
+
+                "fmla   v16.4s, v8.4s, v0.s[0]      \n"
+                "fmla   v17.4s, v8.4s, v1.s[0]      \n"
+                "fmla   v18.4s, v8.4s, v2.s[0]      \n"
+                "fmla   v19.4s, v8.4s, v3.s[0]      \n"
+
+                "fmla   v16.4s, v9.4s, v0.s[1]      \n"
+                "fmla   v17.4s, v9.4s, v1.s[1]      \n"
+                "fmla   v18.4s, v9.4s, v2.s[1]      \n"
+                "fmla   v19.4s, v9.4s, v3.s[1]      \n"
+
+                "fmla   v16.4s, v10.4s, v0.s[2]     \n"
+                "fmla   v17.4s, v10.4s, v1.s[2]     \n"
+                "fmla   v18.4s, v10.4s, v2.s[2]     \n"
+                "fmla   v19.4s, v10.4s, v3.s[2]     \n"
+
+                "subs   %w0, %w0, #1                \n"
+
+                "fmla   v16.4s, v11.4s, v0.s[3]     \n"
+                "fmla   v17.4s, v11.4s, v1.s[3]     \n"
+                "fmla   v18.4s, v11.4s, v2.s[3]     \n"
+                "fmla   v19.4s, v11.4s, v3.s[3]     \n"
+
+                "bne    0b                          \n"
+
+                "st1    {v16.4s, v17.4s, v18.4s, v19.4s}, [%1], #64 \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(tmpptr),  // %2
+                "=r"(kptr0)    // %3
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(tmpptr),
+                "3"(kptr0),
+                "r"(biasptr) // %8
+                : "cc", "memory", "v0", "v1", "v2", "v3", "v8", "v9", "v10", "v11", "v16", "v17", "v18", "v19");
+#else
+            asm volatile(
+                "vld1.f32   {d0-d1}, [%8]   \n"
+                "vmov       q8, q0          \n"
+                "vmov       q9, q0          \n"
+                "vmov       q10, q0         \n"
+                "vmov       q11, q0         \n"
+
+                "0:                         \n"
+
+                "pld        [%2, #512]      \n"
+                "vldm       %2!, {d0-d7}    \n"
+
+                "pld        [%3, #512]      \n"
+                "vldm       %3!, {d8-d15}   \n"
+
+                "vmla.f32   q8, q4, d0[0]   \n"
+                "vmla.f32   q9, q4, d2[0]   \n"
+                "vmla.f32   q10, q4, d4[0]  \n"
+                "vmla.f32   q11, q4, d6[0]  \n"
+
+                "vmla.f32   q8, q5, d0[1]   \n"
+                "vmla.f32   q9, q5, d2[1]   \n"
+                "vmla.f32   q10, q5, d4[1]  \n"
+                "vmla.f32   q11, q5, d6[1]  \n"
+
+                "vmla.f32   q8, q6, d1[0]   \n"
+                "vmla.f32   q9, q6, d3[0]   \n"
+                "vmla.f32   q10, q6, d5[0]  \n"
+                "vmla.f32   q11, q6, d7[0]  \n"
+
+                "subs       %0, %0, #1      \n"
+
+                "vmla.f32   q8, q7, d1[1]   \n"
+                "vmla.f32   q9, q7, d3[1]   \n"
+                "vmla.f32   q10, q7, d5[1]  \n"
+                "vmla.f32   q11, q7, d7[1]  \n"
+
+                "bne        0b              \n"
+
+                "vstm       %1!, {d16-d23}  \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(tmpptr),  // %2
+                "=r"(kptr0)    // %3
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(tmpptr),
+                "3"(kptr0),
+                "r"(biasptr) // %8
+                : "cc", "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11");
+#endif
+        }
+        for (; i + 1 < size; i += 2)
+        {
+#if __aarch64__
+            const float* tmpptr = tmp.channel(i / 12 + (i % 12) / 8 + (i % 12 % 8) / 4 + (i % 12 % 4) / 2);
+            const float* kptr0 = kernel.channel(p / 2 + p % 2);
+#else
+            const float* tmpptr = tmp.channel(i / 8 + (i % 8) / 4 + (i % 4) / 2);
+            const float* kptr0 = kernel.channel(p);
+#endif
+
+            int nn = inch * maxk; // inch always > 0
+
+#if __aarch64__
+            asm volatile(
+                "ld1    {v0.4s}, [%8]               \n"
+                "mov    v16.16b, v0.16b             \n"
+                "mov    v17.16b, v0.16b             \n"
+
+                "0:                                 \n"
+
+                "prfm   pldl1keep, [%2, #256]       \n"
+                "ld1    {v0.4s, v1.4s}, [%2], #32   \n" // r0 r1
+
+                "prfm   pldl1keep, [%3, #512]       \n"
+                "ld1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%3], #64 \n" // w0123
+
+                "fmla   v16.4s, v8.4s, v0.s[0]      \n"
+                "fmla   v17.4s, v8.4s, v1.s[0]      \n"
+
+                "fmla   v16.4s, v9.4s, v0.s[1]      \n"
+                "fmla   v17.4s, v9.4s, v1.s[1]      \n"
+
+                "fmla   v16.4s, v10.4s, v0.s[2]     \n"
+                "fmla   v17.4s, v10.4s, v1.s[2]     \n"
+
+                "subs   %w0, %w0, #1                \n"
+
+                "fmla   v16.4s, v11.4s, v0.s[3]     \n"
+                "fmla   v17.4s, v11.4s, v1.s[3]     \n"
+
+                "bne    0b                          \n"
+
+                "st1    {v16.4s, v17.4s}, [%1], #32 \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(tmpptr),  // %2
+                "=r"(kptr0)    // %3
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(tmpptr),
+                "3"(kptr0),
+                "r"(biasptr) // %8
+                : "cc", "memory", "v0", "v1", "v8", "v9", "v10", "v11", "v16", "v17");
+#else
+            asm volatile(
+                "vld1.f32   {d0-d1}, [%8]   \n"
+                "vmov       q8, q0          \n"
+                "vmov       q9, q0          \n"
+
+                "0:                         \n"
+
+                "pld        [%2, #256]      \n"
+                "vld1.f32   {d0-d3}, [%2 :128]! \n"
+
+                "pld        [%3, #512]      \n"
+                "vldm       %3!, {d8-d15}   \n"
+
+                "vmla.f32   q8, q4, d0[0]   \n"
+                "vmla.f32   q9, q4, d2[0]   \n"
+
+                "vmla.f32   q8, q5, d0[1]   \n"
+                "vmla.f32   q9, q5, d2[1]   \n"
+
+                "vmla.f32   q8, q6, d1[0]   \n"
+                "vmla.f32   q9, q6, d3[0]   \n"
+
+                "subs       %0, %0, #1      \n"
+
+                "vmla.f32   q8, q7, d1[1]   \n"
+                "vmla.f32   q9, q7, d3[1]   \n"
+
+                "bne        0b              \n"
+
+                "vst1.f32   {d16-d19}, [%1 :128]! \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(tmpptr),  // %2
+                "=r"(kptr0)    // %3
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(tmpptr),
+                "3"(kptr0),
+                "r"(biasptr) // %8
+                : "cc", "memory", "q0", "q1", "q4", "q5", "q6", "q7", "q8", "q9");
+#endif
+        }
+        for (; i < size; i++)
+        {
+#if __aarch64__
+            const float* tmpptr = tmp.channel(i / 12 + (i % 12) / 8 + (i % 12 % 8) / 4 + (i % 12 % 4) / 2 + i % 12 % 2);
+            const float* kptr0 = kernel.channel(p / 2 + p % 2);
+#else
+            const float* tmpptr = tmp.channel(i / 8 + (i % 8) / 4 + (i % 4) / 2 + i % 2);
+            const float* kptr0 = kernel.channel(p);
+#endif
+
+            int nn = inch * maxk; // inch always > 0
+
+#if __aarch64__
+            asm volatile(
+                "ld1    {v16.4s}, [%8]              \n"
+
+                "0:                                 \n"
+
+                "prfm   pldl1keep, [%2, #128]       \n"
+                "ld1    {v0.4s}, [%2], #16          \n" // r0
+
+                "prfm   pldl1keep, [%3, #512]       \n"
+                "ld1    {v8.4s, v9.4s, v10.4s, v11.4s}, [%3], #64 \n" // w0123
+
+                "fmla   v16.4s, v8.4s, v0.s[0]      \n"
+                "fmla   v16.4s, v9.4s, v0.s[1]      \n"
+
+                "subs   %w0, %w0, #1                \n"
+
+                "fmla   v16.4s, v10.4s, v0.s[2]     \n"
+                "fmla   v16.4s, v11.4s, v0.s[3]     \n"
+
+                "bne    0b                          \n"
+
+                "st1    {v16.4s}, [%1], #16         \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(tmpptr),  // %2
+                "=r"(kptr0)    // %3
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(tmpptr),
+                "3"(kptr0),
+                "r"(biasptr) // %8
+                : "cc", "memory", "v0", "v8", "v9", "v10", "v11", "v16");
+#else
+            asm volatile(
+                "vld1.f32   {d16-d17}, [%8] \n"
+
+                "0:                         \n"
+
+                "pld        [%2, #128]      \n"
+                "vld1.f32   {d0-d1}, [%2 :128]! \n"
+
+                "pld        [%3, #512]      \n"
+                "vldm       %3!, {d8-d15}   \n"
+
+                "vmla.f32   q8, q4, d0[0]   \n"
+                "vmla.f32   q8, q5, d0[1]   \n"
+
+                "subs       %0, %0, #1      \n"
+
+                "vmla.f32   q8, q6, d1[0]   \n"
+                "vmla.f32   q8, q7, d1[1]   \n"
+
+                "bne        0b              \n"
+
+                "vst1.f32   {d16-d17}, [%1 :128]! \n"
+
+                : "=r"(nn),      // %0
+                "=r"(outptr0), // %1
+                "=r"(tmpptr),  // %2
+                "=r"(kptr0)    // %3
+                : "0"(nn),
+                "1"(outptr0),
+                "2"(tmpptr),
+                "3"(kptr0),
+                "r"(biasptr) // %8
+                : "cc", "memory", "q0", "q4", "q5", "q6", "q7", "q8");
+#endif
+        }
+    }
+}
+
+static void convolution_im2col_sgemm_pack4_neon_a53(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, int kernel_w, int kernel_h, int dilation_w, int dilation_h, int stride_w, int stride_h, const Option& opt)
+{
+    int w = bottom_blob.w;
+    int inch = bottom_blob.c;
+
+    int outw = top_blob.w;
+    int outh = top_blob.h;
+    const int size = outw * outh;
+
+    const int maxk = kernel_w * kernel_h;
+
+    // im2col
+    Mat bottom_im2col(size, maxk, inch, 16u, 4, opt.workspace_allocator);
+    {
+        const int gap = (w * stride_h - outw * stride_w) * 4;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int p = 0; p < inch; p++)
+        {
+            const Mat img = bottom_blob.channel(p);
+            float* ptr = bottom_im2col.channel(p);
+
+            for (int u = 0; u < kernel_h; u++)
+            {
+                for (int v = 0; v < kernel_w; v++)
+                {
+                    const float* sptr = img.row<const float>(dilation_h * u) + dilation_w * v * 4;
+
+                    for (int i = 0; i < outh; i++)
+                    {
+                        int j = 0;
+                        for (; j + 3 < outw; j += 4)
+                        {
+                            float32x4_t _val0 = vld1q_f32(sptr);
+                            float32x4_t _val1 = vld1q_f32(sptr + stride_w * 4);
+                            float32x4_t _val2 = vld1q_f32(sptr + stride_w * 8);
+                            float32x4_t _val3 = vld1q_f32(sptr + stride_w * 12);
+                            vst1q_f32(ptr, _val0);
+                            vst1q_f32(ptr + 4, _val1);
+                            vst1q_f32(ptr + 8, _val2);
+                            vst1q_f32(ptr + 12, _val3);
+
+                            sptr += stride_w * 16;
+                            ptr += 16;
+                        }
+                        for (; j + 1 < outw; j += 2)
+                        {
+                            float32x4_t _val0 = vld1q_f32(sptr);
+                            float32x4_t _val1 = vld1q_f32(sptr + stride_w * 4);
+                            vst1q_f32(ptr, _val0);
+                            vst1q_f32(ptr + 4, _val1);
+
+                            sptr += stride_w * 8;
+                            ptr += 8;
+                        }
+                        for (; j < outw; j++)
+                        {
+                            float32x4_t _val = vld1q_f32(sptr);
+                            vst1q_f32(ptr, _val);
+
+                            sptr += stride_w * 4;
+                            ptr += 4;
+                        }
+
+                        sptr += gap;
+                    }
+                }
+            }
+        }
+    }
+
+    im2col_sgemm_pack4_neon_a53(bottom_im2col, top_blob, kernel, _bias, opt);
+}

--- a/src/layer/arm/convolution_winograd_pack4.h
+++ b/src/layer/arm/convolution_winograd_pack4.h
@@ -1,0 +1,537 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+static void convolution_winograd_f63_transform_input_pack4_neon(const Mat& bottom_blob, Mat& bottom_blob_tm, const Option& opt)
+{
+    const int w = bottom_blob.w;
+    const int inch = bottom_blob.c;
+    const int tiles_w = (bottom_blob.w - 2) / 6;
+    const int tiles_h = (bottom_blob.h - 2) / 6;
+    const int tiles = tiles_w * tiles_h;
+
+    //     bottom_blob_tm.create(tiles, 64, inch, elemsize, elempack, opt.workspace_allocator);
+
+    //         const float itm[8][8] = {
+    //             {1.0f,  0.0f, -5.25f,  0.00f,  5.25f,  0.00f, -1.0f, 0.0f},
+    //
+    //             {0.0f,  1.0f,  1.00f, -4.25f, -4.25f,  1.00f,  1.0f, 0.0f},
+    //             {0.0f, -1.0f,  1.00f,  4.25f, -4.25f, -1.00f,  1.0f, 0.0f},
+    //
+    //             {0.0f,  0.5f,  0.25f, -2.50f, -1.25f,  2.00f,  1.0f, 0.0f},
+    //             {0.0f, -0.5f,  0.25f,  2.50f, -1.25f, -2.00f,  1.0f, 0.0f},
+    //
+    //             {0.0f,  2.0f,  4.00f, -2.50f, -5.00f,  0.50f,  1.0f, 0.0f},
+    //             {0.0f, -2.0f,  4.00f,  2.50f, -5.00f, -0.50f,  1.0f, 0.0f},
+    //
+    //             {0.0f, -1.0f,  0.00f,  5.25f,  0.00f, -5.25f,  0.0f, 1.0f}
+    //         };
+
+    // 0 = r00 - r06 + (r04 - r02) * 5.25
+    // 7 = r07 - r01 + (r03 - r05) * 5.25
+
+    // 1 = (r02 + r06 - r04 * 4.25) + (r01 - r03 * 4.25 + r05)
+    // 2 = (r02 + r06 - r04 * 4.25) - (r01 - r03 * 4.25 + r05)
+
+    // 3 = (r06 + r02 * 0.25 - r04 * 1.25) + (r01 * 0.5 - r03 * 2.5 + r05 * 2)
+    // 4 = (r06 + r02 * 0.25 - r04 * 1.25) - (r01 * 0.5 - r03 * 2.5 + r05 * 2)
+
+    // reuse r04 * 1.25
+    // reuse r03 * 2.5
+    // 5 = (r06 + (r02 - r04 * 1.25) * 4) + (r01 * 2 - r03 * 2.5 + r05 * 0.5)
+    // 6 = (r06 + (r02 - r04 * 1.25) * 4) - (r01 * 2 - r03 * 2.5 + r05 * 0.5)
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int q = 0; q < inch; q++)
+    {
+        const Mat img0 = bottom_blob.channel(q);
+        Mat img0_tm = bottom_blob_tm.channel(q);
+
+        float tmp[8][8][4];
+
+        // tile
+        for (int i = 0; i < tiles_h; i++)
+        {
+            for (int j = 0; j < tiles_w; j++)
+            {
+                const float* r0 = img0.row(i * 6) + (j * 6) * 4;
+
+                for (int m = 0; m < 8; m++)
+                {
+                    float32x4_t _r00 = vld1q_f32(r0);
+                    float32x4_t _r01 = vld1q_f32(r0 + 4);
+                    float32x4_t _r02 = vld1q_f32(r0 + 8);
+                    float32x4_t _r03 = vld1q_f32(r0 + 12);
+                    float32x4_t _r04 = vld1q_f32(r0 + 16);
+                    float32x4_t _r05 = vld1q_f32(r0 + 20);
+                    float32x4_t _r06 = vld1q_f32(r0 + 24);
+                    float32x4_t _r07 = vld1q_f32(r0 + 28);
+
+                    float32x4_t _tmp0m = vmlaq_n_f32(vsubq_f32(_r00, _r06), vsubq_f32(_r04, _r02), 5.25f);
+                    float32x4_t _tmp7m = vmlaq_n_f32(vsubq_f32(_r07, _r01), vsubq_f32(_r03, _r05), 5.25f);
+                    vst1q_f32(tmp[0][m], _tmp0m);
+                    vst1q_f32(tmp[7][m], _tmp7m);
+
+                    float32x4_t _tmp12a = vmlsq_n_f32(vaddq_f32(_r02, _r06), _r04, 4.25f);
+                    float32x4_t _tmp12b = vmlsq_n_f32(vaddq_f32(_r01, _r05), _r03, 4.25f);
+
+                    float32x4_t _tmp1m = vaddq_f32(_tmp12a, _tmp12b);
+                    float32x4_t _tmp2m = vsubq_f32(_tmp12a, _tmp12b);
+                    vst1q_f32(tmp[1][m], _tmp1m);
+                    vst1q_f32(tmp[2][m], _tmp2m);
+
+                    float32x4_t _tmp34a = vmlsq_n_f32(vmlaq_n_f32(_r06, _r02, 0.25f), _r04, 1.25f);
+                    float32x4_t _tmp34b = vmlaq_n_f32(vmlsq_n_f32(vmulq_n_f32(_r01, 0.5f), _r03, 2.5f), _r05, 2.f);
+
+                    float32x4_t _tmp3m = vaddq_f32(_tmp34a, _tmp34b);
+                    float32x4_t _tmp4m = vsubq_f32(_tmp34a, _tmp34b);
+                    vst1q_f32(tmp[3][m], _tmp3m);
+                    vst1q_f32(tmp[4][m], _tmp4m);
+
+                    float32x4_t _tmp56a = vmlaq_n_f32(_r06, vmlsq_n_f32(_r02, _r04, 1.25f), 4.f);
+                    float32x4_t _tmp56b = vmlaq_n_f32(vmlsq_n_f32(vmulq_n_f32(_r01, 2.f), _r03, 2.5f), _r05, 0.5f);
+
+                    float32x4_t _tmp5m = vaddq_f32(_tmp56a, _tmp56b);
+                    float32x4_t _tmp6m = vsubq_f32(_tmp56a, _tmp56b);
+                    vst1q_f32(tmp[5][m], _tmp5m);
+                    vst1q_f32(tmp[6][m], _tmp6m);
+
+                    r0 += w * 4;
+                }
+
+                float* r0_tm_0 = (float*)img0_tm + (i * tiles_w + j) * 4;
+                float* r0_tm_1 = r0_tm_0 + tiles * 4;
+                float* r0_tm_2 = r0_tm_0 + tiles * 8;
+                float* r0_tm_3 = r0_tm_0 + tiles * 12;
+                float* r0_tm_4 = r0_tm_0 + tiles * 16;
+                float* r0_tm_5 = r0_tm_0 + tiles * 20;
+                float* r0_tm_6 = r0_tm_0 + tiles * 24;
+                float* r0_tm_7 = r0_tm_0 + tiles * 28;
+
+                for (int m = 0; m < 8; m++)
+                {
+                    float32x4_t _tmp00 = vld1q_f32(tmp[m][0]);
+                    float32x4_t _tmp01 = vld1q_f32(tmp[m][1]);
+                    float32x4_t _tmp02 = vld1q_f32(tmp[m][2]);
+                    float32x4_t _tmp03 = vld1q_f32(tmp[m][3]);
+                    float32x4_t _tmp04 = vld1q_f32(tmp[m][4]);
+                    float32x4_t _tmp05 = vld1q_f32(tmp[m][5]);
+                    float32x4_t _tmp06 = vld1q_f32(tmp[m][6]);
+                    float32x4_t _tmp07 = vld1q_f32(tmp[m][7]);
+
+                    float32x4_t _r0tm0 = vmlaq_n_f32(vsubq_f32(_tmp00, _tmp06), vsubq_f32(_tmp04, _tmp02), 5.25f);
+                    float32x4_t _r0tm7 = vmlaq_n_f32(vsubq_f32(_tmp07, _tmp01), vsubq_f32(_tmp03, _tmp05), 5.25f);
+
+                    float32x4_t _tmp12a = vmlsq_n_f32(vaddq_f32(_tmp02, _tmp06), _tmp04, 4.25f);
+                    float32x4_t _tmp12b = vmlsq_n_f32(vaddq_f32(_tmp01, _tmp05), _tmp03, 4.25f);
+
+                    float32x4_t _r0tm1 = vaddq_f32(_tmp12a, _tmp12b);
+                    float32x4_t _r0tm2 = vsubq_f32(_tmp12a, _tmp12b);
+
+                    float32x4_t _tmp34a = vmlsq_n_f32(vmlaq_n_f32(_tmp06, _tmp02, 0.25f), _tmp04, 1.25f);
+                    float32x4_t _tmp34b = vmlaq_n_f32(vmlsq_n_f32(vmulq_n_f32(_tmp01, 0.5f), _tmp03, 2.5f), _tmp05, 2.f);
+
+                    float32x4_t _r0tm3 = vaddq_f32(_tmp34a, _tmp34b);
+                    float32x4_t _r0tm4 = vsubq_f32(_tmp34a, _tmp34b);
+
+                    float32x4_t _tmp56a = vmlaq_n_f32(_tmp06, vmlsq_n_f32(_tmp02, _tmp04, 1.25f), 4.f);
+                    float32x4_t _tmp56b = vmlaq_n_f32(vmlsq_n_f32(vmulq_n_f32(_tmp01, 2.f), _tmp03, 2.5f), _tmp05, 0.5f);
+
+                    float32x4_t _r0tm5 = vaddq_f32(_tmp56a, _tmp56b);
+                    float32x4_t _r0tm6 = vsubq_f32(_tmp56a, _tmp56b);
+
+                    vst1q_f32(r0_tm_0, _r0tm0);
+                    vst1q_f32(r0_tm_1, _r0tm1);
+                    vst1q_f32(r0_tm_2, _r0tm2);
+                    vst1q_f32(r0_tm_3, _r0tm3);
+                    vst1q_f32(r0_tm_4, _r0tm4);
+                    vst1q_f32(r0_tm_5, _r0tm5);
+                    vst1q_f32(r0_tm_6, _r0tm6);
+                    vst1q_f32(r0_tm_7, _r0tm7);
+
+                    r0_tm_0 += tiles * 32;
+                    r0_tm_1 += tiles * 32;
+                    r0_tm_2 += tiles * 32;
+                    r0_tm_3 += tiles * 32;
+                    r0_tm_4 += tiles * 32;
+                    r0_tm_5 += tiles * 32;
+                    r0_tm_6 += tiles * 32;
+                    r0_tm_7 += tiles * 32;
+                }
+            }
+        }
+    }
+}
+
+static void convolution_winograd_f63_transform_output_pack4_neon(const Mat& top_blob_tm, Mat& top_blob, const Mat& _bias, const Option& opt)
+{
+    const int outw = top_blob.w;
+    const int outch = top_blob.c;
+    const int tiles_w = top_blob.w / 6;
+    const int tiles_h = top_blob.h / 6;
+    const int tiles = tiles_w * tiles_h;
+
+    const float* bias = _bias;
+
+    //     top_blob_tm.create(tiles, 64, outch, elemsize, elempack);
+
+    //         const float otm[6][8] = {
+    //             {1.0f,  1.0f,   1.0f,   1.0f,   1.0f,  32.0f, 32.0f, 0.0f},
+    //             {0.0f,  1.0f,  -1.0f,   2.0f,  -2.0f,  16.0f,-16.0f, 0.0f},
+    //             {0.0f,  1.0f,   1.0f,   4.0f,   4.0f,   8.0f,  8.0f, 0.0f},
+    //             {0.0f,  1.0f,  -1.0f,   8.0f,  -8.0f,   4.0f, -4.0f, 0.0f},
+    //             {0.0f,  1.0f,   1.0f,  16.0f,  16.0f,   2.0f,  2.0f, 0.0f},
+    //             {0.0f,  1.0f,  -1.0f,  32.0f, -32.0f,   1.0f, -1.0f, 1.0f}
+    //         };
+
+    // 0 = r0 + (r1 + r2) + (r3 + r4)     + (r5 + r6) * 32
+    // 1 =      (r1 - r2) + (r3 - r4) * 2 + (r5 - r6) * 16
+    // 2 =      (r1 + r2) + (r3 + r4) * 4 + (r5 + r6) * 8
+    // 3 =      (r1 - r2) + (r3 - r4) * 8 + (r5 - r6) * 4
+    // 4 =      (r1 + r2) + (r3 + r4) * 16+ (r5 + r6) * 2
+    // 5 = r7 + (r1 - r2) + (r3 - r4) * 32+ (r5 - r6)
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int p = 0; p < outch; p++)
+    {
+        const Mat out0_tm = top_blob_tm.channel(p);
+        Mat out0 = top_blob.channel(p);
+
+        float32x4_t _bias0 = bias ? vld1q_f32((const float*)bias + p * 4) : vdupq_n_f32(0.f);
+
+        float tmp[6][8][4];
+
+        // tile
+        for (int i = 0; i < tiles_h; i++)
+        {
+            for (int j = 0; j < tiles_w; j++)
+            {
+                const float* output0_tm_0 = (const float*)out0_tm + (i * tiles_w + j) * 4;
+                const float* output0_tm_1 = output0_tm_0 + tiles * 4;
+                const float* output0_tm_2 = output0_tm_0 + tiles * 8;
+                const float* output0_tm_3 = output0_tm_0 + tiles * 12;
+                const float* output0_tm_4 = output0_tm_0 + tiles * 16;
+                const float* output0_tm_5 = output0_tm_0 + tiles * 20;
+                const float* output0_tm_6 = output0_tm_0 + tiles * 24;
+                const float* output0_tm_7 = output0_tm_0 + tiles * 28;
+
+                float* output0 = out0.row(i * 6) + (j * 6) * 4;
+
+                // TODO neon optimize
+                for (int m = 0; m < 8; m++)
+                {
+                    float32x4_t _out0tm0 = vld1q_f32(output0_tm_0);
+                    float32x4_t _out0tm1 = vld1q_f32(output0_tm_1);
+                    float32x4_t _out0tm2 = vld1q_f32(output0_tm_2);
+                    float32x4_t _out0tm3 = vld1q_f32(output0_tm_3);
+                    float32x4_t _out0tm4 = vld1q_f32(output0_tm_4);
+                    float32x4_t _out0tm5 = vld1q_f32(output0_tm_5);
+                    float32x4_t _out0tm6 = vld1q_f32(output0_tm_6);
+                    float32x4_t _out0tm7 = vld1q_f32(output0_tm_7);
+
+                    float32x4_t _tmp024a = vaddq_f32(_out0tm1, _out0tm2);
+                    float32x4_t _tmp135a = vsubq_f32(_out0tm1, _out0tm2);
+
+                    float32x4_t _tmp024b = vaddq_f32(_out0tm3, _out0tm4);
+                    float32x4_t _tmp135b = vsubq_f32(_out0tm3, _out0tm4);
+
+                    float32x4_t _tmp024c = vaddq_f32(_out0tm5, _out0tm6);
+                    float32x4_t _tmp135c = vsubq_f32(_out0tm5, _out0tm6);
+
+                    float32x4_t _tmp0m = vaddq_f32(vaddq_f32(_out0tm0, _tmp024a), vmlaq_n_f32(_tmp024b, _tmp024c, 32.f));
+                    float32x4_t _tmp2m = vmlaq_n_f32(vmlaq_n_f32(_tmp024a, _tmp024b, 4.f), _tmp024c, 8.f);
+                    float32x4_t _tmp4m = vmlaq_n_f32(vmlaq_n_f32(_tmp024a, _tmp024b, 16.f), _tmp024c, 2.f);
+                    vst1q_f32(tmp[0][m], _tmp0m);
+                    vst1q_f32(tmp[2][m], _tmp2m);
+                    vst1q_f32(tmp[4][m], _tmp4m);
+
+                    float32x4_t _tmp1m = vmlaq_n_f32(vmlaq_n_f32(_tmp135a, _tmp135b, 2.f), _tmp135c, 16.f);
+                    float32x4_t _tmp3m = vmlaq_n_f32(vmlaq_n_f32(_tmp135a, _tmp135b, 8.f), _tmp135c, 4.f);
+                    float32x4_t _tmp5m = vaddq_f32(vaddq_f32(_out0tm7, _tmp135a), vmlaq_n_f32(_tmp135c, _tmp135b, 32.f));
+                    vst1q_f32(tmp[1][m], _tmp1m);
+                    vst1q_f32(tmp[3][m], _tmp3m);
+                    vst1q_f32(tmp[5][m], _tmp5m);
+
+                    output0_tm_0 += tiles * 32;
+                    output0_tm_1 += tiles * 32;
+                    output0_tm_2 += tiles * 32;
+                    output0_tm_3 += tiles * 32;
+                    output0_tm_4 += tiles * 32;
+                    output0_tm_5 += tiles * 32;
+                    output0_tm_6 += tiles * 32;
+                    output0_tm_7 += tiles * 32;
+                }
+
+                for (int m = 0; m < 6; m++)
+                {
+                    float32x4_t _tmp00 = vld1q_f32(tmp[m][0]);
+                    float32x4_t _tmp01 = vld1q_f32(tmp[m][1]);
+                    float32x4_t _tmp02 = vld1q_f32(tmp[m][2]);
+                    float32x4_t _tmp03 = vld1q_f32(tmp[m][3]);
+                    float32x4_t _tmp04 = vld1q_f32(tmp[m][4]);
+                    float32x4_t _tmp05 = vld1q_f32(tmp[m][5]);
+                    float32x4_t _tmp06 = vld1q_f32(tmp[m][6]);
+                    float32x4_t _tmp07 = vld1q_f32(tmp[m][7]);
+
+                    float32x4_t _tmp024a = vaddq_f32(_tmp01, _tmp02);
+                    float32x4_t _tmp135a = vsubq_f32(_tmp01, _tmp02);
+
+                    float32x4_t _tmp024b = vaddq_f32(_tmp03, _tmp04);
+                    float32x4_t _tmp135b = vsubq_f32(_tmp03, _tmp04);
+
+                    float32x4_t _tmp024c = vaddq_f32(_tmp05, _tmp06);
+                    float32x4_t _tmp135c = vsubq_f32(_tmp05, _tmp06);
+
+                    float32x4_t _out00 = vaddq_f32(_bias0, vaddq_f32(vaddq_f32(_tmp00, _tmp024a), vmlaq_n_f32(_tmp024b, _tmp024c, 32.f)));
+                    float32x4_t _out02 = vaddq_f32(_bias0, vmlaq_n_f32(vmlaq_n_f32(_tmp024a, _tmp024b, 4.f), _tmp024c, 8.f));
+                    float32x4_t _out04 = vaddq_f32(_bias0, vmlaq_n_f32(vmlaq_n_f32(_tmp024a, _tmp024b, 16.f), _tmp024c, 2.f));
+                    vst1q_f32(output0, _out00);
+                    vst1q_f32(output0 + 8, _out02);
+                    vst1q_f32(output0 + 16, _out04);
+
+                    float32x4_t _out01 = vaddq_f32(_bias0, vmlaq_n_f32(vmlaq_n_f32(_tmp135a, _tmp135b, 2.f), _tmp135c, 16.f));
+                    float32x4_t _out03 = vaddq_f32(_bias0, vmlaq_n_f32(vmlaq_n_f32(_tmp135a, _tmp135b, 8.f), _tmp135c, 4.f));
+                    float32x4_t _out05 = vaddq_f32(_bias0, vaddq_f32(vaddq_f32(_tmp07, _tmp135a), vmlaq_n_f32(_tmp135c, _tmp135b, 32.f)));
+                    vst1q_f32(output0 + 4, _out01);
+                    vst1q_f32(output0 + 12, _out03);
+                    vst1q_f32(output0 + 20, _out05);
+
+                    output0 += outw * 4;
+                }
+            }
+        }
+    }
+}
+
+static void convolution_winograd_f43_transform_input_pack4_neon(const Mat& bottom_blob, Mat& bottom_blob_tm, const Option& opt)
+{
+    const int w = bottom_blob.w;
+    const int inch = bottom_blob.c;
+    const int tiles_w = (bottom_blob.w - 2) / 4;
+    const int tiles_h = (bottom_blob.h - 2) / 4;
+    const int tiles = tiles_w * tiles_h;
+
+    //     bottom_blob_tm.create(tiles, 36, inch, elemsize, elempack, opt.workspace_allocator);
+
+    // const float itm[4][4] = {
+    //     {4.0f, 0.0f, -5.0f, 0.0f, 1.0f, 0.0f},
+    //     {0.0f,-4.0f, -4.0f, 1.0f, 1.0f, 0.0f},
+    //     {0.0f, 4.0f, -4.0f,-1.0f, 1.0f, 0.0f},
+    //     {0.0f,-2.0f, -1.0f, 2.0f, 1.0f, 0.0f},
+    //     {0.0f, 2.0f, -1.0f,-2.0f, 1.0f, 0.0f},
+    //     {0.0f, 4.0f,  0.0f,-5.0f, 0.0f, 1.0f}
+    // };
+
+    // 0 =  4 * r00 - 5 * r02 + r04
+    // 1 = -4 * (r01 + r02) + r04 + r03
+    // 2 =  4 * (r01 - r02) + r04 - r03
+    // 3 = -2 * (r01 - r03) + r04 - r02
+    // 4 =  2 * (r01 - r03) + r04 - r02
+    // 5 =  4 * r01 - 5 * r03 + r05
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int q = 0; q < inch; q++)
+    {
+        const Mat img0 = bottom_blob.channel(q);
+        Mat img0_tm = bottom_blob_tm.channel(q);
+
+        float tmp[6][6][4];
+
+        // tile
+        for (int i = 0; i < tiles_h; i++)
+        {
+            for (int j = 0; j < tiles_w; j++)
+            {
+                const float* r0 = img0.row(i * 4) + (j * 4) * 4;
+
+                for (int m = 0; m < 6; m++)
+                {
+                    float32x4_t _r00 = vld1q_f32(r0);
+                    float32x4_t _r01 = vld1q_f32(r0 + 4);
+                    float32x4_t _r02 = vld1q_f32(r0 + 8);
+                    float32x4_t _r03 = vld1q_f32(r0 + 12);
+                    float32x4_t _r04 = vld1q_f32(r0 + 16);
+                    float32x4_t _r05 = vld1q_f32(r0 + 20);
+
+                    float32x4_t _tmp0m = vmlsq_n_f32(vmlaq_n_f32(_r04, _r00, 4.f), _r02, 5.f);
+                    float32x4_t _tmp1m = vmlsq_n_f32(vaddq_f32(_r04, _r03), vaddq_f32(_r01, _r02), 4.f);
+                    float32x4_t _tmp2m = vmlaq_n_f32(vsubq_f32(_r04, _r03), vsubq_f32(_r01, _r02), 4.f);
+                    float32x4_t _tmp3m = vmlsq_n_f32(vsubq_f32(_r04, _r02), vsubq_f32(_r01, _r03), 2.f);
+                    float32x4_t _tmp4m = vmlaq_n_f32(vsubq_f32(_r04, _r02), vsubq_f32(_r01, _r03), 2.f);
+                    float32x4_t _tmp5m = vmlsq_n_f32(vmlaq_n_f32(_r05, _r01, 4.f), _r03, 5.f);
+
+                    vst1q_f32(tmp[0][m], _tmp0m);
+                    vst1q_f32(tmp[1][m], _tmp1m);
+                    vst1q_f32(tmp[2][m], _tmp2m);
+                    vst1q_f32(tmp[3][m], _tmp3m);
+                    vst1q_f32(tmp[4][m], _tmp4m);
+                    vst1q_f32(tmp[5][m], _tmp5m);
+
+                    r0 += w * 4;
+                }
+
+                float* r0_tm_0 = (float*)img0_tm + (i * tiles_w + j) * 4;
+                float* r0_tm_1 = r0_tm_0 + tiles * 4;
+                float* r0_tm_2 = r0_tm_0 + tiles * 8;
+                float* r0_tm_3 = r0_tm_0 + tiles * 12;
+                float* r0_tm_4 = r0_tm_0 + tiles * 16;
+                float* r0_tm_5 = r0_tm_0 + tiles * 20;
+
+                for (int m = 0; m < 6; m++)
+                {
+                    float32x4_t _tmp00 = vld1q_f32(tmp[m][0]);
+                    float32x4_t _tmp01 = vld1q_f32(tmp[m][1]);
+                    float32x4_t _tmp02 = vld1q_f32(tmp[m][2]);
+                    float32x4_t _tmp03 = vld1q_f32(tmp[m][3]);
+                    float32x4_t _tmp04 = vld1q_f32(tmp[m][4]);
+                    float32x4_t _tmp05 = vld1q_f32(tmp[m][5]);
+
+                    float32x4_t _r0tm0 = vmlsq_n_f32(vmlaq_n_f32(_tmp04, _tmp00, 4.f), _tmp02, 5.f);
+                    float32x4_t _r0tm1 = vmlsq_n_f32(vaddq_f32(_tmp04, _tmp03), vaddq_f32(_tmp01, _tmp02), 4.f);
+                    float32x4_t _r0tm2 = vmlaq_n_f32(vsubq_f32(_tmp04, _tmp03), vsubq_f32(_tmp01, _tmp02), 4.f);
+                    float32x4_t _r0tm3 = vmlsq_n_f32(vsubq_f32(_tmp04, _tmp02), vsubq_f32(_tmp01, _tmp03), 2.f);
+                    float32x4_t _r0tm4 = vmlaq_n_f32(vsubq_f32(_tmp04, _tmp02), vsubq_f32(_tmp01, _tmp03), 2.f);
+                    float32x4_t _r0tm5 = vmlsq_n_f32(vmlaq_n_f32(_tmp05, _tmp01, 4.f), _tmp03, 5.f);
+
+                    vst1q_f32(r0_tm_0, _r0tm0);
+                    vst1q_f32(r0_tm_1, _r0tm1);
+                    vst1q_f32(r0_tm_2, _r0tm2);
+                    vst1q_f32(r0_tm_3, _r0tm3);
+                    vst1q_f32(r0_tm_4, _r0tm4);
+                    vst1q_f32(r0_tm_5, _r0tm5);
+
+                    r0_tm_0 += tiles * 24;
+                    r0_tm_1 += tiles * 24;
+                    r0_tm_2 += tiles * 24;
+                    r0_tm_3 += tiles * 24;
+                    r0_tm_4 += tiles * 24;
+                    r0_tm_5 += tiles * 24;
+                }
+            }
+        }
+    }
+}
+
+static void convolution_winograd_f43_transform_output_pack4_neon(const Mat& top_blob_tm, Mat& top_blob, const Mat& _bias, const Option& opt)
+{
+    const int outw = top_blob.w;
+    const int outch = top_blob.c;
+    const int tiles_w = top_blob.w / 4;
+    const int tiles_h = top_blob.h / 4;
+    const int tiles = tiles_w * tiles_h;
+
+    const float* bias = _bias;
+
+    // top_blob_tm.create(tiles, 36, outch, elemsize, elempack);
+
+    // const float otm[4][6] = {
+    //     {1.0f, 1.0f,  1.0f, 1.0f,  1.0f, 0.0f},
+    //     {0.0f, 1.0f, -1.0f, 2.0f, -2.0f, 0.0f},
+    //     {0.0f, 1.0f,  1.0f, 4.0f,  4.0f, 0.0f},
+    //     {0.0f, 1.0f, -1.0f, 8.0f, -8.0f, 1.0f}
+    // };
+
+    // 0 = r00 + (r01 + r02) + (r03 + r04)
+    // 1 =       (r01 - r02) + (r03 - r04) * 2
+    // 2 =       (r01 + r02) + (r03 + r04) * 4
+    // 3 = r05 + (r01 - r02) + (r03 - r04) * 8
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int p = 0; p < outch; p++)
+    {
+        const Mat out0_tm = top_blob_tm.channel(p);
+        Mat out0 = top_blob.channel(p);
+
+        float32x4_t _bias0 = bias ? vld1q_f32((const float*)bias + p * 4) : vdupq_n_f32(0.f);
+
+        float tmp[4][6][4];
+
+        // tile
+        for (int i = 0; i < tiles_h; i++)
+        {
+            for (int j = 0; j < tiles_w; j++)
+            {
+                const float* output0_tm_0 = (const float*)out0_tm + (i * tiles_w + j) * 4;
+                const float* output0_tm_1 = output0_tm_0 + tiles * 4;
+                const float* output0_tm_2 = output0_tm_0 + tiles * 8;
+                const float* output0_tm_3 = output0_tm_0 + tiles * 12;
+                const float* output0_tm_4 = output0_tm_0 + tiles * 16;
+                const float* output0_tm_5 = output0_tm_0 + tiles * 20;
+
+                float* output0 = out0.row(i * 4) + (j * 4) * 4;
+
+                // TODO neon optimize
+                for (int m = 0; m < 6; m++)
+                {
+                    float32x4_t _out0tm0 = vld1q_f32(output0_tm_0);
+                    float32x4_t _out0tm1 = vld1q_f32(output0_tm_1);
+                    float32x4_t _out0tm2 = vld1q_f32(output0_tm_2);
+                    float32x4_t _out0tm3 = vld1q_f32(output0_tm_3);
+                    float32x4_t _out0tm4 = vld1q_f32(output0_tm_4);
+                    float32x4_t _out0tm5 = vld1q_f32(output0_tm_5);
+
+                    float32x4_t _tmp02a = vaddq_f32(_out0tm1, _out0tm2);
+                    float32x4_t _tmp13a = vsubq_f32(_out0tm1, _out0tm2);
+
+                    float32x4_t _tmp02b = vaddq_f32(_out0tm3, _out0tm4);
+                    float32x4_t _tmp13b = vsubq_f32(_out0tm3, _out0tm4);
+
+                    float32x4_t _tmp0m = vaddq_f32(vaddq_f32(_out0tm0, _tmp02a), _tmp02b);
+                    float32x4_t _tmp1m = vmlaq_n_f32(_tmp13a, _tmp13b, 2.f);
+                    float32x4_t _tmp2m = vmlaq_n_f32(_tmp02a, _tmp02b, 4.f);
+                    float32x4_t _tmp3m = vmlaq_n_f32(vaddq_f32(_out0tm5, _tmp13a), _tmp13b, 8.f);
+
+                    vst1q_f32(tmp[0][m], _tmp0m);
+                    vst1q_f32(tmp[1][m], _tmp1m);
+                    vst1q_f32(tmp[2][m], _tmp2m);
+                    vst1q_f32(tmp[3][m], _tmp3m);
+
+                    output0_tm_0 += tiles * 24;
+                    output0_tm_1 += tiles * 24;
+                    output0_tm_2 += tiles * 24;
+                    output0_tm_3 += tiles * 24;
+                    output0_tm_4 += tiles * 24;
+                    output0_tm_5 += tiles * 24;
+                }
+
+                for (int m = 0; m < 4; m++)
+                {
+                    float32x4_t _tmp00 = vld1q_f32(tmp[m][0]);
+                    float32x4_t _tmp01 = vld1q_f32(tmp[m][1]);
+                    float32x4_t _tmp02 = vld1q_f32(tmp[m][2]);
+                    float32x4_t _tmp03 = vld1q_f32(tmp[m][3]);
+                    float32x4_t _tmp04 = vld1q_f32(tmp[m][4]);
+                    float32x4_t _tmp05 = vld1q_f32(tmp[m][5]);
+
+                    float32x4_t _tmp02a = vaddq_f32(_tmp01, _tmp02);
+                    float32x4_t _tmp13a = vsubq_f32(_tmp01, _tmp02);
+
+                    float32x4_t _tmp02b = vaddq_f32(_tmp03, _tmp04);
+                    float32x4_t _tmp13b = vsubq_f32(_tmp03, _tmp04);
+
+                    float32x4_t _out00 = vaddq_f32(_bias0, vaddq_f32(vaddq_f32(_tmp00, _tmp02a), _tmp02b));
+                    float32x4_t _out01 = vaddq_f32(_bias0, vmlaq_n_f32(_tmp13a, _tmp13b, 2.f));
+                    float32x4_t _out02 = vaddq_f32(_bias0, vmlaq_n_f32(_tmp02a, _tmp02b, 4.f));
+                    float32x4_t _out03 = vaddq_f32(_bias0, vmlaq_n_f32(vaddq_f32(_tmp05, _tmp13a), _tmp13b, 8.f));
+
+                    vst1q_f32(output0, _out00);
+                    vst1q_f32(output0 + 4, _out01);
+                    vst1q_f32(output0 + 8, _out02);
+                    vst1q_f32(output0 + 12, _out03);
+
+                    output0 += outw * 4;
+                }
+            }
+        }
+    }
+}

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -329,7 +329,11 @@ int NetPrivate::forward_layer(int layer_index, std::vector<Mat>& blob_mats, cons
     if (layer->one_blob_only)
     {
         int bottom_blob_index = layer->bottoms[0];
-        bottom_blob = blob_mats[bottom_blob_index].shape();
+        bottom_blob.dims = blob_mats[bottom_blob_index].dims;
+        bottom_blob.w = blob_mats[bottom_blob_index].w;
+        bottom_blob.h = blob_mats[bottom_blob_index].h;
+        bottom_blob.c = blob_mats[bottom_blob_index].c;
+        bottom_blob.elempack = blob_mats[bottom_blob_index].elempack;
     }
 #endif
     int ret = do_forward_layer(layer, blob_mats, opt);
@@ -499,7 +503,11 @@ int NetPrivate::forward_layer(int layer_index, std::vector<Mat>& blob_mats, std:
         if (layer->one_blob_only)
         {
             int bottom_blob_index = layer->bottoms[0];
-            bottom_blob = blob_mats[bottom_blob_index].shape();
+            bottom_blob.dims = blob_mats[bottom_blob_index].dims;
+            bottom_blob.w = blob_mats[bottom_blob_index].w;
+            bottom_blob.h = blob_mats[bottom_blob_index].h;
+            bottom_blob.c = blob_mats[bottom_blob_index].c;
+            bottom_blob.elempack = blob_mats[bottom_blob_index].elempack;
         }
 #endif
         ret = do_forward_layer(layer, blob_mats, opt);
@@ -830,7 +838,11 @@ IMAGE_ALLOCATION_FAILED:
         if (layer->one_blob_only)
         {
             int bottom_blob_index = layer->bottoms[0];
-            bottom_blob = blob_mats[bottom_blob_index].shape();
+            bottom_blob.dims = blob_mats[bottom_blob_index].dims;
+            bottom_blob.w = blob_mats[bottom_blob_index].w;
+            bottom_blob.h = blob_mats[bottom_blob_index].h;
+            bottom_blob.c = blob_mats[bottom_blob_index].c;
+            bottom_blob.elempack = blob_mats[bottom_blob_index].elempack;
         }
 #endif
         ret = do_forward_layer(layer, blob_mats, opt);

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -63,6 +63,8 @@ Option::Option()
     use_weight_fp16_storage = false;
 
     flush_denormals = 3;
+
+    use_a53_optimzed_kernel = false;
 }
 
 } // namespace ncnn

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -64,7 +64,7 @@ Option::Option()
 
     flush_denormals = 3;
 
-    use_a53_optimzed_kernel = false;
+    use_a53_optimized_kernel = false;
 }
 
 } // namespace ncnn

--- a/src/option.h
+++ b/src/option.h
@@ -130,7 +130,7 @@ public:
     int flush_denormals;
 
     // turn on for cortex-A53
-    bool use_a53_optimzed_kernel;
+    bool use_a53_optimized_kernel;
 
     bool use_reserved_1;
     bool use_reserved_2;

--- a/src/option.h
+++ b/src/option.h
@@ -129,7 +129,9 @@ public:
     // 3 = DAZ ON,  FTZ ON
     int flush_denormals;
 
-    bool use_reserved_0;
+    // turn on for cortex-A53
+    bool use_a53_optimzed_kernel;
+
     bool use_reserved_1;
     bool use_reserved_2;
     bool use_reserved_3;


### PR DESCRIPTION

qcom425 1t  | baseline | a53 |  
-- | -- | -- | --
squeezenet | 124.39 | 114.89 | -7.64%
mobilenet | 206.12 | 183.58 | -10.94%
mobilenet_v2 | 142.06 | 129.79 | -8.64%
mobilenet_v3 | 129.85 | 120.74 | -7.02%
shufflenet | 86.71 | 82.87 | -4.43%
shufflenet_v2 | 73.02 | 68.24 | -6.55%
mnasnet | 138.52 | 126.06 | -9.00%
proxylessnasnet | 177.83 | 164.68 | -7.39%
efficientnet_b0 | 314.98 | 300.78 | -4.51%
regnety_400m | 183.92 | 169.04 | -8.09%
blazeface | 31.02 | 30.61 | -1.32%
googlenet | 438.95 | 415.28 | -5.39%
resnet18 | 336.22 | 317.67 | -5.52%
alexnet | 597.92 | 602.87 | 0.83%
vgg16 | 2095.2 | 1927.18 | -8.02%
resnet50 | 954.55 | 858.67 | -10.04%
squeezenet_ssd | 291.6 | 281.87 | -3.34%
mobilenet_ssd | 423.34 | 376.51 | -11.06%
mobilenet_yolo | 928.3 | 827.92 | -10.81%
mobilenetv2_yolov3 | 500.5 | 456.2 | -8.85%
yolov4-tiny | 685.72 | 648.05 | -5.49%

