### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/android-armv7-cpu.yml
+++ b/.github/workflows/android-armv7-cpu.yml
@@ -21,6 +21,9 @@ on:
 concurrency:
   group: android-armv7-cpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   android-armv7:
     runs-on: ubuntu-latest

--- a/.github/workflows/android-armv7-gpu.yml
+++ b/.github/workflows/android-armv7-gpu.yml
@@ -23,6 +23,9 @@ on:
 concurrency:
   group: android-armv7-gpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   android-armv7-gpu:
     runs-on: ubuntu-latest

--- a/.github/workflows/android-armv8-cpu.yml
+++ b/.github/workflows/android-armv8-cpu.yml
@@ -21,6 +21,9 @@ on:
 concurrency:
   group: android-armv8-cpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   android-aarch64:
     runs-on: ubuntu-latest

--- a/.github/workflows/android-armv8-gpu.yml
+++ b/.github/workflows/android-armv8-gpu.yml
@@ -23,6 +23,9 @@ on:
 concurrency:
   group: android-armv8-gpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   android-aarch64-gpu:
     runs-on: ubuntu-latest

--- a/.github/workflows/android-x64-cpu.yml
+++ b/.github/workflows/android-x64-cpu.yml
@@ -21,6 +21,9 @@ on:
 concurrency:
   group: android-x64-cpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   android-x86_64:
     runs-on: ubuntu-latest

--- a/.github/workflows/android-x64-gpu.yml
+++ b/.github/workflows/android-x64-gpu.yml
@@ -23,6 +23,9 @@ on:
 concurrency:
   group: android-x64-gpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   android-x86_64-gpu:
     runs-on: ubuntu-latest

--- a/.github/workflows/android-x86-cpu.yml
+++ b/.github/workflows/android-x86-cpu.yml
@@ -21,6 +21,9 @@ on:
 concurrency:
   group: android-x86-cpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   android-x86:
     runs-on: ubuntu-latest

--- a/.github/workflows/android-x86-gpu.yml
+++ b/.github/workflows/android-x86-gpu.yml
@@ -23,6 +23,9 @@ on:
 concurrency:
   group: android-x86-gpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   android-x86-gpu:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -6,8 +6,13 @@ concurrency:
   group: code-format-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   code-format:
+    permissions:
+      contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,8 +20,15 @@ concurrency:
   group: CodeQL-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/elf-riscv32-cpu-gcc.yml
+++ b/.github/workflows/elf-riscv32-cpu-gcc.yml
@@ -25,6 +25,9 @@ on:
 concurrency:
   group: elf-riscv32-cpu-gcc-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   newlib-rv32imc-gcc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/elf-riscv64-cpu-gcc.yml
+++ b/.github/workflows/elf-riscv64-cpu-gcc.yml
@@ -25,6 +25,9 @@ on:
 concurrency:
   group: elf-riscv64-cpu-gcc-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   newlib-rv64gc-gcc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ios-arm64-gpu.yml
+++ b/.github/workflows/ios-arm64-gpu.yml
@@ -27,6 +27,9 @@ concurrency:
   cancel-in-progress: true
 env:
   DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+permissions:
+  contents: read
+
 jobs:
   ios-iphone-os-gpu:
     runs-on: macos-latest

--- a/.github/workflows/ios-cpu.yml
+++ b/.github/workflows/ios-cpu.yml
@@ -25,6 +25,9 @@ concurrency:
   cancel-in-progress: true
 env:
   DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+permissions:
+  contents: read
+
 jobs:
   ios-iphone-os:
     runs-on: macos-latest

--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -25,6 +25,9 @@ concurrency:
   cancel-in-progress: true
 env:
   DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+permissions:
+  contents: read
+
 jobs:
   ios-iphone-simulator:
     runs-on: macos-latest

--- a/.github/workflows/linux-aarch64-cpu-gcc.yml
+++ b/.github/workflows/linux-aarch64-cpu-gcc.yml
@@ -25,6 +25,9 @@ on:
 concurrency:
   group: linux-aarch64-cpu-gcc-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-gcc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linux-arm-cpu-gcc.yml
+++ b/.github/workflows/linux-arm-cpu-gcc.yml
@@ -27,6 +27,9 @@ on:
 concurrency:
   group: linux-arm-cpu-gcc-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-gcc-arm:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linux-loongarch64-cpu-gcc.yml
+++ b/.github/workflows/linux-loongarch64-cpu-gcc.yml
@@ -25,6 +25,9 @@ on:
 concurrency:
   group: linux-loongarch64-cpu-gcc-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-gcc-loongarch64:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linux-mips-cpu-gcc.yml
+++ b/.github/workflows/linux-mips-cpu-gcc.yml
@@ -27,6 +27,9 @@ on:
 concurrency:
   group: linux-mips-cpu-gcc-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-gcc-mipsel:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linux-mips64-cpu-gcc.yml
+++ b/.github/workflows/linux-mips64-cpu-gcc.yml
@@ -27,6 +27,9 @@ on:
 concurrency:
   group: linux-mips64-cpu-gcc-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-gcc-mips64el:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linux-ppc64-cpu-gcc.yml
+++ b/.github/workflows/linux-ppc64-cpu-gcc.yml
@@ -23,6 +23,9 @@ on:
 concurrency:
   group: linux-ppc64-cpu-gcc-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-gcc-ppc64le:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linux-riscv64-cpu-gcc.yml
+++ b/.github/workflows/linux-riscv64-cpu-gcc.yml
@@ -27,6 +27,9 @@ on:
 concurrency:
   group: linux-riscv64-cpu-gcc-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-gcc-riscv64:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linux-x64-cpu-clang-python.yml
+++ b/.github/workflows/linux-x64-cpu-clang-python.yml
@@ -23,6 +23,9 @@ on:
 concurrency:
   group: linux-x64-cpu-clang-python-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-clang-python:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-x64-cpu-clang.yml
+++ b/.github/workflows/linux-x64-cpu-clang.yml
@@ -31,6 +31,9 @@ on:
 concurrency:
   group: linux-x64-cpu-clang-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-clang:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-x64-cpu-gcc.yml
+++ b/.github/workflows/linux-x64-cpu-gcc.yml
@@ -31,6 +31,9 @@ on:
 concurrency:
   group: linux-x64-cpu-gcc-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-gcc:
     runs-on: ubuntu-18.04

--- a/.github/workflows/linux-x64-gpu-clang-python.yml
+++ b/.github/workflows/linux-x64-gpu-clang-python.yml
@@ -25,6 +25,9 @@ on:
 concurrency:
   group: linux-x64-gpu-clang-python-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-clang-gpu:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-x64-gpu-clang.yml
+++ b/.github/workflows/linux-x64-gpu-clang.yml
@@ -31,6 +31,9 @@ on:
 concurrency:
   group: linux-x64-gpu-clang-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-clang-gpu:
     runs-on: [self-hosted, linux, cvm]

--- a/.github/workflows/linux-x64-gpu-gcc.yml
+++ b/.github/workflows/linux-x64-gpu-gcc.yml
@@ -31,6 +31,9 @@ on:
 concurrency:
   group: linux-x64-gpu-gcc-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-gcc-gpu:
     runs-on: [self-hosted, linux, cvm]

--- a/.github/workflows/linux-x86-cpu-clang.yml
+++ b/.github/workflows/linux-x86-cpu-clang.yml
@@ -25,6 +25,9 @@ on:
 concurrency:
   group: linux-x86-cpu-clang-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-clang:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-x86-cpu-gcc.yml
+++ b/.github/workflows/linux-x86-cpu-gcc.yml
@@ -25,6 +25,9 @@ on:
 concurrency:
   group: linux-x86-cpu-gcc-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-gcc:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos-arm64-cpu.yml
+++ b/.github/workflows/macos-arm64-cpu.yml
@@ -23,6 +23,9 @@ concurrency:
   cancel-in-progress: true
 env:
   DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+permissions:
+  contents: read
+
 jobs:
   macos-clang:
     runs-on: macos-latest

--- a/.github/workflows/macos-arm64-gpu.yml
+++ b/.github/workflows/macos-arm64-gpu.yml
@@ -25,6 +25,9 @@ concurrency:
   cancel-in-progress: true
 env:
   DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+permissions:
+  contents: read
+
 jobs:
   macos-clang-gpu:
     runs-on: macos-latest

--- a/.github/workflows/macos-x64-cpu-python.yml
+++ b/.github/workflows/macos-x64-cpu-python.yml
@@ -25,6 +25,9 @@ concurrency:
   cancel-in-progress: true
 env:
   DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+permissions:
+  contents: read
+
 jobs:
   macos-clang:
     runs-on: macos-latest

--- a/.github/workflows/macos-x64-cpu.yml
+++ b/.github/workflows/macos-x64-cpu.yml
@@ -31,6 +31,9 @@ concurrency:
   cancel-in-progress: true
 env:
   DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+permissions:
+  contents: read
+
 jobs:
   macos-clang:
     runs-on: macos-latest

--- a/.github/workflows/macos-x64-gpu.yml
+++ b/.github/workflows/macos-x64-gpu.yml
@@ -33,6 +33,9 @@ concurrency:
   cancel-in-progress: true
 env:
   DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+permissions:
+  contents: read
+
 jobs:
   macos-clang-gpu:
     runs-on: macos-latest

--- a/.github/workflows/pnnx.yml
+++ b/.github/workflows/pnnx.yml
@@ -15,6 +15,9 @@ on:
 concurrency:
   group: pnnx-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   ubuntu:
     runs-on: [self-hosted, linux, cvm]

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -110,6 +110,8 @@ jobs:
         path: wheelhouse/*.whl
 
   upload_all:
+    permissions:
+      contents: none
     name: Upload
     needs: [build_wheels, build_wheels_qemu, build_sdist]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,14 @@ env:
   DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
   EMSCRIPTEN_VERSION: 2.0.8
 
+permissions:
+  contents: read
+
 jobs:
 
   setup:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     outputs:
       VERSION: ${{ steps.get_version.outputs.VERSION }}
@@ -2016,6 +2021,8 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   release:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     needs: [setup, full-source, ubuntu-1804, ubuntu-1804-shared, ubuntu-2004, ubuntu-2004-shared, macos, macos-gpu, ios, ios-gpu, ios-bitcode, ios-gpu-bitcode, android, android-shared, android-gpu, android-gpu-shared, webassembly, windows-vs2015, windows-vs2015-shared, windows-vs2017, windows-vs2017-shared, windows-vs2019, windows-vs2019-shared, windows-vs2022, windows-vs2022-shared]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -9,8 +9,13 @@ concurrency:
   group: sync-wiki-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   sync-wiki:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -21,6 +21,9 @@ on:
 concurrency:
   group: test-coverage-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   linux-gcc-gpu:
     runs-on: [self-hosted, linux, cvm]

--- a/.github/workflows/web-assembly.yml
+++ b/.github/workflows/web-assembly.yml
@@ -23,6 +23,9 @@ on:
 concurrency:
   group: web-assembly-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   webassembly:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-arm-cpu.yml
+++ b/.github/workflows/windows-arm-cpu.yml
@@ -23,6 +23,9 @@ on:
 concurrency:
   group: windows-arm-cpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   windows:
     name: ${{ matrix.vs-version }}

--- a/.github/workflows/windows-arm64-cpu.yml
+++ b/.github/workflows/windows-arm64-cpu.yml
@@ -23,6 +23,9 @@ on:
 concurrency:
   group: windows-arm64-cpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   windows:
     name: ${{ matrix.vs-version }}

--- a/.github/workflows/windows-x64-cpu-vs2019-python.yml
+++ b/.github/workflows/windows-x64-cpu-vs2019-python.yml
@@ -23,6 +23,9 @@ on:
 concurrency:
   group: windows-x64-cpu-vs2019-python-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   windows-vs2019-python:
     runs-on: windows-latest

--- a/.github/workflows/windows-x64-cpu.yml
+++ b/.github/workflows/windows-x64-cpu.yml
@@ -29,6 +29,9 @@ on:
 concurrency:
   group: windows-x64-cpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   windows:
     name: ${{ matrix.vs-version }}

--- a/.github/workflows/windows-x64-gpu.yml
+++ b/.github/workflows/windows-x64-gpu.yml
@@ -31,6 +31,9 @@ on:
 concurrency:
   group: windows-x64-gpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   windows-gpu:
     name: ${{ matrix.vs-version }}

--- a/.github/workflows/windows-x86-cpu.yml
+++ b/.github/workflows/windows-x86-cpu.yml
@@ -23,6 +23,9 @@ on:
 concurrency:
   group: windows-x86-cpu-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   windows-x86:
     name: ${{ matrix.vs-version }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
