### PR TITLE
Fixed linux-gcc noint8t build:

### DIFF
--- a/src/layer/convolution.cpp
+++ b/src/layer/convolution.cpp
@@ -123,6 +123,8 @@ int Convolution::create_pipeline(const Option& opt)
 
         weight_data = weight_data_int8.reshape(weight_data_size);
     }
+#else
+    (void)(opt);
 #endif // NCNN_INT8
 
     return 0;

--- a/src/layer/convolutiondepthwise.cpp
+++ b/src/layer/convolutiondepthwise.cpp
@@ -153,6 +153,8 @@ int ConvolutionDepthWise::create_pipeline(const Option& opt)
 
         weight_data = int8_weight_data;
     }
+#else
+    (void)(opt);
 #endif // NCNN_INT8
 
     return 0;

--- a/src/layer/innerproduct.cpp
+++ b/src/layer/innerproduct.cpp
@@ -91,6 +91,8 @@ int InnerProduct::create_pipeline(const Option& opt)
 
         weight_data = weight_data_int8.reshape(weight_data_size);
     }
+#else
+    (void)(opt);
 #endif // NCNN_INT8
 
     return 0;


### PR DESCRIPTION
Hi, NCNN Team.

I have fixed a several compile warnings for linux-gcc noit8_t build:

https://github.com/Tencent/ncnn/runs/6766410808?check_suite_focus=true

[ 40%] Building CXX object src/CMakeFiles/ncnn.dir/layer/convolution.cpp.o
/home/runner/work/ncnn/ncnn/src/layer/convolution.cpp: In member function ‘virtual int ncnn::Convolution::create_pipeline(const ncnn::Option&)’:
/home/runner/work/ncnn/ncnn/src/layer/convolution.cpp:101:48: warning: unused parameter ‘opt’ [-Wunused-parameter]
 int Convolution::create_pipeline(const Option& opt)
                                                ^~~

/home/runner/work/ncnn/ncnn/src/layer/innerproduct.cpp: In member function ‘virtual int ncnn::InnerProduct::create_pipeline(const ncnn::Option&)’:
/home/runner/work/ncnn/ncnn/src/layer/innerproduct.cpp:75:49: warning: unused parameter ‘opt’ [-Wunused-parameter]
 int InnerProduct::create_pipeline(const Option& opt)
                                                 ^~~

/home/runner/work/ncnn/ncnn/src/layer/convolutiondepthwise.cpp: In member function ‘virtual int ncnn::ConvolutionDepthWise::create_pipeline(const ncnn::Option&)’:
/home/runner/work/ncnn/ncnn/src/layer/convolutiondepthwise.cpp:130:57: warning: unused parameter ‘opt’ [-Wunused-parameter]
 int ConvolutionDepthWise::create_pipeline(const Option& opt)
                                                         ^~~

Could you review & accept my pr, pls ?

Best regards, Evgeny Proydakov