### PR TITLE
Fix broken codepaths with AVX only

### DIFF
--- a/.github/workflows/linux-x64-cpu-gcc.yml
+++ b/.github/workflows/linux-x64-cpu-gcc.yml
@@ -28,7 +28,7 @@ on:
     - 'examples/**'
 jobs:
   linux-gcc:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
     - name: cancel-previous-runs
       uses: styfle/cancel-workflow-action@0.9.1
@@ -81,7 +81,7 @@ jobs:
       run: cd build-noint8 && ctest --output-on-failure -j 2
 
   linux-gcc-cpp03-nostdio-nostring-simplestl:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
     - name: cancel-previous-runs
       uses: styfle/cancel-workflow-action@0.9.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,92 +39,6 @@ jobs:
         name: ${{ env.PACKAGENAME }}
         path: /tmp/${{ env.PACKAGENAME }}.zip
 
-  ubuntu-1604:
-    needs: [setup]
-    runs-on: ubuntu-16.04
-    env:
-      PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-ubuntu-1604
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: apt
-      run: |
-        sudo apt-get install -y libvulkan-dev libprotobuf-dev protobuf-compiler
-    - name: build
-      run: |
-        mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DNCNN_VERSION_STRING="${{ needs.setup.outputs.VERSION }}" \
-            -DNCNN_VULKAN=ON -DNCNN_BUILD_EXAMPLES=OFF -DNCNN_BUILD_TOOLS=ON -DNCNN_BUILD_BENCHMARK=OFF ..
-        cmake --build . -j 2
-        cmake --build . --target install
-    - name: package
-      run: |
-        rm -rf ${{ env.PACKAGENAME }}
-        mkdir -p ${{ env.PACKAGENAME }}
-        cp -r build/install/* ${{ env.PACKAGENAME }}
-        mkdir -p ${{ env.PACKAGENAME }}/bin
-        cp build/tools/caffe/caffe2ncnn ${{ env.PACKAGENAME }}/bin
-        cp build/tools/mxnet/mxnet2ncnn ${{ env.PACKAGENAME }}/bin
-        cp build/tools/onnx/onnx2ncnn ${{ env.PACKAGENAME }}/bin
-        cp build/tools/darknet/darknet2ncnn ${{ env.PACKAGENAME }}/bin
-        cp build/tools/ncnnoptimize ${{ env.PACKAGENAME }}/bin
-        cp build/tools/ncnn2mem ${{ env.PACKAGENAME }}/bin
-        cp build/tools/ncnnmerge ${{ env.PACKAGENAME }}/bin
-        cp build/tools/quantize/ncnn2table ${{ env.PACKAGENAME }}/bin
-        cp build/tools/quantize/ncnn2int8 ${{ env.PACKAGENAME }}/bin
-        strip -g ${{ env.PACKAGENAME }}/bin/*
-        rm -f ${{ env.PACKAGENAME }}.zip
-        zip -9 -r ${{ env.PACKAGENAME }}.zip ${{ env.PACKAGENAME }}
-    - name: upload-zip
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ env.PACKAGENAME }}
-        path: ${{ env.PACKAGENAME }}.zip
-
-  ubuntu-1604-shared:
-    needs: [setup]
-    runs-on: ubuntu-16.04
-    env:
-      PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-ubuntu-1604-shared
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: apt
-      run: |
-        sudo apt-get install -y libvulkan-dev libprotobuf-dev protobuf-compiler
-    - name: build
-      run: |
-        mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DNCNN_VERSION_STRING="${{ needs.setup.outputs.VERSION }}" \
-            -DNCNN_VULKAN=ON -DNCNN_BUILD_EXAMPLES=OFF -DNCNN_BUILD_TOOLS=ON -DNCNN_BUILD_BENCHMARK=OFF -DNCNN_SHARED_LIB=ON ..
-        cmake --build . -j 2
-        cmake --build . --target install
-    - name: package
-      run: |
-        rm -rf ${{ env.PACKAGENAME }}
-        mkdir -p ${{ env.PACKAGENAME }}
-        cp -r -P build/install/* ${{ env.PACKAGENAME }}
-        mkdir -p ${{ env.PACKAGENAME }}/bin
-        cp build/tools/caffe/caffe2ncnn ${{ env.PACKAGENAME }}/bin
-        cp build/tools/mxnet/mxnet2ncnn ${{ env.PACKAGENAME }}/bin
-        cp build/tools/onnx/onnx2ncnn ${{ env.PACKAGENAME }}/bin
-        cp build/tools/darknet/darknet2ncnn ${{ env.PACKAGENAME }}/bin
-        cp build/tools/ncnnoptimize ${{ env.PACKAGENAME }}/bin
-        cp build/tools/ncnn2mem ${{ env.PACKAGENAME }}/bin
-        cp build/tools/ncnnmerge ${{ env.PACKAGENAME }}/bin
-        cp build/tools/quantize/ncnn2table ${{ env.PACKAGENAME }}/bin
-        cp build/tools/quantize/ncnn2int8 ${{ env.PACKAGENAME }}/bin
-        strip -g ${{ env.PACKAGENAME }}/bin/*
-        rm -f ${{ env.PACKAGENAME }}.zip
-        zip -9 -r ${{ env.PACKAGENAME }}.zip ${{ env.PACKAGENAME }}
-    - name: upload-zip
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ env.PACKAGENAME }}
-        path: ${{ env.PACKAGENAME }}.zip
-
   ubuntu-1804:
     needs: [setup]
     runs-on: ubuntu-18.04
@@ -1873,7 +1787,7 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   release:
-    needs: [setup, full-source, ubuntu-1604, ubuntu-1604-shared, ubuntu-1804, ubuntu-1804-shared, ubuntu-2004, ubuntu-2004-shared, macos, macos-gpu, ios, ios-gpu, ios-bitcode, ios-gpu-bitcode, android, android-shared, android-gpu, android-gpu-shared, webassembly, windows-vs2015, windows-vs2015-shared, windows-vs2017, windows-vs2017-shared, windows-vs2019, windows-vs2019-shared]
+    needs: [setup, full-source, ubuntu-1804, ubuntu-1804-shared, ubuntu-2004, ubuntu-2004-shared, macos, macos-gpu, ios, ios-gpu, ios-bitcode, ios-gpu-bitcode, android, android-shared, android-gpu, android-gpu-shared, webassembly, windows-vs2015, windows-vs2015-shared, windows-vs2017, windows-vs2017-shared, windows-vs2019, windows-vs2019-shared]
     runs-on: ubuntu-latest
     steps:
     - name: download
@@ -1897,28 +1811,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-full-source
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: artifacts/${{ env.PACKAGENAME }}/${{ env.PACKAGENAME }}.zip
-        asset_name: ${{ env.PACKAGENAME }}.zip
-        asset_content_type: application/zip
-
-    - name: upload-ncnn-ubuntu-1604
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-ubuntu-1604
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: artifacts/${{ env.PACKAGENAME }}/${{ env.PACKAGENAME }}.zip
-        asset_name: ${{ env.PACKAGENAME }}.zip
-        asset_content_type: application/zip
-
-    - name: upload-ncnn-ubuntu-1604-shared
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-ubuntu-1604-shared
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: artifacts/${{ env.PACKAGENAME }}/${{ env.PACKAGENAME }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1377,8 +1377,8 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
-        7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.121.2-Installer.exe
+        7z x -aoa ./VulkanSDK-1.1.121.2-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: build-x86
       run: |
@@ -1467,8 +1467,8 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
-        7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.121.2-Installer.exe
+        7z x -aoa ./VulkanSDK-1.1.121.2-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: build-x86
       run: |
@@ -1555,8 +1555,8 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
-        7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.121.2-Installer.exe
+        7z x -aoa ./VulkanSDK-1.1.121.2-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: build-x86
       run: |
@@ -1645,8 +1645,8 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
-        7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.121.2-Installer.exe
+        7z x -aoa ./VulkanSDK-1.1.121.2-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: build-x86
       run: |
@@ -1733,8 +1733,8 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
-        7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.121.2-Installer.exe
+        7z x -aoa ./VulkanSDK-1.1.121.2-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: build-x86
       run: |
@@ -1823,8 +1823,8 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
-        7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.121.2-Installer.exe
+        7z x -aoa ./VulkanSDK-1.1.121.2-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: build-x86
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1377,7 +1377,7 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.114.0/windows/VulkanSDK-1.1.114.0-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
         7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: build-x86
@@ -1467,7 +1467,7 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.114.0/windows/VulkanSDK-1.1.114.0-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
         7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: build-x86
@@ -1555,7 +1555,7 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.114.0/windows/VulkanSDK-1.1.114.0-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
         7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: build-x86
@@ -1645,7 +1645,7 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.114.0/windows/VulkanSDK-1.1.114.0-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
         7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: build-x86
@@ -1733,7 +1733,7 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.114.0/windows/VulkanSDK-1.1.114.0-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
         7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: build-x86
@@ -1823,7 +1823,7 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.114.0/windows/VulkanSDK-1.1.114.0-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
         7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: build-x86

--- a/.github/workflows/windows-x64-gpu-vs2017.yml
+++ b/.github/workflows/windows-x64-gpu-vs2017.yml
@@ -61,8 +61,8 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
-        7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.121.2-Installer.exe
+        7z x -aoa ./VulkanSDK-1.1.121.2-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: cache-swiftshader
       id: cache-swiftshader

--- a/.github/workflows/windows-x64-gpu-vs2017.yml
+++ b/.github/workflows/windows-x64-gpu-vs2017.yml
@@ -61,7 +61,7 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.114.0/windows/VulkanSDK-1.1.114.0-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
         7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: cache-swiftshader

--- a/.github/workflows/windows-x64-gpu-vs2019.yml
+++ b/.github/workflows/windows-x64-gpu-vs2019.yml
@@ -61,8 +61,8 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
-        7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.121.2-Installer.exe
+        7z x -aoa ./VulkanSDK-1.1.121.2-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: cache-swiftshader
       id: cache-swiftshader

--- a/.github/workflows/windows-x64-gpu-vs2019.yml
+++ b/.github/workflows/windows-x64-gpu-vs2019.yml
@@ -61,7 +61,7 @@ jobs:
     - name: vulkansdk
       if: steps.cache-vulkansdk.outputs.cache-hit != 'true'
       run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.114.0/windows/VulkanSDK-1.1.114.0-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
+        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/1.1.121.2/windows/VulkanSDK-1.1.121.2-Installer.exe?Human=true -OutFile VulkanSDK-1.1.114.0-Installer.exe
         7z x -aoa ./VulkanSDK-1.1.114.0-Installer.exe -oVulkanSDK
         Remove-Item .\VulkanSDK\Demos, .\VulkanSDK\glslang, .\VulkanSDK\Samples, .\VulkanSDK\shaderc, .\VulkanSDK\spirv-tools, .\VulkanSDK\Third-Party, .\VulkanSDK\Tools, .\VulkanSDK\Tools32 -Recurse
     - name: cache-swiftshader

--- a/src/layer/arm/pooling_arm.cpp
+++ b/src/layer/arm/pooling_arm.cpp
@@ -53,7 +53,6 @@ int Pooling_arm::create_pipeline(const Option& /*opt*/)
         support_bf16_storage = false;
         support_fp16_storage = false;
         support_int8_storage = false;
-        support_image_storage = false;
         support_tensor_storage = false;
 
         support_weight_fp16_storage = false;

--- a/src/layer/lrn.cpp
+++ b/src/layer/lrn.cpp
@@ -106,6 +106,7 @@ int LRN::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
         {
             Option opt_b = opt;
             opt_b.blob_allocator = opt.workspace_allocator;
+            opt_b.use_packing_layout = false;
             copy_make_border(square_blob, square_blob_bordered, pad, local_size - pad - 1, pad, local_size - pad - 1, BORDER_CONSTANT, 0.f, opt_b);
             if (square_blob_bordered.empty())
                 return -100;

--- a/src/layer/mips/pooling_mips.cpp
+++ b/src/layer/mips/pooling_mips.cpp
@@ -40,7 +40,6 @@ int Pooling_mips::create_pipeline(const Option& /*opt*/)
         support_bf16_storage = false;
         support_fp16_storage = false;
         support_int8_storage = false;
-        support_image_storage = false;
         support_tensor_storage = false;
 
         support_weight_fp16_storage = false;

--- a/src/layer/mips/slice_mips.cpp
+++ b/src/layer/mips/slice_mips.cpp
@@ -45,7 +45,11 @@ int Slice_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 slice = (w - q) / (top_blobs.size() - i);
             }
 
-            int out_elempack = opt.use_packing_layout && slice % 4 == 0 ? 4 : 1;
+            int out_elempack = 1;
+#if __mips_msa
+            if (opt.use_packing_layout)
+                out_elempack = slice % 4 == 0 ? 4 : 1;
+#endif
             size_t out_elemsize = elemsize / elempack * out_elempack;
 
             Mat& top_blob = top_blobs[i];
@@ -76,7 +80,11 @@ int Slice_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 slice = (h - q) / (top_blobs.size() - i);
             }
 
-            int out_elempack = opt.use_packing_layout && slice % 4 == 0 ? 4 : 1;
+            int out_elempack = 1;
+#if __mips_msa
+            if (opt.use_packing_layout)
+                out_elempack = slice % 4 == 0 ? 4 : 1;
+#endif
             size_t out_elemsize = elemsize / elempack * out_elempack;
 
             Mat& top_blob = top_blobs[i];
@@ -197,7 +205,11 @@ int Slice_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 slice = (channels - q) / (top_blobs.size() - i);
             }
 
-            int out_elempack = opt.use_packing_layout && slice % 4 == 0 ? 4 : 1;
+            int out_elempack = 1;
+#if __mips_msa
+            if (opt.use_packing_layout)
+                out_elempack = slice % 4 == 0 ? 4 : 1;
+#endif
             size_t out_elemsize = elemsize / elempack * out_elempack;
 
             Mat& top_blob = top_blobs[i];

--- a/src/layer/padding.cpp
+++ b/src/layer/padding.cpp
@@ -316,7 +316,7 @@ int Padding::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) c
         if (elemsize == 1)
             copy_make_border_image<signed char>(bottom_blob, top_blob, 0, left, type, static_cast<signed char>(value));
         if (elemsize == 2)
-            copy_make_border_image<unsigned short>(bottom_blob, top_blob, 0, left, type, opt.use_fp16_storage ? float32_to_float16(value) : float32_to_bfloat16(value));
+            copy_make_border_image<unsigned short>(bottom_blob, top_blob, 0, left, type, support_fp16_storage && opt.use_fp16_storage ? float32_to_float16(value) : float32_to_bfloat16(value));
         if (elemsize == 4)
             copy_make_border_image<float>(bottom_blob, top_blob, 0, left, type, value);
 
@@ -334,7 +334,7 @@ int Padding::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) c
         if (elemsize == 1)
             copy_make_border_image<signed char>(bottom_blob, top_blob, top, left, type, static_cast<signed char>(value));
         if (elemsize == 2)
-            copy_make_border_image<unsigned short>(bottom_blob, top_blob, top, left, type, opt.use_fp16_storage ? float32_to_float16(value) : float32_to_bfloat16(value));
+            copy_make_border_image<unsigned short>(bottom_blob, top_blob, top, left, type, support_fp16_storage && opt.use_fp16_storage ? float32_to_float16(value) : float32_to_bfloat16(value));
         if (elemsize == 4)
             copy_make_border_image<float>(bottom_blob, top_blob, top, left, type, value);
 
@@ -365,7 +365,7 @@ int Padding::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) c
                 }
                 if (elemsize == 2)
                 {
-                    borderm.fill(opt.use_fp16_storage ? float32_to_float16(pad_value) : float32_to_bfloat16(pad_value));
+                    borderm.fill(support_fp16_storage && opt.use_fp16_storage ? float32_to_float16(pad_value) : float32_to_bfloat16(pad_value));
                 }
                 if (elemsize == 4)
                 {
@@ -390,7 +390,7 @@ int Padding::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) c
                 if (elemsize == 1)
                     copy_make_border_image<signed char>(m, borderm, top, left, type, static_cast<signed char>(pad_value));
                 if (elemsize == 2)
-                    copy_make_border_image<unsigned short>(m, borderm, top, left, type, opt.use_fp16_storage ? float32_to_float16(pad_value) : float32_to_bfloat16(pad_value));
+                    copy_make_border_image<unsigned short>(m, borderm, top, left, type, support_fp16_storage && opt.use_fp16_storage ? float32_to_float16(pad_value) : float32_to_bfloat16(pad_value));
                 if (elemsize == 4)
                     copy_make_border_image<float>(m, borderm, top, left, type, pad_value);
             }
@@ -447,7 +447,7 @@ int Padding::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top
         if (elemsize == 1)
             copy_make_border_image<signed char>(bottom_blob, top_blob, 0, _left, type, static_cast<signed char>(value));
         if (elemsize == 2)
-            copy_make_border_image<unsigned short>(bottom_blob, top_blob, 0, _left, type, opt.use_fp16_storage ? float32_to_float16(value) : float32_to_bfloat16(value));
+            copy_make_border_image<unsigned short>(bottom_blob, top_blob, 0, _left, type, support_fp16_storage && opt.use_fp16_storage ? float32_to_float16(value) : float32_to_bfloat16(value));
         if (elemsize == 4)
             copy_make_border_image<float>(bottom_blob, top_blob, 0, _left, type, value);
 
@@ -465,7 +465,7 @@ int Padding::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top
         if (elemsize == 1)
             copy_make_border_image<signed char>(bottom_blob, top_blob, _top, _left, type, static_cast<signed char>(value));
         if (elemsize == 2)
-            copy_make_border_image<unsigned short>(bottom_blob, top_blob, _top, _left, type, opt.use_fp16_storage ? float32_to_float16(value) : float32_to_bfloat16(value));
+            copy_make_border_image<unsigned short>(bottom_blob, top_blob, _top, _left, type, support_fp16_storage && opt.use_fp16_storage ? float32_to_float16(value) : float32_to_bfloat16(value));
         if (elemsize == 4)
             copy_make_border_image<float>(bottom_blob, top_blob, _top, _left, type, value);
 
@@ -495,7 +495,7 @@ int Padding::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top
                 }
                 if (elemsize == 2)
                 {
-                    borderm.fill(opt.use_fp16_storage ? float32_to_float16(pad_value) : float32_to_bfloat16(pad_value));
+                    borderm.fill(support_fp16_storage && opt.use_fp16_storage ? float32_to_float16(pad_value) : float32_to_bfloat16(pad_value));
                 }
                 if (elemsize == 4)
                 {
@@ -521,7 +521,7 @@ int Padding::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top
                 if (elemsize == 1)
                     copy_make_border_image<signed char>(m, borderm, top, left, type, static_cast<signed char>(pad_value));
                 if (elemsize == 2)
-                    copy_make_border_image<unsigned short>(m, borderm, top, left, type, opt.use_fp16_storage ? float32_to_float16(pad_value) : float32_to_bfloat16(pad_value));
+                    copy_make_border_image<unsigned short>(m, borderm, top, left, type, support_fp16_storage && opt.use_fp16_storage ? float32_to_float16(pad_value) : float32_to_bfloat16(pad_value));
                 if (elemsize == 4)
                     copy_make_border_image<float>(m, borderm, top, left, type, pad_value);
             }

--- a/src/layer/riscv/padding_riscv.cpp
+++ b/src/layer/riscv/padding_riscv.cpp
@@ -161,7 +161,7 @@ int Padding_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option& 
             if (front % packn == 0 && out_elempack == packn && !(outc != channels * elempack && type != 0))
             {
                 int front_ = front / elempack;
-#pragma omp parallel for num_threads(opt.num_threads)
+                #pragma omp parallel for num_threads(opt.num_threads)
                 for (int q = 0; q < outc / out_elempack; q++)
                 {
                     Mat borderm = top_blob.channel(q);
@@ -290,7 +290,7 @@ int Padding_riscv::forward_bf16s_fp16s(const Mat& bottom_blob, Mat& top_blob, co
             if (front % packn == 0 && out_elempack == packn && !(outc != channels * elempack && type != 0))
             {
                 int front_ = front / elempack;
-#pragma omp parallel for num_threads(opt.num_threads)
+                #pragma omp parallel for num_threads(opt.num_threads)
                 for (int q = 0; q < outc / out_elempack; q++)
                 {
                     Mat borderm = top_blob.channel(q);
@@ -435,7 +435,7 @@ int Padding_riscv::forward_int8(const Mat& bottom_blob, Mat& top_blob, const Opt
             if (front % packn == 0 && out_elempack == packn && !(outc != channels * elempack && type != 0))
             {
                 int front_ = front / elempack;
-#pragma omp parallel for num_threads(opt.num_threads)
+                #pragma omp parallel for num_threads(opt.num_threads)
                 for (int q = 0; q < outc / out_elempack; q++)
                 {
                     Mat borderm = top_blob.channel(q);

--- a/src/layer/riscv/padding_riscv.cpp
+++ b/src/layer/riscv/padding_riscv.cpp
@@ -79,7 +79,7 @@ int Padding_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option& 
     }
 
     int elembits = bottom_blob.elembits();
-    printf("TEST1\n");
+
     if (elembits == 8)
         return forward_int8(bottom_blob, top_blob, opt);
 
@@ -87,13 +87,12 @@ int Padding_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option& 
     if (opt.use_fp16_storage && elembits == 16)
         return forward_bf16s_fp16s(bottom_blob, top_blob, opt);
 #endif
-    printf("TEST2\n");
 
 #if NCNN_BF16
     if (opt.use_bf16_storage && elembits == 16)
         return forward_bf16s_fp16s(bottom_blob, top_blob, opt);
 #endif
-    printf("TEST3\n");
+
 #if __riscv_vector
     const int packn = csrr_vlenb() / 4;
     const word_type vl = vsetvl_e32m1(packn);
@@ -105,7 +104,6 @@ int Padding_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option& 
     int dims = bottom_blob.dims;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
-    printf("TEST4\n");
 
 #if __riscv_vector
     if (elempack == packn)
@@ -189,7 +187,6 @@ int Padding_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option& 
         }
     }
 #endif // __riscv_vector
-    printf("TEST6\n");
 
     Mat bottom_blob_unpacked = bottom_blob;
     if (elempack != 1)
@@ -199,11 +196,9 @@ int Padding_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option& 
 
         convert_packing(bottom_blob, bottom_blob_unpacked, 1, opt_pack1);
     }
-    printf("TEST7\n");
 
     Mat top_blob_unpacked;
     int ret = Padding::forward(bottom_blob_unpacked, top_blob_unpacked, opt);
-    printf("TEST8\n");
 
     if (ret != 0)
         return ret;
@@ -215,7 +210,6 @@ int Padding_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option& 
         out_elempack = top_blob_unpacked.c % packn == 0 ? packn : 1;
     }
 #endif
-    printf("TEST9\n");
 
     convert_packing(top_blob_unpacked, top_blob, out_elempack, opt);
 

--- a/src/layer/riscv/pooling_riscv.cpp
+++ b/src/layer/riscv/pooling_riscv.cpp
@@ -47,7 +47,6 @@ int Pooling_riscv::create_pipeline(const Option& /*opt*/)
         support_bf16_storage = false;
         support_fp16_storage = false;
         support_int8_storage = false;
-        support_image_storage = false;
         support_tensor_storage = false;
 
         support_weight_fp16_storage = false;

--- a/src/layer/vulkan/mish_vulkan.cpp
+++ b/src/layer/vulkan/mish_vulkan.cpp
@@ -21,6 +21,7 @@ namespace ncnn {
 Mish_vulkan::Mish_vulkan()
 {
     support_vulkan = true;
+    support_image_storage = true;
 
     pipeline_mish = 0;
     pipeline_mish_pack4 = 0;
@@ -136,6 +137,30 @@ int Mish_vulkan::forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const O
     constants[2].i = bottom_top_blob.h;
     constants[3].i = bottom_top_blob.c;
     constants[4].i = bottom_top_blob.cstep;
+
+    const Pipeline* pipeline = elempack == 8 ? pipeline_mish_pack8
+                               : elempack == 4 ? pipeline_mish_pack4
+                               : pipeline_mish;
+
+    cmd.record_pipeline(pipeline, bindings, constants, bottom_top_blob);
+
+    return 0;
+}
+
+int Mish_vulkan::forward_inplace(VkImageMat& bottom_top_blob, VkCompute& cmd, const Option& /*opt*/) const
+{
+    int elempack = bottom_top_blob.elempack;
+
+    std::vector<VkImageMat> bindings(2);
+    bindings[0] = bottom_top_blob;
+    bindings[1] = bottom_top_blob;
+
+    std::vector<vk_constant_type> constants(5);
+    constants[0].i = bottom_top_blob.dims;
+    constants[1].i = bottom_top_blob.w;
+    constants[2].i = bottom_top_blob.h;
+    constants[3].i = bottom_top_blob.c;
+    constants[4].i = 0; //bottom_top_blob.cstep;
 
     const Pipeline* pipeline = elempack == 8 ? pipeline_mish_pack8
                                : elempack == 4 ? pipeline_mish_pack4

--- a/src/layer/vulkan/mish_vulkan.h
+++ b/src/layer/vulkan/mish_vulkan.h
@@ -29,6 +29,7 @@ public:
 
     using Mish::forward_inplace;
     virtual int forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Option& opt) const;
+    virtual int forward_inplace(VkImageMat& bottom_top_blob, VkCompute& cmd, const Option& opt) const;
 
 public:
     Pipeline* pipeline_mish;

--- a/src/layer/vulkan/shader/mish.comp
+++ b/src/layer/vulkan/shader/mish.comp
@@ -28,7 +28,12 @@ layout (constant_id = shape_constant_id_offset + 2) const int h = 0;
 layout (constant_id = shape_constant_id_offset + 3) const int c = 0;
 layout (constant_id = shape_constant_id_offset + 4) const int cstep = 0;
 
+#if NCNN_image_shader
+layout (binding = 0) uniform unfp sampler3D bottom_blob_3d;
+layout (binding = 1, imfmtc1) writeonly uniform unfp image3D top_blob_3d;
+#else
 layout (binding = 0) buffer bottom_top_blob { sfp bottom_top_blob_data[]; };
+#endif
 
 layout (push_constant) uniform parameter
 {
@@ -48,11 +53,19 @@ void main()
     if (gx >= psc(w) || gy >= psc(h) || gz >= psc(c))
         return;
 
+#if NCNN_image_shader
+    afp v = image3d_ld1(bottom_blob_3d, ivec3(gx, gy, gz));
+#else
     const int gi = gz * psc(cstep) + gy * psc(w) + gx;
 
     afp v = buffer_ld1(bottom_top_blob_data, gi);
+#endif
 
     v = v * tanh(log(exp(v) + afp(1.f)));
 
+#if NCNN_image_shader
+    image3d_st1(top_blob_3d, ivec3(gx, gy, gz), v);
+#else
     buffer_st1(bottom_top_blob_data, gi, v);
+#endif
 }

--- a/src/layer/vulkan/shader/mish_pack4.comp
+++ b/src/layer/vulkan/shader/mish_pack4.comp
@@ -28,7 +28,12 @@ layout (constant_id = shape_constant_id_offset + 2) const int h = 0;
 layout (constant_id = shape_constant_id_offset + 3) const int c = 0;
 layout (constant_id = shape_constant_id_offset + 4) const int cstep = 0;
 
+#if NCNN_image_shader
+layout (binding = 0) uniform unfp sampler3D bottom_blob_3d;
+layout (binding = 1, imfmtc4) writeonly uniform unfp image3D top_blob_3d;
+#else
 layout (binding = 0) buffer bottom_top_blob { sfpvec4 bottom_top_blob_data[]; };
+#endif
 
 layout (push_constant) uniform parameter
 {
@@ -48,11 +53,19 @@ void main()
     if (gx >= psc(w) || gy >= psc(h) || gz >= psc(c))
         return;
 
+#if NCNN_image_shader
+    afpvec4 v = image3d_ld4(bottom_blob_3d, ivec3(gx, gy, gz));
+#else
     const int gi = gz * psc(cstep) + gy * psc(w) + gx;
 
     afpvec4 v = buffer_ld4(bottom_top_blob_data, gi);
+#endif
 
     v = v * tanh(log(exp(v) + afpvec4(1.f)));
 
+#if NCNN_image_shader
+    image3d_st4(top_blob_3d, ivec3(gx, gy, gz), v);
+#else
     buffer_st4(bottom_top_blob_data, gi, v);
+#endif
 }

--- a/src/layer/vulkan/shader/mish_pack8.comp
+++ b/src/layer/vulkan/shader/mish_pack8.comp
@@ -29,7 +29,12 @@ layout (constant_id = shape_constant_id_offset + 2) const int h = 0;
 layout (constant_id = shape_constant_id_offset + 3) const int c = 0;
 layout (constant_id = shape_constant_id_offset + 4) const int cstep = 0;
 
+#if NCNN_image_shader
+layout (binding = 0) uniform unfp sampler3D bottom_blob_3d;
+layout (binding = 1, imfmtc4) writeonly uniform unfp image3D top_blob_3d;
+#else
 layout (binding = 0) buffer bottom_top_blob { sfpvec8 bottom_top_blob_data[]; };
+#endif
 
 layout (push_constant) uniform parameter
 {
@@ -49,12 +54,20 @@ void main()
     if (gx >= psc(w) || gy >= psc(h) || gz >= psc(c))
         return;
 
+#if NCNN_image_shader
+    afpvec8 v = image3d_ld8(bottom_blob_3d, ivec3(gx, gy, gz));
+#else
     const int gi = gz * psc(cstep) + gy * psc(w) + gx;
 
     afpvec8 v = buffer_ld8(bottom_top_blob_data, gi);
+#endif
 
     v[0] = v[0] * tanh(log(exp(v[0]) + afpvec4(1.f)));
     v[1] = v[1] * tanh(log(exp(v[1]) + afpvec4(1.f)));
 
+#if NCNN_image_shader
+    image3d_st8(top_blob_3d, ivec3(gx, gy, gz), v);
+#else
     buffer_st8(bottom_top_blob_data, gi, v);
+#endif
 }

--- a/src/layer/vulkan/shader/swish.comp
+++ b/src/layer/vulkan/shader/swish.comp
@@ -28,7 +28,12 @@ layout (constant_id = shape_constant_id_offset + 2) const int h = 0;
 layout (constant_id = shape_constant_id_offset + 3) const int c = 0;
 layout (constant_id = shape_constant_id_offset + 4) const int cstep = 0;
 
+#if NCNN_image_shader
+layout (binding = 0) uniform unfp sampler3D bottom_blob_3d;
+layout (binding = 1, imfmtc1) writeonly uniform unfp image3D top_blob_3d;
+#else
 layout (binding = 0) buffer bottom_top_blob { sfp bottom_top_blob_data[]; };
+#endif
 
 layout (push_constant) uniform parameter
 {
@@ -48,11 +53,19 @@ void main()
     if (gx >= psc(w) || gy >= psc(h) || gz >= psc(c))
         return;
 
+#if NCNN_image_shader
+    afp v = image3d_ld1(bottom_blob_3d, ivec3(gx, gy, gz));
+#else
     const int gi = gz * psc(cstep) + gy * psc(w) + gx;
 
     afp v = buffer_ld1(bottom_top_blob_data, gi);
+#endif
 
     v = v / (afp(1.f) + exp(-v));
 
+#if NCNN_image_shader
+    image3d_st1(top_blob_3d, ivec3(gx, gy, gz), v);
+#else
     buffer_st1(bottom_top_blob_data, gi, v);
+#endif
 }

--- a/src/layer/vulkan/shader/swish_pack4.comp
+++ b/src/layer/vulkan/shader/swish_pack4.comp
@@ -28,7 +28,12 @@ layout (constant_id = shape_constant_id_offset + 2) const int h = 0;
 layout (constant_id = shape_constant_id_offset + 3) const int c = 0;
 layout (constant_id = shape_constant_id_offset + 4) const int cstep = 0;
 
+#if NCNN_image_shader
+layout (binding = 0) uniform unfp sampler3D bottom_blob_3d;
+layout (binding = 1, imfmtc4) writeonly uniform unfp image3D top_blob_3d;
+#else
 layout (binding = 0) buffer bottom_top_blob { sfpvec4 bottom_top_blob_data[]; };
+#endif
 
 layout (push_constant) uniform parameter
 {
@@ -48,11 +53,19 @@ void main()
     if (gx >= psc(w) || gy >= psc(h) || gz >= psc(c))
         return;
 
+#if NCNN_image_shader
+    afpvec4 v = image3d_ld4(bottom_blob_3d, ivec3(gx, gy, gz));
+#else
     const int gi = gz * psc(cstep) + gy * psc(w) + gx;
 
     afpvec4 v = buffer_ld4(bottom_top_blob_data, gi);
+#endif
 
     v = v / (afpvec4(1.f) + exp(-v));
 
+#if NCNN_image_shader
+    image3d_st4(top_blob_3d, ivec3(gx, gy, gz), v);
+#else
     buffer_st4(bottom_top_blob_data, gi, v);
+#endif
 }

--- a/src/layer/vulkan/shader/swish_pack8.comp
+++ b/src/layer/vulkan/shader/swish_pack8.comp
@@ -29,7 +29,12 @@ layout (constant_id = shape_constant_id_offset + 2) const int h = 0;
 layout (constant_id = shape_constant_id_offset + 3) const int c = 0;
 layout (constant_id = shape_constant_id_offset + 4) const int cstep = 0;
 
+#if NCNN_image_shader
+layout (binding = 0) uniform unfp sampler3D bottom_blob_3d;
+layout (binding = 1, imfmtc4) writeonly uniform unfp image3D top_blob_3d;
+#else
 layout (binding = 0) buffer bottom_top_blob { sfpvec8 bottom_top_blob_data[]; };
+#endif
 
 layout (push_constant) uniform parameter
 {
@@ -49,12 +54,20 @@ void main()
     if (gx >= psc(w) || gy >= psc(h) || gz >= psc(c))
         return;
 
+#if NCNN_image_shader
+    afpvec8 v = image3d_ld8(bottom_blob_3d, ivec3(gx, gy, gz));
+#else
     const int gi = gz * psc(cstep) + gy * psc(w) + gx;
 
     afpvec8 v = buffer_ld8(bottom_top_blob_data, gi);
+#endif
 
     v[0] = v[0] / (afpvec4(1.f) + exp(-v[0]));
     v[1] = v[1] / (afpvec4(1.f) + exp(-v[1]));
 
+#if NCNN_image_shader
+    image3d_st8(top_blob_3d, ivec3(gx, gy, gz), v);
+#else
     buffer_st8(bottom_top_blob_data, gi, v);
+#endif
 }

--- a/src/layer/vulkan/swish_vulkan.cpp
+++ b/src/layer/vulkan/swish_vulkan.cpp
@@ -21,6 +21,7 @@ namespace ncnn {
 Swish_vulkan::Swish_vulkan()
 {
     support_vulkan = true;
+    support_image_storage = true;
 
     pipeline_swish = 0;
     pipeline_swish_pack4 = 0;
@@ -136,6 +137,30 @@ int Swish_vulkan::forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const 
     constants[2].i = bottom_top_blob.h;
     constants[3].i = bottom_top_blob.c;
     constants[4].i = bottom_top_blob.cstep;
+
+    const Pipeline* pipeline = elempack == 8 ? pipeline_swish_pack8
+                               : elempack == 4 ? pipeline_swish_pack4
+                               : pipeline_swish;
+
+    cmd.record_pipeline(pipeline, bindings, constants, bottom_top_blob);
+
+    return 0;
+}
+
+int Swish_vulkan::forward_inplace(VkImageMat& bottom_top_blob, VkCompute& cmd, const Option& /*opt*/) const
+{
+    int elempack = bottom_top_blob.elempack;
+
+    std::vector<VkImageMat> bindings(2);
+    bindings[0] = bottom_top_blob;
+    bindings[1] = bottom_top_blob;
+
+    std::vector<vk_constant_type> constants(5);
+    constants[0].i = bottom_top_blob.dims;
+    constants[1].i = bottom_top_blob.w;
+    constants[2].i = bottom_top_blob.h;
+    constants[3].i = bottom_top_blob.c;
+    constants[4].i = 0; //bottom_top_blob.cstep;
 
     const Pipeline* pipeline = elempack == 8 ? pipeline_swish_pack8
                                : elempack == 4 ? pipeline_swish_pack4

--- a/src/layer/vulkan/swish_vulkan.h
+++ b/src/layer/vulkan/swish_vulkan.h
@@ -29,6 +29,7 @@ public:
 
     using Swish::forward_inplace;
     virtual int forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, const Option& opt) const;
+    virtual int forward_inplace(VkImageMat& bottom_top_blob, VkCompute& cmd, const Option& opt) const;
 
 public:
     Pipeline* pipeline_swish;

--- a/src/layer/x86/convolution_x86.cpp
+++ b/src/layer/x86/convolution_x86.cpp
@@ -490,7 +490,6 @@ int Convolution_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option
             {
 #endif
 
-
                 conv2x2s1_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
 #if __AVX2__
             }

--- a/src/layer/x86/convolution_x86.cpp
+++ b/src/layer/x86/convolution_x86.cpp
@@ -426,11 +426,14 @@ int Convolution_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option
             {
                 conv1x1s1_sgemm_fp16_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
             }
-#endif
             if (!opt.use_weight_fp16_storage)
             {
+#endif
+
                 conv1x1s1_sgemm_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
+#if __AVX2__
             }
+#endif
 
             if (activation)
             {
@@ -445,12 +448,15 @@ int Convolution_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option
             {
                 conv1x1s2_fp16_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
             }
-#endif
             if (!opt.use_weight_fp16_storage)
 
             {
+#endif
+
                 conv1x1s2_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
+#if __AVX2__
             }
+#endif
             if (activation)
             {
                 activation->forward_inplace(top_blob, opt);
@@ -480,13 +486,15 @@ int Convolution_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option
             {
                 conv2x2s1_fp16_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
             }
-#endif
-
             if (!opt.use_weight_fp16_storage)
             {
-                conv2x2s1_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
-            }
+#endif
 
+
+                conv2x2s1_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
+#if __AVX2__
+            }
+#endif
             if (activation)
             {
                 activation->forward_inplace(top_blob, opt);

--- a/src/layer/x86/convolutiondepthwise_x86.cpp
+++ b/src/layer/x86/convolutiondepthwise_x86.cpp
@@ -369,12 +369,14 @@ int ConvolutionDepthWise_x86::forward(const Mat& bottom_blob, Mat& top_blob, con
                 {
                     convdw3x3s1_fp16_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
                 }
-#endif
                 if (!opt.use_weight_fp16_storage)
                 {
-                    convdw3x3s1_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
-                }
+#endif
 
+                    convdw3x3s1_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
+#if __AVX2__
+                }
+#endif
                 if (activation)
                 {
                     activation->forward_inplace(top_blob, opt);
@@ -389,12 +391,13 @@ int ConvolutionDepthWise_x86::forward(const Mat& bottom_blob, Mat& top_blob, con
                 {
                     convdw3x3s2_fp16_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
                 }
-#endif
                 if (!opt.use_weight_fp16_storage)
                 {
+#endif
                     convdw3x3s2_pack8_avx(bottom_blob_bordered, top_blob, weight_data_packed, bias_data, opt);
+#if __AVX2__
                 }
-
+#endif
                 if (activation)
                 {
                     activation->forward_inplace(top_blob, opt);

--- a/src/layer/x86/lstm_x86.cpp
+++ b/src/layer/x86/lstm_x86.cpp
@@ -24,7 +24,7 @@ namespace ncnn {
 
 LSTM_x86::LSTM_x86()
 {
-#ifdef __AVX__
+#ifdef __AVX2__
     support_weight_fp16_storage = true;
 #endif
     one_blob_only = false;
@@ -33,7 +33,7 @@ LSTM_x86::LSTM_x86()
 
 int LSTM_x86::create_pipeline(const Option& opt)
 {
-#if __AVX__
+#if __AVX2__
     if (opt.use_weight_fp16_storage)
     {
         ncnn::cast_float32_to_float16(weight_xc_data, weight_xc_data_fp16, opt);

--- a/src/layer/x86/pooling_x86.cpp
+++ b/src/layer/x86/pooling_x86.cpp
@@ -48,7 +48,6 @@ int Pooling_x86::create_pipeline(const Option& /*opt*/)
         support_bf16_storage = false;
         support_fp16_storage = false;
         support_int8_storage = false;
-        support_image_storage = false;
         support_tensor_storage = false;
 
         support_weight_fp16_storage = false;

--- a/tests/testutil.h
+++ b/tests/testutil.h
@@ -591,7 +591,7 @@ int test_layer_gpu(int typeindex, const ncnn::ParamDict& pd, const std::vector<n
         // forward
         ncnn::VkCompute cmd(vkdev);
 
-        if (opt.use_image_storage)
+        if (op->support_image_storage && opt.use_image_storage)
         {
             // upload
             std::vector<ncnn::VkImageMat> a_gpu(a.size());
@@ -999,7 +999,7 @@ int test_layer_gpu(int typeindex, const ncnn::ParamDict& pd, const std::vector<n
         // forward
         ncnn::VkCompute cmd(vkdev);
 
-        if (opt.use_image_storage)
+        if (op->support_image_storage && opt.use_image_storage)
         {
             // upload
             ncnn::VkImageMat a_gpu;

--- a/tests/testutil.h
+++ b/tests/testutil.h
@@ -381,12 +381,6 @@ int test_layer_cpu(int typeindex, const ncnn::ParamDict& pd, const std::vector<n
     opt.num_threads = 1;
     opt.use_vulkan_compute = false;
 
-    if (!op->support_packing) opt.use_packing_layout = false;
-    if (!op->support_bf16_storage) opt.use_bf16_storage = false;
-    if (!op->support_fp16_storage) opt.use_fp16_storage = false;
-    if (!op->support_fp16_storage) opt.use_fp16_arithmetic = false;
-    if (!op->support_weight_fp16_storage) opt.use_weight_fp16_storage = false;
-
     op->create_pipeline(opt);
 
     std::vector<ncnn::Mat> a4(a.size());
@@ -560,11 +554,6 @@ int test_layer_gpu(int typeindex, const ncnn::ParamDict& pd, const std::vector<n
     ncnn::Option opt = _opt;
     opt.num_threads = 1;
     opt.use_vulkan_compute = true;
-
-    if (!op->support_packing) opt.use_packing_layout = false;
-    if (!op->support_bf16_storage) opt.use_bf16_storage = false;
-    if (!op->support_image_storage) opt.use_image_storage = false;
-    if (!op->support_weight_fp16_storage) opt.use_weight_fp16_storage = false;
 
 #if __APPLE__
     opt.use_image_storage = false;
@@ -813,12 +802,6 @@ int test_layer_cpu(int typeindex, const ncnn::ParamDict& pd, const std::vector<n
     opt.num_threads = 1;
     opt.use_vulkan_compute = false;
 
-    if (!op->support_packing) opt.use_packing_layout = false;
-    if (!op->support_bf16_storage) opt.use_bf16_storage = false;
-    if (!op->support_fp16_storage) opt.use_fp16_storage = false;
-    if (!op->support_fp16_storage) opt.use_fp16_arithmetic = false;
-    if (!op->support_weight_fp16_storage) opt.use_weight_fp16_storage = false;
-
     op->create_pipeline(opt);
 
     ncnn::Mat a4;
@@ -975,11 +958,6 @@ int test_layer_gpu(int typeindex, const ncnn::ParamDict& pd, const std::vector<n
     ncnn::Option opt = _opt;
     opt.num_threads = 1;
     opt.use_vulkan_compute = true;
-
-    if (!op->support_packing) opt.use_packing_layout = false;
-    if (!op->support_bf16_storage) opt.use_bf16_storage = false;
-    if (!op->support_image_storage) opt.use_image_storage = false;
-    if (!op->support_weight_fp16_storage) opt.use_weight_fp16_storage = false;
 
 #if __APPLE__
     opt.use_image_storage = false;


### PR DESCRIPTION
Fix a couple of broken codepaths involving opt.use_weight_fp16_storage, when only AVX is enabled and not AVX2. This was not caught in tests as the testutil actually applied some overrides on the Option object to prevent enabling certain functions when the layer doesn't support it. 

I think this shouldn't happen as users may also enable Option features even though some layers might not support it, as such I removed that code from testutil.h.