### PR TITLE
fix(examples): optimize nms_sorted_bboxes

### DIFF
--- a/examples/fasterrcnn.cpp
+++ b/examples/fasterrcnn.cpp
@@ -82,31 +82,34 @@ static void qsort_descent_inplace(std::vector<Object>& objects)
     qsort_descent_inplace(objects, 0, objects.size() - 1);
 }
 
-static void nms_sorted_bboxes(const std::vector<Object>& objects, std::vector<int>& picked, float nms_threshold)
+static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold, bool agnostic = false)
 {
     picked.clear();
 
-    const int n = objects.size();
+    const int n = faceobjects.size();
 
     std::vector<float> areas(n);
     for (int i = 0; i < n; i++)
     {
-        areas[i] = objects[i].rect.area();
+        areas[i] = faceobjects[i].rect.area();
     }
 
     for (int i = 0; i < n; i++)
     {
-        const Object& a = objects[i];
+        const Object& a = faceobjects[i];
 
         int keep = 1;
         for (int j = 0; j < (int)picked.size(); j++)
         {
-            const Object& b = objects[picked[j]];
+            const Object& b = faceobjects[picked[j]];
+
+            if (!agnostic && a.label != b.label) 
+                continue;
 
             // intersection over union
             float inter_area = intersection_area(a, b);
             float union_area = areas[i] + areas[picked[j]] - inter_area;
-            //             float IoU = inter_area / union_area
+            // float IoU = inter_area / union_area
             if (inter_area / union_area > nms_threshold)
                 keep = 0;
         }

--- a/examples/fasterrcnn.cpp
+++ b/examples/fasterrcnn.cpp
@@ -103,7 +103,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         {
             const Object& b = faceobjects[picked[j]];
 
-            if (!agnostic && a.label != b.label) 
+            if (!agnostic && a.label != b.label)
                 continue;
 
             // intersection over union

--- a/examples/nanodet.cpp
+++ b/examples/nanodet.cpp
@@ -84,7 +84,7 @@ static void qsort_descent_inplace(std::vector<Object>& faceobjects)
     qsort_descent_inplace(faceobjects, 0, faceobjects.size() - 1);
 }
 
-static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold)
+static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold, bool agnostic = false)
 {
     picked.clear();
 
@@ -93,7 +93,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
     std::vector<float> areas(n);
     for (int i = 0; i < n; i++)
     {
-        areas[i] = faceobjects[i].rect.width * faceobjects[i].rect.height;
+        areas[i] = faceobjects[i].rect.area();
     }
 
     for (int i = 0; i < n; i++)
@@ -104,6 +104,9 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         for (int j = 0; j < (int)picked.size(); j++)
         {
             const Object& b = faceobjects[picked[j]];
+
+            if (!agnostic && a.label != b.label) 
+                continue;
 
             // intersection over union
             float inter_area = intersection_area(a, b);

--- a/examples/nanodet.cpp
+++ b/examples/nanodet.cpp
@@ -105,7 +105,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         {
             const Object& b = faceobjects[picked[j]];
 
-            if (!agnostic && a.label != b.label) 
+            if (!agnostic && a.label != b.label)
                 continue;
 
             // intersection over union

--- a/examples/nanodetplus_pnnx.cpp
+++ b/examples/nanodetplus_pnnx.cpp
@@ -84,7 +84,7 @@ static void qsort_descent_inplace(std::vector<Object>& faceobjects)
     qsort_descent_inplace(faceobjects, 0, faceobjects.size() - 1);
 }
 
-static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold)
+static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold, bool agnostic = false)
 {
     picked.clear();
 
@@ -93,7 +93,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
     std::vector<float> areas(n);
     for (int i = 0; i < n; i++)
     {
-        areas[i] = faceobjects[i].rect.width * faceobjects[i].rect.height;
+        areas[i] = faceobjects[i].rect.area();
     }
 
     for (int i = 0; i < n; i++)
@@ -104,6 +104,9 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         for (int j = 0; j < (int)picked.size(); j++)
         {
             const Object& b = faceobjects[picked[j]];
+
+            if (!agnostic && a.label != b.label) 
+                continue;
 
             // intersection over union
             float inter_area = intersection_area(a, b);

--- a/examples/nanodetplus_pnnx.cpp
+++ b/examples/nanodetplus_pnnx.cpp
@@ -105,7 +105,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         {
             const Object& b = faceobjects[picked[j]];
 
-            if (!agnostic && a.label != b.label) 
+            if (!agnostic && a.label != b.label)
                 continue;
 
             // intersection over union

--- a/examples/rfcn.cpp
+++ b/examples/rfcn.cpp
@@ -82,31 +82,34 @@ static void qsort_descent_inplace(std::vector<Object>& objects)
     qsort_descent_inplace(objects, 0, objects.size() - 1);
 }
 
-static void nms_sorted_bboxes(const std::vector<Object>& objects, std::vector<int>& picked, float nms_threshold)
+static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold, bool agnostic = false)
 {
     picked.clear();
 
-    const int n = objects.size();
+    const int n = faceobjects.size();
 
     std::vector<float> areas(n);
     for (int i = 0; i < n; i++)
     {
-        areas[i] = objects[i].rect.area();
+        areas[i] = faceobjects[i].rect.area();
     }
 
     for (int i = 0; i < n; i++)
     {
-        const Object& a = objects[i];
+        const Object& a = faceobjects[i];
 
         int keep = 1;
         for (int j = 0; j < (int)picked.size(); j++)
         {
-            const Object& b = objects[picked[j]];
+            const Object& b = faceobjects[picked[j]];
+
+            if (!agnostic && a.label != b.label) 
+                continue;
 
             // intersection over union
             float inter_area = intersection_area(a, b);
             float union_area = areas[i] + areas[picked[j]] - inter_area;
-            //             float IoU = inter_area / union_area
+            // float IoU = inter_area / union_area
             if (inter_area / union_area > nms_threshold)
                 keep = 0;
         }

--- a/examples/rfcn.cpp
+++ b/examples/rfcn.cpp
@@ -103,7 +103,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         {
             const Object& b = faceobjects[picked[j]];
 
-            if (!agnostic && a.label != b.label) 
+            if (!agnostic && a.label != b.label)
                 continue;
 
             // intersection over union

--- a/examples/yolact.cpp
+++ b/examples/yolact.cpp
@@ -84,31 +84,34 @@ static void qsort_descent_inplace(std::vector<Object>& objects)
     qsort_descent_inplace(objects, 0, objects.size() - 1);
 }
 
-static void nms_sorted_bboxes(const std::vector<Object>& objects, std::vector<int>& picked, float nms_threshold)
+static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold, bool agnostic = false)
 {
     picked.clear();
 
-    const int n = objects.size();
+    const int n = faceobjects.size();
 
     std::vector<float> areas(n);
     for (int i = 0; i < n; i++)
     {
-        areas[i] = objects[i].rect.area();
+        areas[i] = faceobjects[i].rect.area();
     }
 
     for (int i = 0; i < n; i++)
     {
-        const Object& a = objects[i];
+        const Object& a = faceobjects[i];
 
         int keep = 1;
         for (int j = 0; j < (int)picked.size(); j++)
         {
-            const Object& b = objects[picked[j]];
+            const Object& b = faceobjects[picked[j]];
+
+            if (!agnostic && a.label != b.label) 
+                continue;
 
             // intersection over union
             float inter_area = intersection_area(a, b);
             float union_area = areas[i] + areas[picked[j]] - inter_area;
-            //             float IoU = inter_area / union_area
+            // float IoU = inter_area / union_area
             if (inter_area / union_area > nms_threshold)
                 keep = 0;
         }

--- a/examples/yolact.cpp
+++ b/examples/yolact.cpp
@@ -105,7 +105,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         {
             const Object& b = faceobjects[picked[j]];
 
-            if (!agnostic && a.label != b.label) 
+            if (!agnostic && a.label != b.label)
                 continue;
 
             // intersection over union

--- a/examples/yolov5.cpp
+++ b/examples/yolov5.cpp
@@ -139,7 +139,7 @@ static void qsort_descent_inplace(std::vector<Object>& faceobjects)
     qsort_descent_inplace(faceobjects, 0, faceobjects.size() - 1);
 }
 
-static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold)
+static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold, bool agnostic = false)
 {
     picked.clear();
 
@@ -159,6 +159,9 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         for (int j = 0; j < (int)picked.size(); j++)
         {
             const Object& b = faceobjects[picked[j]];
+
+            if (!agnostic && a.label != b.label) 
+                continue;
 
             // intersection over union
             float inter_area = intersection_area(a, b);

--- a/examples/yolov5.cpp
+++ b/examples/yolov5.cpp
@@ -160,7 +160,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         {
             const Object& b = faceobjects[picked[j]];
 
-            if (!agnostic && a.label != b.label) 
+            if (!agnostic && a.label != b.label)
                 continue;
 
             // intersection over union

--- a/examples/yolov5_pnnx.cpp
+++ b/examples/yolov5_pnnx.cpp
@@ -84,7 +84,7 @@ static void qsort_descent_inplace(std::vector<Object>& faceobjects)
     qsort_descent_inplace(faceobjects, 0, faceobjects.size() - 1);
 }
 
-static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold)
+static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold, bool agnostic = false)
 {
     picked.clear();
 
@@ -104,6 +104,9 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         for (int j = 0; j < (int)picked.size(); j++)
         {
             const Object& b = faceobjects[picked[j]];
+
+            if (!agnostic && a.label != b.label) 
+                continue;
 
             // intersection over union
             float inter_area = intersection_area(a, b);

--- a/examples/yolov5_pnnx.cpp
+++ b/examples/yolov5_pnnx.cpp
@@ -115,6 +115,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
             if (inter_area / union_area > nms_threshold)
                 keep = 0;
         }
+        
 
         if (keep)
             picked.push_back(i);

--- a/examples/yolov5_pnnx.cpp
+++ b/examples/yolov5_pnnx.cpp
@@ -114,6 +114,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
             // float IoU = inter_area / union_area
             if (inter_area / union_area > nms_threshold)
                 keep = 0;
+                
         }
 
         if (keep)

--- a/examples/yolov5_pnnx.cpp
+++ b/examples/yolov5_pnnx.cpp
@@ -115,7 +115,6 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
             if (inter_area / union_area > nms_threshold)
                 keep = 0;
         }
-        
 
         if (keep)
             picked.push_back(i);

--- a/examples/yolov5_pnnx.cpp
+++ b/examples/yolov5_pnnx.cpp
@@ -105,7 +105,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         {
             const Object& b = faceobjects[picked[j]];
 
-            if (!agnostic && a.label != b.label) 
+            if (!agnostic && a.label != b.label)
                 continue;
 
             // intersection over union

--- a/examples/yolov5_pnnx.cpp
+++ b/examples/yolov5_pnnx.cpp
@@ -114,7 +114,6 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
             // float IoU = inter_area / union_area
             if (inter_area / union_area > nms_threshold)
                 keep = 0;
-                
         }
 
         if (keep)

--- a/examples/yolov7.cpp
+++ b/examples/yolov7.cpp
@@ -107,7 +107,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         {
             const Object& b = faceobjects[picked[j]];
 
-            if (!agnostic && a.label != b.label) 
+            if (!agnostic && a.label != b.label)
                 continue;
 
             // intersection over union

--- a/examples/yolov7.cpp
+++ b/examples/yolov7.cpp
@@ -86,26 +86,29 @@ static void qsort_descent_inplace(std::vector<Object>& objects)
     qsort_descent_inplace(objects, 0, objects.size() - 1);
 }
 
-static void nms_sorted_bboxes(const std::vector<Object>& objects, std::vector<int>& picked, float nms_threshold)
+static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold, bool agnostic = false)
 {
     picked.clear();
 
-    const int n = objects.size();
+    const int n = faceobjects.size();
 
     std::vector<float> areas(n);
     for (int i = 0; i < n; i++)
     {
-        areas[i] = objects[i].rect.area();
+        areas[i] = faceobjects[i].rect.area();
     }
 
     for (int i = 0; i < n; i++)
     {
-        const Object& a = objects[i];
+        const Object& a = faceobjects[i];
 
         int keep = 1;
         for (int j = 0; j < (int)picked.size(); j++)
         {
-            const Object& b = objects[picked[j]];
+            const Object& b = faceobjects[picked[j]];
+
+            if (!agnostic && a.label != b.label) 
+                continue;
 
             // intersection over union
             float inter_area = intersection_area(a, b);

--- a/examples/yolov7_pnnx.cpp
+++ b/examples/yolov7_pnnx.cpp
@@ -84,7 +84,7 @@ static void qsort_descent_inplace(std::vector<Object>& faceobjects)
     qsort_descent_inplace(faceobjects, 0, faceobjects.size() - 1);
 }
 
-static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold)
+static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold, bool agnostic = false)
 {
     picked.clear();
 
@@ -104,6 +104,9 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         for (int j = 0; j < (int)picked.size(); j++)
         {
             const Object& b = faceobjects[picked[j]];
+
+            if (!agnostic && a.label != b.label) 
+                continue;
 
             // intersection over union
             float inter_area = intersection_area(a, b);

--- a/examples/yolov7_pnnx.cpp
+++ b/examples/yolov7_pnnx.cpp
@@ -105,7 +105,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         {
             const Object& b = faceobjects[picked[j]];
 
-            if (!agnostic && a.label != b.label) 
+            if (!agnostic && a.label != b.label)
                 continue;
 
             // intersection over union

--- a/examples/yolox.cpp
+++ b/examples/yolox.cpp
@@ -145,7 +145,7 @@ static void qsort_descent_inplace(std::vector<Object>& objects)
     qsort_descent_inplace(objects, 0, objects.size() - 1);
 }
 
-static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold)
+static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vector<int>& picked, float nms_threshold, bool agnostic = false)
 {
     picked.clear();
 
@@ -165,6 +165,9 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         for (int j = 0; j < (int)picked.size(); j++)
         {
             const Object& b = faceobjects[picked[j]];
+
+            if (!agnostic && a.label != b.label) 
+                continue;
 
             // intersection over union
             float inter_area = intersection_area(a, b);

--- a/examples/yolox.cpp
+++ b/examples/yolox.cpp
@@ -166,7 +166,7 @@ static void nms_sorted_bboxes(const std::vector<Object>& faceobjects, std::vecto
         {
             const Object& b = faceobjects[picked[j]];
 
-            if (!agnostic && a.label != b.label) 
+            if (!agnostic && a.label != b.label)
                 continue;
 
             // intersection over union


### PR DESCRIPTION
增加参数agnostic来控制执行nms时是否需要忽略目标类别。默认为false，按照不同类别各自做nms。

解决了以下问题：

在使用**yolov5_pnnx.cpp**时发现：两个重合较多的不同类别目标通过nms之后就只剩一个了，让人误以为有一个目标没有检测出来，如图1：
![image](https://user-images.githubusercontent.com/32835610/178701985-fb0afb87-5869-46f5-96ab-70f8af63898b.png)

经过优化之后，效果如图2：
![image](https://user-images.githubusercontent.com/32835610/178702576-3db8fc8e-9e47-46dc-8987-a100f29438c4.png)

