### PR TITLE
In examples, add missing header files for std::greater

### DIFF
--- a/examples/shufflenetv2.cpp
+++ b/examples/shufflenetv2.cpp
@@ -23,6 +23,7 @@
 #endif
 #include <stdio.h>
 #include <vector>
+#include <functional>
 
 static int detect_shufflenetv2(const cv::Mat& bgr, std::vector<float>& cls_scores)
 {

--- a/examples/squeezenet.cpp
+++ b/examples/squeezenet.cpp
@@ -23,6 +23,7 @@
 #endif
 #include <stdio.h>
 #include <vector>
+#include <functional>
 
 static int detect_squeezenet(const cv::Mat& bgr, std::vector<float>& cls_scores)
 {

--- a/examples/squeezenet_c_api.cpp
+++ b/examples/squeezenet_c_api.cpp
@@ -23,6 +23,7 @@
 #endif
 #include <stdio.h>
 #include <vector>
+#include <functional>
 
 static int detect_squeezenet(const cv::Mat& bgr, std::vector<float>& cls_scores)
 {


### PR DESCRIPTION
Hi, NiHui

This PR only affect examples building. Add `#include <functional>` for `std::greater`.

The cppreference shows the required header file : https://en.cppreference.com/w/cpp/utility/functional/greater

Without which, the examples failed to compile on qnx-sdp-700 compiler.