### PR TITLE
修正eq校准中使用错误的索引

### DIFF
--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -1095,7 +1095,7 @@ int QuantNet::quantize_EQ()
                         pixel_convert_type = pixel_convert_type | (type_to_pixel << ncnn::Mat::PIXEL_CONVERT_SHIFT);
                     }
 
-                    ncnn::Mat in = read_and_resize_image(shapes[j], listspaths[j][i], pixel_convert_type);
+                    ncnn::Mat in = read_and_resize_image(shapes[jj], listspaths[jj][ii], pixel_convert_type);
 
                     in.substract_mean_normalize(mean_vals.data(), norm_vals.data());
 
@@ -1204,7 +1204,7 @@ int QuantNet::quantize_EQ()
                         pixel_convert_type = pixel_convert_type | (type_to_pixel << ncnn::Mat::PIXEL_CONVERT_SHIFT);
                     }
 
-                    ncnn::Mat in = read_and_resize_image(shapes[j], listspaths[j][i], pixel_convert_type);
+                    ncnn::Mat in = read_and_resize_image(shapes[jj], listspaths[jj][ii], pixel_convert_type);
 
                     in.substract_mean_normalize(mean_vals.data(), norm_vals.data());
 


### PR DESCRIPTION
eq校准里的 ij 已经使用了 使用ii jj来索引input blobs和images 但是在调用read_and_resize_image时使用的还是i和j