### PR TITLE
OpenMP fault error in quick sorting function

### DIFF
--- a/examples/scrfd.cpp
+++ b/examples/scrfd.cpp
@@ -60,17 +60,14 @@ static void qsort_descent_inplace(std::vector<FaceObject>& faceobjects, int left
         }
     }
 
-    #pragma omp parallel sections
-    {
-        #pragma omp section
+        #pragma omp task firstprivate(faceobjects,left,j)
         {
             if (left < j) qsort_descent_inplace(faceobjects, left, j);
         }
-        #pragma omp section
+        #pragma omp task firstprivate(faceobjects,right,i)
         {
             if (i < right) qsort_descent_inplace(faceobjects, i, right);
         }
-    }
 }
 
 static void qsort_descent_inplace(std::vector<FaceObject>& faceobjects)


### PR DESCRIPTION
This variant of recursive quick sorting function with OpenMP produce fault error. Due shared vars.
I made changes for correct working OpneMP