### PR TITLE
Remove two potential warnings for VisualStudio

### DIFF
--- a/src/mat.h
+++ b/src/mat.h
@@ -1460,7 +1460,7 @@ inline size_t VkMat::total() const
 
 inline int VkMat::elembits() const
 {
-    return elempack ? elemsize * 8 / elempack : 0;
+    return elempack ? static_cast<int>(elemsize) * 8 / elempack : 0;
 }
 
 inline Mat VkMat::shape() const
@@ -1662,7 +1662,7 @@ inline size_t VkImageMat::total() const
 
 inline int VkImageMat::elembits() const
 {
-    return elempack ? elemsize * 8 / elempack : 0;
+    return elempack ? static_cast<int>(elemsize) * 8 / elempack : 0;
 }
 
 inline Mat VkImageMat::shape() const


### PR DESCRIPTION
There are two warnings about data conversion(`size_t` to `int`) in `mat.h` when compiling on VisualStudio, this PR fixed them.