### PR TITLE
fix video load error in python examples[yolov4]

### DIFF
--- a/python/examples/yolov4.py
+++ b/python/examples/yolov4.py
@@ -50,4 +50,4 @@ if __name__ == "__main__":
 
             objects = net(frame)
 
-            draw_detection_objects(m, net.class_names, objects)
+            draw_detection_objects(frame, net.class_names, objects)


### PR DESCRIPTION
在 python/examples/yolov4.py 中， 如果判断为摄像头输入并且获取摄像头帧后，运行模型的函数变量引用错误。