### PR TITLE
Fixed compile warnings for clang compiler on MacOS. [-Wunused-parameter]

### DIFF
--- a/src/layer/x86/convolution_x86.cpp
+++ b/src/layer/x86/convolution_x86.cpp
@@ -1177,7 +1177,6 @@ int Convolution_x86::forward_int8_x86(const Mat& bottom_blob, Mat& top_blob, con
     int h = bottom_blob_bordered.h;
     int channels = bottom_blob_bordered.c;
     int elempack = bottom_blob_bordered.elempack;
-    size_t elemsize = bottom_blob_bordered.elemsize;
 
     const int kernel_extent_w = dilation_w * (kernel_w - 1) + 1;
     const int kernel_extent_h = dilation_h * (kernel_h - 1) + 1;

--- a/src/layer/x86/convolutiondepthwise_x86.cpp
+++ b/src/layer/x86/convolutiondepthwise_x86.cpp
@@ -672,7 +672,6 @@ int ConvolutionDepthWise_x86::forward_int8_x86(const Mat& bottom_blob, Mat& top_
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int channels = bottom_blob.c;
-    size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
     int elembits = bottom_blob.elembits();


### PR DESCRIPTION
Hi, NCNN Team.

I fixed several compile warnings for clang MacOS.
Could you review and accept my changes, pls?

https://github.com/Tencent/ncnn/runs/2781578810?check_suite_focus=true

/Users/runner/work/ncnn/ncnn/src/layer/x86/convolution_x86.cpp:1180:12: warning: unused variable 'elemsize' [-Wunused-variable]
    size_t elemsize = bottom_blob_bordered.elemsize;
           ^

/Users/runner/work/ncnn/ncnn/src/layer/x86/convolutiondepthwise_x86.cpp:675:12: warning: unused variable 'elemsize' [-Wunused-variable]
    size_t elemsize = bottom_blob.elemsize;
           ^
1 warning generated.

Best regards, Proydakov Evgeny.