### PR TITLE
arm neon optimization for pooling bf16s, fix some bf16s packing issue, relax winograd transform intrinsic order

### DIFF
--- a/src/layer/arm/concat_arm.cpp
+++ b/src/layer/arm/concat_arm.cpp
@@ -385,7 +385,11 @@ int Concat_arm::forward_bf16s_fp16s(const std::vector<Mat>& bottom_blobs, std::v
         int out_elempack = 1;
         if (opt.use_packing_layout)
         {
+#if __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
             out_elempack = opt.use_fp16_arithmetic && top_w % 8 == 0 ? 8 : top_w % 4 == 0 ? 4 : 1;
+#else
+            out_elempack = top_w % 4 == 0 ? 4 : 1;
+#endif
         }
         size_t out_elemsize = elemsize / elempack * out_elempack;
 
@@ -426,7 +430,11 @@ int Concat_arm::forward_bf16s_fp16s(const std::vector<Mat>& bottom_blobs, std::v
         int out_elempack = 1;
         if (opt.use_packing_layout)
         {
+#if __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
             out_elempack = opt.use_fp16_arithmetic && top_h % 8 == 0 ? 8 : top_h % 4 == 0 ? 4 : 1;
+#else
+            out_elempack = top_h % 4 == 0 ? 4 : 1;
+#endif
         }
         size_t out_elemsize = elemsize / elempack * out_elempack;
 
@@ -609,7 +617,11 @@ int Concat_arm::forward_bf16s_fp16s(const std::vector<Mat>& bottom_blobs, std::v
         int out_elempack = 1;
         if (opt.use_packing_layout)
         {
+#if __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
             out_elempack = opt.use_fp16_arithmetic && top_channels % 8 == 0 ? 8 : top_channels % 4 == 0 ? 4 : 1;
+#else
+            out_elempack = top_channels % 4 == 0 ? 4 : 1;
+#endif
         }
         size_t out_elemsize = elemsize / elempack * out_elempack;
 

--- a/src/layer/arm/convolution_winograd_transform_pack4.h
+++ b/src/layer/arm/convolution_winograd_transform_pack4.h
@@ -79,32 +79,33 @@ static void conv3x3s1_winograd63_transform_input_pack4_neon(const Mat& bottom_bl
 
                     float32x4_t _tmp0m = vmlaq_n_f32(vsubq_f32(_r00, _r06), vsubq_f32(_r04, _r02), 5.25f);
                     float32x4_t _tmp7m = vmlaq_n_f32(vsubq_f32(_r07, _r01), vsubq_f32(_r03, _r05), 5.25f);
-                    vst1q_f32(tmp[0][m], _tmp0m);
-                    vst1q_f32(tmp[7][m], _tmp7m);
 
                     float32x4_t _tmp12a = vmlsq_n_f32(vaddq_f32(_r02, _r06), _r04, 4.25f);
                     float32x4_t _tmp12b = vmlsq_n_f32(vaddq_f32(_r01, _r05), _r03, 4.25f);
 
                     float32x4_t _tmp1m = vaddq_f32(_tmp12a, _tmp12b);
                     float32x4_t _tmp2m = vsubq_f32(_tmp12a, _tmp12b);
-                    vst1q_f32(tmp[1][m], _tmp1m);
-                    vst1q_f32(tmp[2][m], _tmp2m);
 
                     float32x4_t _tmp34a = vmlsq_n_f32(vmlaq_n_f32(_r06, _r02, 0.25f), _r04, 1.25f);
                     float32x4_t _tmp34b = vmlaq_n_f32(vmlsq_n_f32(vmulq_n_f32(_r01, 0.5f), _r03, 2.5f), _r05, 2.f);
 
                     float32x4_t _tmp3m = vaddq_f32(_tmp34a, _tmp34b);
                     float32x4_t _tmp4m = vsubq_f32(_tmp34a, _tmp34b);
-                    vst1q_f32(tmp[3][m], _tmp3m);
-                    vst1q_f32(tmp[4][m], _tmp4m);
 
                     float32x4_t _tmp56a = vmlaq_n_f32(_r06, vmlsq_n_f32(_r02, _r04, 1.25f), 4.f);
                     float32x4_t _tmp56b = vmlaq_n_f32(vmlsq_n_f32(vmulq_n_f32(_r01, 2.f), _r03, 2.5f), _r05, 0.5f);
 
                     float32x4_t _tmp5m = vaddq_f32(_tmp56a, _tmp56b);
                     float32x4_t _tmp6m = vsubq_f32(_tmp56a, _tmp56b);
+
+                    vst1q_f32(tmp[0][m], _tmp0m);
+                    vst1q_f32(tmp[1][m], _tmp1m);
+                    vst1q_f32(tmp[2][m], _tmp2m);
+                    vst1q_f32(tmp[3][m], _tmp3m);
+                    vst1q_f32(tmp[4][m], _tmp4m);
                     vst1q_f32(tmp[5][m], _tmp5m);
                     vst1q_f32(tmp[6][m], _tmp6m);
+                    vst1q_f32(tmp[7][m], _tmp7m);
 
                     r0 += w * 4;
                 }
@@ -250,15 +251,16 @@ static void conv3x3s1_winograd63_transform_output_pack4_neon(const Mat& top_blob
                     float32x4_t _tmp0m = vaddq_f32(vaddq_f32(_out0tm0, _tmp024a), vmlaq_n_f32(_tmp024b, _tmp024c, 32.f));
                     float32x4_t _tmp2m = vmlaq_n_f32(vmlaq_n_f32(_tmp024a, _tmp024b, 4.f), _tmp024c, 8.f);
                     float32x4_t _tmp4m = vmlaq_n_f32(vmlaq_n_f32(_tmp024a, _tmp024b, 16.f), _tmp024c, 2.f);
-                    vst1q_f32(tmp[0][m], _tmp0m);
-                    vst1q_f32(tmp[2][m], _tmp2m);
-                    vst1q_f32(tmp[4][m], _tmp4m);
 
                     float32x4_t _tmp1m = vmlaq_n_f32(vmlaq_n_f32(_tmp135a, _tmp135b, 2.f), _tmp135c, 16.f);
                     float32x4_t _tmp3m = vmlaq_n_f32(vmlaq_n_f32(_tmp135a, _tmp135b, 8.f), _tmp135c, 4.f);
                     float32x4_t _tmp5m = vaddq_f32(vaddq_f32(_out0tm7, _tmp135a), vmlaq_n_f32(_tmp135c, _tmp135b, 32.f));
+
+                    vst1q_f32(tmp[0][m], _tmp0m);
                     vst1q_f32(tmp[1][m], _tmp1m);
+                    vst1q_f32(tmp[2][m], _tmp2m);
                     vst1q_f32(tmp[3][m], _tmp3m);
+                    vst1q_f32(tmp[4][m], _tmp4m);
                     vst1q_f32(tmp[5][m], _tmp5m);
 
                     output0_tm_0 += tiles * 32;
@@ -294,15 +296,16 @@ static void conv3x3s1_winograd63_transform_output_pack4_neon(const Mat& top_blob
                     float32x4_t _out00 = vaddq_f32(_bias0, vaddq_f32(vaddq_f32(_tmp00, _tmp024a), vmlaq_n_f32(_tmp024b, _tmp024c, 32.f)));
                     float32x4_t _out02 = vaddq_f32(_bias0, vmlaq_n_f32(vmlaq_n_f32(_tmp024a, _tmp024b, 4.f), _tmp024c, 8.f));
                     float32x4_t _out04 = vaddq_f32(_bias0, vmlaq_n_f32(vmlaq_n_f32(_tmp024a, _tmp024b, 16.f), _tmp024c, 2.f));
-                    vst1q_f32(output0, _out00);
-                    vst1q_f32(output0 + 8, _out02);
-                    vst1q_f32(output0 + 16, _out04);
 
                     float32x4_t _out01 = vaddq_f32(_bias0, vmlaq_n_f32(vmlaq_n_f32(_tmp135a, _tmp135b, 2.f), _tmp135c, 16.f));
                     float32x4_t _out03 = vaddq_f32(_bias0, vmlaq_n_f32(vmlaq_n_f32(_tmp135a, _tmp135b, 8.f), _tmp135c, 4.f));
                     float32x4_t _out05 = vaddq_f32(_bias0, vaddq_f32(vaddq_f32(_tmp07, _tmp135a), vmlaq_n_f32(_tmp135c, _tmp135b, 32.f)));
+
+                    vst1q_f32(output0, _out00);
                     vst1q_f32(output0 + 4, _out01);
+                    vst1q_f32(output0 + 8, _out02);
                     vst1q_f32(output0 + 12, _out03);
+                    vst1q_f32(output0 + 16, _out04);
                     vst1q_f32(output0 + 20, _out05);
 
                     output0 += outw * 4;

--- a/src/layer/arm/convolution_winograd_transform_pack4_bf16s.h
+++ b/src/layer/arm/convolution_winograd_transform_pack4_bf16s.h
@@ -79,32 +79,33 @@ static void conv3x3s1_winograd63_transform_input_pack4_bf16s_neon(const Mat& bot
 
                     float32x4_t _tmp0m = vmlaq_n_f32(vsubq_f32(_r00, _r06), vsubq_f32(_r04, _r02), 5.25f);
                     float32x4_t _tmp7m = vmlaq_n_f32(vsubq_f32(_r07, _r01), vsubq_f32(_r03, _r05), 5.25f);
-                    vst1q_f32(tmp[0][m], _tmp0m);
-                    vst1q_f32(tmp[7][m], _tmp7m);
 
                     float32x4_t _tmp12a = vmlsq_n_f32(vaddq_f32(_r02, _r06), _r04, 4.25f);
                     float32x4_t _tmp12b = vmlsq_n_f32(vaddq_f32(_r01, _r05), _r03, 4.25f);
 
                     float32x4_t _tmp1m = vaddq_f32(_tmp12a, _tmp12b);
                     float32x4_t _tmp2m = vsubq_f32(_tmp12a, _tmp12b);
-                    vst1q_f32(tmp[1][m], _tmp1m);
-                    vst1q_f32(tmp[2][m], _tmp2m);
 
                     float32x4_t _tmp34a = vmlsq_n_f32(vmlaq_n_f32(_r06, _r02, 0.25f), _r04, 1.25f);
                     float32x4_t _tmp34b = vmlaq_n_f32(vmlsq_n_f32(vmulq_n_f32(_r01, 0.5f), _r03, 2.5f), _r05, 2.f);
 
                     float32x4_t _tmp3m = vaddq_f32(_tmp34a, _tmp34b);
                     float32x4_t _tmp4m = vsubq_f32(_tmp34a, _tmp34b);
-                    vst1q_f32(tmp[3][m], _tmp3m);
-                    vst1q_f32(tmp[4][m], _tmp4m);
 
                     float32x4_t _tmp56a = vmlaq_n_f32(_r06, vmlsq_n_f32(_r02, _r04, 1.25f), 4.f);
                     float32x4_t _tmp56b = vmlaq_n_f32(vmlsq_n_f32(vmulq_n_f32(_r01, 2.f), _r03, 2.5f), _r05, 0.5f);
 
                     float32x4_t _tmp5m = vaddq_f32(_tmp56a, _tmp56b);
                     float32x4_t _tmp6m = vsubq_f32(_tmp56a, _tmp56b);
+
+                    vst1q_f32(tmp[0][m], _tmp0m);
+                    vst1q_f32(tmp[1][m], _tmp1m);
+                    vst1q_f32(tmp[2][m], _tmp2m);
+                    vst1q_f32(tmp[3][m], _tmp3m);
+                    vst1q_f32(tmp[4][m], _tmp4m);
                     vst1q_f32(tmp[5][m], _tmp5m);
                     vst1q_f32(tmp[6][m], _tmp6m);
+                    vst1q_f32(tmp[7][m], _tmp7m);
 
                     r0 += w * 4;
                 }
@@ -250,15 +251,16 @@ static void conv3x3s1_winograd63_transform_output_pack4_bf16s_neon(const Mat& to
                     float32x4_t _tmp0m = vaddq_f32(vaddq_f32(_out0tm0, _tmp024a), vmlaq_n_f32(_tmp024b, _tmp024c, 32.f));
                     float32x4_t _tmp2m = vmlaq_n_f32(vmlaq_n_f32(_tmp024a, _tmp024b, 4.f), _tmp024c, 8.f);
                     float32x4_t _tmp4m = vmlaq_n_f32(vmlaq_n_f32(_tmp024a, _tmp024b, 16.f), _tmp024c, 2.f);
-                    vst1q_f32(tmp[0][m], _tmp0m);
-                    vst1q_f32(tmp[2][m], _tmp2m);
-                    vst1q_f32(tmp[4][m], _tmp4m);
 
                     float32x4_t _tmp1m = vmlaq_n_f32(vmlaq_n_f32(_tmp135a, _tmp135b, 2.f), _tmp135c, 16.f);
                     float32x4_t _tmp3m = vmlaq_n_f32(vmlaq_n_f32(_tmp135a, _tmp135b, 8.f), _tmp135c, 4.f);
                     float32x4_t _tmp5m = vaddq_f32(vaddq_f32(_out0tm7, _tmp135a), vmlaq_n_f32(_tmp135c, _tmp135b, 32.f));
+
+                    vst1q_f32(tmp[0][m], _tmp0m);
                     vst1q_f32(tmp[1][m], _tmp1m);
+                    vst1q_f32(tmp[2][m], _tmp2m);
                     vst1q_f32(tmp[3][m], _tmp3m);
+                    vst1q_f32(tmp[4][m], _tmp4m);
                     vst1q_f32(tmp[5][m], _tmp5m);
 
                     output0_tm_0 += tiles * 32;
@@ -294,15 +296,16 @@ static void conv3x3s1_winograd63_transform_output_pack4_bf16s_neon(const Mat& to
                     float32x4_t _out00 = vaddq_f32(_bias0, vaddq_f32(vaddq_f32(_tmp00, _tmp024a), vmlaq_n_f32(_tmp024b, _tmp024c, 32.f)));
                     float32x4_t _out02 = vaddq_f32(_bias0, vmlaq_n_f32(vmlaq_n_f32(_tmp024a, _tmp024b, 4.f), _tmp024c, 8.f));
                     float32x4_t _out04 = vaddq_f32(_bias0, vmlaq_n_f32(vmlaq_n_f32(_tmp024a, _tmp024b, 16.f), _tmp024c, 2.f));
-                    vst1_u16(output0, vcvt_bf16_f32(_out00));
-                    vst1_u16(output0 + 8, vcvt_bf16_f32(_out02));
-                    vst1_u16(output0 + 16, vcvt_bf16_f32(_out04));
 
                     float32x4_t _out01 = vaddq_f32(_bias0, vmlaq_n_f32(vmlaq_n_f32(_tmp135a, _tmp135b, 2.f), _tmp135c, 16.f));
                     float32x4_t _out03 = vaddq_f32(_bias0, vmlaq_n_f32(vmlaq_n_f32(_tmp135a, _tmp135b, 8.f), _tmp135c, 4.f));
                     float32x4_t _out05 = vaddq_f32(_bias0, vaddq_f32(vaddq_f32(_tmp07, _tmp135a), vmlaq_n_f32(_tmp135c, _tmp135b, 32.f)));
+
+                    vst1_u16(output0, vcvt_bf16_f32(_out00));
                     vst1_u16(output0 + 4, vcvt_bf16_f32(_out01));
+                    vst1_u16(output0 + 8, vcvt_bf16_f32(_out02));
                     vst1_u16(output0 + 12, vcvt_bf16_f32(_out03));
+                    vst1_u16(output0 + 16, vcvt_bf16_f32(_out04));
                     vst1_u16(output0 + 20, vcvt_bf16_f32(_out05));
 
                     output0 += outw * 4;

--- a/src/layer/arm/convolution_winograd_transform_pack4_fp16s.h
+++ b/src/layer/arm/convolution_winograd_transform_pack4_fp16s.h
@@ -79,32 +79,33 @@ static void conv3x3s1_winograd63_transform_input_pack4_fp16sa_neon(const Mat& bo
 
                     float16x4_t _tmp0m = vfma_n_f16(vsub_f16(_r00, _r06), vsub_f16(_r04, _r02), 5.25f);
                     float16x4_t _tmp7m = vfma_n_f16(vsub_f16(_r07, _r01), vsub_f16(_r03, _r05), 5.25f);
-                    vst1_f16(tmp[0][m], _tmp0m);
-                    vst1_f16(tmp[7][m], _tmp7m);
 
                     float16x4_t _tmp12a = vfms_n_f16(vadd_f16(_r02, _r06), _r04, 4.25f);
                     float16x4_t _tmp12b = vfms_n_f16(vadd_f16(_r01, _r05), _r03, 4.25f);
 
                     float16x4_t _tmp1m = vadd_f16(_tmp12a, _tmp12b);
                     float16x4_t _tmp2m = vsub_f16(_tmp12a, _tmp12b);
-                    vst1_f16(tmp[1][m], _tmp1m);
-                    vst1_f16(tmp[2][m], _tmp2m);
 
                     float16x4_t _tmp34a = vfms_n_f16(vfma_n_f16(_r06, _r02, 0.25f), _r04, 1.25f);
                     float16x4_t _tmp34b = vfma_n_f16(vfms_n_f16(vmul_n_f16(_r01, 0.5f), _r03, 2.5f), _r05, 2.f);
 
                     float16x4_t _tmp3m = vadd_f16(_tmp34a, _tmp34b);
                     float16x4_t _tmp4m = vsub_f16(_tmp34a, _tmp34b);
-                    vst1_f16(tmp[3][m], _tmp3m);
-                    vst1_f16(tmp[4][m], _tmp4m);
 
                     float16x4_t _tmp56a = vfma_n_f16(_r06, vfms_n_f16(_r02, _r04, 1.25f), 4.f);
                     float16x4_t _tmp56b = vfma_n_f16(vfms_n_f16(vmul_n_f16(_r01, 2.f), _r03, 2.5f), _r05, 0.5f);
 
                     float16x4_t _tmp5m = vadd_f16(_tmp56a, _tmp56b);
                     float16x4_t _tmp6m = vsub_f16(_tmp56a, _tmp56b);
+
+                    vst1_f16(tmp[0][m], _tmp0m);
+                    vst1_f16(tmp[1][m], _tmp1m);
+                    vst1_f16(tmp[2][m], _tmp2m);
+                    vst1_f16(tmp[3][m], _tmp3m);
+                    vst1_f16(tmp[4][m], _tmp4m);
                     vst1_f16(tmp[5][m], _tmp5m);
                     vst1_f16(tmp[6][m], _tmp6m);
+                    vst1_f16(tmp[7][m], _tmp7m);
 
                     r0 += w * 4;
                 }
@@ -250,15 +251,16 @@ static void conv3x3s1_winograd63_transform_output_pack4_fp16sa_neon(const Mat& t
                     float16x4_t _tmp0m = vadd_f16(vadd_f16(_out0tm0, _tmp024a), vfma_n_f16(_tmp024b, _tmp024c, 32.f));
                     float16x4_t _tmp2m = vfma_n_f16(vfma_n_f16(_tmp024a, _tmp024b, 4.f), _tmp024c, 8.f);
                     float16x4_t _tmp4m = vfma_n_f16(vfma_n_f16(_tmp024a, _tmp024b, 16.f), _tmp024c, 2.f);
-                    vst1_f16(tmp[0][m], _tmp0m);
-                    vst1_f16(tmp[2][m], _tmp2m);
-                    vst1_f16(tmp[4][m], _tmp4m);
 
                     float16x4_t _tmp1m = vfma_n_f16(vfma_n_f16(_tmp135a, _tmp135b, 2.f), _tmp135c, 16.f);
                     float16x4_t _tmp3m = vfma_n_f16(vfma_n_f16(_tmp135a, _tmp135b, 8.f), _tmp135c, 4.f);
                     float16x4_t _tmp5m = vadd_f16(vadd_f16(_out0tm7, _tmp135a), vfma_n_f16(_tmp135c, _tmp135b, 32.f));
+
+                    vst1_f16(tmp[0][m], _tmp0m);
                     vst1_f16(tmp[1][m], _tmp1m);
+                    vst1_f16(tmp[2][m], _tmp2m);
                     vst1_f16(tmp[3][m], _tmp3m);
+                    vst1_f16(tmp[4][m], _tmp4m);
                     vst1_f16(tmp[5][m], _tmp5m);
 
                     output0_tm_0 += tiles * 32;
@@ -294,15 +296,16 @@ static void conv3x3s1_winograd63_transform_output_pack4_fp16sa_neon(const Mat& t
                     float16x4_t _out00 = vadd_f16(_bias0, vadd_f16(vadd_f16(_tmp00, _tmp024a), vfma_n_f16(_tmp024b, _tmp024c, 32.f)));
                     float16x4_t _out02 = vadd_f16(_bias0, vfma_n_f16(vfma_n_f16(_tmp024a, _tmp024b, 4.f), _tmp024c, 8.f));
                     float16x4_t _out04 = vadd_f16(_bias0, vfma_n_f16(vfma_n_f16(_tmp024a, _tmp024b, 16.f), _tmp024c, 2.f));
-                    vst1_f16(output0, _out00);
-                    vst1_f16(output0 + 8, _out02);
-                    vst1_f16(output0 + 16, _out04);
 
                     float16x4_t _out01 = vadd_f16(_bias0, vfma_n_f16(vfma_n_f16(_tmp135a, _tmp135b, 2.f), _tmp135c, 16.f));
                     float16x4_t _out03 = vadd_f16(_bias0, vfma_n_f16(vfma_n_f16(_tmp135a, _tmp135b, 8.f), _tmp135c, 4.f));
                     float16x4_t _out05 = vadd_f16(_bias0, vadd_f16(vadd_f16(_tmp07, _tmp135a), vfma_n_f16(_tmp135c, _tmp135b, 32.f)));
+
+                    vst1_f16(output0, _out00);
                     vst1_f16(output0 + 4, _out01);
+                    vst1_f16(output0 + 8, _out02);
                     vst1_f16(output0 + 12, _out03);
+                    vst1_f16(output0 + 16, _out04);
                     vst1_f16(output0 + 20, _out05);
 
                     output0 += outw * 4;

--- a/src/layer/arm/convolution_winograd_transform_pack8_fp16s.h
+++ b/src/layer/arm/convolution_winograd_transform_pack8_fp16s.h
@@ -79,32 +79,33 @@ static void conv3x3s1_winograd63_transform_input_pack8_fp16sa_neon(const Mat& bo
 
                     float16x8_t _tmp0m = vfmaq_n_f16(vsubq_f16(_r00, _r06), vsubq_f16(_r04, _r02), 5.25f);
                     float16x8_t _tmp7m = vfmaq_n_f16(vsubq_f16(_r07, _r01), vsubq_f16(_r03, _r05), 5.25f);
-                    vst1q_f16(tmp[0][m], _tmp0m);
-                    vst1q_f16(tmp[7][m], _tmp7m);
 
                     float16x8_t _tmp12a = vfmsq_n_f16(vaddq_f16(_r02, _r06), _r04, 4.25f);
                     float16x8_t _tmp12b = vfmsq_n_f16(vaddq_f16(_r01, _r05), _r03, 4.25f);
 
                     float16x8_t _tmp1m = vaddq_f16(_tmp12a, _tmp12b);
                     float16x8_t _tmp2m = vsubq_f16(_tmp12a, _tmp12b);
-                    vst1q_f16(tmp[1][m], _tmp1m);
-                    vst1q_f16(tmp[2][m], _tmp2m);
 
                     float16x8_t _tmp34a = vfmsq_n_f16(vfmaq_n_f16(_r06, _r02, 0.25f), _r04, 1.25f);
                     float16x8_t _tmp34b = vfmaq_n_f16(vfmsq_n_f16(vmulq_n_f16(_r01, 0.5f), _r03, 2.5f), _r05, 2.f);
 
                     float16x8_t _tmp3m = vaddq_f16(_tmp34a, _tmp34b);
                     float16x8_t _tmp4m = vsubq_f16(_tmp34a, _tmp34b);
-                    vst1q_f16(tmp[3][m], _tmp3m);
-                    vst1q_f16(tmp[4][m], _tmp4m);
 
                     float16x8_t _tmp56a = vfmaq_n_f16(_r06, vfmsq_n_f16(_r02, _r04, 1.25f), 4.f);
                     float16x8_t _tmp56b = vfmaq_n_f16(vfmsq_n_f16(vmulq_n_f16(_r01, 2.f), _r03, 2.5f), _r05, 0.5f);
 
                     float16x8_t _tmp5m = vaddq_f16(_tmp56a, _tmp56b);
                     float16x8_t _tmp6m = vsubq_f16(_tmp56a, _tmp56b);
+
+                    vst1q_f16(tmp[0][m], _tmp0m);
+                    vst1q_f16(tmp[1][m], _tmp1m);
+                    vst1q_f16(tmp[2][m], _tmp2m);
+                    vst1q_f16(tmp[3][m], _tmp3m);
+                    vst1q_f16(tmp[4][m], _tmp4m);
                     vst1q_f16(tmp[5][m], _tmp5m);
                     vst1q_f16(tmp[6][m], _tmp6m);
+                    vst1q_f16(tmp[7][m], _tmp7m);
 
                     r0 += w * 8;
                 }
@@ -250,15 +251,16 @@ static void conv3x3s1_winograd63_transform_output_pack8_fp16sa_neon(const Mat& t
                     float16x8_t _tmp0m = vaddq_f16(vaddq_f16(_out0tm0, _tmp024a), vfmaq_n_f16(_tmp024b, _tmp024c, 32.f));
                     float16x8_t _tmp2m = vfmaq_n_f16(vfmaq_n_f16(_tmp024a, _tmp024b, 4.f), _tmp024c, 8.f);
                     float16x8_t _tmp4m = vfmaq_n_f16(vfmaq_n_f16(_tmp024a, _tmp024b, 16.f), _tmp024c, 2.f);
-                    vst1q_f16(tmp[0][m], _tmp0m);
-                    vst1q_f16(tmp[2][m], _tmp2m);
-                    vst1q_f16(tmp[4][m], _tmp4m);
 
                     float16x8_t _tmp1m = vfmaq_n_f16(vfmaq_n_f16(_tmp135a, _tmp135b, 2.f), _tmp135c, 16.f);
                     float16x8_t _tmp3m = vfmaq_n_f16(vfmaq_n_f16(_tmp135a, _tmp135b, 8.f), _tmp135c, 4.f);
                     float16x8_t _tmp5m = vaddq_f16(vaddq_f16(_out0tm7, _tmp135a), vfmaq_n_f16(_tmp135c, _tmp135b, 32.f));
+
+                    vst1q_f16(tmp[0][m], _tmp0m);
                     vst1q_f16(tmp[1][m], _tmp1m);
+                    vst1q_f16(tmp[2][m], _tmp2m);
                     vst1q_f16(tmp[3][m], _tmp3m);
+                    vst1q_f16(tmp[4][m], _tmp4m);
                     vst1q_f16(tmp[5][m], _tmp5m);
 
                     output0_tm_0 += tiles * 64;
@@ -294,15 +296,16 @@ static void conv3x3s1_winograd63_transform_output_pack8_fp16sa_neon(const Mat& t
                     float16x8_t _out00 = vaddq_f16(_bias0, vaddq_f16(vaddq_f16(_tmp00, _tmp024a), vfmaq_n_f16(_tmp024b, _tmp024c, 32.f)));
                     float16x8_t _out02 = vaddq_f16(_bias0, vfmaq_n_f16(vfmaq_n_f16(_tmp024a, _tmp024b, 4.f), _tmp024c, 8.f));
                     float16x8_t _out04 = vaddq_f16(_bias0, vfmaq_n_f16(vfmaq_n_f16(_tmp024a, _tmp024b, 16.f), _tmp024c, 2.f));
-                    vst1q_f16(output0, _out00);
-                    vst1q_f16(output0 + 16, _out02);
-                    vst1q_f16(output0 + 32, _out04);
 
                     float16x8_t _out01 = vaddq_f16(_bias0, vfmaq_n_f16(vfmaq_n_f16(_tmp135a, _tmp135b, 2.f), _tmp135c, 16.f));
                     float16x8_t _out03 = vaddq_f16(_bias0, vfmaq_n_f16(vfmaq_n_f16(_tmp135a, _tmp135b, 8.f), _tmp135c, 4.f));
                     float16x8_t _out05 = vaddq_f16(_bias0, vaddq_f16(vaddq_f16(_tmp07, _tmp135a), vfmaq_n_f16(_tmp135c, _tmp135b, 32.f)));
+
+                    vst1q_f16(output0, _out00);
                     vst1q_f16(output0 + 8, _out01);
+                    vst1q_f16(output0 + 16, _out02);
                     vst1q_f16(output0 + 24, _out03);
+                    vst1q_f16(output0 + 32, _out04);
                     vst1q_f16(output0 + 40, _out05);
 
                     output0 += outw * 8;

--- a/src/layer/arm/flatten_arm.cpp
+++ b/src/layer/arm/flatten_arm.cpp
@@ -70,10 +70,12 @@ int Flatten_arm::forward(const Mat& bottom_blob, Mat& top_blob, const Option& op
     int total = size * channels * elempack;
 
     int out_elempack = 1;
+#if __ARM_NEON
     if (opt.use_packing_layout)
     {
         out_elempack = total % 4 == 0 ? 4 : 1;
     }
+#endif
     size_t out_elemsize = elemsize / elempack * out_elempack;
 
     if (out_elempack == 1)
@@ -232,10 +234,16 @@ int Flatten_arm::forward_bf16s_fp16s(const Mat& bottom_blob, Mat& top_blob, cons
     int total = size * channels * elempack;
 
     int out_elempack = 1;
+#if __ARM_NEON
     if (opt.use_packing_layout)
     {
+#if __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
         out_elempack = opt.use_fp16_arithmetic && total % 8 == 0 ? 8 : total % 4 == 0 ? 4 : 1;
+#else
+        out_elempack = total % 4 == 0 ? 4 : 1;
+#endif
     }
+#endif
     size_t out_elemsize = elemsize / elempack * out_elempack;
 
     if (out_elempack == 1)

--- a/src/layer/arm/pooling_2x2_pack4_bf16s.h
+++ b/src/layer/arm/pooling_2x2_pack4_bf16s.h
@@ -1,0 +1,194 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+static void pooling2x2s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_blob, const Option& opt)
+{
+    int w = bottom_blob.w;
+    int inch = bottom_blob.c;
+
+    int outw = top_blob.w;
+    int outh = top_blob.h;
+
+    const int tailstep = (w - 2 * outw + w) * 4;
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int q = 0; q < inch; q++)
+    {
+        const Mat img0 = bottom_blob.channel(q);
+        unsigned short* outptr = top_blob.channel(q);
+
+        const unsigned short* r0 = img0.row<const unsigned short>(0);
+        const unsigned short* r1 = img0.row<const unsigned short>(1);
+
+        for (int i = 0; i < outh; i++)
+        {
+            int j = 0;
+
+            for (; j + 3 < outw; j += 4)
+            {
+#if __aarch64__
+                asm volatile(
+                    "prfm   pldl1keep, [%1, #256]   \n"
+                    "ld1    {v0.4h, v1.4h, v2.4h, v3.4h}, [%1], #32 \n"
+
+                    "shll   v0.4s, v0.4h, #16       \n"
+                    "shll   v1.4s, v1.4h, #16       \n"
+                    "shll   v2.4s, v2.4h, #16       \n"
+                    "shll   v3.4s, v3.4h, #16       \n"
+
+                    "fmax   v0.4s, v0.4s, v1.4s     \n"
+                    "fmax   v2.4s, v2.4s, v3.4s     \n"
+
+                    "prfm   pldl1keep, [%1, #256]   \n"
+                    "ld1    {v4.4h, v5.4h, v6.4h, v7.4h}, [%1], #32 \n"
+
+                    "shll   v4.4s, v4.4h, #16       \n"
+                    "shll   v5.4s, v5.4h, #16       \n"
+                    "shll   v6.4s, v6.4h, #16       \n"
+                    "shll   v7.4s, v7.4h, #16       \n"
+
+                    "fmax   v4.4s, v4.4s, v5.4s     \n"
+                    "fmax   v6.4s, v6.4s, v7.4s     \n"
+
+                    "prfm   pldl1keep, [%2, #256]   \n"
+                    "ld1    {v16.4h, v17.4h, v18.4h, v19.4h}, [%2], #32 \n"
+
+                    "shll   v16.4s, v16.4h, #16     \n"
+                    "shll   v17.4s, v17.4h, #16     \n"
+                    "shll   v18.4s, v18.4h, #16     \n"
+                    "shll   v19.4s, v19.4h, #16     \n"
+
+                    "fmax   v16.4s, v16.4s, v17.4s  \n"
+                    "fmax   v18.4s, v18.4s, v19.4s  \n"
+
+                    "prfm   pldl1keep, [%2, #256]   \n"
+                    "ld1    {v20.4h, v21.4h, v22.4h, v23.4h}, [%2], #32 \n"
+
+                    "shll   v20.4s, v20.4h, #16     \n"
+                    "shll   v21.4s, v21.4h, #16     \n"
+                    "shll   v22.4s, v22.4h, #16     \n"
+                    "shll   v23.4s, v23.4h, #16     \n"
+
+                    "fmax   v20.4s, v20.4s, v21.4s  \n"
+                    "fmax   v22.4s, v22.4s, v23.4s  \n"
+
+                    "fmax   v0.4s, v0.4s, v16.4s    \n"
+                    "fmax   v1.4s, v2.4s, v18.4s    \n"
+                    "fmax   v2.4s, v4.4s, v20.4s    \n"
+                    "fmax   v3.4s, v6.4s, v22.4s    \n"
+
+                    "shrn   v0.4h, v0.4s, #16       \n"
+                    "shrn   v1.4h, v1.4s, #16       \n"
+                    "shrn   v2.4h, v2.4s, #16       \n"
+                    "shrn   v3.4h, v3.4s, #16       \n"
+
+                    "st1    {v0.4h, v1.4h, v2.4h, v3.4h}, [%0], #32 \n"
+
+                    : "=r"(outptr), // %0
+                    "=r"(r0),     // %1
+                    "=r"(r1)      // %2
+                    : "0"(outptr),
+                    "1"(r0),
+                    "2"(r1)
+                    : "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23");
+#else  // __aarch64__
+                asm volatile(
+                    "pld        [%1, #256]      \n"
+                    "vld1.u16   {d4-d7}, [%1]!  \n"
+
+                    "vshll.u16  q0, d4, #16     \n"
+                    "vshll.u16  q1, d5, #16     \n"
+                    "vshll.u16  q2, d6, #16     \n"
+                    "vshll.u16  q3, d7, #16     \n"
+
+                    "vmax.f32   q0, q0, q1      \n"
+                    "vmax.f32   q2, q2, q3      \n"
+
+                    "pld        [%1, #256]      \n"
+                    "vld1.u16   {d12-d15}, [%1]! \n"
+
+                    "vshll.u16  q4, d12, #16    \n"
+                    "vshll.u16  q5, d13, #16    \n"
+                    "vshll.u16  q6, d14, #16    \n"
+                    "vshll.u16  q7, d15, #16    \n"
+
+                    "vmax.f32   q4, q4, q5      \n"
+                    "vmax.f32   q6, q6, q7      \n"
+
+                    "pld        [%2, #256]      \n"
+                    "vld1.u16   {d20-d23}, [%2]! \n"
+
+                    "vshll.u16  q8, d20, #16    \n"
+                    "vshll.u16  q9, d21, #16    \n"
+                    "vshll.u16  q10, d22, #16   \n"
+                    "vshll.u16  q11, d23, #16   \n"
+
+                    "vmax.f32   q8, q8, q9      \n"
+                    "vmax.f32   q10, q10, q11   \n"
+
+                    "pld        [%2, #256]      \n"
+                    "vld1.u16   {d28-d31}, [%2]! \n"
+
+                    "vshll.u16  q12, d28, #16   \n"
+                    "vshll.u16  q13, d29, #16   \n"
+                    "vshll.u16  q14, d30, #16   \n"
+                    "vshll.u16  q15, d31, #16   \n"
+
+                    "vmax.f32   q12, q12, q13   \n"
+                    "vmax.f32   q14, q14, q15   \n"
+
+                    "vmax.f32   q0, q0, q8      \n"
+                    "vmax.f32   q1, q2, q10     \n"
+                    "vmax.f32   q2, q4, q12     \n"
+                    "vmax.f32   q3, q6, q14     \n"
+
+                    "vshrn.u32  d0, q0, #16     \n"
+                    "vshrn.u32  d1, q1, #16     \n"
+                    "vshrn.u32  d2, q2, #16     \n"
+                    "vshrn.u32  d3, q3, #16     \n"
+
+                    "vst1.u16   {d0-d3}, [%0]!  \n"
+
+                    : "=r"(outptr), // %0
+                    "=r"(r0),     // %1
+                    "=r"(r1)      // %2
+                    : "0"(outptr),
+                    "1"(r0),
+                    "2"(r1)
+                    : "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15");
+#endif // __aarch64__
+            }
+            for (; j < outw; j++)
+            {
+                float32x4_t _r00 = vcvt_f32_bf16(vld1_u16(r0));
+                float32x4_t _r01 = vcvt_f32_bf16(vld1_u16(r0 + 4));
+                float32x4_t _r10 = vcvt_f32_bf16(vld1_u16(r1));
+                float32x4_t _r11 = vcvt_f32_bf16(vld1_u16(r1 + 4));
+
+                float32x4_t _max0 = vmaxq_f32(_r00, _r01);
+                float32x4_t _max1 = vmaxq_f32(_r10, _r11);
+                float32x4_t _max = vmaxq_f32(_max0, _max1);
+
+                vst1_u16(outptr, vcvt_bf16_f32(_max));
+
+                r0 += 8;
+                r1 += 8;
+                outptr += 4;
+            }
+
+            r0 += tailstep;
+            r1 += tailstep;
+        }
+    }
+}

--- a/src/layer/arm/pooling_3x3_pack4_bf16s.h
+++ b/src/layer/arm/pooling_3x3_pack4_bf16s.h
@@ -160,22 +160,16 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     : "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31");
 #else  // __aarch64__
                 asm volatile(
-                    //                     "pld        [%1, #512]      \n"
-                    //                     "vldm       %1!, {d0-d7}    \n"
-
                     "pld        [%1, #256]      \n"
                     "vld1.u16   {d4-d7}, [%1]!  \n"
+
+                    "pld        [%2, #256]      \n"
+                    "vld1.u16   {d12-d15}, [%2]! \n"
 
                     "vshll.u16  q0, d4, #16     \n"
                     "vshll.u16  q1, d5, #16     \n"
                     "vshll.u16  q2, d6, #16     \n"
                     "vshll.u16  q3, d7, #16     \n"
-
-                    //                     "pld        [%2, #512]      \n"
-                    //                     "vldm       %2!, {d8-d15}   \n"
-
-                    "pld        [%2, #256]      \n"
-                    "vld1.u16   {d12-d15}, [%2]! \n"
 
                     "vshll.u16  q4, d12, #16    \n"
                     "vshll.u16  q5, d13, #16    \n"
@@ -184,9 +178,6 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
 
                     "vmax.f32   q0, q0, q4      \n"
                     "vmax.f32   q1, q1, q5      \n"
-
-                    //                     "pld        [%3, #512]      \n"
-                    //                     "vldm       %3!, {d16-d23}  \n"
 
                     "pld        [%3, #256]      \n"
                     "vld1.u16   {d20-d23}, [%3]! \n"
@@ -202,9 +193,6 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vmax.f32   q0, q0, q8      \n"
                     "vmax.f32   q1, q1, q9      \n"
 
-                    //                     "pld        [%1, #512]      \n"
-                    //                     "vldm       %1!, {d8-d15}   \n"
-
                     "pld        [%1, #256]      \n"
                     "vld1.u16   {d12-d15}, [%1]! \n"
 
@@ -216,9 +204,6 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vmax.f32   q2, q2, q10     \n"
                     "vmax.f32   q3, q3, q11     \n"
 
-                    //                     "pld        [%2, #512]      \n"
-                    //                     "vldm       %2!, {d16-d23}  \n"
-
                     "pld        [%2, #256]      \n"
                     "vld1.u16   {d20-d23}, [%2]! \n"
 
@@ -229,9 +214,6 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
 
                     "vmax.f32   q4, q4, q8      \n"
                     "vmax.f32   q5, q5, q9      \n"
-
-                    //                     "pld        [%3, #512]      \n"
-                    //                     "vldm       %3!, {d24-d31}  \n"
 
                     "pld        [%3, #256]      \n"
                     "vld1.u16   {d28-d31}, [%3]! \n"
@@ -247,17 +229,14 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vmax.f32   q4, q4, q12     \n"
                     "vmax.f32   q5, q5, q13     \n"
 
-                    //                     "vld1.f32   {d24-d25}, [%1 :128] \n"
-                    //                     "vld1.f32   {d26-d27}, [%2 :128] \n"
                     "vld1.u16   {d25}, [%1]     \n"
-                    "vshll.u16  q12, d25, #16   \n"
                     "vld1.u16   {d27}, [%2]     \n"
+                    "vshll.u16  q12, d25, #16   \n"
                     "vshll.u16  q13, d27, #16   \n"
 
                     "vmax.f32   q6, q6, q14     \n"
                     "vmax.f32   q7, q7, q15     \n"
 
-                    //                     "vld1.f32   {d28-d29}, [%3 :128] \n"
                     "vld1.u16   {d29}, [%3]     \n"
                     "vshll.u16  q14, d29, #16   \n"
 
@@ -279,7 +258,6 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vshrn.u32  d26, q14, #16   \n"
                     "vshrn.u32  d27, q15, #16   \n"
 
-                    //                     "vstm       %0!, {d24-d31}  \n"
                     "vst1.u16   {d24-d27}, [%0]! \n"
 
                     : "=r"(outptr), // %0
@@ -365,22 +343,16 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     : "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23");
 #else  // __aarch64__
                 asm volatile(
-                    //                     "pld        [%1, #512]      \n"
-                    //                     "vldm       %1!, {d0-d7}    \n"
-
                     "pld        [%1, #256]      \n"
                     "vld1.u16   {d4-d7}, [%1]!  \n"
+
+                    "pld        [%2, #256]      \n"
+                    "vld1.u16   {d12-d15}, [%2]! \n"
 
                     "vshll.u16  q0, d4, #16     \n"
                     "vshll.u16  q1, d5, #16     \n"
                     "vshll.u16  q2, d6, #16     \n"
                     "vshll.u16  q3, d7, #16     \n"
-
-                    //                     "pld        [%2, #512]      \n"
-                    //                     "vldm       %2!, {d8-d15}   \n"
-
-                    "pld        [%2, #256]      \n"
-                    "vld1.u16   {d12-d15}, [%2]! \n"
 
                     "vshll.u16  q4, d12, #16    \n"
                     "vshll.u16  q5, d13, #16    \n"
@@ -389,9 +361,6 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
 
                     "vmax.f32   q12, q0, q4     \n"
                     "vmax.f32   q13, q1, q5     \n"
-
-                    //                     "pld        [%3, #512]      \n"
-                    //                     "vldm       %3!, {d16-d23}  \n"
 
                     "pld        [%3, #256]      \n"
                     "vld1.u16   {d20-d23}, [%3]! \n"
@@ -404,21 +373,18 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vmax.f32   q14, q2, q6     \n"
                     "vmax.f32   q15, q3, q7     \n"
 
-                    //                     "vld1.f32   {d0-d1}, [%1 :128] \n"
                     "vld1.u16   {d1}, [%1]      \n"
                     "vshll.u16  q0, d1, #16     \n"
 
                     "vmax.f32   q12, q12, q8    \n"
                     "vmax.f32   q13, q13, q9    \n"
 
-                    //                     "vld1.f32   {d2-d3}, [%2 :128] \n"
                     "vld1.u16   {d3}, [%2]      \n"
                     "vshll.u16  q1, d3, #16     \n"
 
                     "vmax.f32   q14, q14, q10   \n"
                     "vmax.f32   q15, q15, q11   \n"
 
-                    //                     "vld1.f32   {d4-d5}, [%3 :128] \n"
                     "vld1.u16   {d5}, [%3]      \n"
                     "vshll.u16  q2, d5, #16     \n"
 

--- a/src/layer/arm/pooling_3x3_pack4_bf16s.h
+++ b/src/layer/arm/pooling_3x3_pack4_bf16s.h
@@ -160,8 +160,8 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     : "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31");
 #else  // __aarch64__
                 asm volatile(
-//                     "pld        [%1, #512]      \n"
-//                     "vldm       %1!, {d0-d7}    \n"
+                    //                     "pld        [%1, #512]      \n"
+                    //                     "vldm       %1!, {d0-d7}    \n"
 
                     "pld        [%1, #256]      \n"
                     "vld1.u16   {d4-d7}, [%1]!  \n"
@@ -171,8 +171,8 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vshll.u16  q2, d6, #16     \n"
                     "vshll.u16  q3, d7, #16     \n"
 
-//                     "pld        [%2, #512]      \n"
-//                     "vldm       %2!, {d8-d15}   \n"
+                    //                     "pld        [%2, #512]      \n"
+                    //                     "vldm       %2!, {d8-d15}   \n"
 
                     "pld        [%2, #256]      \n"
                     "vld1.u16   {d12-d15}, [%2]! \n"
@@ -185,8 +185,8 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vmax.f32   q0, q0, q4      \n"
                     "vmax.f32   q1, q1, q5      \n"
 
-//                     "pld        [%3, #512]      \n"
-//                     "vldm       %3!, {d16-d23}  \n"
+                    //                     "pld        [%3, #512]      \n"
+                    //                     "vldm       %3!, {d16-d23}  \n"
 
                     "pld        [%3, #256]      \n"
                     "vld1.u16   {d20-d23}, [%3]! \n"
@@ -202,8 +202,8 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vmax.f32   q0, q0, q8      \n"
                     "vmax.f32   q1, q1, q9      \n"
 
-//                     "pld        [%1, #512]      \n"
-//                     "vldm       %1!, {d8-d15}   \n"
+                    //                     "pld        [%1, #512]      \n"
+                    //                     "vldm       %1!, {d8-d15}   \n"
 
                     "pld        [%1, #256]      \n"
                     "vld1.u16   {d12-d15}, [%1]! \n"
@@ -216,8 +216,8 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vmax.f32   q2, q2, q10     \n"
                     "vmax.f32   q3, q3, q11     \n"
 
-//                     "pld        [%2, #512]      \n"
-//                     "vldm       %2!, {d16-d23}  \n"
+                    //                     "pld        [%2, #512]      \n"
+                    //                     "vldm       %2!, {d16-d23}  \n"
 
                     "pld        [%2, #256]      \n"
                     "vld1.u16   {d20-d23}, [%2]! \n"
@@ -230,8 +230,8 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vmax.f32   q4, q4, q8      \n"
                     "vmax.f32   q5, q5, q9      \n"
 
-//                     "pld        [%3, #512]      \n"
-//                     "vldm       %3!, {d24-d31}  \n"
+                    //                     "pld        [%3, #512]      \n"
+                    //                     "vldm       %3!, {d24-d31}  \n"
 
                     "pld        [%3, #256]      \n"
                     "vld1.u16   {d28-d31}, [%3]! \n"
@@ -247,8 +247,8 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vmax.f32   q4, q4, q12     \n"
                     "vmax.f32   q5, q5, q13     \n"
 
-//                     "vld1.f32   {d24-d25}, [%1 :128] \n"
-//                     "vld1.f32   {d26-d27}, [%2 :128] \n"
+                    //                     "vld1.f32   {d24-d25}, [%1 :128] \n"
+                    //                     "vld1.f32   {d26-d27}, [%2 :128] \n"
                     "vld1.u16   {d25}, [%1]     \n"
                     "vshll.u16  q12, d25, #16   \n"
                     "vld1.u16   {d27}, [%2]     \n"
@@ -257,7 +257,7 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vmax.f32   q6, q6, q14     \n"
                     "vmax.f32   q7, q7, q15     \n"
 
-//                     "vld1.f32   {d28-d29}, [%3 :128] \n"
+                    //                     "vld1.f32   {d28-d29}, [%3 :128] \n"
                     "vld1.u16   {d29}, [%3]     \n"
                     "vshll.u16  q14, d29, #16   \n"
 
@@ -279,7 +279,7 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vshrn.u32  d26, q14, #16   \n"
                     "vshrn.u32  d27, q15, #16   \n"
 
-//                     "vstm       %0!, {d24-d31}  \n"
+                    //                     "vstm       %0!, {d24-d31}  \n"
                     "vst1.u16   {d24-d27}, [%0]! \n"
 
                     : "=r"(outptr), // %0
@@ -365,8 +365,8 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     : "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23");
 #else  // __aarch64__
                 asm volatile(
-//                     "pld        [%1, #512]      \n"
-//                     "vldm       %1!, {d0-d7}    \n"
+                    //                     "pld        [%1, #512]      \n"
+                    //                     "vldm       %1!, {d0-d7}    \n"
 
                     "pld        [%1, #256]      \n"
                     "vld1.u16   {d4-d7}, [%1]!  \n"
@@ -376,8 +376,8 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vshll.u16  q2, d6, #16     \n"
                     "vshll.u16  q3, d7, #16     \n"
 
-//                     "pld        [%2, #512]      \n"
-//                     "vldm       %2!, {d8-d15}   \n"
+                    //                     "pld        [%2, #512]      \n"
+                    //                     "vldm       %2!, {d8-d15}   \n"
 
                     "pld        [%2, #256]      \n"
                     "vld1.u16   {d12-d15}, [%2]! \n"
@@ -390,8 +390,8 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vmax.f32   q12, q0, q4     \n"
                     "vmax.f32   q13, q1, q5     \n"
 
-//                     "pld        [%3, #512]      \n"
-//                     "vldm       %3!, {d16-d23}  \n"
+                    //                     "pld        [%3, #512]      \n"
+                    //                     "vldm       %3!, {d16-d23}  \n"
 
                     "pld        [%3, #256]      \n"
                     "vld1.u16   {d20-d23}, [%3]! \n"
@@ -404,21 +404,21 @@ static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_b
                     "vmax.f32   q14, q2, q6     \n"
                     "vmax.f32   q15, q3, q7     \n"
 
-//                     "vld1.f32   {d0-d1}, [%1 :128] \n"
+                    //                     "vld1.f32   {d0-d1}, [%1 :128] \n"
                     "vld1.u16   {d1}, [%1]      \n"
                     "vshll.u16  q0, d1, #16     \n"
 
                     "vmax.f32   q12, q12, q8    \n"
                     "vmax.f32   q13, q13, q9    \n"
 
-//                     "vld1.f32   {d2-d3}, [%2 :128] \n"
+                    //                     "vld1.f32   {d2-d3}, [%2 :128] \n"
                     "vld1.u16   {d3}, [%2]      \n"
                     "vshll.u16  q1, d3, #16     \n"
 
                     "vmax.f32   q14, q14, q10   \n"
                     "vmax.f32   q15, q15, q11   \n"
 
-//                     "vld1.f32   {d4-d5}, [%3 :128] \n"
+                    //                     "vld1.f32   {d4-d5}, [%3 :128] \n"
                     "vld1.u16   {d5}, [%3]      \n"
                     "vshll.u16  q2, d5, #16     \n"
 

--- a/src/layer/arm/pooling_3x3_pack4_bf16s.h
+++ b/src/layer/arm/pooling_3x3_pack4_bf16s.h
@@ -1,0 +1,482 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+static void pooling3x3s2_max_pack4_bf16s_neon(const Mat& bottom_blob, Mat& top_blob, const Option& opt)
+{
+    int w = bottom_blob.w;
+    int inch = bottom_blob.c;
+
+    int outw = top_blob.w;
+    int outh = top_blob.h;
+
+    const int tailstep = (w - 2 * outw + w) * 4;
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int q = 0; q < inch; q++)
+    {
+        const Mat img0 = bottom_blob.channel(q);
+        unsigned short* outptr = top_blob.channel(q);
+
+        const unsigned short* r0 = img0.row<const unsigned short>(0);
+        const unsigned short* r1 = img0.row<const unsigned short>(1);
+        const unsigned short* r2 = img0.row<const unsigned short>(2);
+
+        for (int i = 0; i < outh; i++)
+        {
+            int j = 0;
+
+            for (; j + 3 < outw; j += 4)
+            {
+#if __aarch64__
+                asm volatile(
+                    "prfm   pldl1keep, [%1, #256]   \n"
+                    "ld1    {v0.4h, v1.4h, v2.4h, v3.4h}, [%1], #32 \n"
+
+                    "shll   v0.4s, v0.4h, #16       \n"
+                    "shll   v1.4s, v1.4h, #16       \n"
+                    "shll   v2.4s, v2.4h, #16       \n"
+                    "shll   v3.4s, v3.4h, #16       \n"
+
+                    "fmax   v16.4s, v0.4s, v1.4s    \n"
+                    "fmax   v17.4s, v2.4s, v3.4s    \n"
+
+                    "prfm   pldl1keep, [%1, #256]   \n"
+                    "ld1    {v4.4h, v5.4h, v6.4h, v7.4h}, [%1], #32 \n"
+
+                    "shll   v4.4s, v4.4h, #16       \n"
+                    "shll   v5.4s, v5.4h, #16       \n"
+                    "shll   v6.4s, v6.4h, #16       \n"
+                    "shll   v7.4s, v7.4h, #16       \n"
+
+                    "fmax   v18.4s, v4.4s, v5.4s    \n"
+                    "fmax   v19.4s, v6.4s, v7.4s    \n"
+
+                    "ld1    {v8.4h}, [%1]           \n"
+                    "shll   v8.4s, v8.4h, #16       \n"
+
+                    "fmax   v20.4s, v16.4s, v2.4s   \n"
+                    "fmax   v21.4s, v17.4s, v4.4s   \n"
+
+                    "prfm   pldl1keep, [%2, #256]   \n"
+                    "ld1    {v0.4h, v1.4h, v2.4h, v3.4h}, [%2], #32 \n"
+
+                    "shll   v0.4s, v0.4h, #16       \n"
+                    "shll   v1.4s, v1.4h, #16       \n"
+                    "shll   v2.4s, v2.4h, #16       \n"
+                    "shll   v3.4s, v3.4h, #16       \n"
+
+                    "fmax   v22.4s, v18.4s, v6.4s   \n"
+                    "fmax   v23.4s, v19.4s, v8.4s   \n"
+
+                    "prfm   pldl1keep, [%2, #256]   \n"
+                    "ld1    {v4.4h, v5.4h, v6.4h, v7.4h}, [%2], #32 \n"
+
+                    "shll   v4.4s, v4.4h, #16       \n"
+                    "shll   v5.4s, v5.4h, #16       \n"
+                    "shll   v6.4s, v6.4h, #16       \n"
+                    "shll   v7.4s, v7.4h, #16       \n"
+
+                    "fmax   v16.4s, v0.4s, v1.4s    \n"
+                    "fmax   v17.4s, v2.4s, v3.4s    \n"
+
+                    "fmax   v18.4s, v4.4s, v5.4s    \n"
+                    "fmax   v19.4s, v6.4s, v7.4s    \n"
+
+                    "ld1    {v8.4h}, [%2]           \n"
+                    "shll   v8.4s, v8.4h, #16       \n"
+
+                    "fmax   v24.4s, v16.4s, v2.4s   \n"
+                    "fmax   v25.4s, v17.4s, v4.4s   \n"
+
+                    "prfm   pldl1keep, [%3, #256]   \n"
+                    "ld1    {v0.4h, v1.4h, v2.4h, v3.4h}, [%3], #32 \n"
+
+                    "shll   v0.4s, v0.4h, #16       \n"
+                    "shll   v1.4s, v1.4h, #16       \n"
+                    "shll   v2.4s, v2.4h, #16       \n"
+                    "shll   v3.4s, v3.4h, #16       \n"
+
+                    "fmax   v26.4s, v18.4s, v6.4s   \n"
+                    "fmax   v27.4s, v19.4s, v8.4s   \n"
+
+                    "prfm   pldl1keep, [%3, #256]   \n"
+                    "ld1    {v4.4h, v5.4h, v6.4h, v7.4h}, [%3], #32 \n"
+
+                    "shll   v4.4s, v4.4h, #16       \n"
+                    "shll   v5.4s, v5.4h, #16       \n"
+                    "shll   v6.4s, v6.4h, #16       \n"
+                    "shll   v7.4s, v7.4h, #16       \n"
+
+                    "fmax   v16.4s, v0.4s, v1.4s    \n"
+                    "fmax   v17.4s, v2.4s, v3.4s    \n"
+
+                    "fmax   v18.4s, v4.4s, v5.4s    \n"
+                    "fmax   v19.4s, v6.4s, v7.4s    \n"
+
+                    "ld1    {v8.4h}, [%3]           \n"
+                    "shll   v8.4s, v8.4h, #16       \n"
+
+                    "fmax   v28.4s, v16.4s, v2.4s   \n"
+                    "fmax   v29.4s, v17.4s, v4.4s   \n"
+                    "fmax   v30.4s, v18.4s, v6.4s   \n"
+                    "fmax   v31.4s, v19.4s, v8.4s   \n"
+
+                    "fmax   v20.4s, v20.4s, v24.4s  \n"
+                    "fmax   v21.4s, v21.4s, v25.4s  \n"
+                    "fmax   v22.4s, v22.4s, v26.4s  \n"
+                    "fmax   v23.4s, v23.4s, v27.4s  \n"
+
+                    "fmax   v20.4s, v20.4s, v28.4s  \n"
+                    "fmax   v21.4s, v21.4s, v29.4s  \n"
+                    "fmax   v22.4s, v22.4s, v30.4s  \n"
+                    "fmax   v23.4s, v23.4s, v31.4s  \n"
+
+                    "shrn   v20.4h, v20.4s, #16     \n"
+                    "shrn   v21.4h, v21.4s, #16     \n"
+                    "shrn   v22.4h, v22.4s, #16     \n"
+                    "shrn   v23.4h, v23.4s, #16     \n"
+
+                    "st1    {v20.4h, v21.4h, v22.4h, v23.4h}, [%0], #32 \n"
+
+                    : "=r"(outptr), // %0
+                    "=r"(r0),     // %1
+                    "=r"(r1),     // %2
+                    "=r"(r2)      // %3
+                    : "0"(outptr),
+                    "1"(r0),
+                    "2"(r1),
+                    "3"(r2)
+                    : "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31");
+#else  // __aarch64__
+                asm volatile(
+//                     "pld        [%1, #512]      \n"
+//                     "vldm       %1!, {d0-d7}    \n"
+
+                    "pld        [%1, #256]      \n"
+                    "vld1.u16   {d4-d7}, [%1]!  \n"
+
+                    "vshll.u16  q0, d4, #16     \n"
+                    "vshll.u16  q1, d5, #16     \n"
+                    "vshll.u16  q2, d6, #16     \n"
+                    "vshll.u16  q3, d7, #16     \n"
+
+//                     "pld        [%2, #512]      \n"
+//                     "vldm       %2!, {d8-d15}   \n"
+
+                    "pld        [%2, #256]      \n"
+                    "vld1.u16   {d12-d15}, [%2]! \n"
+
+                    "vshll.u16  q4, d12, #16    \n"
+                    "vshll.u16  q5, d13, #16    \n"
+                    "vshll.u16  q6, d14, #16    \n"
+                    "vshll.u16  q7, d15, #16    \n"
+
+                    "vmax.f32   q0, q0, q4      \n"
+                    "vmax.f32   q1, q1, q5      \n"
+
+//                     "pld        [%3, #512]      \n"
+//                     "vldm       %3!, {d16-d23}  \n"
+
+                    "pld        [%3, #256]      \n"
+                    "vld1.u16   {d20-d23}, [%3]! \n"
+
+                    "vshll.u16  q8, d20, #16    \n"
+                    "vshll.u16  q9, d21, #16    \n"
+                    "vshll.u16  q10, d22, #16   \n"
+                    "vshll.u16  q11, d23, #16   \n"
+
+                    "vmax.f32   q2, q2, q6      \n"
+                    "vmax.f32   q3, q3, q7      \n"
+
+                    "vmax.f32   q0, q0, q8      \n"
+                    "vmax.f32   q1, q1, q9      \n"
+
+//                     "pld        [%1, #512]      \n"
+//                     "vldm       %1!, {d8-d15}   \n"
+
+                    "pld        [%1, #256]      \n"
+                    "vld1.u16   {d12-d15}, [%1]! \n"
+
+                    "vshll.u16  q4, d12, #16    \n"
+                    "vshll.u16  q5, d13, #16    \n"
+                    "vshll.u16  q6, d14, #16    \n"
+                    "vshll.u16  q7, d15, #16    \n"
+
+                    "vmax.f32   q2, q2, q10     \n"
+                    "vmax.f32   q3, q3, q11     \n"
+
+//                     "pld        [%2, #512]      \n"
+//                     "vldm       %2!, {d16-d23}  \n"
+
+                    "pld        [%2, #256]      \n"
+                    "vld1.u16   {d20-d23}, [%2]! \n"
+
+                    "vshll.u16  q8, d20, #16    \n"
+                    "vshll.u16  q9, d21, #16    \n"
+                    "vshll.u16  q10, d22, #16   \n"
+                    "vshll.u16  q11, d23, #16   \n"
+
+                    "vmax.f32   q4, q4, q8      \n"
+                    "vmax.f32   q5, q5, q9      \n"
+
+//                     "pld        [%3, #512]      \n"
+//                     "vldm       %3!, {d24-d31}  \n"
+
+                    "pld        [%3, #256]      \n"
+                    "vld1.u16   {d28-d31}, [%3]! \n"
+
+                    "vshll.u16  q12, d28, #16   \n"
+                    "vshll.u16  q13, d29, #16   \n"
+                    "vshll.u16  q14, d30, #16   \n"
+                    "vshll.u16  q15, d31, #16   \n"
+
+                    "vmax.f32   q6, q6, q10     \n"
+                    "vmax.f32   q7, q7, q11     \n"
+
+                    "vmax.f32   q4, q4, q12     \n"
+                    "vmax.f32   q5, q5, q13     \n"
+
+//                     "vld1.f32   {d24-d25}, [%1 :128] \n"
+//                     "vld1.f32   {d26-d27}, [%2 :128] \n"
+                    "vld1.u16   {d25}, [%1]     \n"
+                    "vshll.u16  q12, d25, #16   \n"
+                    "vld1.u16   {d27}, [%2]     \n"
+                    "vshll.u16  q13, d27, #16   \n"
+
+                    "vmax.f32   q6, q6, q14     \n"
+                    "vmax.f32   q7, q7, q15     \n"
+
+//                     "vld1.f32   {d28-d29}, [%3 :128] \n"
+                    "vld1.u16   {d29}, [%3]     \n"
+                    "vshll.u16  q14, d29, #16   \n"
+
+                    "vmax.f32   q8, q12, q13    \n"
+                    "vmax.f32   q8, q8, q14     \n"
+
+                    "vmax.f32   q12, q0, q1     \n"
+                    "vmax.f32   q13, q2, q3     \n"
+                    "vmax.f32   q14, q4, q5     \n"
+                    "vmax.f32   q15, q6, q7     \n"
+
+                    "vmax.f32   q12, q12, q2    \n"
+                    "vmax.f32   q13, q13, q4    \n"
+                    "vmax.f32   q14, q14, q6    \n"
+                    "vmax.f32   q15, q15, q8    \n"
+
+                    "vshrn.u32  d24, q12, #16   \n"
+                    "vshrn.u32  d25, q13, #16   \n"
+                    "vshrn.u32  d26, q14, #16   \n"
+                    "vshrn.u32  d27, q15, #16   \n"
+
+//                     "vstm       %0!, {d24-d31}  \n"
+                    "vst1.u16   {d24-d27}, [%0]! \n"
+
+                    : "=r"(outptr), // %0
+                    "=r"(r0),     // %1
+                    "=r"(r1),     // %2
+                    "=r"(r2)      // %3
+                    : "0"(outptr),
+                    "1"(r0),
+                    "2"(r1),
+                    "3"(r2)
+                    : "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15");
+#endif // __aarch64__
+            }
+            for (; j + 1 < outw; j += 2)
+            {
+#if __aarch64__
+                asm volatile(
+                    "prfm   pldl1keep, [%1, #256]   \n"
+                    "ld1    {v0.4h, v1.4h, v2.4h, v3.4h}, [%1], #32 \n"
+
+                    "prfm   pldl1keep, [%2, #256]   \n"
+                    "ld1    {v4.4h, v5.4h, v6.4h, v7.4h}, [%2], #32 \n"
+
+                    "shll   v0.4s, v0.4h, #16       \n"
+                    "shll   v1.4s, v1.4h, #16       \n"
+                    "shll   v2.4s, v2.4h, #16       \n"
+                    "shll   v3.4s, v3.4h, #16       \n"
+
+                    "shll   v4.4s, v4.4h, #16       \n"
+                    "shll   v5.4s, v5.4h, #16       \n"
+                    "shll   v6.4s, v6.4h, #16       \n"
+                    "shll   v7.4s, v7.4h, #16       \n"
+
+                    "fmax   v16.4s, v0.4s, v4.4s    \n"
+                    "fmax   v17.4s, v1.4s, v5.4s    \n"
+
+                    "prfm   pldl1keep, [%3, #256]   \n"
+                    "ld1    {v20.4h, v21.4h, v22.4h, v23.4h}, [%3], #32 \n"
+
+                    "shll   v20.4s, v20.4h, #16     \n"
+                    "shll   v21.4s, v21.4h, #16     \n"
+                    "shll   v22.4s, v22.4h, #16     \n"
+                    "shll   v23.4s, v23.4h, #16     \n"
+
+                    "fmax   v18.4s, v2.4s, v6.4s    \n"
+                    "fmax   v19.4s, v3.4s, v7.4s    \n"
+
+                    "ld1    {v0.4s}, [%1]           \n"
+
+                    "fmax   v16.4s, v16.4s, v20.4s  \n"
+                    "fmax   v17.4s, v17.4s, v21.4s  \n"
+
+                    "ld1    {v1.4s}, [%2]           \n"
+
+                    "fmax   v18.4s, v18.4s, v22.4s  \n"
+                    "fmax   v19.4s, v19.4s, v23.4s  \n"
+
+                    "ld1    {v2.4s}, [%3]           \n"
+
+                    "fmax   v3.4s, v0.4s, v1.4s     \n"
+
+                    "fmax   v20.4s, v16.4s, v17.4s  \n"
+                    "fmax   v21.4s, v18.4s, v19.4s  \n"
+
+                    "fmax   v3.4s, v3.4s, v2.4s     \n"
+
+                    "fmax   v20.4s, v20.4s, v18.4s  \n"
+                    "fmax   v21.4s, v21.4s, v3.4s   \n"
+
+                    "shrn   v20.4h, v20.4s, #16     \n"
+                    "shrn   v21.4h, v21.4s, #16     \n"
+
+                    "st1    {v20.4h, v21.4h}, [%0], #16 \n"
+
+                    : "=r"(outptr), // %0
+                    "=r"(r0),     // %1
+                    "=r"(r1),     // %2
+                    "=r"(r2)      // %3
+                    : "0"(outptr),
+                    "1"(r0),
+                    "2"(r1),
+                    "3"(r2)
+                    : "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23");
+#else  // __aarch64__
+                asm volatile(
+//                     "pld        [%1, #512]      \n"
+//                     "vldm       %1!, {d0-d7}    \n"
+
+                    "pld        [%1, #256]      \n"
+                    "vld1.u16   {d4-d7}, [%1]!  \n"
+
+                    "vshll.u16  q0, d4, #16     \n"
+                    "vshll.u16  q1, d5, #16     \n"
+                    "vshll.u16  q2, d6, #16     \n"
+                    "vshll.u16  q3, d7, #16     \n"
+
+//                     "pld        [%2, #512]      \n"
+//                     "vldm       %2!, {d8-d15}   \n"
+
+                    "pld        [%2, #256]      \n"
+                    "vld1.u16   {d12-d15}, [%2]! \n"
+
+                    "vshll.u16  q4, d12, #16    \n"
+                    "vshll.u16  q5, d13, #16    \n"
+                    "vshll.u16  q6, d14, #16    \n"
+                    "vshll.u16  q7, d15, #16    \n"
+
+                    "vmax.f32   q12, q0, q4     \n"
+                    "vmax.f32   q13, q1, q5     \n"
+
+//                     "pld        [%3, #512]      \n"
+//                     "vldm       %3!, {d16-d23}  \n"
+
+                    "pld        [%3, #256]      \n"
+                    "vld1.u16   {d20-d23}, [%3]! \n"
+
+                    "vshll.u16  q8, d20, #16    \n"
+                    "vshll.u16  q9, d21, #16    \n"
+                    "vshll.u16  q10, d22, #16   \n"
+                    "vshll.u16  q11, d23, #16   \n"
+
+                    "vmax.f32   q14, q2, q6     \n"
+                    "vmax.f32   q15, q3, q7     \n"
+
+//                     "vld1.f32   {d0-d1}, [%1 :128] \n"
+                    "vld1.u16   {d1}, [%1]      \n"
+                    "vshll.u16  q0, d1, #16     \n"
+
+                    "vmax.f32   q12, q12, q8    \n"
+                    "vmax.f32   q13, q13, q9    \n"
+
+//                     "vld1.f32   {d2-d3}, [%2 :128] \n"
+                    "vld1.u16   {d3}, [%2]      \n"
+                    "vshll.u16  q1, d3, #16     \n"
+
+                    "vmax.f32   q14, q14, q10   \n"
+                    "vmax.f32   q15, q15, q11   \n"
+
+//                     "vld1.f32   {d4-d5}, [%3 :128] \n"
+                    "vld1.u16   {d5}, [%3]      \n"
+                    "vshll.u16  q2, d5, #16     \n"
+
+                    "vmax.f32   q3, q0, q1      \n"
+
+                    "vmax.f32   q4, q12, q13    \n"
+                    "vmax.f32   q5, q14, q15    \n"
+
+                    "vmax.f32   q3, q3, q2      \n"
+
+                    "vmax.f32   q4, q4, q14     \n"
+                    "vmax.f32   q5, q5, q3      \n"
+
+                    "vshrn.u32  d8, q4, #16     \n"
+                    "vshrn.u32  d9, q5, #16     \n"
+
+                    "vst1.u16   {d8-d9}, [%0]!  \n"
+
+                    : "=r"(outptr), // %0
+                    "=r"(r0),     // %1
+                    "=r"(r1),     // %2
+                    "=r"(r2)      // %3
+                    : "0"(outptr),
+                    "1"(r0),
+                    "2"(r1),
+                    "3"(r2)
+                    : "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15");
+#endif // __aarch64__
+            }
+            for (; j < outw; j++)
+            {
+                float32x4_t _r00 = vcvt_f32_bf16(vld1_u16(r0));
+                float32x4_t _r01 = vcvt_f32_bf16(vld1_u16(r0 + 4));
+                float32x4_t _r02 = vcvt_f32_bf16(vld1_u16(r0 + 8));
+                float32x4_t _r10 = vcvt_f32_bf16(vld1_u16(r1));
+                float32x4_t _r11 = vcvt_f32_bf16(vld1_u16(r1 + 4));
+                float32x4_t _r12 = vcvt_f32_bf16(vld1_u16(r1 + 8));
+                float32x4_t _r20 = vcvt_f32_bf16(vld1_u16(r2));
+                float32x4_t _r21 = vcvt_f32_bf16(vld1_u16(r2 + 4));
+                float32x4_t _r22 = vcvt_f32_bf16(vld1_u16(r2 + 8));
+
+                float32x4_t _max0 = vmaxq_f32(vmaxq_f32(_r00, _r01), _r02);
+                float32x4_t _max1 = vmaxq_f32(vmaxq_f32(_r10, _r11), _r12);
+                float32x4_t _max2 = vmaxq_f32(vmaxq_f32(_r20, _r21), _r22);
+
+                float32x4_t _max = vmaxq_f32(vmaxq_f32(_max0, _max1), _max2);
+
+                vst1_u16(outptr, vcvt_bf16_f32(_max));
+
+                r0 += 8;
+                r1 += 8;
+                r2 += 8;
+                outptr += 4;
+            }
+
+            r0 += tailstep;
+            r1 += tailstep;
+            r2 += tailstep;
+        }
+    }
+}

--- a/src/layer/arm/pooling_arm.cpp
+++ b/src/layer/arm/pooling_arm.cpp
@@ -28,6 +28,8 @@ namespace ncnn {
 #if __ARM_NEON
 #include "pooling_2x2_pack4.h"
 #include "pooling_3x3_pack4.h"
+#include "pooling_2x2_pack4_bf16s.h"
+#include "pooling_3x3_pack4_bf16s.h"
 #endif
 
 Pooling_arm::Pooling_arm()
@@ -1339,6 +1341,20 @@ int Pooling_arm::forward_bf16s(const Mat& bottom_blob, Mat& top_blob, const Opti
 #if __ARM_NEON
         if (elempack == 4)
         {
+            if (kernel_w == 2 && kernel_h == 2 && stride_w == 2 && stride_h == 2)
+            {
+                pooling2x2s2_max_pack4_bf16s_neon(bottom_blob_bordered, top_blob, opt);
+
+                return 0;
+            }
+
+            if (kernel_w == 3 && kernel_h == 3 && stride_w == 2 && stride_h == 2)
+            {
+                pooling3x3s2_max_pack4_bf16s_neon(bottom_blob_bordered, top_blob, opt);
+
+                return 0;
+            }
+
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
             {


### PR DESCRIPTION
raspberry pi 3b+

|model|fp32|bf16|bf16-pr3847|
|---|---|---|---|
|yolo-fastestv2 1t|87.95|75.54|67.79|
|yolo-fastestv2 4t|68.42|46.98|43.13|
