### PR TITLE
enable-vulkan-memory-model

### DIFF
--- a/src/layer/vulkan/innerproduct_vulkan.cpp
+++ b/src/layer/vulkan/innerproduct_vulkan.cpp
@@ -105,7 +105,6 @@ int InnerProduct_vulkan::create_pipeline(const Option& _opt)
             local_size_xyz.c = 1;
         }
 
-        // fprintf(stdout, "******** partA in_elempack %d out_elempack %d \n ", in_elempack, out_elempack);
         int shader_type_index = -1;
         if (in_elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::innerproduct_gemm;
         if (in_elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::innerproduct_gemm_wp4;
@@ -213,8 +212,6 @@ int InnerProduct_vulkan::create_pipeline(const Option& _opt)
             specializations[0 + 1].i = out_sum8_shape_packed.w;
             specializations[0 + 2].i = out_sum8_shape_packed.h;
 
-            // fprintf(stdout, "******** partB in_elempack %d out_elempack %d \n ", in_elempack, out_elempack);
-
             int shader_type_index = -1;
             if (in_elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::innerproduct_sum8;
             if (in_elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::innerproduct_sum8_pack4;
@@ -278,8 +275,6 @@ int InnerProduct_vulkan::create_pipeline(const Option& _opt)
             local_size_xyz.c = 1;
         }
 
-        // fprintf(stdout, "******** partC in_elempack %d out_elempack %d \n ", in_elempack, out_elempack);
-
         int shader_type_index = -1;
         if (in_elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::innerproduct;
         if (in_elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::innerproduct_pack4;
@@ -317,7 +312,6 @@ int InnerProduct_vulkan::create_pipeline(const Option& _opt)
 
         Mat local_size_xyz(std::min(16, num_output / out_elempack), 4, 1, (void*)0);
 
-        // fprintf(stdout, "******** partD in_elempack %d out_elempack %d \n ", in_elempack, out_elempack);
         int shader_type_index = -1;
         if (in_elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::innerproduct_gemm;
         if (in_elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::innerproduct_gemm_wp4;

--- a/src/layer/vulkan/innerproduct_vulkan.cpp
+++ b/src/layer/vulkan/innerproduct_vulkan.cpp
@@ -105,6 +105,7 @@ int InnerProduct_vulkan::create_pipeline(const Option& _opt)
             local_size_xyz.c = 1;
         }
 
+        // fprintf(stdout, "******** partA in_elempack %d out_elempack %d \n ", in_elempack, out_elempack);
         int shader_type_index = -1;
         if (in_elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::innerproduct_gemm;
         if (in_elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::innerproduct_gemm_wp4;
@@ -212,6 +213,8 @@ int InnerProduct_vulkan::create_pipeline(const Option& _opt)
             specializations[0 + 1].i = out_sum8_shape_packed.w;
             specializations[0 + 2].i = out_sum8_shape_packed.h;
 
+        // fprintf(stdout, "******** partB in_elempack %d out_elempack %d \n ", in_elempack, out_elempack);
+
             int shader_type_index = -1;
             if (in_elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::innerproduct_sum8;
             if (in_elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::innerproduct_sum8_pack4;
@@ -275,6 +278,9 @@ int InnerProduct_vulkan::create_pipeline(const Option& _opt)
             local_size_xyz.c = 1;
         }
 
+
+        // fprintf(stdout, "******** partC in_elempack %d out_elempack %d \n ", in_elempack, out_elempack);
+
         int shader_type_index = -1;
         if (in_elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::innerproduct;
         if (in_elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::innerproduct_pack4;
@@ -312,6 +318,7 @@ int InnerProduct_vulkan::create_pipeline(const Option& _opt)
 
         Mat local_size_xyz(std::min(16, num_output / out_elempack), 4, 1, (void*)0);
 
+        // fprintf(stdout, "******** partD in_elempack %d out_elempack %d \n ", in_elempack, out_elempack);
         int shader_type_index = -1;
         if (in_elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::innerproduct_gemm;
         if (in_elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::innerproduct_gemm_wp4;

--- a/src/layer/vulkan/innerproduct_vulkan.cpp
+++ b/src/layer/vulkan/innerproduct_vulkan.cpp
@@ -213,7 +213,7 @@ int InnerProduct_vulkan::create_pipeline(const Option& _opt)
             specializations[0 + 1].i = out_sum8_shape_packed.w;
             specializations[0 + 2].i = out_sum8_shape_packed.h;
 
-        // fprintf(stdout, "******** partB in_elempack %d out_elempack %d \n ", in_elempack, out_elempack);
+            // fprintf(stdout, "******** partB in_elempack %d out_elempack %d \n ", in_elempack, out_elempack);
 
             int shader_type_index = -1;
             if (in_elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::innerproduct_sum8;
@@ -277,7 +277,6 @@ int InnerProduct_vulkan::create_pipeline(const Option& _opt)
             local_size_xyz.h = 1;
             local_size_xyz.c = 1;
         }
-
 
         // fprintf(stdout, "******** partC in_elempack %d out_elempack %d \n ", in_elempack, out_elempack);
 

--- a/src/layer/vulkan/shader/absval.comp
+++ b/src/layer/vulkan/shader/absval.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/absval_pack4.comp
+++ b/src/layer/vulkan/shader/absval_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/absval_pack8.comp
+++ b/src/layer/vulkan/shader/absval_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/batchnorm.comp
+++ b/src/layer/vulkan/shader/batchnorm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/batchnorm_pack4.comp
+++ b/src/layer/vulkan/shader/batchnorm_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/batchnorm_pack8.comp
+++ b/src/layer/vulkan/shader/batchnorm_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/binaryop.comp
+++ b/src/layer/vulkan/shader/binaryop.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/binaryop_broadcast.comp
+++ b/src/layer/vulkan/shader/binaryop_broadcast.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/binaryop_broadcast_a1_pack4.comp
+++ b/src/layer/vulkan/shader/binaryop_broadcast_a1_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/binaryop_broadcast_a1_pack8.comp
+++ b/src/layer/vulkan/shader/binaryop_broadcast_a1_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/binaryop_broadcast_b1_pack4.comp
+++ b/src/layer/vulkan/shader/binaryop_broadcast_b1_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/binaryop_broadcast_b1_pack8.comp
+++ b/src/layer/vulkan/shader/binaryop_broadcast_b1_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/binaryop_broadcast_pack4.comp
+++ b/src/layer/vulkan/shader/binaryop_broadcast_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/binaryop_broadcast_pack8.comp
+++ b/src/layer/vulkan/shader/binaryop_broadcast_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/binaryop_pack4.comp
+++ b/src/layer/vulkan/shader/binaryop_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/binaryop_pack8.comp
+++ b/src/layer/vulkan/shader/binaryop_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/cast_fp16_to_fp32.comp
+++ b/src/layer/vulkan/shader/cast_fp16_to_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/cast_fp16_to_fp32_pack4.comp
+++ b/src/layer/vulkan/shader/cast_fp16_to_fp32_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/cast_fp16_to_fp32_pack8.comp
+++ b/src/layer/vulkan/shader/cast_fp16_to_fp32_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/cast_fp32_to_fp16.comp
+++ b/src/layer/vulkan/shader/cast_fp32_to_fp16.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/cast_fp32_to_fp16_pack4.comp
+++ b/src/layer/vulkan/shader/cast_fp32_to_fp16_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/cast_fp32_to_fp16_pack8.comp
+++ b/src/layer/vulkan/shader/cast_fp32_to_fp16_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/clip.comp
+++ b/src/layer/vulkan/shader/clip.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/clip_pack4.comp
+++ b/src/layer/vulkan/shader/clip_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/clip_pack8.comp
+++ b/src/layer/vulkan/shader/clip_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/concat.comp
+++ b/src/layer/vulkan/shader/concat.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/concat_pack4.comp
+++ b/src/layer/vulkan/shader/concat_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/concat_pack4to1.comp
+++ b/src/layer/vulkan/shader/concat_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/concat_pack8.comp
+++ b/src/layer/vulkan/shader/concat_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/concat_pack8to1.comp
+++ b/src/layer/vulkan/shader/concat_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/concat_pack8to4.comp
+++ b/src/layer/vulkan/shader/concat_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution.comp
+++ b/src/layer/vulkan/shader/convolution.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_1x1s1d1.comp
+++ b/src/layer/vulkan/shader/convolution_1x1s1d1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_3x3s1d1_winograd23_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution_3x3s1d1_winograd23_transform_input.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_3x3s1d1_winograd23_transform_output.comp
+++ b/src/layer/vulkan/shader/convolution_3x3s1d1_winograd23_transform_output.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_3x3s1d1_winograd43_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution_3x3s1d1_winograd43_transform_input.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_3x3s1d1_winograd43_transform_output.comp
+++ b/src/layer/vulkan/shader/convolution_3x3s1d1_winograd43_transform_output.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_3x3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_3x3s1d1_winograd_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack1to4.comp
+++ b/src/layer/vulkan/shader/convolution_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack1to4_1x1s1d1.comp
+++ b/src/layer/vulkan/shader/convolution_pack1to4_1x1s1d1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack1to4_3x3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack1to4_3x3s1d1_winograd_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack1to4_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack1to4_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack1to8.comp
+++ b/src/layer/vulkan/shader/convolution_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack1to8_1x1s1d1.comp
+++ b/src/layer/vulkan/shader/convolution_pack1to8_1x1s1d1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack1to8_3x3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack1to8_3x3s1d1_winograd_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack1to8_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack1to8_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack4.comp
+++ b/src/layer/vulkan/shader/convolution_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack4_1x1s1d1.comp
+++ b/src/layer/vulkan/shader/convolution_pack4_1x1s1d1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack4_3x3s1d1_winograd23_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution_pack4_3x3s1d1_winograd23_transform_input.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack4_3x3s1d1_winograd23_transform_output.comp
+++ b/src/layer/vulkan/shader/convolution_pack4_3x3s1d1_winograd23_transform_output.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack4_3x3s1d1_winograd43_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution_pack4_3x3s1d1_winograd43_transform_input.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack4_3x3s1d1_winograd43_transform_output.comp
+++ b/src/layer/vulkan/shader/convolution_pack4_3x3s1d1_winograd43_transform_output.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack4_3x3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack4_3x3s1d1_winograd_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack4_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack4_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack4to1.comp
+++ b/src/layer/vulkan/shader/convolution_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack4to1_1x1s1d1.comp
+++ b/src/layer/vulkan/shader/convolution_pack4to1_1x1s1d1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack4to1_3x3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack4to1_3x3s1d1_winograd_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack4to1_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack4to1_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolution_pack4to8.comp
+++ b/src/layer/vulkan/shader/convolution_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack4to8_1x1s1d1.comp
+++ b/src/layer/vulkan/shader/convolution_pack4to8_1x1s1d1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack4to8_3x3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack4to8_3x3s1d1_winograd_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack4to8_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack4to8_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8.comp
+++ b/src/layer/vulkan/shader/convolution_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8_1x1s1d1.comp
+++ b/src/layer/vulkan/shader/convolution_pack8_1x1s1d1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8_3x3s1d1_winograd23_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution_pack8_3x3s1d1_winograd23_transform_input.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8_3x3s1d1_winograd23_transform_output.comp
+++ b/src/layer/vulkan/shader/convolution_pack8_3x3s1d1_winograd23_transform_output.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8_3x3s1d1_winograd43_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution_pack8_3x3s1d1_winograd43_transform_input.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8_3x3s1d1_winograd43_transform_output.comp
+++ b/src/layer/vulkan/shader/convolution_pack8_3x3s1d1_winograd43_transform_output.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8_3x3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack8_3x3s1d1_winograd_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack8_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8to1.comp
+++ b/src/layer/vulkan/shader/convolution_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8to1_1x1s1d1.comp
+++ b/src/layer/vulkan/shader/convolution_pack8to1_1x1s1d1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8to1_3x3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack8to1_3x3s1d1_winograd_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8to1_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack8to1_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8to4.comp
+++ b/src/layer/vulkan/shader/convolution_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8to4_1x1s1d1.comp
+++ b/src/layer/vulkan/shader/convolution_pack8to4_1x1s1d1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8to4_3x3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack8to4_3x3s1d1_winograd_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolution_pack8to4_gemm.comp
+++ b/src/layer/vulkan/shader/convolution_pack8to4_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolutiondepthwise.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolutiondepthwise_group.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise_group.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolutiondepthwise_group_pack1to4.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise_group_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolutiondepthwise_group_pack1to8.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise_group_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolutiondepthwise_group_pack4.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise_group_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolutiondepthwise_group_pack4to1.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise_group_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolutiondepthwise_group_pack4to8.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise_group_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolutiondepthwise_group_pack8.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise_group_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolutiondepthwise_group_pack8to1.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise_group_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolutiondepthwise_group_pack8to4.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise_group_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/convolutiondepthwise_pack4.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/convolutiondepthwise_pack8.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/crop.comp
+++ b/src/layer/vulkan/shader/crop.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/crop_pack1to4.comp
+++ b/src/layer/vulkan/shader/crop_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/crop_pack1to8.comp
+++ b/src/layer/vulkan/shader/crop_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/crop_pack4.comp
+++ b/src/layer/vulkan/shader/crop_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/crop_pack4to1.comp
+++ b/src/layer/vulkan/shader/crop_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/crop_pack4to8.comp
+++ b/src/layer/vulkan/shader/crop_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/crop_pack8.comp
+++ b/src/layer/vulkan/shader/crop_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/crop_pack8to1.comp
+++ b/src/layer/vulkan/shader/crop_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/crop_pack8to4.comp
+++ b/src/layer/vulkan/shader/crop_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolution.comp
+++ b/src/layer/vulkan/shader/deconvolution.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolution_col2im.comp
+++ b/src/layer/vulkan/shader/deconvolution_col2im.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolution_gemm.comp
+++ b/src/layer/vulkan/shader/deconvolution_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolution_pack1to4.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolution_pack1to4_gemm.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack1to4_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolution_pack1to8.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolution_pack1to8_gemm.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack1to8_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolution_pack4.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolution_pack4_col2im.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack4_col2im.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolution_pack4_gemm.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack4_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolution_pack4to1.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolution_pack4to1_gemm.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack4to1_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolution_pack4to8.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolution_pack4to8_gemm.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack4to8_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolution_pack8.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolution_pack8_col2im.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack8_col2im.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolution_pack8_gemm.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack8_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolution_pack8to1.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolution_pack8to1_gemm.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack8to1_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolution_pack8to4.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolution_pack8to4_gemm.comp
+++ b/src/layer/vulkan/shader/deconvolution_pack8to4_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolutiondepthwise.comp
+++ b/src/layer/vulkan/shader/deconvolutiondepthwise.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolutiondepthwise_group.comp
+++ b/src/layer/vulkan/shader/deconvolutiondepthwise_group.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack1to4.comp
+++ b/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack1to8.comp
+++ b/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack4.comp
+++ b/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack4to1.comp
+++ b/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack4to8.comp
+++ b/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack8.comp
+++ b/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack8to1.comp
+++ b/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack8to4.comp
+++ b/src/layer/vulkan/shader/deconvolutiondepthwise_group_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deconvolutiondepthwise_pack4.comp
+++ b/src/layer/vulkan/shader/deconvolutiondepthwise_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deconvolutiondepthwise_pack8.comp
+++ b/src/layer/vulkan/shader/deconvolutiondepthwise_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/deepcopy.comp
+++ b/src/layer/vulkan/shader/deepcopy.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deepcopy_pack4.comp
+++ b/src/layer/vulkan/shader/deepcopy_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/deepcopy_pack8.comp
+++ b/src/layer/vulkan/shader/deepcopy_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/dropout.comp
+++ b/src/layer/vulkan/shader/dropout.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/dropout_pack4.comp
+++ b/src/layer/vulkan/shader/dropout_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/dropout_pack8.comp
+++ b/src/layer/vulkan/shader/dropout_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/eltwise.comp
+++ b/src/layer/vulkan/shader/eltwise.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/eltwise_pack4.comp
+++ b/src/layer/vulkan/shader/eltwise_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/eltwise_pack8.comp
+++ b/src/layer/vulkan/shader/eltwise_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/flatten.comp
+++ b/src/layer/vulkan/shader/flatten.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/flatten_pack1to4.comp
+++ b/src/layer/vulkan/shader/flatten_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/flatten_pack1to8.comp
+++ b/src/layer/vulkan/shader/flatten_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/flatten_pack4.comp
+++ b/src/layer/vulkan/shader/flatten_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/flatten_pack4to8.comp
+++ b/src/layer/vulkan/shader/flatten_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/flatten_pack8.comp
+++ b/src/layer/vulkan/shader/flatten_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/hardsigmoid.comp
+++ b/src/layer/vulkan/shader/hardsigmoid.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/hardsigmoid_pack4.comp
+++ b/src/layer/vulkan/shader/hardsigmoid_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/hardsigmoid_pack8.comp
+++ b/src/layer/vulkan/shader/hardsigmoid_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/hardswish.comp
+++ b/src/layer/vulkan/shader/hardswish.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/hardswish_pack4.comp
+++ b/src/layer/vulkan/shader/hardswish_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/hardswish_pack8.comp
+++ b/src/layer/vulkan/shader/hardswish_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct.comp
+++ b/src/layer/vulkan/shader/innerproduct.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_gemm.comp
+++ b/src/layer/vulkan/shader/innerproduct_gemm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_gemm_wp1to4.comp
+++ b/src/layer/vulkan/shader/innerproduct_gemm_wp1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_gemm_wp1to8.comp
+++ b/src/layer/vulkan/shader/innerproduct_gemm_wp1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_gemm_wp4.comp
+++ b/src/layer/vulkan/shader/innerproduct_gemm_wp4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_gemm_wp4to1.comp
+++ b/src/layer/vulkan/shader/innerproduct_gemm_wp4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_gemm_wp4to8.comp
+++ b/src/layer/vulkan/shader/innerproduct_gemm_wp4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_gemm_wp8.comp
+++ b/src/layer/vulkan/shader/innerproduct_gemm_wp8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_gemm_wp8to1.comp
+++ b/src/layer/vulkan/shader/innerproduct_gemm_wp8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_gemm_wp8to4.comp
+++ b/src/layer/vulkan/shader/innerproduct_gemm_wp8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_pack1to4.comp
+++ b/src/layer/vulkan/shader/innerproduct_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_pack1to8.comp
+++ b/src/layer/vulkan/shader/innerproduct_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_pack4.comp
+++ b/src/layer/vulkan/shader/innerproduct_pack4.comp
@@ -14,7 +14,6 @@
 
 #version 450
 #pragma use_vulkan_memory_model
-#extension GL_EXT_control_flow_attributes : enable
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif
@@ -97,6 +96,8 @@ void main()
     }
 
 #if NCNN_image_shader
+    int wx=0;
+
     for (int i = 0; i < psc(w); i++)
     {
         afpvec4 v = image3d_ld4(bottom_blob, ivec3(i, 0, 0));

--- a/src/layer/vulkan/shader/innerproduct_pack4.comp
+++ b/src/layer/vulkan/shader/innerproduct_pack4.comp
@@ -96,7 +96,7 @@ void main()
     }
 
 #if NCNN_image_shader
-    int wx=0;
+    int wx = 0;
 
     for (int i = 0; i < psc(w); i++)
     {

--- a/src/layer/vulkan/shader/innerproduct_pack4.comp
+++ b/src/layer/vulkan/shader/innerproduct_pack4.comp
@@ -13,7 +13,8 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
+#extension GL_EXT_control_flow_attributes : enable
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif
@@ -96,8 +97,6 @@ void main()
     }
 
 #if NCNN_image_shader
-    int wx = 0;
-
     for (int i = 0; i < psc(w); i++)
     {
         afpvec4 v = image3d_ld4(bottom_blob, ivec3(i, 0, 0));
@@ -135,34 +134,26 @@ void main()
     }
 #endif
 
-    if (activation_type == 1)
+    switch(activation_type)
     {
-        sum = max(sum, afp(0.f));
-    }
-    if (activation_type == 2)
-    {
-        const afp slope = afp(activation_param_0);
-        sum = mix(sum, sum * afp(slope), lessThan(sum, afpvec4(0.f)));
-    }
-    if (activation_type == 3)
-    {
-        const afp const_min = afp(activation_param_0);
-        const afp const_max = afp(activation_param_1);
-        sum = clamp(sum, const_min, const_max);
-    }
-    if (activation_type == 4)
-    {
-        sum = afp(1.f) / (afp(1.f) + exp(-sum));
-    }
-    if (activation_type == 5)
-    {
-        sum = sum * tanh(log(exp(sum) + afp(1.f)));
-    }
-    if (activation_type == 6)
-    {
-        const afp alpha = afp(activation_param_0);
-        const afp beta = afp(activation_param_1);
-        sum = sum * clamp(sum * afp(alpha) + afp(beta), afp(0.f), afp(1.f));
+        case 1:
+            sum = max(sum, afp(0.f));
+            break;
+        case 2:
+            sum = mix(sum, sum * afp(activation_param_0), lessThan(sum, afpvec4(0.f)));
+            break;
+        case 3:
+            sum = clamp(sum, afp(activation_param_0), afp(activation_param_1));
+            break;
+        case 4:
+            sum = afp(1.f) / (afp(1.f) + exp(-sum));
+            break;
+        case 5:
+            sum = sum * tanh(log(exp(sum) + afp(1.f)));
+            break;
+        case 6:
+            sum = sum * clamp(sum * afp(activation_param_0) + afp(activation_param_1), afp(0.f), afp(1.f));
+            break;
     }
 
 #if NCNN_image_shader

--- a/src/layer/vulkan/shader/innerproduct_pack4to1.comp
+++ b/src/layer/vulkan/shader/innerproduct_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_pack4to8.comp
+++ b/src/layer/vulkan/shader/innerproduct_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_pack8.comp
+++ b/src/layer/vulkan/shader/innerproduct_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_pack8to1.comp
+++ b/src/layer/vulkan/shader/innerproduct_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_pack8to4.comp
+++ b/src/layer/vulkan/shader/innerproduct_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_reduce_sum8.comp
+++ b/src/layer/vulkan/shader/innerproduct_reduce_sum8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_reduce_sum8_pack4.comp
+++ b/src/layer/vulkan/shader/innerproduct_reduce_sum8_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_reduce_sum8_pack8.comp
+++ b/src/layer/vulkan/shader/innerproduct_reduce_sum8_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_sum8.comp
+++ b/src/layer/vulkan/shader/innerproduct_sum8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_sum8_pack1to4.comp
+++ b/src/layer/vulkan/shader/innerproduct_sum8_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_sum8_pack1to8.comp
+++ b/src/layer/vulkan/shader/innerproduct_sum8_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_sum8_pack4.comp
+++ b/src/layer/vulkan/shader/innerproduct_sum8_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_sum8_pack4to1.comp
+++ b/src/layer/vulkan/shader/innerproduct_sum8_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/innerproduct_sum8_pack4to8.comp
+++ b/src/layer/vulkan/shader/innerproduct_sum8_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_sum8_pack8.comp
+++ b/src/layer/vulkan/shader/innerproduct_sum8_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_sum8_pack8to1.comp
+++ b/src/layer/vulkan/shader/innerproduct_sum8_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/innerproduct_sum8_pack8to4.comp
+++ b/src/layer/vulkan/shader/innerproduct_sum8_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/instancenorm_coeffs.comp
+++ b/src/layer/vulkan/shader/instancenorm_coeffs.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/instancenorm_coeffs_pack4.comp
+++ b/src/layer/vulkan/shader/instancenorm_coeffs_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/instancenorm_coeffs_pack8.comp
+++ b/src/layer/vulkan/shader/instancenorm_coeffs_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/instancenorm_norm.comp
+++ b/src/layer/vulkan/shader/instancenorm_norm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/instancenorm_norm_pack4.comp
+++ b/src/layer/vulkan/shader/instancenorm_norm_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/instancenorm_norm_pack8.comp
+++ b/src/layer/vulkan/shader/instancenorm_norm_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/instancenorm_reduce_mean.comp
+++ b/src/layer/vulkan/shader/instancenorm_reduce_mean.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/instancenorm_reduce_mean_pack4.comp
+++ b/src/layer/vulkan/shader/instancenorm_reduce_mean_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/instancenorm_reduce_mean_pack8.comp
+++ b/src/layer/vulkan/shader/instancenorm_reduce_mean_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/instancenorm_reduce_sum4_fp16_to_fp32.comp
+++ b/src/layer/vulkan/shader/instancenorm_reduce_sum4_fp16_to_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/instancenorm_reduce_sum4_fp16_to_fp32_pack4.comp
+++ b/src/layer/vulkan/shader/instancenorm_reduce_sum4_fp16_to_fp32_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/instancenorm_reduce_sum4_fp16_to_fp32_pack8.comp
+++ b/src/layer/vulkan/shader/instancenorm_reduce_sum4_fp16_to_fp32_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/instancenorm_reduce_sum4_fp32.comp
+++ b/src/layer/vulkan/shader/instancenorm_reduce_sum4_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/instancenorm_reduce_sum4_fp32_pack4.comp
+++ b/src/layer/vulkan/shader/instancenorm_reduce_sum4_fp32_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/instancenorm_reduce_sum4_fp32_pack8.comp
+++ b/src/layer/vulkan/shader/instancenorm_reduce_sum4_fp32_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/instancenorm_sub_mean_square.comp
+++ b/src/layer/vulkan/shader/instancenorm_sub_mean_square.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/instancenorm_sub_mean_square_pack4.comp
+++ b/src/layer/vulkan/shader/instancenorm_sub_mean_square_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/instancenorm_sub_mean_square_pack8.comp
+++ b/src/layer/vulkan/shader/instancenorm_sub_mean_square_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/interp.comp
+++ b/src/layer/vulkan/shader/interp.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/interp_bicubic.comp
+++ b/src/layer/vulkan/shader/interp_bicubic.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/interp_bicubic_coeffs.comp
+++ b/src/layer/vulkan/shader/interp_bicubic_coeffs.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/interp_bicubic_pack4.comp
+++ b/src/layer/vulkan/shader/interp_bicubic_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/interp_bicubic_pack8.comp
+++ b/src/layer/vulkan/shader/interp_bicubic_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/interp_pack4.comp
+++ b/src/layer/vulkan/shader/interp_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/interp_pack8.comp
+++ b/src/layer/vulkan/shader/interp_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/lrn_norm.comp
+++ b/src/layer/vulkan/shader/lrn_norm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/lrn_norm_across_channel_pack4.comp
+++ b/src/layer/vulkan/shader/lrn_norm_across_channel_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/lrn_norm_across_channel_pack8.comp
+++ b/src/layer/vulkan/shader/lrn_norm_across_channel_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/lrn_norm_within_channel_pack4.comp
+++ b/src/layer/vulkan/shader/lrn_norm_within_channel_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/lrn_norm_within_channel_pack8.comp
+++ b/src/layer/vulkan/shader/lrn_norm_within_channel_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/lrn_square_pad.comp
+++ b/src/layer/vulkan/shader/lrn_square_pad.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/lrn_square_pad_across_channel_pack4.comp
+++ b/src/layer/vulkan/shader/lrn_square_pad_across_channel_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/lrn_square_pad_across_channel_pack8.comp
+++ b/src/layer/vulkan/shader/lrn_square_pad_across_channel_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/lrn_square_pad_within_channel_pack4.comp
+++ b/src/layer/vulkan/shader/lrn_square_pad_within_channel_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/lrn_square_pad_within_channel_pack8.comp
+++ b/src/layer/vulkan/shader/lrn_square_pad_within_channel_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/mish.comp
+++ b/src/layer/vulkan/shader/mish.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/mish_pack4.comp
+++ b/src/layer/vulkan/shader/mish_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/mish_pack8.comp
+++ b/src/layer/vulkan/shader/mish_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/normalize_coeffs.comp
+++ b/src/layer/vulkan/shader/normalize_coeffs.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/normalize_coeffs_pack4.comp
+++ b/src/layer/vulkan/shader/normalize_coeffs_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/normalize_coeffs_pack8.comp
+++ b/src/layer/vulkan/shader/normalize_coeffs_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/normalize_norm.comp
+++ b/src/layer/vulkan/shader/normalize_norm.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/normalize_norm_pack4.comp
+++ b/src/layer/vulkan/shader/normalize_norm_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/normalize_norm_pack8.comp
+++ b/src/layer/vulkan/shader/normalize_norm_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/normalize_reduce_sum4_fp16_to_fp32.comp
+++ b/src/layer/vulkan/shader/normalize_reduce_sum4_fp16_to_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/normalize_reduce_sum4_fp16_to_fp32_pack4.comp
+++ b/src/layer/vulkan/shader/normalize_reduce_sum4_fp16_to_fp32_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/normalize_reduce_sum4_fp16_to_fp32_pack8.comp
+++ b/src/layer/vulkan/shader/normalize_reduce_sum4_fp16_to_fp32_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/normalize_reduce_sum4_fp32.comp
+++ b/src/layer/vulkan/shader/normalize_reduce_sum4_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/normalize_reduce_sum4_fp32_pack4.comp
+++ b/src/layer/vulkan/shader/normalize_reduce_sum4_fp32_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/normalize_reduce_sum4_fp32_pack8.comp
+++ b/src/layer/vulkan/shader/normalize_reduce_sum4_fp32_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing.comp
+++ b/src/layer/vulkan/shader/packing.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/packing_fp16_to_fp32.comp
+++ b/src/layer/vulkan/shader/packing_fp16_to_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/packing_fp32_to_fp16.comp
+++ b/src/layer/vulkan/shader/packing_fp32_to_fp16.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/packing_pack1to4.comp
+++ b/src/layer/vulkan/shader/packing_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/packing_pack1to4_fp16_to_fp32.comp
+++ b/src/layer/vulkan/shader/packing_pack1to4_fp16_to_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/packing_pack1to4_fp32_to_fp16.comp
+++ b/src/layer/vulkan/shader/packing_pack1to4_fp32_to_fp16.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/packing_pack1to8.comp
+++ b/src/layer/vulkan/shader/packing_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack1to8_fp16_to_fp32.comp
+++ b/src/layer/vulkan/shader/packing_pack1to8_fp16_to_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack1to8_fp32_to_fp16.comp
+++ b/src/layer/vulkan/shader/packing_pack1to8_fp32_to_fp16.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack4.comp
+++ b/src/layer/vulkan/shader/packing_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/packing_pack4_fp16_to_fp32.comp
+++ b/src/layer/vulkan/shader/packing_pack4_fp16_to_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/packing_pack4_fp32_to_fp16.comp
+++ b/src/layer/vulkan/shader/packing_pack4_fp32_to_fp16.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/packing_pack4to1.comp
+++ b/src/layer/vulkan/shader/packing_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/packing_pack4to1_fp16_to_fp32.comp
+++ b/src/layer/vulkan/shader/packing_pack4to1_fp16_to_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/packing_pack4to1_fp32_to_fp16.comp
+++ b/src/layer/vulkan/shader/packing_pack4to1_fp32_to_fp16.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/packing_pack4to8.comp
+++ b/src/layer/vulkan/shader/packing_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack4to8_fp16_to_fp32.comp
+++ b/src/layer/vulkan/shader/packing_pack4to8_fp16_to_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack4to8_fp32_to_fp16.comp
+++ b/src/layer/vulkan/shader/packing_pack4to8_fp32_to_fp16.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack8.comp
+++ b/src/layer/vulkan/shader/packing_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack8_fp16_to_fp32.comp
+++ b/src/layer/vulkan/shader/packing_pack8_fp16_to_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack8_fp32_to_fp16.comp
+++ b/src/layer/vulkan/shader/packing_pack8_fp32_to_fp16.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack8to1.comp
+++ b/src/layer/vulkan/shader/packing_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack8to1_fp16_to_fp32.comp
+++ b/src/layer/vulkan/shader/packing_pack8to1_fp16_to_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack8to1_fp32_to_fp16.comp
+++ b/src/layer/vulkan/shader/packing_pack8to1_fp32_to_fp16.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack8to4.comp
+++ b/src/layer/vulkan/shader/packing_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack8to4_fp16_to_fp32.comp
+++ b/src/layer/vulkan/shader/packing_pack8to4_fp16_to_fp32.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/packing_pack8to4_fp32_to_fp16.comp
+++ b/src/layer/vulkan/shader/packing_pack8to4_fp32_to_fp16.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/padding.comp
+++ b/src/layer/vulkan/shader/padding.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/padding_3d.comp
+++ b/src/layer/vulkan/shader/padding_3d.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/padding_3d_pack4.comp
+++ b/src/layer/vulkan/shader/padding_3d_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/padding_3d_pack8.comp
+++ b/src/layer/vulkan/shader/padding_3d_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/padding_pack1to4.comp
+++ b/src/layer/vulkan/shader/padding_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/padding_pack1to8.comp
+++ b/src/layer/vulkan/shader/padding_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/padding_pack4.comp
+++ b/src/layer/vulkan/shader/padding_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/padding_pack4to1.comp
+++ b/src/layer/vulkan/shader/padding_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/padding_pack4to8.comp
+++ b/src/layer/vulkan/shader/padding_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/padding_pack8.comp
+++ b/src/layer/vulkan/shader/padding_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/padding_pack8to1.comp
+++ b/src/layer/vulkan/shader/padding_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/padding_pack8to4.comp
+++ b/src/layer/vulkan/shader/padding_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/permute.comp
+++ b/src/layer/vulkan/shader/permute.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/permute_pack1to4.comp
+++ b/src/layer/vulkan/shader/permute_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/permute_pack1to8.comp
+++ b/src/layer/vulkan/shader/permute_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/permute_pack4.comp
+++ b/src/layer/vulkan/shader/permute_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/permute_pack4to1.comp
+++ b/src/layer/vulkan/shader/permute_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/permute_pack4to8.comp
+++ b/src/layer/vulkan/shader/permute_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/permute_pack8.comp
+++ b/src/layer/vulkan/shader/permute_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/permute_pack8to1.comp
+++ b/src/layer/vulkan/shader/permute_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/permute_pack8to4.comp
+++ b/src/layer/vulkan/shader/permute_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/pixelshuffle.comp
+++ b/src/layer/vulkan/shader/pixelshuffle.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/pixelshuffle_pack4.comp
+++ b/src/layer/vulkan/shader/pixelshuffle_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/pixelshuffle_pack4to1.comp
+++ b/src/layer/vulkan/shader/pixelshuffle_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/pixelshuffle_pack8.comp
+++ b/src/layer/vulkan/shader/pixelshuffle_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/pixelshuffle_pack8to1.comp
+++ b/src/layer/vulkan/shader/pixelshuffle_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/pixelshuffle_pack8to4.comp
+++ b/src/layer/vulkan/shader/pixelshuffle_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/pooling.comp
+++ b/src/layer/vulkan/shader/pooling.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/pooling_adaptive.comp
+++ b/src/layer/vulkan/shader/pooling_adaptive.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/pooling_adaptive_pack4.comp
+++ b/src/layer/vulkan/shader/pooling_adaptive_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/pooling_adaptive_pack8.comp
+++ b/src/layer/vulkan/shader/pooling_adaptive_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/pooling_global.comp
+++ b/src/layer/vulkan/shader/pooling_global.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/pooling_global_pack4.comp
+++ b/src/layer/vulkan/shader/pooling_global_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/pooling_global_pack8.comp
+++ b/src/layer/vulkan/shader/pooling_global_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/pooling_pack4.comp
+++ b/src/layer/vulkan/shader/pooling_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/pooling_pack8.comp
+++ b/src/layer/vulkan/shader/pooling_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/prelu.comp
+++ b/src/layer/vulkan/shader/prelu.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/prelu_pack4.comp
+++ b/src/layer/vulkan/shader/prelu_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/prelu_pack8.comp
+++ b/src/layer/vulkan/shader/prelu_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/priorbox.comp
+++ b/src/layer/vulkan/shader/priorbox.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/priorbox_mxnet.comp
+++ b/src/layer/vulkan/shader/priorbox_mxnet.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/relu.comp
+++ b/src/layer/vulkan/shader/relu.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/relu_pack4.comp
+++ b/src/layer/vulkan/shader/relu_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/relu_pack8.comp
+++ b/src/layer/vulkan/shader/relu_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/reorg.comp
+++ b/src/layer/vulkan/shader/reorg.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/reorg_pack1to4.comp
+++ b/src/layer/vulkan/shader/reorg_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/reorg_pack1to8.comp
+++ b/src/layer/vulkan/shader/reorg_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/reorg_pack4.comp
+++ b/src/layer/vulkan/shader/reorg_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/reorg_pack4to8.comp
+++ b/src/layer/vulkan/shader/reorg_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/reorg_pack8.comp
+++ b/src/layer/vulkan/shader/reorg_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/reshape.comp
+++ b/src/layer/vulkan/shader/reshape.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/reshape_pack1to4.comp
+++ b/src/layer/vulkan/shader/reshape_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/reshape_pack1to8.comp
+++ b/src/layer/vulkan/shader/reshape_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/reshape_pack4.comp
+++ b/src/layer/vulkan/shader/reshape_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/reshape_pack4to1.comp
+++ b/src/layer/vulkan/shader/reshape_pack4to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/reshape_pack4to8.comp
+++ b/src/layer/vulkan/shader/reshape_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/reshape_pack8.comp
+++ b/src/layer/vulkan/shader/reshape_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/reshape_pack8to1.comp
+++ b/src/layer/vulkan/shader/reshape_pack8to1.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/reshape_pack8to4.comp
+++ b/src/layer/vulkan/shader/reshape_pack8to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/scale.comp
+++ b/src/layer/vulkan/shader/scale.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/scale_pack4.comp
+++ b/src/layer/vulkan/shader/scale_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/scale_pack8.comp
+++ b/src/layer/vulkan/shader/scale_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/shufflechannel.comp
+++ b/src/layer/vulkan/shader/shufflechannel.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/shufflechannel_pack4.comp
+++ b/src/layer/vulkan/shader/shufflechannel_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/shufflechannel_pack8.comp
+++ b/src/layer/vulkan/shader/shufflechannel_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/sigmoid.comp
+++ b/src/layer/vulkan/shader/sigmoid.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/sigmoid_pack4.comp
+++ b/src/layer/vulkan/shader/sigmoid_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/sigmoid_pack8.comp
+++ b/src/layer/vulkan/shader/sigmoid_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/slice.comp
+++ b/src/layer/vulkan/shader/slice.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/slice_pack1to4.comp
+++ b/src/layer/vulkan/shader/slice_pack1to4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/slice_pack1to8.comp
+++ b/src/layer/vulkan/shader/slice_pack1to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/slice_pack4.comp
+++ b/src/layer/vulkan/shader/slice_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/slice_pack4to8.comp
+++ b/src/layer/vulkan/shader/slice_pack4to8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/slice_pack8.comp
+++ b/src/layer/vulkan/shader/slice_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/softmax_div_sum.comp
+++ b/src/layer/vulkan/shader/softmax_div_sum.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/softmax_div_sum_pack4.comp
+++ b/src/layer/vulkan/shader/softmax_div_sum_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/softmax_div_sum_pack8.comp
+++ b/src/layer/vulkan/shader/softmax_div_sum_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/softmax_exp_sub_max.comp
+++ b/src/layer/vulkan/shader/softmax_exp_sub_max.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/softmax_exp_sub_max_pack4.comp
+++ b/src/layer/vulkan/shader/softmax_exp_sub_max_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/softmax_exp_sub_max_pack8.comp
+++ b/src/layer/vulkan/shader/softmax_exp_sub_max_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/softmax_reduce_max.comp
+++ b/src/layer/vulkan/shader/softmax_reduce_max.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/softmax_reduce_max_pack4.comp
+++ b/src/layer/vulkan/shader/softmax_reduce_max_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/softmax_reduce_max_pack8.comp
+++ b/src/layer/vulkan/shader/softmax_reduce_max_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/softmax_reduce_sum.comp
+++ b/src/layer/vulkan/shader/softmax_reduce_sum.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/softmax_reduce_sum_pack4.comp
+++ b/src/layer/vulkan/shader/softmax_reduce_sum_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/softmax_reduce_sum_pack8.comp
+++ b/src/layer/vulkan/shader/softmax_reduce_sum_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/swish.comp
+++ b/src/layer/vulkan/shader/swish.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/swish_pack4.comp
+++ b/src/layer/vulkan/shader/swish_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/swish_pack8.comp
+++ b/src/layer/vulkan/shader/swish_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/tanh.comp
+++ b/src/layer/vulkan/shader/tanh.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/tanh_pack4.comp
+++ b/src/layer/vulkan/shader/tanh_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/tanh_pack8.comp
+++ b/src/layer/vulkan/shader/tanh_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };

--- a/src/layer/vulkan/shader/unaryop.comp
+++ b/src/layer/vulkan/shader/unaryop.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/unaryop_pack4.comp
+++ b/src/layer/vulkan/shader/unaryop_pack4.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 #endif

--- a/src/layer/vulkan/shader/unaryop_pack8.comp
+++ b/src/layer/vulkan/shader/unaryop_pack8.comp
@@ -13,7 +13,7 @@
 // specific language governing permissions and limitations under the License.
 
 #version 450
-
+#pragma use_vulkan_memory_model
 #if NCNN_fp16_storage
 #extension GL_EXT_shader_16bit_storage: require
 struct sfpvec8 { f16vec4 abcd; f16vec4 efgh; };


### PR DESCRIPTION
## 背景

add use_vulkan_memory_model

写了个 [gmem_bandwidth benchmark](https://github.com/tpoisonooo/how-to-optimize-gemm/blob/5611c9673379ce1395cbe65c620981534ee51bae/vulkan/benchmark/gmem_bandwidth.comp#L2)，
在 jetson nano 上，加这句可提升 8% 带宽。

## 测试
实跑对 vgg16 **稳定**有 <1ms 的效果 +_+
 
修改前：
```bash
✗ ./benchncnn 100 1 0 0 0
[0 NVIDIA Tegra X1 (nvgpu)]  queueC=0[16]  queueG=0[16]  queueT=0[16]
[0 NVIDIA Tegra X1 (nvgpu)]  bugsbn1=0  bugbilz=0  bugcopc=0  bugihfa=0
[0 NVIDIA Tegra X1 (nvgpu)]  fp16-p/s/a=1/1/1  int8-p/s/a=1/1/1
[0 NVIDIA Tegra X1 (nvgpu)]  subgroup=32  basic=1  vote=1  ballot=1  shuffle=1
loop_count = 100
num_threads = 1
powersave = 0
gpu_device = 0
cooling_down = 0
...
               vgg16  min =  145.30  max =  151.08  avg =  146.55
```
修改后：
```bash
✗ ./benchncnn 100 1 0 0 0
[0 NVIDIA Tegra X1 (nvgpu)]  queueC=0[16]  queueG=0[16]  queueT=0[16]
[0 NVIDIA Tegra X1 (nvgpu)]  bugsbn1=0  bugbilz=0  bugcopc=0  bugihfa=0
[0 NVIDIA Tegra X1 (nvgpu)]  fp16-p/s/a=1/1/1  int8-p/s/a=1/1/1
[0 NVIDIA Tegra X1 (nvgpu)]  subgroup=32  basic=1  vote=1  ballot=1  shuffle=1
loop_count = 100
num_threads = 1
powersave = 0
gpu_device = 0
cooling_down = 0
...
               vgg16  min =  145.27  max =  147.97  avg =  145.93
```

跑了一下午了...不是抖动。