### PR TITLE
detach extracted mat so net could be destroyed earlier

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2609,6 +2609,13 @@ int Extractor::extract(int blob_index, Mat& feat, int type)
     // *INDENT-ON*
     // clang-format on
 
+    if (d->opt.use_local_pool_allocator && feat.allocator == d->net->d->local_blob_allocator)
+    {
+        // detach the returned mat from local pool allocator
+        // so we could destroy net instance much earlier
+        feat = feat.clone();
+    }
+
     set_kmp_blocktime(old_blocktime);
     set_flush_denormals(old_flush_denormals);
 

--- a/tests/test_c_api.cpp
+++ b/tests/test_c_api.cpp
@@ -286,6 +286,8 @@ static int test_c_api_2()
         ncnn_extractor_destroy(ex);
     }
 
+    ncnn_net_destroy(net);
+
     // check c
     bool success = false;
     if (c)
@@ -315,8 +317,6 @@ static int test_c_api_2()
     ncnn_mat_destroy(a);
     ncnn_mat_destroy(b);
     ncnn_mat_destroy(c);
-
-    ncnn_net_destroy(net);
 
     ncnn_option_destroy(opt);
 


### PR DESCRIPTION
detach mat from local blob allocator so net instance could be destroyed much earlier