### PR TITLE
Fixed several compile warnings for ios build:

### DIFF
--- a/src/layer/arm/convolution_3x3_pack4to1_bf16s.h
+++ b/src/layer/arm/convolution_3x3_pack4to1_bf16s.h
@@ -17,7 +17,6 @@ static void conv3x3s1_winograd63_pack4to1_bf16s_neon(const Mat& bottom_blob, Mat
     int w = bottom_blob.w;
     int h = bottom_blob.h;
     int inch = bottom_blob.c;
-    size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 
     int outw = top_blob.w;

--- a/src/layer/arm/convolution_arm.cpp
+++ b/src/layer/arm/convolution_arm.cpp
@@ -531,7 +531,6 @@ int Convolution_arm::forward(const Mat& bottom_blob, Mat& top_blob, const Option
 
     w = bottom_blob_bordered.w;
     h = bottom_blob_bordered.h;
-    int size = w * h;
 
     int outw = (w - kernel_extent_w) / stride_w + 1;
     int outh = (h - kernel_extent_h) / stride_h + 1;
@@ -1698,7 +1697,6 @@ int Convolution_arm::forward_int8_arm(const Mat& bottom_blob, Mat& top_blob, con
 
     int w = bottom_blob_bordered.w;
     int h = bottom_blob_bordered.h;
-    int channels = bottom_blob_bordered.c;
     int elempack = bottom_blob_bordered.elempack;
 
     const int kernel_extent_w = dilation_w * (kernel_w - 1) + 1;
@@ -1735,6 +1733,7 @@ int Convolution_arm::forward_int8_arm(const Mat& bottom_blob, Mat& top_blob, con
         return -100;
 
 #if NCNN_ARM82DOT
+    int channels = bottom_blob_bordered.c;
     const int num_input = channels * elempack;
 #endif
 


### PR DESCRIPTION
Hello, NCNN Team.

I have fixed a several compile warnings in iOS build:

https://github.com/Tencent/ncnn/runs/6753217124?check_suite_focus=true

In file included from /Users/evgeny.proydakov/repository/ncnn/src/layer/arm/convolution_arm.cpp:84:
/Users/evgeny.proydakov/repository/ncnn/src/layer/arm/convolution_3x3_pack4to1_bf16s.h:20:12: warning: unused variable 'elemsize' [-Wunused-variable]
    size_t elemsize = bottom_blob.elemsize;
           ^
/Users/evgeny.proydakov/repository/ncnn/src/layer/arm/convolution_arm.cpp:534:9: warning: unused variable 'size' [-Wunused-variable]
    int size = w * h;
        ^
/Users/evgeny.proydakov/repository/ncnn/src/layer/arm/convolution_arm.cpp:1701:9: warning: unused variable 'channels' [-Wunused-variable]
    int channels = bottom_blob_bordered.c;
        ^

Could you review & merge my pr, pls?

Best regards, Evgeny Proydakov