### PR TITLE
Update deconvolution_x86.cpp

### DIFF
--- a/src/layer/x86/deconvolution_x86.cpp
+++ b/src/layer/x86/deconvolution_x86.cpp
@@ -150,7 +150,6 @@ int Deconvolution_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Opti
 
     int w = bottom_blob.w;
     int h = bottom_blob.h;
-    int channels = bottom_blob.c;
     size_t elemsize = bottom_blob.elemsize;
     int elempack = bottom_blob.elempack;
 


### PR DESCRIPTION
fix compile warnings for unused parameter.

```
/home/PJLAB/konghuanjun/FQVIT/ncnn/build/src/layer/x86/deconvolution_x86_avx.cpp:153:9: warning: unused variable ‘channels’ [-Wunused-variable]
  153 |     int channels = bottom_blob.c;
      |         ^~~~~~~~

```