### PR TITLE
Fixed compile warning in tools:

### DIFF
--- a/tools/modelwriter.h
+++ b/tools/modelwriter.h
@@ -2209,7 +2209,7 @@ int ModelWriter::save(const char* parampath, const char* binpath)
 
     if (mac)
     {
-        fprintf(stderr, "mac = %llu = %.2f M\n", mac, mac / 1000000.0);
+        fprintf(stderr, "mac = %llu = %.2f M\n", static_cast<long long unsigned>(mac), mac / 1000000.0);
     }
 
     return 0;


### PR DESCRIPTION
Hi, NCNN Team.

I have fixed a compile warning in tools modelwriter.h:

https://github.com/Tencent/ncnn/runs/6752464727?check_suite_focus=true

/data/action/runner1/_work/ncnn/ncnn/tools/modelwriter.h:2212:35: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 3 has type ‘uint64_t’ {aka ‘long unsigned int’} [-Wformat=]
      |         fprintf(stderr, "mac = %llu = %.2f M\n", mac, mac / 1000000.0);
      |                                ~~~^              ~~~
      |                                   |              |
      |                                   |              uint64_t {aka long unsigned int}
      |                                   long long unsigned int
      |                                %lu

Could you review and accept my change, pls ?

Best regards, Evgeny Proydakov.