### PR TITLE
Custom compile flags to hide known compile warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,7 +290,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang
         target_compile_options(ncnn PRIVATE /wd4251)
     endif()
 else()
-    target_compile_options(ncnn PRIVATE "-Wall" "-Wextra" "-Wno-unused-function" "-Wno-unused-variable" "-Wno-unused-parameter" "-Wno-#warnings")
+    target_compile_options(ncnn PRIVATE "-Wall" "-Wextra" "-Wno-unused-function" "-Wno-unused-variable" "-Wno-unused-parameter" "-Wno-#warnings" "-Wno-cpp")
 
     if(NOT NCNN_DISABLE_PIC)
         set_target_properties(ncnn PROPERTIES POSITION_INDEPENDENT_CODE ON INTERFACE_POSITION_INDEPENDENT_CODE ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,7 +290,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang
         target_compile_options(ncnn PRIVATE /wd4251)
     endif()
 else()
-    target_compile_options(ncnn PRIVATE -Wall -Wextra -Wno-unused-function)
+    target_compile_options(ncnn PRIVATE "-Wall" "-Wextra" "-Wno-unused-function" "-Wno-unused-variable" "-Wno-unused-parameter" "-Wno-#warnings")
 
     if(NOT NCNN_DISABLE_PIC)
         set_target_properties(ncnn PROPERTIES POSITION_INDEPENDENT_CODE ON INTERFACE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Hi, Nihui

This PR ignore unused variable / parameters and -W#warnings on Linux with Clang13/GCC 9.3 compiler.

Thus, less warnings are displayed during compilation on Linux.