### PR TITLE
Fixed compile warning in linux-gcc-arm64 build arm82:

### DIFF
--- a/src/layer/arm/convolution_arm_asimdhp.cpp
+++ b/src/layer/arm/convolution_arm_asimdhp.cpp
@@ -429,7 +429,6 @@ int Convolution_arm::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const
 
     w = bottom_blob_bordered.w;
     h = bottom_blob_bordered.h;
-    int size = w * h;
 
     int outw = (w - kernel_extent_w) / stride_w + 1;
     int outh = (h - kernel_extent_h) / stride_h + 1;


### PR DESCRIPTION
Hi, NCNN Team.

I have fixed a compile warning in linux-gcc-arm64 (arm82) build:

https://github.com/Tencent/ncnn/runs/6755820231?check_suite_focus=true

/home/runner/work/ncnn/ncnn/src/layer/arm/convolution_arm_asimdhp.cpp: In member function ‘int ncnn::Convolution_arm::forward_fp16sa(const ncnn::Mat&, ncnn::Mat&, const ncnn::Option&) const’:
/home/runner/work/ncnn/ncnn/src/layer/arm/convolution_arm_asimdhp.cpp:432:9: warning: unused variable ‘size’ [-Wunused-variable]
      |     int size = w * h;
      |         ^~~~

Could you review and accept my change, pls?

Best regards, Evgeny Proydakov.