### PR TITLE
Added Khadas VIM3 Amlogic A311D benchmark

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1093,6 +1093,48 @@ cooling_down = 1
   mobilenetv2_yolov3  min =  241.08  max =  283.54  avg =  248.69
 ```
 
+### Khadas VIM3, Amlogic A311D (Cortex-A73 2.2GHz x 4 + Cortex-A53 1.8GHz x 2)
+
+```
+khadas@Khadas:~/src/ncnn/build/benchmark$ ./benchncnn 8 4 0
+loop_count = 8
+num_threads = 4
+powersave = 0
+gpu_device = -1
+cooling_down = 1
+          squeezenet  min =   30.41  max =   31.60  avg =   30.77
+     squeezenet_int8  min =   22.90  max =   23.25  avg =   23.05
+           mobilenet  min =   41.15  max =   43.74  avg =   42.54
+      mobilenet_int8  min =   21.51  max =   21.73  avg =   21.59
+        mobilenet_v2  min =   38.40  max =   48.42  avg =   39.99
+        mobilenet_v3  min =   28.59  max =   28.92  avg =   28.75
+          shufflenet  min =   21.45  max =   22.02  avg =   21.80
+       shufflenet_v2  min =   17.89  max =   18.75  avg =   18.41
+             mnasnet  min =   32.63  max =   32.99  avg =   32.86
+     proxylessnasnet  min =   34.64  max =   35.23  avg =   34.95
+     efficientnet_b0  min =   54.21  max =   55.11  avg =   54.53
+   efficientnetv2_b0  min =   60.40  max =   67.12  avg =   61.59
+        regnety_400m  min =   44.48  max =   45.19  avg =   44.73
+           blazeface  min =    6.30  max =    6.60  avg =    6.42
+           googlenet  min =   82.00  max =   83.10  avg =   82.61
+      googlenet_int8  min =   62.26  max =   62.93  avg =   62.58
+            resnet18  min =   76.44  max =   77.69  avg =   76.99
+       resnet18_int8  min =   47.11  max =   60.65  avg =   49.32
+             alexnet  min =   69.62  max =   71.72  avg =   70.07
+               vgg16  min =  404.06  max =  420.23  avg =  409.68
+          vgg16_int8  min =  255.44  max =  279.67  avg =  259.34
+            resnet50  min =  181.19  max =  189.97  avg =  182.90
+       resnet50_int8  min =  123.59  max =  124.25  avg =  123.87
+      squeezenet_ssd  min =   89.93  max =  100.39  avg =   91.84
+ squeezenet_ssd_int8  min =   64.18  max =   70.68  avg =   65.32
+       mobilenet_ssd  min =   89.30  max =   97.50  avg =   90.63
+  mobilenet_ssd_int8  min =   45.81  max =   46.21  avg =   45.97
+      mobilenet_yolo  min =  195.86  max =  203.00  avg =  198.64
+  mobilenetv2_yolov3  min =  125.46  max =  132.40  avg =  127.01
+         yolov4-tiny  min =  150.44  max =  154.86  avg =  151.87
+           nanodet_m  min =   50.55  max =   51.29  avg =   50.97
+```
+
 ### Rockchip RK3399 (Cortex-A72 1.8GHz x 2 + Cortex-A53 1.5GHz x 4)
 ```
 rk3399_firefly_box:/data/local/tmp/ncnn/benchmark # ./benchncnn 8 2 2


### PR DESCRIPTION
#### Khadas VIM3, Amlogic A311D (Cortex-A73 2.2GHz x 4 + Cortex-A53 1.8GHz x 2)

```
khadas@Khadas:~/src/ncnn/build/benchmark$ ./benchncnn 8 4 0
loop_count = 8
num_threads = 4
powersave = 0
gpu_device = -1
cooling_down = 1
          squeezenet  min =   30.41  max =   31.60  avg =   30.77
     squeezenet_int8  min =   22.90  max =   23.25  avg =   23.05
           mobilenet  min =   41.15  max =   43.74  avg =   42.54
      mobilenet_int8  min =   21.51  max =   21.73  avg =   21.59
        mobilenet_v2  min =   38.40  max =   48.42  avg =   39.99
        mobilenet_v3  min =   28.59  max =   28.92  avg =   28.75
          shufflenet  min =   21.45  max =   22.02  avg =   21.80
       shufflenet_v2  min =   17.89  max =   18.75  avg =   18.41
             mnasnet  min =   32.63  max =   32.99  avg =   32.86
     proxylessnasnet  min =   34.64  max =   35.23  avg =   34.95
     efficientnet_b0  min =   54.21  max =   55.11  avg =   54.53
   efficientnetv2_b0  min =   60.40  max =   67.12  avg =   61.59
        regnety_400m  min =   44.48  max =   45.19  avg =   44.73
           blazeface  min =    6.30  max =    6.60  avg =    6.42
           googlenet  min =   82.00  max =   83.10  avg =   82.61
      googlenet_int8  min =   62.26  max =   62.93  avg =   62.58
            resnet18  min =   76.44  max =   77.69  avg =   76.99
       resnet18_int8  min =   47.11  max =   60.65  avg =   49.32
             alexnet  min =   69.62  max =   71.72  avg =   70.07
               vgg16  min =  404.06  max =  420.23  avg =  409.68
          vgg16_int8  min =  255.44  max =  279.67  avg =  259.34
            resnet50  min =  181.19  max =  189.97  avg =  182.90
       resnet50_int8  min =  123.59  max =  124.25  avg =  123.87
      squeezenet_ssd  min =   89.93  max =  100.39  avg =   91.84
 squeezenet_ssd_int8  min =   64.18  max =   70.68  avg =   65.32
       mobilenet_ssd  min =   89.30  max =   97.50  avg =   90.63
  mobilenet_ssd_int8  min =   45.81  max =   46.21  avg =   45.97
      mobilenet_yolo  min =  195.86  max =  203.00  avg =  198.64
  mobilenetv2_yolov3  min =  125.46  max =  132.40  avg =  127.01
         yolov4-tiny  min =  150.44  max =  154.86  avg =  151.87
           nanodet_m  min =   50.55  max =   51.29  avg =   50.97
```