### PR TITLE
Corrected the path for python version installation

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -49,13 +49,13 @@ make
 
 ## Install
 ```bash
-cd /pathto/ncnn/python
+cd /pathto/ncnn
 pip install .
 ```
 
 if you use conda or miniconda, you can also install as following:
 ```bash
-cd /pathto/ncnn/python
+cd /pathto/ncnn
 python3 setup.py install
 ```
 


### PR DESCRIPTION
The current path direction to ncnn-python installation at (https://github.com/Tencent/ncnn/blob/master/python/README.md) fails to find the correct files for installation.