### PR TITLE
Fixed compile warnings for clang compiler on MacOS ARM. [-Wunused-variable]

### DIFF
--- a/src/layer/arm/convolution_3x3_pack4_fp16s.h
+++ b/src/layer/arm/convolution_3x3_pack4_fp16s.h
@@ -1155,7 +1155,6 @@ static void conv3x3s1_winograd64_pack4_fp16sa_neon(const Mat& bottom_blob, Mat& 
 
 static void conv3x3s1_pack4_fp16sa_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
 {
-    int w = bottom_blob.w;
     int inch = bottom_blob.c;
     int outw = top_blob.w;
     int outh = top_blob.h;

--- a/src/layer/arm/convolution_3x3_pack8_fp16s.h
+++ b/src/layer/arm/convolution_3x3_pack8_fp16s.h
@@ -2246,7 +2246,6 @@ static void conv3x3s1_winograd42_pack8_fp16sa_neon(const Mat& bottom_blob, Mat& 
 
 static void conv3x3s1_pack8_fp16sa_neon(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, const Option& opt)
 {
-    int w = bottom_blob.w;
     int inch = bottom_blob.c;
     int outw = top_blob.w;
     int outh = top_blob.h;

--- a/src/layer/arm/convolution_arm.cpp
+++ b/src/layer/arm/convolution_arm.cpp
@@ -1073,7 +1073,6 @@ int Convolution_arm::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const 
 {
     int w = bottom_blob.w;
     int h = bottom_blob.h;
-    int channels = bottom_blob.c;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
@@ -1618,7 +1617,6 @@ int Convolution_arm::forward_bf16s(const Mat& bottom_blob, Mat& top_blob, const 
 {
     int w = bottom_blob.w;
     int h = bottom_blob.h;
-    int channels = bottom_blob.c;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
@@ -1994,7 +1992,6 @@ int Convolution_arm::forward_int8_arm(const Mat& bottom_blob, Mat& top_blob, con
     int h = bottom_blob_bordered.h;
     int channels = bottom_blob_bordered.c;
     int elempack = bottom_blob_bordered.elempack;
-    size_t elemsize = bottom_blob_bordered.elemsize;
 
     const int kernel_extent_w = dilation_w * (kernel_w - 1) + 1;
     const int kernel_extent_h = dilation_h * (kernel_h - 1) + 1;
@@ -2026,7 +2023,9 @@ int Convolution_arm::forward_int8_arm(const Mat& bottom_blob, Mat& top_blob, con
     if (top_blob.empty())
         return -100;
 
+#if __ARM_FEATURE_DOTPROD
     const int num_input = channels * elempack;
+#endif
 
     Mat top_blob_int32;
     top_blob_int32.create(outw, outh, num_output / out_elempack, (size_t)(4u * out_elempack), out_elempack, opt.workspace_allocator);

--- a/src/layer/arm/convolutiondepthwise_arm.cpp
+++ b/src/layer/arm/convolutiondepthwise_arm.cpp
@@ -1494,7 +1494,6 @@ int ConvolutionDepthWise_arm::forward_int8_arm(const Mat& bottom_blob, Mat& top_
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int channels = bottom_blob.c;
-    size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
     int elembits = bottom_blob.elembits();


### PR DESCRIPTION
Hi, NCNN Team.

I fixed several compile warnings for arm & macOS.
Could you review & accept my changes, pls?

https://github.com/Tencent/ncnn/runs/2792117250?check_suite_focus=true
/Users/runner/work/ncnn/ncnn/src/layer/arm/convolution_3x3_pack4_fp16s.h:1158:9: warning: unused variable 'w' [-Wunused-variable]
    int w = bottom_blob.w;
        ^

Best regards, Proydakov Evgeny.