### PR TITLE
Fixing TypeError assertions in test_extractor.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ build*/
 .idea
 cmake-build-debug
 cmake-build-release
+
+# Compiled python
+__pycache__
+*.pyc
+*.pyd

--- a/python/tests/test_extractor.py
+++ b/python/tests/test_extractor.py
@@ -20,9 +20,8 @@ alloctor = ncnn.PoolAllocator()
 
 
 def test_extractor():
-    with pytest.raises(TypeError) as execinfo:
+    with pytest.raises(TypeError, match="No constructor"):
         ex = ncnn.Extractor()
-        assert "No constructor" in str(execinfo.value)
 
     dr = ncnn.DataReaderFromEmpty()
 
@@ -53,9 +52,8 @@ def test_extractor():
 
 
 def test_extractor_index():
-    with pytest.raises(TypeError) as execinfo:
+    with pytest.raises(TypeError, match="No constructor"):
         ex = ncnn.Extractor()
-        assert "No constructor" in str(execinfo.value)
 
     dr = ncnn.DataReaderFromEmpty()
 


### PR DESCRIPTION
The `assert` statement will not take effect in my local test, and I use this `match` parameter to replace it.

cc @nihui @caishanli 