### PR TITLE
feat(src): add mat default constructor

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -188,6 +188,7 @@ ncnn_mat_t ncnn_mat_create()
 {
     return (ncnn_mat_t)(new Mat());
 }
+
 ncnn_mat_t ncnn_mat_create_1d(int w, ncnn_allocator_t allocator)
 {
     return (ncnn_mat_t)(new Mat(w, (size_t)4u, (Allocator*)allocator));

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -184,6 +184,10 @@ void ncnn_option_set_use_vulkan_compute(ncnn_option_t opt, int use_vulkan_comput
 }
 
 /* mat api */
+ncnn_mat_t ncnn_mat_create()
+{
+    return (ncnn_mat_t)(new Mat());
+}
 ncnn_mat_t ncnn_mat_create_1d(int w, ncnn_allocator_t allocator)
 {
     return (ncnn_mat_t)(new Mat(w, (size_t)4u, (Allocator*)allocator));

--- a/src/c_api.h
+++ b/src/c_api.h
@@ -56,7 +56,7 @@ NCNN_EXPORT void ncnn_option_set_use_vulkan_compute(ncnn_option_t opt, int use_v
 
 /* mat api */
 typedef struct __ncnn_mat_t* ncnn_mat_t;
-
+NCNN_EXPORT ncnn_mat_t ncnn_mat_create();
 NCNN_EXPORT ncnn_mat_t ncnn_mat_create_1d(int w, ncnn_allocator_t allocator);
 NCNN_EXPORT ncnn_mat_t ncnn_mat_create_2d(int w, int h, ncnn_allocator_t allocator);
 NCNN_EXPORT ncnn_mat_t ncnn_mat_create_3d(int w, int h, int c, ncnn_allocator_t allocator);


### PR DESCRIPTION
Rust 的设计是强制 RAII，[rust-ncnn](https://github.com/tpoisonooo/rust-ncnn/blob/6e260a3cefeb4720547d6bf85171cdfa8d6b6951/ncnn-rs/examples/benchmark.rs#L15) 需要 C API 有 mat 的默认构造函数，这样 ncnn_rs::mat::Mat 才有合理的 `new` 实现。

现在写的  https://github.com/tpoisonooo/rust-ncnn/blob/6e260a3cefeb4720547d6bf85171cdfa8d6b6951/ncnn-rs/src/mat.rs#L15 不太合理的。