### PR TITLE
riscv general optimization for convolution sgemm and winograd and innerproduct

### DIFF
--- a/src/layer/riscv/convolution_3x3.h
+++ b/src/layer/riscv/convolution_3x3.h
@@ -1,0 +1,1411 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+static void conv3x3s1_winograd23_transform_kernel_rvv(const Mat& kernel, Mat& kernel_tm2, int inch, int outch, const Option& opt)
+{
+    Mat kernel_tm(4 * 4, inch, outch);
+
+    // G
+    const float ktm[4][3] = {
+        {1.0f, 0.0f, 0.0f},
+        {1.0f / 2, 1.0f / 2, 1.0f / 2},
+        {1.0f / 2, -1.0f / 2, 1.0f / 2},
+        {0.0f, 0.0f, 1.0f}
+    };
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int p = 0; p < outch; p++)
+    {
+        for (int q = 0; q < inch; q++)
+        {
+            const float* kernel0 = (const float*)kernel + p * inch * 9 + q * 9;
+            float* kernel_tm0 = kernel_tm.channel(p).row(q);
+
+            // transform kernel
+            const float* k0 = kernel0;
+            const float* k1 = kernel0 + 3;
+            const float* k2 = kernel0 + 6;
+
+            // h
+            float tmp[4][3];
+            for (int i = 0; i < 4; i++)
+            {
+                tmp[i][0] = k0[0] * ktm[i][0] + k0[1] * ktm[i][1] + k0[2] * ktm[i][2];
+                tmp[i][1] = k1[0] * ktm[i][0] + k1[1] * ktm[i][1] + k1[2] * ktm[i][2];
+                tmp[i][2] = k2[0] * ktm[i][0] + k2[1] * ktm[i][1] + k2[2] * ktm[i][2];
+            }
+
+            // U
+            for (int j = 0; j < 4; j++)
+            {
+                float* tmpp = &tmp[j][0];
+
+                for (int i = 0; i < 4; i++)
+                {
+                    kernel_tm0[j * 4 + i] = tmpp[0] * ktm[i][0] + tmpp[1] * ktm[i][1] + tmpp[2] * ktm[i][2];
+                }
+            }
+        }
+    }
+
+    // interleave
+    // src = 16-inch-outch
+    // dst = inch-16-outch
+#if __riscv_vector
+    kernel_tm2.create(8 * inch, 16, outch / 8 + (outch % 8) / 4 + outch % 4);
+#else
+    kernel_tm2.create(2 * inch, 16, outch / 2 + outch % 2);
+#endif
+
+    int q = 0;
+#if __riscv_vector
+    for (; q + 7 < outch; q += 8)
+    {
+        Mat g0 = kernel_tm2.channel(q / 8);
+
+        for (int k = 0; k < 16; k++)
+        {
+            float* g00 = g0.row(k);
+
+            for (int p = 0; p < inch; p++)
+            {
+                for (int i = 0; i < 8; i++)
+                {
+                    const float* k00 = kernel_tm.channel(q + i).row(p);
+                    g00[0] = k00[k];
+                    g00++;
+                }
+            }
+        }
+    }
+    for (; q + 3 < outch; q += 4)
+    {
+        Mat g0 = kernel_tm2.channel(q / 8 + (q % 8) / 4);
+
+        for (int k = 0; k < 16; k++)
+        {
+            float* g00 = g0.row(k);
+
+            for (int p = 0; p < inch; p++)
+            {
+                for (int i = 0; i < 4; i++)
+                {
+                    const float* k00 = kernel_tm.channel(q + i).row(p);
+                    g00[0] = k00[k];
+                    g00++;
+                }
+            }
+        }
+    }
+#else  // __riscv_vector
+    for (; q + 1 < outch; q += 2)
+    {
+        Mat g0 = kernel_tm2.channel(q / 2);
+
+        for (int k = 0; k < 16; k++)
+        {
+            float* g00 = g0.row(k);
+
+            for (int p = 0; p < inch; p++)
+            {
+                for (int i = 0; i < 2; i++)
+                {
+                    const float* k00 = kernel_tm.channel(q + i).row(p);
+                    g00[0] = k00[k];
+                    g00++;
+                }
+            }
+        }
+    }
+#endif // __riscv_vector
+    for (; q < outch; q++)
+    {
+#if __riscv_vector
+        Mat g0 = kernel_tm2.channel(q / 8 + (q % 8) / 4 + q % 4);
+#else
+        Mat g0 = kernel_tm2.channel(q / 2 + q % 2);
+#endif
+
+        for (int k = 0; k < 16; k++)
+        {
+            float* g00 = g0.row(k);
+
+            for (int p = 0; p < inch; p++)
+            {
+                const float* k00 = kernel_tm.channel(q).row(p);
+                g00[0] = k00[k];
+                g00++;
+            }
+        }
+    }
+}
+
+static void conv3x3s1_winograd23_rvv(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel_tm, const Mat& bias, const Option& opt)
+{
+#if __riscv_vector
+    const int packn = csrr_vlenb() / 4;
+    const word_type vl = vsetvl_e32m1(packn);
+#endif
+
+    int w = bottom_blob.w;
+    int h = bottom_blob.h;
+    int inch = bottom_blob.c;
+
+    int outw = top_blob.w;
+    int outh = top_blob.h;
+    int outch = top_blob.c;
+
+    // pad to 2n+2, winograd F(2,3)
+    Mat bottom_blob_bordered = bottom_blob;
+
+    outw = (outw + 1) / 2 * 2;
+    outh = (outh + 1) / 2 * 2;
+
+    w = outw + 2;
+    h = outh + 2;
+    Option opt_b = opt;
+    opt_b.blob_allocator = opt.workspace_allocator;
+    copy_make_border(bottom_blob, bottom_blob_bordered, 0, h - bottom_blob.h, 0, w - bottom_blob.w, 0, 0.f, opt_b);
+
+    // BEGIN transform input
+    Mat bottom_blob_tm;
+    {
+        int w_tiles = outw / 2;
+        int h_tiles = outh / 2;
+        int tiles = w_tiles * h_tiles;
+
+        bottom_blob_tm.create(tiles, 16, inch, 4u, opt.workspace_allocator);
+        conv3x3s1_winograd23_transform_input_rvv(bottom_blob_bordered, bottom_blob_tm, opt);
+    }
+    bottom_blob_bordered = Mat();
+    // END transform input
+
+    // BEGIN dot
+    Mat top_blob_tm;
+    {
+        int w_tm = outw / 2 * 4;
+        int h_tm = outh / 2 * 4;
+
+        const int tiles = h_tm / 4 * w_tm / 4;
+
+        // permute
+        Mat bottom_blob_tm2;
+#if __riscv_vector
+        if (tiles >= packn)
+            bottom_blob_tm2.create(packn * inch, tiles / packn + tiles % packn, 16, 4u, opt.workspace_allocator);
+#else
+        if (tiles >= 4)
+            bottom_blob_tm2.create(4 * inch, tiles / 4 + tiles % 4, 16, 4u, opt.workspace_allocator);
+#endif
+        else
+            bottom_blob_tm2.create(1 * inch, tiles, 16, 4u, opt.workspace_allocator);
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int r = 0; r < 16; r++)
+        {
+            Mat tm2 = bottom_blob_tm2.channel(r);
+
+            // tile
+            int i = 0;
+#if __riscv_vector
+            for (; i + (packn - 1) < tiles; i += packn)
+            {
+                float* tmpptr = tm2.row(i / packn);
+
+                const float* r0 = bottom_blob_tm;
+
+                r0 += (r * tiles + i);
+
+                for (int q = 0; q < inch; q++)
+                {
+                    vse32_v_f32m1(tmpptr, vle32_v_f32m1(r0, vl), vl);
+                    r0 += bottom_blob_tm.cstep;
+                    tmpptr += packn;
+                }
+            }
+#else // __riscv_vector
+            for (; i + 3 < tiles; i += 4)
+            {
+                float* tmpptr = tm2.row(i / 4);
+
+                const float* r0 = bottom_blob_tm;
+
+                r0 += (r * tiles + i);
+
+                for (int q = 0; q < inch; q++)
+                {
+                    tmpptr[0] = r0[0];
+                    tmpptr[1] = r0[1];
+                    tmpptr[2] = r0[2];
+                    tmpptr[3] = r0[3];
+
+                    r0 += bottom_blob_tm.cstep;
+                    tmpptr += 4;
+                }
+            }
+#endif // __riscv_vector
+            for (; i < tiles; i++)
+            {
+#if __riscv_vector
+                float* tmpptr = tm2.row(i / packn + i % packn);
+#else
+                float* tmpptr = tm2.row(i / 4 + i % 4);
+#endif
+
+                const float* r0 = bottom_blob_tm;
+
+                r0 += (r * tiles + i);
+
+                for (int q = 0; q < inch; q++)
+                {
+                    tmpptr[0] = r0[0];
+
+                    r0 += bottom_blob_tm.cstep;
+                    tmpptr += 1;
+                }
+            }
+        }
+
+        bottom_blob_tm = Mat();
+        // permute end
+
+        top_blob_tm.create(tiles, 16, outch, 4u, opt.workspace_allocator);
+
+#if __riscv_vector
+        int nn_outch = outch >> 3;
+        int remain_outch_start = nn_outch << 3;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int pp = 0; pp < nn_outch; pp++)
+        {
+            int p = pp * 8;
+
+            float* output0_tm = top_blob_tm.channel(p);
+            float* output1_tm = top_blob_tm.channel(p + 1);
+            float* output2_tm = top_blob_tm.channel(p + 2);
+            float* output3_tm = top_blob_tm.channel(p + 3);
+            float* output4_tm = top_blob_tm.channel(p + 4);
+            float* output5_tm = top_blob_tm.channel(p + 5);
+            float* output6_tm = top_blob_tm.channel(p + 6);
+            float* output7_tm = top_blob_tm.channel(p + 7);
+
+            const Mat kernel0_tm = kernel_tm.channel(p / 8);
+
+            for (int r = 0; r < 16; r++)
+            {
+                const Mat bb2 = bottom_blob_tm2.channel(r);
+
+                int i = 0;
+                for (; i + (packn - 1) < tiles; i += packn)
+                {
+                    const float* r0 = bb2.row(i / packn);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    vfloat32m1_t _sum0 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum1 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum2 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum3 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum4 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum5 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum6 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum7 = vfmv_v_f_f32m1(0.f, vl);
+
+                    int j = 0;
+                    for (; j < nn; j++)
+                    {
+                        vfloat32m1_t _val = vle32_v_f32m1(r0, vl);
+                        _sum0 = vfmacc_vf_f32m1(_sum0, k0[0], _val, vl);
+                        _sum1 = vfmacc_vf_f32m1(_sum1, k0[1], _val, vl);
+                        _sum2 = vfmacc_vf_f32m1(_sum2, k0[2], _val, vl);
+                        _sum3 = vfmacc_vf_f32m1(_sum3, k0[3], _val, vl);
+                        _sum4 = vfmacc_vf_f32m1(_sum4, k0[4], _val, vl);
+                        _sum5 = vfmacc_vf_f32m1(_sum5, k0[5], _val, vl);
+                        _sum6 = vfmacc_vf_f32m1(_sum6, k0[6], _val, vl);
+                        _sum7 = vfmacc_vf_f32m1(_sum7, k0[7], _val, vl);
+                        r0 += packn;
+                        k0 += 8;
+                    }
+
+                    vse32_v_f32m1(output0_tm, _sum0, vl);
+                    vse32_v_f32m1(output1_tm, _sum1, vl);
+                    vse32_v_f32m1(output2_tm, _sum2, vl);
+                    vse32_v_f32m1(output3_tm, _sum3, vl);
+                    vse32_v_f32m1(output4_tm, _sum4, vl);
+                    vse32_v_f32m1(output5_tm, _sum5, vl);
+                    vse32_v_f32m1(output6_tm, _sum6, vl);
+                    vse32_v_f32m1(output7_tm, _sum7, vl);
+
+                    output0_tm += packn;
+                    output1_tm += packn;
+                    output2_tm += packn;
+                    output3_tm += packn;
+                    output4_tm += packn;
+                    output5_tm += packn;
+                    output6_tm += packn;
+                    output7_tm += packn;
+                }
+                for (; i < tiles; i++)
+                {
+                    const float* r0 = bb2.row(i / packn + i % packn);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    float sum0 = 0.f;
+                    float sum1 = 0.f;
+                    float sum2 = 0.f;
+                    float sum3 = 0.f;
+                    float sum4 = 0.f;
+                    float sum5 = 0.f;
+                    float sum6 = 0.f;
+                    float sum7 = 0.f;
+
+                    int j = 0;
+                    for (; j < nn; j++)
+                    {
+                        sum0 += r0[0] * k0[0];
+                        sum1 += r0[0] * k0[1];
+                        sum2 += r0[0] * k0[2];
+                        sum3 += r0[0] * k0[3];
+                        sum4 += r0[0] * k0[4];
+                        sum5 += r0[0] * k0[5];
+                        sum6 += r0[0] * k0[6];
+                        sum7 += r0[0] * k0[7];
+
+                        r0 += 1;
+                        k0 += 8;
+                    }
+
+                    output0_tm[0] = sum0;
+                    output1_tm[0] = sum1;
+                    output2_tm[0] = sum2;
+                    output3_tm[0] = sum3;
+                    output4_tm[0] = sum4;
+                    output5_tm[0] = sum5;
+                    output6_tm[0] = sum6;
+                    output7_tm[0] = sum7;
+
+                    output0_tm++;
+                    output1_tm++;
+                    output2_tm++;
+                    output3_tm++;
+                    output4_tm++;
+                    output5_tm++;
+                    output6_tm++;
+                    output7_tm++;
+                }
+            }
+        }
+
+        nn_outch = (outch - remain_outch_start) >> 2;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int pp = 0; pp < nn_outch; pp++)
+        {
+            int p = remain_outch_start + pp * 4;
+
+            float* output0_tm = top_blob_tm.channel(p);
+            float* output1_tm = top_blob_tm.channel(p + 1);
+            float* output2_tm = top_blob_tm.channel(p + 2);
+            float* output3_tm = top_blob_tm.channel(p + 3);
+
+            const Mat kernel0_tm = kernel_tm.channel(p / 8 + (p % 8) / 4);
+
+            for (int r = 0; r < 16; r++)
+            {
+                const Mat bb2 = bottom_blob_tm2.channel(r);
+
+                int i = 0;
+                for (; i + (packn - 1) < tiles; i += packn)
+                {
+                    const float* r0 = bb2.row(i / packn);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    vfloat32m1_t _sum0 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum1 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum2 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum3 = vfmv_v_f_f32m1(0.f, vl);
+
+                    int j = 0;
+                    for (; j < nn; j++)
+                    {
+                        vfloat32m1_t _val = vle32_v_f32m1(r0, vl);
+                        _sum0 = vfmacc_vf_f32m1(_sum0, k0[0], _val, vl);
+                        _sum1 = vfmacc_vf_f32m1(_sum1, k0[1], _val, vl);
+                        _sum2 = vfmacc_vf_f32m1(_sum2, k0[2], _val, vl);
+                        _sum3 = vfmacc_vf_f32m1(_sum3, k0[3], _val, vl);
+                        r0 += packn;
+                        k0 += 4;
+                    }
+
+                    vse32_v_f32m1(output0_tm, _sum0, vl);
+                    vse32_v_f32m1(output1_tm, _sum1, vl);
+                    vse32_v_f32m1(output2_tm, _sum2, vl);
+                    vse32_v_f32m1(output3_tm, _sum3, vl);
+
+                    output0_tm += 4;
+                    output1_tm += 4;
+                    output2_tm += 4;
+                    output3_tm += 4;
+                }
+                for (; i < tiles; i++)
+                {
+                    const float* r0 = bb2.row(i / packn + i % packn);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    float sum0 = 0.f;
+                    float sum1 = 0.f;
+                    float sum2 = 0.f;
+                    float sum3 = 0.f;
+
+                    int j = 0;
+                    for (; j < nn; j++)
+                    {
+                        sum0 += r0[0] * k0[0];
+                        sum1 += r0[0] * k0[1];
+                        sum2 += r0[0] * k0[2];
+                        sum3 += r0[0] * k0[3];
+
+                        r0 += 1;
+                        k0 += 4;
+                    }
+
+                    output0_tm[0] = sum0;
+                    output1_tm[0] = sum1;
+                    output2_tm[0] = sum2;
+                    output3_tm[0] = sum3;
+
+                    output0_tm++;
+                    output1_tm++;
+                    output2_tm++;
+                    output3_tm++;
+                }
+            }
+        }
+
+        remain_outch_start += nn_outch << 2;
+#else
+        int nn_outch = outch >> 1;
+        int remain_outch_start = nn_outch << 1;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int pp = 0; pp < nn_outch; pp++)
+        {
+            int p = pp * 2;
+
+            float* output0_tm = top_blob_tm.channel(p);
+            float* output1_tm = top_blob_tm.channel(p + 1);
+
+            const Mat kernel0_tm = kernel_tm.channel(p / 2);
+
+            for (int r = 0; r < 16; r++)
+            {
+                const Mat bb2 = bottom_blob_tm2.channel(r);
+
+                int i = 0;
+                for (; i + 3 < tiles; i += 4)
+                {
+                    const float* r0 = bb2.row(i / 4);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    float sum00 = 0.f;
+                    float sum01 = 0.f;
+                    float sum02 = 0.f;
+                    float sum03 = 0.f;
+                    float sum10 = 0.f;
+                    float sum11 = 0.f;
+                    float sum12 = 0.f;
+                    float sum13 = 0.f;
+
+                    for (int j = 0; j < nn; j++)
+                    {
+                        float w0 = k0[0];
+                        float w1 = k0[1];
+                        sum00 += r0[0] * w0;
+                        sum01 += r0[1] * w0;
+                        sum02 += r0[2] * w0;
+                        sum03 += r0[3] * w0;
+                        sum10 += r0[0] * w1;
+                        sum11 += r0[1] * w1;
+                        sum12 += r0[2] * w1;
+                        sum13 += r0[3] * w1;
+
+                        r0 += 4;
+                        k0 += 2;
+                    }
+
+                    output0_tm[0] = sum00;
+                    output0_tm[1] = sum01;
+                    output0_tm[2] = sum02;
+                    output0_tm[3] = sum03;
+                    output1_tm[0] = sum10;
+                    output1_tm[1] = sum11;
+                    output1_tm[2] = sum12;
+                    output1_tm[3] = sum13;
+
+                    output0_tm += 4;
+                    output1_tm += 4;
+                }
+                for (; i < tiles; i++)
+                {
+                    const float* r0 = bb2.row(i / 4 + i % 4);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    float sum00 = 0.f;
+                    float sum10 = 0.f;
+
+                    for (int j = 0; j < nn; j++)
+                    {
+                        float val0 = r0[0];
+                        sum00 += val0 * k0[0];
+                        sum10 += val0 * k0[1];
+
+                        r0 += 1;
+                        k0 += 2;
+                    }
+
+                    output0_tm[0] = sum00;
+                    output1_tm[0] = sum10;
+                    output0_tm++;
+                    output1_tm++;
+                }
+            }
+        }
+#endif
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int p = remain_outch_start; p < outch; p++)
+        {
+            float* output0_tm = top_blob_tm.channel(p);
+
+#if __riscv_vector
+            const Mat kernel0_tm = kernel_tm.channel(p / 8 + (p % 8) / 4 + p % 4);
+#else
+            const Mat kernel0_tm = kernel_tm.channel(p / 2 + p % 2);
+#endif
+
+            for (int r = 0; r < 16; r++)
+            {
+                const Mat bb2 = bottom_blob_tm2.channel(r);
+
+                int i = 0;
+#if __riscv_vector
+                for (; i + (packn - 1) < tiles; i += packn)
+                {
+                    const float* r0 = bb2.row(i / packn);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    vfloat32m1_t _sum0 = vfmv_v_f_f32m1(0.f, vl);
+
+                    for (; j < nn; j++)
+                    {
+                        _sum0 = vfmacc_vf_f32m1(_sum0, k0[0], vle32_v_f32m1(r0, vl), vl);
+                        r0 += packn;
+                        k0++;
+                    }
+
+                    vse32_v_f32m1(output0_tm, _sum0, vl);
+                    output0_tm += packn;
+                }
+#else // __riscv_vector
+                for (; i + 3 < tiles; i += 4)
+                {
+                    const float* r0 = bb2.row(i / 4);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    float sum0 = 0.f;
+                    float sum1 = 0.f;
+                    float sum2 = 0.f;
+                    float sum3 = 0.f;
+
+                    for (int j = 0; j < nn; j++)
+                    {
+                        __builtin_prefetch(r0 + 16);
+                        __builtin_prefetch(k0 + 4);
+                        float w0 = k0[0];
+                        sum0 += r0[0] * w0;
+                        sum1 += r0[1] * w0;
+                        sum2 += r0[2] * w0;
+                        sum3 += r0[3] * w0;
+
+                        r0 += 4;
+                        k0++;
+                    }
+
+                    output0_tm[0] = sum0;
+                    output0_tm[1] = sum1;
+                    output0_tm[2] = sum2;
+                    output0_tm[3] = sum3;
+                    output0_tm += 4;
+                }
+#else  // __riscv_vector
+                for (; i < tiles; i++)
+                {
+#if __riscv_vector
+                    const float* r0 = bb2.row(i / packn + i % packn);
+#else
+                    const float* r0 = bb2.row(i / 4 + i % 4);
+#endif
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    float sum = 0.f;
+
+                    for (int j = 0; j < nn; j++)
+                    {
+                        sum += r0[0] * k0[0];
+                        r0 += 1;
+                        k0 += 1;
+                    }
+
+                    output0_tm[0] = sum;
+                    output0_tm += 1;
+                }
+            }
+        }
+    }
+    bottom_blob_tm = Mat();
+    // END dot
+
+    // BEGIN transform output
+    Mat top_blob_bordered;
+    if (outw == top_blob.w && outh == top_blob.h)
+    {
+        top_blob_bordered = top_blob;
+    }
+    else
+    {
+        top_blob_bordered.create(outw, outh, outch, 4u, opt.workspace_allocator);
+    }
+    {
+        conv3x3s1_winograd23_transform_output_rvv(top_blob_tm, top_blob_bordered, bias, opt);
+    }
+    // END transform output
+
+    // cut result pad
+    copy_cut_border(top_blob_bordered, top_blob, 0, top_blob_bordered.h - top_blob.h, 0, top_blob_bordered.w - top_blob.w, opt);
+}
+
+static void conv3x3s1_winograd43_transform_kernel_rvv(const Mat& kernel, Mat& kernel_tm2, int inch, int outch, const Option& opt)
+{
+    Mat kernel_tm(6 * 6, inch, outch);
+
+    // G
+    const float ktm[6][3] = {
+        {1.0f / 4, 0.0f, 0.0f},
+        {-1.0f / 6, -1.0f / 6, -1.0f / 6},
+        {-1.0f / 6, 1.0f / 6, -1.0f / 6},
+        {1.0f / 24, 1.0f / 12, 1.0f / 6},
+        {1.0f / 24, -1.0f / 12, 1.0f / 6},
+        {0.0f, 0.0f, 1.0f}
+    };
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int p = 0; p < outch; p++)
+    {
+        for (int q = 0; q < inch; q++)
+        {
+            const float* kernel0 = (const float*)kernel + p * inch * 9 + q * 9;
+            float* kernel_tm0 = kernel_tm.channel(p).row(q);
+
+            // transform kernel
+            const float* k0 = kernel0;
+            const float* k1 = kernel0 + 3;
+            const float* k2 = kernel0 + 6;
+
+            // h
+            float tmp[6][3];
+            for (int i = 0; i < 6; i++)
+            {
+                tmp[i][0] = k0[0] * ktm[i][0] + k0[1] * ktm[i][1] + k0[2] * ktm[i][2];
+                tmp[i][1] = k1[0] * ktm[i][0] + k1[1] * ktm[i][1] + k1[2] * ktm[i][2];
+                tmp[i][2] = k2[0] * ktm[i][0] + k2[1] * ktm[i][1] + k2[2] * ktm[i][2];
+            }
+
+            // U
+            for (int j = 0; j < 6; j++)
+            {
+                float* tmpp = &tmp[j][0];
+
+                for (int i = 0; i < 6; i++)
+                {
+                    kernel_tm0[j * 6 + i] = tmpp[0] * ktm[i][0] + tmpp[1] * ktm[i][1] + tmpp[2] * ktm[i][2];
+                }
+            }
+        }
+    }
+
+    // interleave
+    // src = 36-inch-outch
+    // dst = inch-36-outch
+#if __riscv_vector
+    kernel_tm2.create(8 * inch, 36, outch / 8 + (outch % 8) / 4 + outch % 4);
+#else
+    kernel_tm2.create(2 * inch, 36, outch / 2 + outch % 2);
+#endif
+
+    int q = 0;
+#if __riscv_vector
+    for (; q + 7 < outch; q += 8)
+    {
+        Mat g0 = kernel_tm2.channel(q / 8);
+
+        for (int k = 0; k < 36; k++)
+        {
+            float* g00 = g0.row(k);
+
+            for (int p = 0; p < inch; p++)
+            {
+                for (int i = 0; i < 8; i++)
+                {
+                    const float* k00 = kernel_tm.channel(q + i).row(p);
+                    g00[0] = k00[k];
+                    g00++;
+                }
+            }
+        }
+    }
+    for (; q + 3 < outch; q += 4)
+    {
+        Mat g0 = kernel_tm2.channel(q / 8 + (q % 8) / 4);
+
+        for (int k = 0; k < 36; k++)
+        {
+            float* g00 = g0.row(k);
+
+            for (int p = 0; p < inch; p++)
+            {
+                for (int i = 0; i < 4; i++)
+                {
+                    const float* k00 = kernel_tm.channel(q + i).row(p);
+                    g00[0] = k00[k];
+                    g00++;
+                }
+            }
+        }
+    }
+#else  // __riscv_vector
+    for (; q + 1 < outch; q += 2)
+    {
+        Mat g0 = kernel_tm2.channel(q / 2);
+
+        for (int k = 0; k < 36; k++)
+        {
+            float* g00 = g0.row(k);
+
+            for (int p = 0; p < inch; p++)
+            {
+                for (int i = 0; i < 2; i++)
+                {
+                    const float* k00 = kernel_tm.channel(q + i).row(p);
+                    g00[0] = k00[k];
+                    g00++;
+                }
+            }
+        }
+    }
+#endif // __riscv_vector
+    for (; q < outch; q++)
+    {
+#if __riscv_vector
+        Mat g0 = kernel_tm2.channel(q / 8 + (q % 8) / 4 + q % 4);
+#else
+        Mat g0 = kernel_tm2.channel(q / 2 + q % 2);
+#endif
+
+        for (int k = 0; k < 36; k++)
+        {
+            float* g00 = g0.row(k);
+
+            for (int p = 0; p < inch; p++)
+            {
+                const float* k00 = kernel_tm.channel(q).row(p);
+                g00[0] = k00[k];
+                g00++;
+            }
+        }
+    }
+}
+
+static void conv3x3s1_winograd43_rvv(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel_tm, const Mat& bias, const Option& opt)
+{
+    int w = bottom_blob.w;
+    int h = bottom_blob.h;
+    int inch = bottom_blob.c;
+
+    int outw = top_blob.w;
+    int outh = top_blob.h;
+    int outch = top_blob.c;
+
+    // pad to 4n+2, winograd F(4,3)
+    Mat bottom_blob_bordered = bottom_blob;
+
+    outw = (outw + 3) / 4 * 4;
+    outh = (outh + 3) / 4 * 4;
+
+    w = outw + 2;
+    h = outh + 2;
+
+    Option opt_b = opt;
+    opt_b.blob_allocator = opt.workspace_allocator;
+    copy_make_border(bottom_blob, bottom_blob_bordered, 0, h - bottom_blob.h, 0, w - bottom_blob.w, 0, 0.f, opt_b);
+
+    // BEGIN transform input
+    Mat bottom_blob_tm;
+    {
+        int w_tiles = outw / 4;
+        int h_tiles = outh / 4;
+        int tiles = w_tiles * h_tiles;
+
+        bottom_blob_tm.create(tiles, 36, inch, 4u, opt.workspace_allocator);
+        conv3x3s1_winograd43_transform_input_rvv(bottom_blob_bordered, bottom_blob_tm, opt);
+    }
+    bottom_blob_bordered = Mat();
+    // END transform input
+
+    // BEGIN dot
+    Mat top_blob_tm;
+    {
+        int w_tm = outw / 4 * 6;
+        int h_tm = outh / 4 * 6;
+
+        const int tiles = h_tm / 6 * w_tm / 6;
+
+        // permute
+        Mat bottom_blob_tm2;
+#if __riscv_vector
+        if (tiles >= packn)
+            bottom_blob_tm2.create(packn * inch, tiles / packn + tiles % packn, 36, 4u, opt.workspace_allocator);
+#else
+        if (tiles >= 4)
+            bottom_blob_tm2.create(4 * inch, tiles / 4 + tiles % 4, 36, 4u, opt.workspace_allocator);
+#endif
+        else
+            bottom_blob_tm2.create(1 * inch, tiles, 36, 4u, opt.workspace_allocator);
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int r = 0; r < 36; r++)
+        {
+            Mat tm2 = bottom_blob_tm2.channel(r);
+
+            // tile
+            int i = 0;
+#if __riscv_vector
+            for (; i + (packn - 1) < tiles; i += packn)
+            {
+                float* tmpptr = tm2.row(i / packn);
+
+                const float* r0 = bottom_blob_tm;
+
+                r0 += (r * tiles + i);
+
+                for (int q = 0; q < inch; q++)
+                {
+                    vse32_v_f32m1(tmpptr, vle32_v_f32m1(r0, vl), vl);
+                    r0 += bottom_blob_tm.cstep;
+                    tmpptr += packn;
+                }
+            }
+#else // __riscv_vector
+            for (; i + 3 < tiles; i += 4)
+            {
+                float* tmpptr = tm2.row(i / 4);
+
+                const float* r0 = bottom_blob_tm;
+
+                r0 += (r * tiles + i);
+
+                for (int q = 0; q < inch; q++)
+                {
+                    tmpptr[0] = r0[0];
+                    tmpptr[1] = r0[1];
+                    tmpptr[2] = r0[2];
+                    tmpptr[3] = r0[3];
+
+                    r0 += bottom_blob_tm.cstep;
+                    tmpptr += 4;
+                }
+            }
+#endif // __riscv_vector
+            for (; i < tiles; i++)
+            {
+#if __riscv_vector
+                float* tmpptr = tm2.row(i / packn + i % packn);
+#else
+                float* tmpptr = tm2.row(i / 4 + i % 4);
+#endif
+
+                const float* r0 = bottom_blob_tm;
+
+                r0 += (r * tiles + i);
+
+                for (int q = 0; q < inch; q++)
+                {
+                    tmpptr[0] = r0[0];
+
+                    r0 += bottom_blob_tm.cstep;
+                    tmpptr += 1;
+                }
+            }
+        }
+
+        bottom_blob_tm = Mat();
+        // permute end
+
+        top_blob_tm.create(tiles, 16, outch, 4u, opt.workspace_allocator);
+
+#if __riscv_vector
+        int nn_outch = outch >> 3;
+        int remain_outch_start = nn_outch << 3;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int pp = 0; pp < nn_outch; pp++)
+        {
+            int p = pp * 8;
+
+            float* output0_tm = top_blob_tm.channel(p);
+            float* output1_tm = top_blob_tm.channel(p + 1);
+            float* output2_tm = top_blob_tm.channel(p + 2);
+            float* output3_tm = top_blob_tm.channel(p + 3);
+            float* output4_tm = top_blob_tm.channel(p + 4);
+            float* output5_tm = top_blob_tm.channel(p + 5);
+            float* output6_tm = top_blob_tm.channel(p + 6);
+            float* output7_tm = top_blob_tm.channel(p + 7);
+
+            const Mat kernel0_tm = kernel_tm.channel(p / 8);
+
+            for (int r = 0; r < 36; r++)
+            {
+                const Mat bb2 = bottom_blob_tm2.channel(r);
+
+                int i = 0;
+                for (; i + (packn - 1) < tiles; i += packn)
+                {
+                    const float* r0 = bb2.row(i / packn);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    vfloat32m1_t _sum0 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum1 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum2 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum3 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum4 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum5 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum6 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum7 = vfmv_v_f_f32m1(0.f, vl);
+
+                    int j = 0;
+                    for (; j < nn; j++)
+                    {
+                        vfloat32m1_t _val = vle32_v_f32m1(r0, vl);
+                        _sum0 = vfmacc_vf_f32m1(_sum0, k0[0], _val, vl);
+                        _sum1 = vfmacc_vf_f32m1(_sum1, k0[1], _val, vl);
+                        _sum2 = vfmacc_vf_f32m1(_sum2, k0[2], _val, vl);
+                        _sum3 = vfmacc_vf_f32m1(_sum3, k0[3], _val, vl);
+                        _sum4 = vfmacc_vf_f32m1(_sum4, k0[4], _val, vl);
+                        _sum5 = vfmacc_vf_f32m1(_sum5, k0[5], _val, vl);
+                        _sum6 = vfmacc_vf_f32m1(_sum6, k0[6], _val, vl);
+                        _sum7 = vfmacc_vf_f32m1(_sum7, k0[7], _val, vl);
+                        r0 += packn;
+                        k0 += 8;
+                    }
+
+                    vse32_v_f32m1(output0_tm, _sum0, vl);
+                    vse32_v_f32m1(output1_tm, _sum1, vl);
+                    vse32_v_f32m1(output2_tm, _sum2, vl);
+                    vse32_v_f32m1(output3_tm, _sum3, vl);
+                    vse32_v_f32m1(output4_tm, _sum4, vl);
+                    vse32_v_f32m1(output5_tm, _sum5, vl);
+                    vse32_v_f32m1(output6_tm, _sum6, vl);
+                    vse32_v_f32m1(output7_tm, _sum7, vl);
+
+                    output0_tm += packn;
+                    output1_tm += packn;
+                    output2_tm += packn;
+                    output3_tm += packn;
+                    output4_tm += packn;
+                    output5_tm += packn;
+                    output6_tm += packn;
+                    output7_tm += packn;
+                }
+                for (; i < tiles; i++)
+                {
+                    const float* r0 = bb2.row(i / packn + i % packn);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    float sum0 = 0.f;
+                    float sum1 = 0.f;
+                    float sum2 = 0.f;
+                    float sum3 = 0.f;
+                    float sum4 = 0.f;
+                    float sum5 = 0.f;
+                    float sum6 = 0.f;
+                    float sum7 = 0.f;
+
+                    int j = 0;
+                    for (; j < nn; j++)
+                    {
+                        sum0 += r0[0] * k0[0];
+                        sum1 += r0[0] * k0[1];
+                        sum2 += r0[0] * k0[2];
+                        sum3 += r0[0] * k0[3];
+                        sum4 += r0[0] * k0[4];
+                        sum5 += r0[0] * k0[5];
+                        sum6 += r0[0] * k0[6];
+                        sum7 += r0[0] * k0[7];
+
+                        r0 += 1;
+                        k0 += 8;
+                    }
+
+                    output0_tm[0] = sum0;
+                    output1_tm[0] = sum1;
+                    output2_tm[0] = sum2;
+                    output3_tm[0] = sum3;
+                    output4_tm[0] = sum4;
+                    output5_tm[0] = sum5;
+                    output6_tm[0] = sum6;
+                    output7_tm[0] = sum7;
+
+                    output0_tm++;
+                    output1_tm++;
+                    output2_tm++;
+                    output3_tm++;
+                    output4_tm++;
+                    output5_tm++;
+                    output6_tm++;
+                    output7_tm++;
+                }
+            }
+        }
+
+        nn_outch = (outch - remain_outch_start) >> 2;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int pp = 0; pp < nn_outch; pp++)
+        {
+            int p = remain_outch_start + pp * 4;
+
+            float* output0_tm = top_blob_tm.channel(p);
+            float* output1_tm = top_blob_tm.channel(p + 1);
+            float* output2_tm = top_blob_tm.channel(p + 2);
+            float* output3_tm = top_blob_tm.channel(p + 3);
+
+            const Mat kernel0_tm = kernel_tm.channel(p / 8 + (p % 8) / 4);
+
+            for (int r = 0; r < 36; r++)
+            {
+                const Mat bb2 = bottom_blob_tm2.channel(r);
+
+                int i = 0;
+                for (; i + (packn - 1) < tiles; i += packn)
+                {
+                    const float* r0 = bb2.row(i / packn);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    vfloat32m1_t _sum0 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum1 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum2 = vfmv_v_f_f32m1(0.f, vl);
+                    vfloat32m1_t _sum3 = vfmv_v_f_f32m1(0.f, vl);
+
+                    int j = 0;
+                    for (; j < nn; j++)
+                    {
+                        vfloat32m1_t _val = vle32_v_f32m1(r0, vl);
+                        _sum0 = vfmacc_vf_f32m1(_sum0, k0[0], _val, vl);
+                        _sum1 = vfmacc_vf_f32m1(_sum1, k0[1], _val, vl);
+                        _sum2 = vfmacc_vf_f32m1(_sum2, k0[2], _val, vl);
+                        _sum3 = vfmacc_vf_f32m1(_sum3, k0[3], _val, vl);
+                        r0 += packn;
+                        k0 += 4;
+                    }
+
+                    vse32_v_f32m1(output0_tm, _sum0, vl);
+                    vse32_v_f32m1(output1_tm, _sum1, vl);
+                    vse32_v_f32m1(output2_tm, _sum2, vl);
+                    vse32_v_f32m1(output3_tm, _sum3, vl);
+
+                    output0_tm += 4;
+                    output1_tm += 4;
+                    output2_tm += 4;
+                    output3_tm += 4;
+                }
+                for (; i < tiles; i++)
+                {
+                    const float* r0 = bb2.row(i / packn + i % packn);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    float sum0 = 0.f;
+                    float sum1 = 0.f;
+                    float sum2 = 0.f;
+                    float sum3 = 0.f;
+
+                    int j = 0;
+                    for (; j < nn; j++)
+                    {
+                        sum0 += r0[0] * k0[0];
+                        sum1 += r0[0] * k0[1];
+                        sum2 += r0[0] * k0[2];
+                        sum3 += r0[0] * k0[3];
+
+                        r0 += 1;
+                        k0 += 4;
+                    }
+
+                    output0_tm[0] = sum0;
+                    output1_tm[0] = sum1;
+                    output2_tm[0] = sum2;
+                    output3_tm[0] = sum3;
+
+                    output0_tm++;
+                    output1_tm++;
+                    output2_tm++;
+                    output3_tm++;
+                }
+            }
+        }
+
+        remain_outch_start += nn_outch << 2;
+#else
+        int nn_outch = outch >> 1;
+        int remain_outch_start = nn_outch << 1;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int pp = 0; pp < nn_outch; pp++)
+        {
+            int p = pp * 2;
+
+            float* output0_tm = top_blob_tm.channel(p);
+            float* output1_tm = top_blob_tm.channel(p + 1);
+
+            const Mat kernel0_tm = kernel_tm.channel(p / 2);
+
+            for (int r = 0; r < 36; r++)
+            {
+                const Mat bb2 = bottom_blob_tm2.channel(r);
+
+                int i = 0;
+                for (; i + 3 < tiles; i += 4)
+                {
+                    const float* r0 = bb2.row(i / 4);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    float sum00 = 0.f;
+                    float sum01 = 0.f;
+                    float sum02 = 0.f;
+                    float sum03 = 0.f;
+                    float sum10 = 0.f;
+                    float sum11 = 0.f;
+                    float sum12 = 0.f;
+                    float sum13 = 0.f;
+
+                    for (int j = 0; j < nn; j++)
+                    {
+                        float w0 = k0[0];
+                        float w1 = k0[1];
+                        sum00 += r0[0] * w0;
+                        sum01 += r0[1] * w0;
+                        sum02 += r0[2] * w0;
+                        sum03 += r0[3] * w0;
+                        sum10 += r0[0] * w1;
+                        sum11 += r0[1] * w1;
+                        sum12 += r0[2] * w1;
+                        sum13 += r0[3] * w1;
+
+                        r0 += 4;
+                        k0 += 2;
+                    }
+
+                    output0_tm[0] = sum00;
+                    output0_tm[1] = sum01;
+                    output0_tm[2] = sum02;
+                    output0_tm[3] = sum03;
+                    output1_tm[0] = sum10;
+                    output1_tm[1] = sum11;
+                    output1_tm[2] = sum12;
+                    output1_tm[3] = sum13;
+
+                    output0_tm += 4;
+                    output1_tm += 4;
+                }
+                for (; i < tiles; i++)
+                {
+                    const float* r0 = bb2.row(i / 4 + i % 4);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    float sum00 = 0.f;
+                    float sum10 = 0.f;
+
+                    for (int j = 0; j < nn; j++)
+                    {
+                        float val0 = r0[0];
+                        sum00 += val0 * k0[0];
+                        sum10 += val0 * k0[1];
+
+                        r0 += 1;
+                        k0 += 2;
+                    }
+
+                    output0_tm[0] = sum00;
+                    output1_tm[0] = sum10;
+                    output0_tm++;
+                    output1_tm++;
+                }
+            }
+        }
+#endif
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int p = remain_outch_start; p < outch; p++)
+        {
+            float* output0_tm = top_blob_tm.channel(p);
+
+#if __riscv_vector
+            const Mat kernel0_tm = kernel_tm.channel(p / 8 + (p % 8) / 4 + p % 4);
+#else
+            const Mat kernel0_tm = kernel_tm.channel(p / 2 + p % 2);
+#endif
+
+            for (int r = 0; r < 36; r++)
+            {
+                const Mat bb2 = bottom_blob_tm2.channel(r);
+
+                int i = 0;
+#if __riscv_vector
+                for (; i + (packn - 1) < tiles; i += packn)
+                {
+                    const float* r0 = bb2.row(i / packn);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    vfloat32m1_t _sum0 = vfmv_v_f_f32m1(0.f, vl);
+
+                    for (; j < nn; j++)
+                    {
+                        _sum0 = vfmacc_vf_f32m1(_sum0, k0[0], vle32_v_f32m1(r0, vl), vl);
+                        r0 += packn;
+                        k0++;
+                    }
+
+                    vse32_v_f32m1(output0_tm, _sum0, vl);
+                    output0_tm += packn;
+                }
+#else // __riscv_vector
+                for (; i + 3 < tiles; i += 4)
+                {
+                    const float* r0 = bb2.row(i / 4);
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    float sum0 = 0.f;
+                    float sum1 = 0.f;
+                    float sum2 = 0.f;
+                    float sum3 = 0.f;
+
+                    for (int j = 0; j < nn; j++)
+                    {
+                        __builtin_prefetch(r0 + 16);
+                        __builtin_prefetch(k0 + 4);
+                        float w0 = k0[0];
+                        sum0 += r0[0] * w0;
+                        sum1 += r0[1] * w0;
+                        sum2 += r0[2] * w0;
+                        sum3 += r0[3] * w0;
+
+                        r0 += 4;
+                        k0++;
+                    }
+
+                    output0_tm[0] = sum0;
+                    output0_tm[1] = sum1;
+                    output0_tm[2] = sum2;
+                    output0_tm[3] = sum3;
+                    output0_tm += 4;
+                }
+#else  // __riscv_vector
+                for (; i < tiles; i++)
+                {
+#if __riscv_vector
+                    const float* r0 = bb2.row(i / packn + i % packn);
+#else
+                    const float* r0 = bb2.row(i / 4 + i % 4);
+#endif
+                    const float* k0 = kernel0_tm.row(r);
+
+                    int nn = inch; // inch always > 0
+
+                    float sum = 0.f;
+
+                    for (int j = 0; j < nn; j++)
+                    {
+                        sum += r0[0] * k0[0];
+                        r0 += 1;
+                        k0 += 1;
+                    }
+
+                    output0_tm[0] = sum;
+                    output0_tm += 1;
+                }
+            }
+        }
+    }
+    bottom_blob_tm = Mat();
+    // END dot
+
+    // BEGIN transform output
+    Mat top_blob_bordered;
+    if (outw == top_blob.w && outh == top_blob.h)
+    {
+        top_blob_bordered = top_blob;
+    }
+    else
+    {
+        top_blob_bordered.create(outw, outh, outch, 4u, opt.workspace_allocator);
+    }
+    {
+        conv3x3s1_winograd43_transform_output_rvv(top_blob_tm, top_blob_bordered, bias, opt);
+    }
+    // END transform output
+
+    // cut result pad
+    copy_cut_border(top_blob_bordered, top_blob, 0, top_blob_bordered.h - top_blob.h, 0, top_blob_bordered.w - top_blob.w, opt);
+}

--- a/src/layer/riscv/convolution_3x3.h
+++ b/src/layer/riscv/convolution_3x3.h
@@ -234,7 +234,7 @@ static void conv3x3s1_winograd23_rvv(const Mat& bottom_blob, Mat& top_blob, cons
                     tmpptr += packn;
                 }
             }
-#else // __riscv_vector
+#else  // __riscv_vector
             for (; i + 3 < tiles; i += 4)
             {
                 float* tmpptr = tm2.row(i / 4);
@@ -663,7 +663,7 @@ static void conv3x3s1_winograd23_rvv(const Mat& bottom_blob, Mat& top_blob, cons
                     output0_tm[3] = sum3;
                     output0_tm += 4;
                 }
-#else  // __riscv_vector
+#else // __riscv_vector
                 for (; i < tiles; i++)
                 {
 #if __riscv_vector
@@ -932,7 +932,7 @@ static void conv3x3s1_winograd43_rvv(const Mat& bottom_blob, Mat& top_blob, cons
                     tmpptr += packn;
                 }
             }
-#else // __riscv_vector
+#else  // __riscv_vector
             for (; i + 3 < tiles; i += 4)
             {
                 float* tmpptr = tm2.row(i / 4);
@@ -1361,7 +1361,7 @@ static void conv3x3s1_winograd43_rvv(const Mat& bottom_blob, Mat& top_blob, cons
                     output0_tm[3] = sum3;
                     output0_tm += 4;
                 }
-#else  // __riscv_vector
+#else // __riscv_vector
                 for (; i < tiles; i++)
                 {
 #if __riscv_vector

--- a/src/layer/riscv/convolution_3x3.h
+++ b/src/layer/riscv/convolution_3x3.h
@@ -458,10 +458,10 @@ static void conv3x3s1_winograd23_rvv(const Mat& bottom_blob, Mat& top_blob, cons
                     vse32_v_f32m1(output2_tm, _sum2, vl);
                     vse32_v_f32m1(output3_tm, _sum3, vl);
 
-                    output0_tm += 4;
-                    output1_tm += 4;
-                    output2_tm += 4;
-                    output3_tm += 4;
+                    output0_tm += packn;
+                    output1_tm += packn;
+                    output2_tm += packn;
+                    output3_tm += packn;
                 }
                 for (; i < tiles; i++)
                 {
@@ -1161,10 +1161,10 @@ static void conv3x3s1_winograd43_rvv(const Mat& bottom_blob, Mat& top_blob, cons
                     vse32_v_f32m1(output2_tm, _sum2, vl);
                     vse32_v_f32m1(output3_tm, _sum3, vl);
 
-                    output0_tm += 4;
-                    output1_tm += 4;
-                    output2_tm += 4;
-                    output3_tm += 4;
+                    output0_tm += packn;
+                    output1_tm += packn;
+                    output2_tm += packn;
+                    output3_tm += packn;
                 }
                 for (; i < tiles; i++)
                 {

--- a/src/layer/riscv/convolution_3x3.h
+++ b/src/layer/riscv/convolution_3x3.h
@@ -663,7 +663,7 @@ static void conv3x3s1_winograd23_rvv(const Mat& bottom_blob, Mat& top_blob, cons
                     output0_tm[3] = sum3;
                     output0_tm += 4;
                 }
-#else // __riscv_vector
+#endif // __riscv_vector
                 for (; i < tiles; i++)
                 {
 #if __riscv_vector
@@ -1361,7 +1361,7 @@ static void conv3x3s1_winograd43_rvv(const Mat& bottom_blob, Mat& top_blob, cons
                     output0_tm[3] = sum3;
                     output0_tm += 4;
                 }
-#else // __riscv_vector
+#endif // __riscv_vector
                 for (; i < tiles; i++)
                 {
 #if __riscv_vector

--- a/src/layer/riscv/convolution_3x3.h
+++ b/src/layer/riscv/convolution_3x3.h
@@ -620,7 +620,7 @@ static void conv3x3s1_winograd23_rvv(const Mat& bottom_blob, Mat& top_blob, cons
 
                     vfloat32m1_t _sum0 = vfmv_v_f_f32m1(0.f, vl);
 
-                    for (; j < nn; j++)
+                    for (int j = 0; j < nn; j++)
                     {
                         _sum0 = vfmacc_vf_f32m1(_sum0, k0[0], vle32_v_f32m1(r0, vl), vl);
                         r0 += packn;
@@ -1323,7 +1323,7 @@ static void conv3x3s1_winograd43_rvv(const Mat& bottom_blob, Mat& top_blob, cons
 
                     vfloat32m1_t _sum0 = vfmv_v_f_f32m1(0.f, vl);
 
-                    for (; j < nn; j++)
+                    for (int j = 0; j < nn; j++)
                     {
                         _sum0 = vfmacc_vf_f32m1(_sum0, k0[0], vle32_v_f32m1(r0, vl), vl);
                         r0 += packn;

--- a/src/layer/riscv/convolution_3x3.h
+++ b/src/layer/riscv/convolution_3x3.h
@@ -855,6 +855,11 @@ static void conv3x3s1_winograd43_transform_kernel_rvv(const Mat& kernel, Mat& ke
 
 static void conv3x3s1_winograd43_rvv(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel_tm, const Mat& bias, const Option& opt)
 {
+#if __riscv_vector
+    const int packn = csrr_vlenb() / 4;
+    const word_type vl = vsetvl_e32m1(packn);
+#endif
+
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int inch = bottom_blob.c;

--- a/src/layer/riscv/convolution_3x3.h
+++ b/src/layer/riscv/convolution_3x3.h
@@ -630,7 +630,7 @@ static void conv3x3s1_winograd23_rvv(const Mat& bottom_blob, Mat& top_blob, cons
                     vse32_v_f32m1(output0_tm, _sum0, vl);
                     output0_tm += packn;
                 }
-#else // __riscv_vector
+#else  // __riscv_vector
                 for (; i + 3 < tiles; i += 4)
                 {
                     const float* r0 = bb2.row(i / 4);
@@ -1328,7 +1328,7 @@ static void conv3x3s1_winograd43_rvv(const Mat& bottom_blob, Mat& top_blob, cons
                     vse32_v_f32m1(output0_tm, _sum0, vl);
                     output0_tm += packn;
                 }
-#else // __riscv_vector
+#else  // __riscv_vector
                 for (; i + 3 < tiles; i += 4)
                 {
                     const float* r0 = bb2.row(i / 4);

--- a/src/layer/riscv/convolution_3x3.h
+++ b/src/layer/riscv/convolution_3x3.h
@@ -983,7 +983,7 @@ static void conv3x3s1_winograd43_rvv(const Mat& bottom_blob, Mat& top_blob, cons
         bottom_blob_tm = Mat();
         // permute end
 
-        top_blob_tm.create(tiles, 16, outch, 4u, opt.workspace_allocator);
+        top_blob_tm.create(tiles, 36, outch, 4u, opt.workspace_allocator);
 
 #if __riscv_vector
         int nn_outch = outch >> 3;

--- a/src/layer/riscv/convolution_riscv.h
+++ b/src/layer/riscv/convolution_riscv.h
@@ -43,8 +43,9 @@ public:
 
     // packn
     Mat weight_data_packed;
-    Mat weight_winograd63_data;
+    Mat weight_winograd23_data;
     Mat weight_winograd43_data;
+    Mat weight_winograd63_data;
 
     // fp16
     Mat weight_data_fp16;

--- a/src/layer/riscv/convolution_sgemm.h
+++ b/src/layer/riscv/convolution_sgemm.h
@@ -432,7 +432,7 @@ static void im2col_sgemm_rvv(const Mat& bottom_im2col, Mat& top_blob, const Mat&
 
             outptr0 += packn;
         }
-#else // __riscv_vector
+#else  // __riscv_vector
         for (; i + 3 < size; i += 4)
         {
             const float* tmpptr = tmp.channel(i / 4);

--- a/src/layer/riscv/convolution_sgemm.h
+++ b/src/layer/riscv/convolution_sgemm.h
@@ -95,7 +95,11 @@ static void im2col_sgemm_rvv(const Mat& bottom_im2col, Mat& top_blob, const Mat&
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int i = remain_size_start; i < size; i++)
         {
+#if __riscv_vector
             float* tmpptr = tmp.channel(i / packn + i % packn);
+#else
+            float* tmpptr = tmp.channel(i / 4 + i % 4);
+#endif
 
             for (int q = 0; q < inch; q++)
             {

--- a/src/layer/riscv/convolution_sgemm.h
+++ b/src/layer/riscv/convolution_sgemm.h
@@ -34,10 +34,16 @@ static void im2col_sgemm_rvv(const Mat& bottom_im2col, Mat& top_blob, const Mat&
 #if __riscv_vector
     if (size >= packn)
         tmp.create(packn * maxk, inch, size / packn + size % packn, 4u, 1, opt.workspace_allocator);
+#else
+    if (size >= 4)
+        tmp.create(4 * maxk, inch, size / 4 + size % 4, 4u, 1, opt.workspace_allocator);
+#endif
     else
         tmp.create(maxk, inch, size, 4u, 1, opt.workspace_allocator);
     {
+#if __riscv_vector
         int nn_size = size / packn;
+        int remain_size_start = nn_size * packn;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int ii = 0; ii < nn_size; ii++)
@@ -58,8 +64,33 @@ static void im2col_sgemm_rvv(const Mat& bottom_im2col, Mat& top_blob, const Mat&
                 }
             }
         }
+#else // __riscv_vector
+        int nn_size = size / 4;
+        int remain_size_start = nn_size * 4;
 
-        int remain_size_start = nn_size * packn;
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int ii = 0; ii < nn_size; ii++)
+        {
+            int i = ii * 4;
+
+            float* tmpptr = tmp.channel(i / 4);
+
+            for (int q = 0; q < inch; q++)
+            {
+                const float* img0 = (const float*)bottom_im2col.channel(q) + i;
+
+                for (int k = 0; k < maxk; k++)
+                {
+                    tmpptr[0] = img0[0];
+                    tmpptr[1] = img0[1];
+                    tmpptr[2] = img0[2];
+                    tmpptr[3] = img0[3];
+                    img0 += size;
+                    tmpptr += 4;
+                }
+            }
+        }
+#endif // __riscv_vector
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int i = remain_size_start; i < size; i++)
@@ -79,28 +110,6 @@ static void im2col_sgemm_rvv(const Mat& bottom_im2col, Mat& top_blob, const Mat&
             }
         }
     }
-#else // __riscv_vector
-    tmp.create(maxk, inch, size, 4u, 1, opt.workspace_allocator);
-    {
-        #pragma omp parallel for num_threads(opt.num_threads)
-        for (int i = 0; i < size; i++)
-        {
-            float* tmpptr = tmp.channel(i);
-
-            for (int q = 0; q < inch; q++)
-            {
-                const float* img0 = (const float*)bottom_im2col.channel(q) + i;
-
-                for (int k = 0; k < maxk; k++)
-                {
-                    tmpptr[0] = img0[0];
-                    img0 += size;
-                    tmpptr += 1;
-                }
-            }
-        }
-    }
-#endif // __riscv_vector
 
 #if __riscv_vector
     int nn_outch = outch >> 3;
@@ -307,6 +316,92 @@ static void im2col_sgemm_rvv(const Mat& bottom_im2col, Mat& top_blob, const Mat&
     }
 
     remain_outch_start += nn_outch << 2;
+#else // __riscv_vector
+    int nn_outch = outch >> 1;
+    int remain_outch_start = nn_outch << 1;
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int pp = 0; pp < nn_outch; pp++)
+    {
+        int p = pp * 2;
+
+        float* outptr0 = top_blob.channel(p);
+        float* outptr1 = top_blob.channel(p + 1);
+
+        const float zeros[2] = {0.f, 0.f};
+        const float* biasptr = bias ? bias + p : zeros;
+
+        int i = 0;
+        for (; i + 3 < size; i += 4)
+        {
+            const float* tmpptr = tmp.channel(i / 4);
+            const float* kptr = kernel.channel(p / 2);
+
+            int nn = inch * maxk; // inch always > 0
+
+            float sum00 = biasptr[0];
+            float sum01 = biasptr[0];
+            float sum02 = biasptr[0];
+            float sum03 = biasptr[0];
+            float sum10 = biasptr[1];
+            float sum11 = biasptr[1];
+            float sum12 = biasptr[1];
+            float sum13 = biasptr[1];
+
+            for (int q = 0; q < nn; q++)
+            {
+                float k0 = kptr[0];
+                float k1 = kptr[1];
+                sum00 += tmpptr[0] * k0;
+                sum01 += tmpptr[1] * k0;
+                sum02 += tmpptr[2] * k0;
+                sum03 += tmpptr[3] * k0;
+                sum10 += tmpptr[0] * k1;
+                sum11 += tmpptr[1] * k1;
+                sum12 += tmpptr[2] * k1;
+                sum13 += tmpptr[3] * k1;
+                tmpptr += 4;
+                kptr += 4;
+            }
+
+            outptr0[0] = sum00;
+            outptr0[1] = sum01;
+            outptr0[2] = sum02;
+            outptr0[3] = sum03;
+            outptr1[0] = sum10;
+            outptr1[1] = sum11;
+            outptr1[2] = sum12;
+            outptr1[3] = sum13;
+
+            outptr0 += 4;
+            outptr1 += 4;
+        }
+        for (; i < size; i++)
+        {
+            const float* tmpptr = tmp.channel(i / 4 + i % 4);
+            const float* kptr = kernel.channel(p / 2);
+
+            int nn = inch * maxk; // inch always > 0
+
+            float sum0 = biasptr[0];
+            float sum1 = biasptr[1];
+
+            for (int q = 0; q < nn; q++)
+            {
+                sum0 += tmpptr[0] * kptr[0];
+                sum1 += tmpptr[0] * kptr[1];
+                tmpptr++;
+                kptr += 4;
+            }
+
+            outptr0[0] = sum0;
+            outptr1[0] = sum1;
+
+            outptr0++;
+            outptr1++;
+        }
+    }
+#endif // __riscv_vector
 
     #pragma omp parallel for num_threads(opt.num_threads)
     for (int p = remain_outch_start; p < outch; p++)
@@ -316,6 +411,7 @@ static void im2col_sgemm_rvv(const Mat& bottom_im2col, Mat& top_blob, const Mat&
         const float bias0 = bias ? bias[p] : 0.f;
 
         int i = 0;
+#if __riscv_vector
         for (; i + (packn - 1) < size; i += packn)
         {
             const float* tmpptr = tmp.channel(i / packn);
@@ -336,10 +432,47 @@ static void im2col_sgemm_rvv(const Mat& bottom_im2col, Mat& top_blob, const Mat&
 
             outptr0 += packn;
         }
+#else // __riscv_vector
+        for (; i + 3 < size; i += 4)
+        {
+            const float* tmpptr = tmp.channel(i / 4);
+            const float* kptr = kernel.channel(p / 2 + p % 2);
+
+            int nn = inch * maxk; // inch always > 0
+
+            float sum0 = bias0;
+            float sum1 = bias0;
+            float sum2 = bias0;
+            float sum3 = bias0;
+
+            for (int q = 0; q < nn; q++)
+            {
+                float k0 = kptr[0];
+                sum0 += tmpptr[0] * k0;
+                sum1 += tmpptr[1] * k0;
+                sum2 += tmpptr[2] * k0;
+                sum3 += tmpptr[3] * k0;
+                tmpptr += 4;
+                kptr++;
+            }
+
+            outptr0[0] = sum0;
+            outptr0[1] = sum1;
+            outptr0[2] = sum2;
+            outptr0[3] = sum3;
+
+            outptr0 += 4;
+        }
+#endif // __riscv_vector
         for (; i < size; i++)
         {
+#if __riscv_vector
             const float* tmpptr = tmp.channel(i / packn + i % packn);
             const float* kptr = kernel.channel(p / 8 + (p % 8) / 4 + p % 4);
+#else
+            const float* tmpptr = tmp.channel(i / 4 + i % 4);
+            const float* kptr = kernel.channel(p / 2 + p % 2);
+#endif
 
             int nn = inch * maxk; // inch always > 0
 
@@ -357,36 +490,6 @@ static void im2col_sgemm_rvv(const Mat& bottom_im2col, Mat& top_blob, const Mat&
             outptr0++;
         }
     }
-#else // __riscv_vector
-    #pragma omp parallel for num_threads(opt.num_threads)
-    for (int p = 0; p < outch; p++)
-    {
-        float* outptr0 = top_blob.channel(p);
-
-        const float bias0 = bias ? bias[p] : 0.f;
-
-        for (int i = 0; i < size; i++)
-        {
-            const float* tmpptr = tmp.channel(i);
-            const float* kptr = kernel.channel(p);
-
-            int nn = inch * maxk; // inch always > 0
-
-            float sum0 = bias0;
-
-            for (int q = 0; q < nn; q++)
-            {
-                sum0 += tmpptr[0] * kptr[0];
-                tmpptr++;
-                kptr++;
-            }
-
-            outptr0[0] = sum0;
-
-            outptr0++;
-        }
-    }
-#endif // __riscv_vector
 }
 
 static void convolution_im2col_sgemm_transform_kernel_rvv(const Mat& _kernel, Mat& kernel_tm, int inch, int outch, int kernel_w, int kernel_h)
@@ -399,8 +502,12 @@ static void convolution_im2col_sgemm_transform_kernel_rvv(const Mat& _kernel, Ma
     Mat kernel = _kernel.reshape(maxk, inch, outch);
 #if __riscv_vector
     kernel_tm.create(8 * maxk, inch, outch / 8 + (outch % 8) / 4 + outch % 4);
+#else
+    kernel_tm.create(2 * maxk, inch, outch / 2 + outch % 2);
+#endif
 
     int q = 0;
+#if __riscv_vector
     for (; q + 7 < outch; q += 8)
     {
         const Mat k0 = kernel.channel(q);
@@ -467,11 +574,38 @@ static void convolution_im2col_sgemm_transform_kernel_rvv(const Mat& _kernel, Ma
             }
         }
     }
+#else
+    for (; q + 1 < outch; q += 2)
+    {
+        const Mat k0 = kernel.channel(q);
+        const Mat k1 = kernel.channel(q + 1);
+
+        float* g00 = kernel_tm.channel(q / 2);
+
+        for (int p = 0; p < inch; p++)
+        {
+            const float* k00 = k0.row(p);
+            const float* k10 = k1.row(p);
+
+            for (int k = 0; k < maxk; k++)
+            {
+                g00[0] = k00[k];
+                g00[1] = k10[k];
+
+                g00 += 2;
+            }
+        }
+    }
+#endif // __riscv_vector
     for (; q < outch; q++)
     {
         const Mat k0 = kernel.channel(q);
 
+#if __riscv_vector
         float* g00 = kernel_tm.channel(q / 8 + (q % 8) / 4 + q % 4);
+#else
+        float* g00 = kernel_tm.channel(q / 2 + q % 2);
+#endif
 
         for (int p = 0; p < inch; p++)
         {
@@ -485,9 +619,6 @@ static void convolution_im2col_sgemm_transform_kernel_rvv(const Mat& _kernel, Ma
             }
         }
     }
-#else
-    kernel_tm = kernel;
-#endif // __riscv_vector
 }
 
 static void convolution_im2col_sgemm_rvv(const Mat& bottom_blob, Mat& top_blob, const Mat& kernel, const Mat& _bias, int kernel_w, int kernel_h, int dilation_w, int dilation_h, int stride_w, int stride_h, const Option& opt)

--- a/src/layer/riscv/convolution_sgemm.h
+++ b/src/layer/riscv/convolution_sgemm.h
@@ -365,7 +365,7 @@ static void im2col_sgemm_rvv(const Mat& bottom_im2col, Mat& top_blob, const Mat&
                 sum12 += tmpptr[2] * k1;
                 sum13 += tmpptr[3] * k1;
                 tmpptr += 4;
-                kptr += 4;
+                kptr += 2;
             }
 
             outptr0[0] = sum00;
@@ -395,7 +395,7 @@ static void im2col_sgemm_rvv(const Mat& bottom_im2col, Mat& top_blob, const Mat&
                 sum0 += tmpptr[0] * kptr[0];
                 sum1 += tmpptr[0] * kptr[1];
                 tmpptr++;
-                kptr += 4;
+                kptr += 2;
             }
 
             outptr0[0] = sum0;

--- a/src/layer/riscv/convolution_winograd_transform.h
+++ b/src/layer/riscv/convolution_winograd_transform.h
@@ -1,0 +1,405 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+static void conv3x3s1_winograd43_transform_input_rvv(const Mat& bottom_blob, Mat& bottom_blob_tm, const Option& opt)
+{
+    const int w = bottom_blob.w;
+    const int h = bottom_blob.h;
+    const int inch = bottom_blob.c;
+
+    const int w_tiles = (w - 2) / 4;
+    const int h_tiles = (h - 2) / 4;
+    const int tiles = w_tiles * h_tiles;
+
+    // const float itm[6][6] = {
+    //     {4.0f, 0.0f, -5.0f, 0.0f, 1.0f, 0.0f},
+    //     {0.0f,-4.0f, -4.0f, 1.0f, 1.0f, 0.0f},
+    //     {0.0f, 4.0f, -4.0f,-1.0f, 1.0f, 0.0f},
+    //     {0.0f,-2.0f, -1.0f, 2.0f, 1.0f, 0.0f},
+    //     {0.0f, 2.0f, -1.0f,-2.0f, 1.0f, 0.0f},
+    //     {0.0f, 4.0f,  0.0f,-5.0f, 0.0f, 1.0f}
+    // };
+
+    // 0 =  4 * r00 - 5 * r02 + r04
+    // 1 = -4 * (r01 + r02) + r04 + r03
+    // 2 =  4 * (r01 - r02) + r04 - r03
+    // 3 = -2 * (r01 - r03) + r04 - r02
+    // 4 =  2 * (r01 - r03) + r04 - r02
+    // 5 =  4 * r01 - 5 * r03 + r05
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int q = 0; q < inch; q++)
+    {
+        const Mat img0 = bottom_blob.channel(q);
+        Mat img0_tm = bottom_blob_tm.channel(q);
+
+        float tmp[6][6];
+
+        // tile
+        for (int i = 0; i < h_tiles; i++)
+        {
+            for (int j = 0; j < w_tiles; j++)
+            {
+                const float* r0 = img0.row(i * 4) + (j * 4);
+
+                for (int m = 0; m < 6; m++)
+                {
+                    float r00 = r0[0];
+                    float r01 = r0[1];
+                    float r02 = r0[2];
+                    float r03 = r0[3];
+                    float r04 = r0[4];
+                    float r05 = r0[5];
+
+                    float tmp0m = 4 * r00 - 5 * r02 + r04;
+                    float tmp1m = -4 * (r01 + r02) + r04 + r03;
+                    float tmp2m = 4 * (r01 - r02) + r04 - r03;
+                    float tmp3m = -2 * (r01 - r03) + r04 - r02;
+                    float tmp4m = 2 * (r01 - r03) + r04 - r02;
+                    float tmp5m = 4 * r01 - 5 * r03 + r05;
+
+                    tmp[0][m] = tmp0m;
+                    tmp[1][m] = tmp1m;
+                    tmp[2][m] = tmp2m;
+                    tmp[3][m] = tmp3m;
+                    tmp[4][m] = tmp4m;
+                    tmp[5][m] = tmp5m;
+
+                    r0 += w;
+                }
+
+                float* r0_tm_0 = (float*)img0_tm + (i * w_tiles + j);
+                float* r0_tm_1 = r0_tm_0 + tiles;
+                float* r0_tm_2 = r0_tm_0 + tiles * 2;
+                float* r0_tm_3 = r0_tm_0 + tiles * 3;
+                float* r0_tm_4 = r0_tm_0 + tiles * 4;
+                float* r0_tm_5 = r0_tm_0 + tiles * 5;
+
+                for (int m = 0; m < 6; m++)
+                {
+                    float tmp00 = tmp[m][0];
+                    float tmp01 = tmp[m][1];
+                    float tmp02 = tmp[m][2];
+                    float tmp03 = tmp[m][3];
+                    float tmp04 = tmp[m][4];
+                    float tmp05 = tmp[m][5];
+
+                    float r0tm0 = 4 * tmp00 - 5 * tmp02 + tmp04;
+                    float r0tm1 = -4 * (tmp01 + tmp02) + tmp04 + tmp03;
+                    float r0tm2 = 4 * (tmp01 - tmp02) + tmp04 - tmp03;
+                    float r0tm3 = -2 * (tmp01 - tmp03) + tmp04 - tmp02;
+                    float r0tm4 = 2 * (tmp01 - tmp03) + tmp04 - tmp02;
+                    float r0tm5 = 4 * tmp01 - 5 * tmp03 + tmp05;
+
+                    r0_tm_0[0] = r0tm0;
+                    r0_tm_1[0] = r0tm1;
+                    r0_tm_2[0] = r0tm2;
+                    r0_tm_3[0] = r0tm3;
+                    r0_tm_4[0] = r0tm4;
+                    r0_tm_5[0] = r0tm5;
+
+                    r0_tm_0 += tiles * 6;
+                    r0_tm_1 += tiles * 6;
+                    r0_tm_2 += tiles * 6;
+                    r0_tm_3 += tiles * 6;
+                    r0_tm_4 += tiles * 6;
+                    r0_tm_5 += tiles * 6;
+                }
+            }
+        }
+    }
+}
+
+static void conv3x3s1_winograd43_transform_output_rvv(const Mat& top_blob_tm, Mat& top_blob, const Mat& bias, const Option& opt)
+{
+    const int outw = top_blob.w;
+    const int outh = top_blob.h;
+    const int outch = top_blob.c;
+
+    const int w_tiles = outw / 4;
+    const int h_tiles = outh / 4;
+    const int tiles = w_tiles * h_tiles;
+
+    const float* biasptr = bias;
+
+    // const float otm[4][6] = {
+    //     {1.0f, 1.0f,  1.0f, 1.0f,  1.0f, 0.0f},
+    //     {0.0f, 1.0f, -1.0f, 2.0f, -2.0f, 0.0f},
+    //     {0.0f, 1.0f,  1.0f, 4.0f,  4.0f, 0.0f},
+    //     {0.0f, 1.0f, -1.0f, 8.0f, -8.0f, 1.0f}
+    // };
+
+    // 0 = r00 + (r01 + r02) + (r03 + r04)
+    // 1 =       (r01 - r02) + (r03 - r04) * 2
+    // 2 =       (r01 + r02) + (r03 + r04) * 4
+    // 3 = r05 + (r01 - r02) + (r03 - r04) * 8
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int p = 0; p < outch; p++)
+    {
+        const Mat out0_tm = top_blob_tm.channel(p);
+        Mat out0 = top_blob.channel(p);
+
+        float bias0 = biasptr ? biasptr[p] : 0.f;
+
+        float tmp[4][6];
+
+        // tile
+        for (int i = 0; i < h_tiles; i++)
+        {
+            for (int j = 0; j < w_tiles; j++)
+            {
+                const float* output0_tm_0 = (const float*)out0_tm + (i * w_tiles + j);
+                const float* output0_tm_1 = output0_tm_0 + tiles;
+                const float* output0_tm_2 = output0_tm_0 + tiles * 2;
+                const float* output0_tm_3 = output0_tm_0 + tiles * 3;
+                const float* output0_tm_4 = output0_tm_0 + tiles * 4;
+                const float* output0_tm_5 = output0_tm_0 + tiles * 5;
+
+                float* output0 = out0.row(i * 4) + (j * 4);
+
+                for (int m = 0; m < 6; m++)
+                {
+                    float out0tm0 = output0_tm_0[0];
+                    float out0tm1 = output0_tm_1[0];
+                    float out0tm2 = output0_tm_2[0];
+                    float out0tm3 = output0_tm_3[0];
+                    float out0tm4 = output0_tm_4[0];
+                    float out0tm5 = output0_tm_5[0];
+
+                    float tmp02a = out0tm1 + out0tm2;
+                    float tmp13a = out0tm1 - out0tm2;
+
+                    float tmp02b = out0tm3 + out0tm4;
+                    float tmp13b = out0tm3 - out0tm4;
+
+                    float tmp0m = out0tm0 + tmp02a + tmp02b;
+                    float tmp1m = tmp13a + tmp13b * 2;
+                    float tmp2m = tmp02a + tmp02b * 4;
+                    float tmp3m = out0tm5 + tmp13a + tmp13b * 8;
+
+                    tmp[0][m] = tmp0m;
+                    tmp[1][m] = tmp1m;
+                    tmp[2][m] = tmp2m;
+                    tmp[3][m] = tmp3m;
+
+                    output0_tm_0 += tiles * 6;
+                    output0_tm_1 += tiles * 6;
+                    output0_tm_2 += tiles * 6;
+                    output0_tm_3 += tiles * 6;
+                    output0_tm_4 += tiles * 6;
+                    output0_tm_5 += tiles * 6;
+                }
+
+                for (int m = 0; m < 4; m++)
+                {
+                    float tmp00 = tmp[m][0];
+                    float tmp01 = tmp[m][1];
+                    float tmp02 = tmp[m][2];
+                    float tmp03 = tmp[m][3];
+                    float tmp04 = tmp[m][4];
+                    float tmp05 = tmp[m][5];
+
+                    float tmp02a = tmp01 + tmp02;
+                    float tmp13a = tmp01 - tmp02;
+
+                    float tmp02b = tmp03 + tmp04;
+                    float tmp13b = tmp03 - tmp04;
+
+                    float out00 = bias0 + tmp00 + tmp02a + tmp02b;
+                    float out01 = bias0 + tmp13a + tmp13b * 2;
+                    float out02 = bias0 + tmp02a + tmp02b * 4;
+                    float out03 = bias0 + tmp05 + tmp13a + tmp13b * 8;
+
+                    output0[0] = out00;
+                    output0[1] = out01;
+                    output0[2] = out02;
+                    output0[3] = out03;
+
+                    output0 += outw;
+                }
+            }
+        }
+    }
+}
+
+static void conv3x3s1_winograd23_transform_input_rvv(const Mat& bottom_blob, Mat& bottom_blob_tm, const Option& opt)
+{
+    const int w = bottom_blob.w;
+    const int h = bottom_blob.h;
+    const int inch = bottom_blob.c;
+
+    const int w_tiles = (w - 2) / 2;
+    const int h_tiles = (h - 2) / 2;
+    const int tiles = w_tiles * h_tiles;
+
+    // const float itm[4][4] = {
+    //     {1.0f,  0.0f, -1.0f,  0.0f},
+    //     {0.0f,  1.0f,  1.00f, 0.0f},
+    //     {0.0f, -1.0f,  1.00f, 0.0f},
+    //     {0.0f, -1.0f,  0.00f, 1.0f}
+    // };
+
+    // 0 = r00 - r02
+    // 1 = r01 + r02
+    // 2 = r02 - r01
+    // 3 = r03 - r01
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int q = 0; q < inch; q++)
+    {
+        const Mat img0 = bottom_blob.channel(q);
+        Mat img0_tm = bottom_blob_tm.channel(q);
+
+        float tmp[4][4];
+
+        // tile
+        for (int i = 0; i < h_tiles; i++)
+        {
+            for (int j = 0; j < w_tiles; j++)
+            {
+                const float* r0 = img0.row(i * 2) + (j * 2);
+
+                for (int m = 0; m < 4; m++)
+                {
+                    float r00 = r0[0];
+                    float r01 = r0[1];
+                    float r02 = r0[2];
+                    float r03 = r0[3];
+
+                    float tmp0m = r00 - r02;
+                    float tmp1m = r01 + r02;
+                    float tmp2m = r02 - r01;
+                    float tmp3m = r03 - r01;
+
+                    tmp[0][m] = tmp0m;
+                    tmp[1][m] = tmp1m;
+                    tmp[2][m] = tmp2m;
+                    tmp[3][m] = tmp3m;
+
+                    r0 += w;
+                }
+
+                float* r0_tm_0 = (float*)img0_tm + (i * w_tiles + j);
+                float* r0_tm_1 = r0_tm_0 + tiles;
+                float* r0_tm_2 = r0_tm_0 + tiles * 2;
+                float* r0_tm_3 = r0_tm_0 + tiles * 3;
+
+                for (int m = 0; m < 4; m++)
+                {
+                    float tmp00 = tmp[m][0];
+                    float tmp01 = tmp[m][1];
+                    float tmp02 = tmp[m][2];
+                    float tmp03 = tmp[m][3];
+
+                    float r0tm0 = tmp00 - tmp02;
+                    float r0tm1 = tmp01 + tmp02;
+                    float r0tm2 = tmp02 - tmp01;
+                    float r0tm3 = tmp03 - tmp01;
+
+                    r0_tm_0[0] = r0tm0;
+                    r0_tm_1[0] = r0tm1;
+                    r0_tm_2[0] = r0tm2;
+                    r0_tm_3[0] = r0tm3;
+
+                    r0_tm_0 += tiles * 4;
+                    r0_tm_1 += tiles * 4;
+                    r0_tm_2 += tiles * 4;
+                    r0_tm_3 += tiles * 4;
+                }
+            }
+        }
+    }
+}
+
+static void conv3x3s1_winograd23_transform_output_rvv(const Mat& top_blob_tm, Mat& top_blob, const Mat& bias, const Option& opt)
+{
+    const int outw = top_blob.w;
+    const int outh = top_blob.h;
+    const int outch = top_blob.c;
+
+    const int w_tiles = outw / 2;
+    const int h_tiles = outh / 2;
+    const int tiles = w_tiles * h_tiles;
+
+    const float* biasptr = bias;
+
+    // const float otm[2][4] = {
+    //     {1.0f,  1.0f,  1.0f,  0.0f},
+    //     {0.0f,  1.0f, -1.0f,  1.0f}
+    // };
+
+    // 0 = r00 + r01 + r02
+    // 1 = r01 - r02 + r03
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int p = 0; p < outch; p++)
+    {
+        const Mat out0_tm = top_blob_tm.channel(p);
+        Mat out0 = top_blob.channel(p);
+
+        float bias0 = biasptr ? biasptr[p] : 0.f;
+
+        float tmp[2][4];
+
+        // tile
+        for (int i = 0; i < h_tiles; i++)
+        {
+            for (int j = 0; j < w_tiles; j++)
+            {
+                const float* output0_tm_0 = (const float*)out0_tm + (i * w_tiles + j);
+                const float* output0_tm_1 = output0_tm_0 + tiles;
+                const float* output0_tm_2 = output0_tm_0 + tiles * 2;
+                const float* output0_tm_3 = output0_tm_0 + tiles * 3;
+
+                float* output0 = out0.row(i * 2) + (j * 2);
+
+                for (int m = 0; m < 4; m++)
+                {
+                    float out0tm0 = output0_tm_0[0];
+                    float out0tm1 = output0_tm_1[0];
+                    float out0tm2 = output0_tm_2[0];
+                    float out0tm3 = output0_tm_3[0];
+
+                    float tmp0m = out0tm0 + out0tm1 + out0tm2;
+                    float tmp1m = out0tm1 - out0tm2 + out0tm3;
+
+                    tmp[0][m] = tmp0m;
+                    tmp[1][m] = tmp1m;
+
+                    output0_tm_0 += tiles * 4;
+                    output0_tm_1 += tiles * 4;
+                    output0_tm_2 += tiles * 4;
+                    output0_tm_3 += tiles * 4;
+                }
+
+                for (int m = 0; m < 2; m++)
+                {
+                    float tmp00 = tmp[m][0];
+                    float tmp01 = tmp[m][1];
+                    float tmp02 = tmp[m][2];
+                    float tmp03 = tmp[m][3];
+
+                    float out00 = bias0 + tmp00 + tmp01 + tmp02;
+                    float out01 = bias0 + tmp01 - tmp02 + tmp03;
+
+                    output0[0] = out00;
+                    output0[1] = out01;
+
+                    output0 += outw;
+                }
+            }
+        }
+    }
+}

--- a/src/layer/riscv/convolutiondepthwise_3x3.h
+++ b/src/layer/riscv/convolutiondepthwise_3x3.h
@@ -1,0 +1,193 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+static void convdw3x3s1_rvv(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Mat& _bias, const Option& opt)
+{
+    int w = bottom_blob.w;
+
+    int outw = top_blob.w;
+    int outh = top_blob.h;
+
+    const int group = bottom_blob.c;
+
+    const float* kernel = _kernel;
+    const float* bias = _bias;
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int g = 0; g < group; g++)
+    {
+        Mat out = top_blob.channel(g);
+
+        const float bias0 = bias ? bias[g] : 0.f;
+
+        const float* kernel0 = kernel + g * 9;
+
+        float* outptr0 = out;
+        float* outptr1 = outptr0 + outw;
+
+        const float* img0 = bottom_blob.channel(g);
+
+        const float* r0 = img0;
+        const float* r1 = img0 + w;
+        const float* r2 = img0 + w * 2;
+        const float* r3 = img0 + w * 3;
+
+        const float* k0 = kernel0;
+        const float* k1 = kernel0 + 3;
+        const float* k2 = kernel0 + 6;
+
+        int i = 0;
+
+        for (; i + 1 < outh; i += 2)
+        {
+            for (int j = 0; j < outw; j++)
+            {
+                float sum = bias0;
+                float sum2 = bias0;
+
+                sum += r0[0] * k0[0];
+                sum += r0[1] * k0[1];
+                sum += r0[2] * k0[2];
+                sum2 += r1[0] * k0[0];
+                sum2 += r1[1] * k0[1];
+                sum2 += r1[2] * k0[2];
+                sum += r1[0] * k1[0];
+                sum += r1[1] * k1[1];
+                sum += r1[2] * k1[2];
+                sum2 += r2[0] * k1[0];
+                sum2 += r2[1] * k1[1];
+                sum2 += r2[2] * k1[2];
+                sum += r2[0] * k2[0];
+                sum += r2[1] * k2[1];
+                sum += r2[2] * k2[2];
+                sum2 += r3[0] * k2[0];
+                sum2 += r3[1] * k2[1];
+                sum2 += r3[2] * k2[2];
+
+                *outptr0 = sum;
+                *outptr1 = sum2;
+
+                r0++;
+                r1++;
+                r2++;
+                r3++;
+                outptr0++;
+                outptr1++;
+            }
+
+            r0 += 2 + w;
+            r1 += 2 + w;
+            r2 += 2 + w;
+            r3 += 2 + w;
+
+            outptr0 += outw;
+            outptr1 += outw;
+        }
+
+        for (; i < outh; i++)
+        {
+            for (int j = 0; j < outw; j++)
+            {
+                float sum = bias0;
+                sum += r0[0] * k0[0];
+                sum += r0[1] * k0[1];
+                sum += r0[2] * k0[2];
+                sum += r1[0] * k1[0];
+                sum += r1[1] * k1[1];
+                sum += r1[2] * k1[2];
+                sum += r2[0] * k2[0];
+                sum += r2[1] * k2[1];
+                sum += r2[2] * k2[2];
+
+                *outptr0 = sum;
+
+                r0++;
+                r1++;
+                r2++;
+                outptr0++;
+            }
+
+            r0 += 2;
+            r1 += 2;
+            r2 += 2;
+        }
+    }
+}
+
+static void convdw3x3s2_rvv(const Mat& bottom_blob, Mat& top_blob, const Mat& _kernel, const Mat& _bias, const Option& opt)
+{
+    int w = bottom_blob.w;
+
+    int outw = top_blob.w;
+    int outh = top_blob.h;
+
+    const int group = bottom_blob.c;
+
+    const int tailstep = w - 2 * outw + w;
+
+    const float* kernel = _kernel;
+    const float* bias = _bias;
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int g = 0; g < group; g++)
+    {
+        Mat out = top_blob.channel(g);
+
+        const float bias0 = bias ? bias[g] : 0.f;
+
+        const float* kernel0 = kernel + g * 9;
+
+        float* outptr = out;
+
+        const float* img0 = bottom_blob.channel(g);
+
+        const float* r0 = img0;
+        const float* r1 = img0 + w;
+        const float* r2 = img0 + w * 2;
+
+        const float* k0 = kernel0;
+        const float* k1 = kernel0 + 3;
+        const float* k2 = kernel0 + 6;
+
+        int i = 0;
+
+        for (; i < outh; i++)
+        {
+            for (int j = 0; j < outw; j++)
+            {
+                float sum = bias0;
+                sum += r0[0] * k0[0];
+                sum += r0[1] * k0[1];
+                sum += r0[2] * k0[2];
+                sum += r1[0] * k1[0];
+                sum += r1[1] * k1[1];
+                sum += r1[2] * k1[2];
+                sum += r2[0] * k2[0];
+                sum += r2[1] * k2[1];
+                sum += r2[2] * k2[2];
+
+                *outptr = sum;
+
+                r0 += 2;
+                r1 += 2;
+                r2 += 2;
+                outptr++;
+            }
+
+            r0 += tailstep;
+            r1 += tailstep;
+            r2 += tailstep;
+        }
+    }
+}

--- a/src/layer/riscv/convolutiondepthwise_riscv.cpp
+++ b/src/layer/riscv/convolutiondepthwise_riscv.cpp
@@ -30,6 +30,8 @@
 
 namespace ncnn {
 
+#include "convolutiondepthwise_3x3.h"
+
 #if __riscv_vector
 #include "convolutiondepthwise_3x3_packn.h"
 #include "convolutiondepthwise_5x5_packn.h"
@@ -406,6 +408,25 @@ int ConvolutionDepthWise_riscv::forward(const Mat& bottom_blob, Mat& top_blob, c
 
         if (elempack == 1)
         {
+            if (kernel_w == 3 && kernel_h == 3 && dilation_w == 1 && dilation_h == 1 && stride_w == 1 && stride_h == 1)
+            {
+                convdw3x3s1_rvv(bottom_blob_bordered, top_blob, weight_data, bias_data, opt);
+
+                if (activation)
+                {
+                    activation->forward_inplace(top_blob, opt);
+                }
+            }
+            else if (kernel_w == 3 && kernel_h == 3 && dilation_w == 1 && dilation_h == 1 && stride_w == 2 && stride_h == 2)
+            {
+                convdw3x3s2_rvv(bottom_blob_bordered, top_blob, weight_data, bias_data, opt);
+
+                if (activation)
+                {
+                    activation->forward_inplace(top_blob, opt);
+                }
+            }
+            else
             {
                 const int maxk = kernel_w * kernel_h;
 

--- a/src/layer/riscv/innerproduct_riscv.cpp
+++ b/src/layer/riscv/innerproduct_riscv.cpp
@@ -287,7 +287,7 @@ int InnerProduct_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Opt
 
         vse32_v_f32m1((float*)top_blob + p, _sum, vl);
     }
-#else  // __riscv_vector
+#else // __riscv_vector
     int nn_num_output = num_output / 4;
     int remain_num_output_start = nn_num_output * 4;
 

--- a/src/layer/riscv/innerproduct_riscv.cpp
+++ b/src/layer/riscv/innerproduct_riscv.cpp
@@ -288,7 +288,62 @@ int InnerProduct_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Opt
         vse32_v_f32m1((float*)top_blob + p, _sum, vl);
     }
 #else  // __riscv_vector
-    int remain_num_output_start = 0;
+    int nn_num_output = num_output / 4;
+    int remain_num_output_start = nn_num_output * 4;
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int pp = 0; pp < nn_num_output; pp++)
+    {
+        int p = pp * 4;
+
+        float sum0 = 0.f;
+        float sum1 = 0.f;
+        float sum2 = 0.f;
+        float sum3 = 0.f;
+
+        if (bias_term)
+        {
+            sum0 = bias_data[p];
+            sum1 = bias_data[p + 1];
+            sum2 = bias_data[p + 2];
+            sum3 = bias_data[p + 3];
+        }
+
+        const float* w0 = weight_data_ptr + num_input * p;
+        const float* w1 = weight_data_ptr + num_input * (p + 1);
+        const float* w2 = weight_data_ptr + num_input * (p + 2);
+        const float* w3 = weight_data_ptr + num_input * (p + 3);
+
+        // channels
+        for (int q = 0; q < channels; q++)
+        {
+            const float* m = bottom_blob.channel(q);
+
+            for (int i = 0; i < size; i++)
+            {
+                sum0 += *m * *w0;
+                sum1 += *m * *w1;
+                sum2 += *m * *w2;
+                sum3 += *m * *w3;
+
+                m++;
+                w0++;
+                w1++;
+                w2++;
+                w3++;
+            }
+        }
+
+        sum0 = activation_ss(sum0, activation_type, activation_params);
+        sum1 = activation_ss(sum1, activation_type, activation_params);
+        sum2 = activation_ss(sum2, activation_type, activation_params);
+        sum3 = activation_ss(sum3, activation_type, activation_params);
+
+        top_blob[p] = sum0;
+        top_blob[p + 1] = sum1;
+        top_blob[p + 2] = sum2;
+        top_blob[p + 3] = sum3;
+    }
 #endif // __riscv_vector
 
     // num_output


### PR DESCRIPTION
StarFive VisionFive V1 RV64GC 1.5GHz x 2

|model|baseline|pr3857|diff|
|---|---|---|---|
|squeezenet|1697.78|609.41|-64.11%|
|mobilenet|2239.54|993.87|-55.62%|
|mobilenet_v2|1468.94|728.17|-50.43%|
|mobilenet_v3|1191.72|674.72|-43.38%|
|shufflenet|623.26|358.98|-42.40%|
|shufflenet_v2|608.18|303.73|-50.06%|
|mnasnet|1379.11|735.94|-46.64%|
|proxylessnasnet|1523|871.64|-42.77%|
|efficientnet_b0|2147.2|1355.94|-36.85%|
|efficientnetv2_b0|3967.31|1325.71|-66.58%|
|regnety_400m|1718.47|878.48|-48.88%|
|blazeface|192.36|106.69|-44.54%|
|googlenet|9846.36|2484.78|-74.76%|
|resnet18|12075.38|2198.83|-81.79%|
|alexnet|4575.12|2252.52|-50.77%|
|vgg16|146658.11|18000.95|-87.73%|
|resnet50|20093.45|5499.88|-72.63%|
|squeezenet_ssd|8924.95|1904.07|-78.67%|
|mobilenet_ssd|4967.77|2230.24|-55.11%|
|mobilenet_yolo|13190.93|6003.25|-54.49%|
|mobilenetv2_yolov3|5637.48|2685.14|-52.37%|
|yolov4-tiny|29967.02|4873.81|-83.74%|
|nanodet_m|1589.48|836.73|-47.36%|
|yolo-fastest-1.1|849.2|437.98|-48.42%|
|yolo-fastestv2|670.07|393.94|-41.21%|
