### PR TITLE
some misspell

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -120,7 +120,7 @@ memory usage is the RSS item in top utility output
 |inference time(8 thread)|152ms|38ms|
 |memory usage|138.16M|21.56M|
 |library binary size|6.9M|<500K|
-|compability|armeabi-v7a-hard with neon or arm64-v8a|armeabi-v7a with neon or arm64-v8a|
+|compatibility|armeabi-v7a-hard with neon or arm64-v8a|armeabi-v7a with neon or arm64-v8a|
 |thirdparty dependency|boost gflags glog lmdb openblas opencv protobuf|none|
 
 ### FAQ

--- a/docs/benchmark/the-benchmark-of-caffe-android-lib,-mini-caffe,-and-ncnn.md
+++ b/docs/benchmark/the-benchmark-of-caffe-android-lib,-mini-caffe,-and-ncnn.md
@@ -38,7 +38,7 @@ RAM: 3G
 
 Benchmark method: 
 
-Run squeezenet, mobilenet inference 23 times in a loop, discard the the first three warmup records, and then calculate the average inference time
+Run squeezenet, mobilenet inference 23 times in a loop, discard the first three warmup records, and then calculate the average inference time
 
 Run vgg169 times in a loop, discard the first warmup record, and then calculate the average inference time
 

--- a/docs/how-to-build/how-to-build.md
+++ b/docs/how-to-build/how-to-build.md
@@ -43,7 +43,7 @@ tar -xf vulkansdk-linux-x86_64-1.2.154.0.tar.gz
 export VULKAN_SDK=$(pwd)/1.2.154.0/x86_64
 ```
 
-To use Vulkan after building ncnn later, you will also need to have Vulkan driver for your GPU. For AMD and Intel GPUs these can be found in Mesa graphics driver, which usually is installed by default on all distros (i.e. `sudo apt install mesa-vulkan-drivers` on Debian/Ubuntu). For Nvidia GPUs the propietary Nvidia driver must be downloaded and installed (some distros will allow easier installation in some way). After installing Vulkan driver, confirm Vulkan libraries and driver are working, by using `vulkaninfo` or `vulkaninfo | grep deviceType`, it should list GPU device type. If there are more than one GPU installed (including the case of integrated GPU and discrete GPU, commonly found in laptops), you might need to note the order of devices to use later on.
+To use Vulkan after building ncnn later, you will also need to have Vulkan driver for your GPU. For AMD and Intel GPUs these can be found in Mesa graphics driver, which usually is installed by default on all distros (i.e. `sudo apt install mesa-vulkan-drivers` on Debian/Ubuntu). For Nvidia GPUs the proprietary Nvidia driver must be downloaded and installed (some distros will allow easier installation in some way). After installing Vulkan driver, confirm Vulkan libraries and driver are working, by using `vulkaninfo` or `vulkaninfo | grep deviceType`, it should list GPU device type. If there are more than one GPU installed (including the case of integrated GPU and discrete GPU, commonly found in laptops), you might need to note the order of devices to use later on.
 
 Nvidia Jetson devices the Vulkan support should be present in Nvidia provided SDK (Jetpack) or prebuild OS images.
 

--- a/docs/how-to-use-and-FAQ/build-minimal-library.md
+++ b/docs/how-to-use-and-FAQ/build-minimal-library.md
@@ -71,7 +71,7 @@ cmake -DNCNN_PIXEL_ROTATE=OFF -DNCNN_PIXEL_AFFINE=OFF ..
 cmake -DNCNN_PIXEL=OFF ..
 ```
 
-* Cannot use functions transfering from image to pixels like `Mat::from_pixels / from_pixels_resize / to_pixels / to_pixels_resize`, and need create a Mat and fill in data by hand.
+* Cannot use functions transferring from image to pixels like `Mat::from_pixels / from_pixels_resize / to_pixels / to_pixels_resize`, and need create a Mat and fill in data by hand.
 
 ### disable openmp
 

--- a/docs/how-to-use-and-FAQ/use-ncnn-with-alexnet.md
+++ b/docs/how-to-use-and-FAQ/use-ncnn-with-alexnet.md
@@ -44,7 +44,7 @@ caffe2ncnn deploy.prototxt bvlc_alexnet.caffemodel alexnet.param alexnet.bin
 
 ### strip visible string
 
-It is already enough for deploying with param and bin file only, but there are visible strings in param file, it may not be suitable to distrubute plain neural network information in your APP.
+It is already enough for deploying with param and bin file only, but there are visible strings in param file, it may not be suitable to distribute plain neural network information in your APP.
 
 You can use ncnn2mem tool to convert plain model file to binary representation. It will generate alexnet.param.bin and two static array code files.
 ```
@@ -85,7 +85,7 @@ net.clear();
 
 ncnn Mat is the data structure for input and output data
 
-Input image should be converted to Mat, and substracted mean values and normalized when needed
+Input image should be converted to Mat, and subtracted mean values and normalized when needed
 
 ```cpp
 #include "mat.h"

--- a/examples/synset_words.txt
+++ b/examples/synset_words.txt
@@ -10,7 +10,7 @@ n01514859 hen
 n01518878 ostrich, Struthio camelus
 n01530575 brambling, Fringilla montifringilla
 n01531178 goldfinch, Carduelis carduelis
-n01532829 house finch, linnet, Carpodacus mexicanus
+n01532829 house finch, linnet, Carpodacus mexicans
 n01534433 junco, snowbird
 n01537544 indigo bunting, indigo finch, indigo bird, Passerina cyanea
 n01558993 robin, American robin, Turdus migratorius
@@ -120,7 +120,7 @@ n01978287 Dungeness crab, Cancer magister
 n01978455 rock crab, Cancer irroratus
 n01980166 fiddler crab
 n01981276 king crab, Alaska crab, Alaskan king crab, Alaska king crab, Paralithodes camtschatica
-n01983481 American lobster, Northern lobster, Maine lobster, Homarus americanus
+n01983481 American lobster, Northern lobster, Maine lobster, Homarus americans
 n01984695 spiny lobster, langouste, rock lobster, crawfish, crayfish, sea crawfish
 n01985128 crayfish, crawfish, crawdad, crawdaddy
 n01986214 hermit crab
@@ -293,7 +293,7 @@ n02129165 lion, king of beasts, Panthera leo
 n02129604 tiger, Panthera tigris
 n02130308 cheetah, chetah, Acinonyx jubatus
 n02132136 brown bear, bruin, Ursus arctos
-n02133161 American black bear, black bear, Ursus americanus, Euarctos americanus
+n02133161 American black bear, black bear, Ursus americans, Euarctos americans
 n02134084 ice bear, polar bear, Ursus Maritimus, Thalarctos maritimus
 n02134418 sloth bear, Melursus ursinus, Ursus ursinus
 n02137549 mongoose

--- a/examples/yolact.cpp
+++ b/examples/yolact.cpp
@@ -190,7 +190,7 @@ static int detect_yolact(const cv::Mat& bgr, std::vector<Object>& objects)
                         float w = scale * ar / 550;
                         float h = scale / ar / 550;
 
-                        // This is for backward compatability with a bug where I made everything square by accident
+                        // This is for backward compatibility with a bug where I made everything square by accident
                         // cfg.backbone.use_square_anchors:
                         h = w;
 

--- a/python/ncnn/model_zoo/yolact.py
+++ b/python/ncnn/model_zoo/yolact.py
@@ -213,7 +213,7 @@ class Yolact:
                             w = scale * ar / self.target_size
                             h = scale / ar / self.target_size
 
-                            # This is for backward compatability with a bug where I made everything square by accident
+                            # This is for backward compatibility with a bug where I made everything square by accident
                             h = w
 
                             prior_data += [cx, cy, w, h]

--- a/tools/caffe/caffe.proto
+++ b/tools/caffe/caffe.proto
@@ -1658,6 +1658,6 @@ message PReLUParameter {
 
   // Initial value of a_i. Default is a_i=0.25 for all i.
   optional FillerParameter filler = 1;
-  // Whether or not slope paramters are shared across channels.
+  // Whether or not slope parameters are shared across channels.
   optional bool channel_shared = 2 [default = false];
 }

--- a/tools/darknet/README.md
+++ b/tools/darknet/README.md
@@ -37,7 +37,7 @@ Loading weights...
 Converting model...
 83 layers, 91 blobs generated.
 NOTE: The input of darknet uses: mean_vals=0 and norm_vals=1/255.f.
-NOTE: Remeber to use ncnnoptimize for better performance.
+NOTE: Remember to use ncnnoptimize for better performance.
 ```
 
 ### 2. Optimize graphic

--- a/tools/darknet/darknet2ncnn.cpp
+++ b/tools/darknet/darknet2ncnn.cpp
@@ -956,7 +956,7 @@ int main(int argc, char** argv)
         printf("NOTE: There are %d unmerged yolo output layer. Make sure all outputs are processed with nms.\n", yolo_layer_count);
     if (letter_box_enabled)
         printf("NOTE: Make sure your pre-processing and post-processing support letter_box.\n");
-    printf("NOTE: Remeber to use ncnnoptimize for better performance.\n");
+    printf("NOTE: Remember to use ncnnoptimize for better performance.\n");
 
     return 0;
 }

--- a/tools/keras/readme.md
+++ b/tools/keras/readme.md
@@ -4,7 +4,7 @@
 [https://github.com/azeme1/keras2ncnn](https://github.com/azeme1/keras2ncnn)
 
 ----
-### From tensorflow 2.x, you can also export mlir and use mlir2ncnn which is maintaince by the official.
+### From tensorflow 2.x, you can also export mlir and use mlir2ncnn which is maintained by the official.
 
 The source code is located here: [https://github.com/Tencent/ncnn/tree/master/tools/mlir](https://github.com/Tencent/ncnn/tree/master/tools/mlir)  
 For Chinese, you can refer the guide here [https://zhuanlan.zhihu.com/p/152535430](https://zhuanlan.zhihu.com/p/152535430)

--- a/tools/onnx/onnx.proto
+++ b/tools/onnx/onnx.proto
@@ -129,7 +129,7 @@ message AttributeProto {
   // implementations needed to use has_field hueristics to determine
   // which value field was in use.  For IR_VERSION 0.0.2 or later, this
   // field MUST be set and match the f|i|s|t|... field in use.  This
-  // change was made to accomodate proto3 implementations.
+  // change was made to accommodate proto3 implementations.
   optional AttributeType type = 20;   // discriminator that indicates which field below is in use
 
   // Exactly ONE of the following fields must be present for this version of the IR


### PR DESCRIPTION
```shell
# edward @ edward-pc in ~/code/cpp/ncnn on git:master o [23:36:05]
$ misspell .
docs/Home.md:123:1: "compability" is a misspelling of "compatibility"
docs/how-to-use-and-FAQ/build-minimal-library.md:74:23: "transfering" is a misspelling of "transferring"
docs/how-to-use-and-FAQ/quantized-int8-inference.md:26:53: "substract" is a misspelling of "subtract"
docs/how-to-use-and-FAQ/use-ncnn-with-alexnet.md:47:136: "distrubute" is a misspelling of "distribute"
docs/how-to-use-and-FAQ/use-ncnn-with-alexnet.md:88:44: "substracted" is a misspelling of "subtracted"
docs/how-to-build/how-to-build.md:46:300: "propietary" is a misspelling of "proprietary"
examples/squeezenet_c_api.cpp:39:13: "substract" is a misspelling of "subtract"
examples/yolact.cpp:193:48: "compatability" is a misspelling of "compatibility"
examples/synset_words.txt:13:42: "mexicanus" is a misspelling of "mexicans"
examples/synset_words.txt:123:69: "americanus" is a misspelling of "americans"
examples/synset_words.txt:296:49: "americanus" is a misspelling of "americans"
examples/synset_words.txt:296:70: "americanus" is a misspelling of "americans"
python/ncnn/model_zoo/yolact.py:216:51: "compatability" is a misspelling of "compatibility"
python/tests/test_mat.py:576:9: "substract" is a misspelling of "subtract"
src/c_api.h:107:26: "substract" is a misspelling of "subtract"
src/c_api.cpp:353:14: "substract" is a misspelling of "subtract"
src/c_api.cpp:355:17: "substract" is a misspelling of "subtract"
python/src/main.cpp:500:5: "substract" is a misspelling of "subtract"
src/layer/arm/convolution_1x1_int8.h:40:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_int8.h:82:42: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack1to4_int8.h:40:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack1to4_int8.h:82:51: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack4.h:40:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack4.h:64:43: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack4_fp16s.h:667:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack4_fp16s.h:716:50: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack4to8_fp16s.h:304:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack4to8_fp16s.h:353:53: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack4_bf16s.h:40:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack4_bf16s.h:89:49: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack8to1_int8.h:40:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack8to1_int8.h:89:51: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack8_fp16s.h:40:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack8_fp16s.h:89:50: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack4to1.h:1872:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack4to1.h:1896:46: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack8to1_fp16s.h:761:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack8to1_fp16s.h:810:53: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack8to4_int8.h:40:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack8to4_int8.h:89:51: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack4to1_bf16s.h:2191:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack4to1_bf16s.h:2240:52: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack8to4_fp16s.h:785:20: "shrinked" is a misspelling of "shrunk"
src/layer/arm/convolution_1x1_pack8to4_fp16s.h:834:53: "shrinked" is a misspelling of "shrunk"
src/layer/arm/neon_mathfun.h:177:19: "substract" is a misspelling of "subtract"
src/layer/arm/neon_mathfun_fp16s.h:231:19: "substract" is a misspelling of "subtract"
src/layer/arm/neon_mathfun_fp16s.h:292:19: "substract" is a misspelling of "subtract"
src/layer/mips/mips_mathfun.h:157:19: "substract" is a misspelling of "subtract"
src/layer/riscv/convolution_1x1_packn.h:43:20: "shrinked" is a misspelling of "shrunk"
src/layer/riscv/convolution_1x1_packn.h:67:42: "shrinked" is a misspelling of "shrunk"
src/layer/riscv/convolution_1x1_packnto1_fp16s.h:43:20: "shrinked" is a misspelling of "shrunk"
src/layer/riscv/convolution_1x1_packnto1_fp16s.h:67:52: "shrinked" is a misspelling of "shrunk"
src/layer/riscv/convolution_1x1_packn_fp16s.h:43:20: "shrinked" is a misspelling of "shrunk"
src/layer/riscv/convolution_1x1_packn_fp16s.h:67:49: "shrinked" is a misspelling of "shrunk"
src/layer/riscv/convolution_1x1_packnto1.h:43:20: "shrinked" is a misspelling of "shrunk"
src/layer/riscv/convolution_1x1_packnto1.h:67:45: "shrinked" is a misspelling of "shrunk"
src/layer/riscv/rvv_mathfun_fp16s.h:138:23: "substract" is a misspelling of "subtract"
src/layer/riscv/rvv_mathfun.h:138:23: "substract" is a misspelling of "subtract"
src/layer/x86/convolution_1x1_pack4.h:379:20: "shrinked" is a misspelling of "shrunk"
src/layer/x86/convolution_1x1_pack4.h:403:42: "shrinked" is a misspelling of "shrunk"
src/layer/x86/convolution_1x1_pack8to4_int8.h:40:20: "shrinked" is a misspelling of "shrunk"
src/layer/x86/convolution_1x1_pack8.h:977:20: "shrinked" is a misspelling of "shrunk"
src/layer/x86/convolution_1x1_pack8to4_int8.h:64:50: "shrinked" is a misspelling of "shrunk"
src/layer/x86/convolution_1x1_pack8_fp16.h:1012:20: "shrinked" is a misspelling of "shrunk"
src/layer/x86/convolution_1x1_pack8_fp16.h:1036:47: "shrinked" is a misspelling of "shrunk"
src/layer/x86/convolution_1x1_pack8.h:1001:42: "shrinked" is a misspelling of "shrunk"
src/layer/x86/sse_mathfun.h:253:19: "substract" is a misspelling of "subtract"
src/mat.cpp:789:10: "substract" is a misspelling of "subtract"
src/mat.cpp:795:11: "substract" is a misspelling of "subtract"
src/mat.cpp:833:11: "substract" is a misspelling of "subtract"
src/mat.h:274:7: "substract" is a misspelling of "subtract"
src/mat.h:275:9: "substract" is a misspelling of "subtract"
tools/darknet/README.md:40:6: "Remeber" is a misspelling of "Remember"
tools/keras/readme.md:7:77: "maintaince" is a misspelling of "maintained"
tools/darknet/darknet2ncnn.cpp:959:18: "Remeber" is a misspelling of "Remember"
tools/mlir/tf_types.cc:296:61: "compatibilty" is a misspelling of "compatibility"
tools/caffe/caffe.proto:434:46: "substract" is a misspelling of "subtract"
tools/caffe/caffe.proto:1118:67: "explicitely" is a misspelling of "explicitly"
tools/caffe/caffe.proto:1661:26: "paramters" is a misspelling of "parameters"
tools/onnx/onnx.proto:132:24: "accomodate" is a misspelling of "accommodate"
```


just fix a part of