### PR TITLE
[docs] Fix typo

### DIFF
--- a/docs/faq.en.md
+++ b/docs/faq.en.md
@@ -216,7 +216,7 @@ Fully customizable op, first change to one that can export (e.g. concat slice), 
 
    2. [Learn in 5 minutes! Converting TorchScript models to ncnn models with PNNX](https://zhuanlan.zhihu.com/p/427512763)
 
-# 使用
+# Using
 
 - ## vkEnumeratePhysicalDevices failed -3
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -111,7 +111,7 @@
 
 # 怎样添加ncnn库到项目中？cmake方式怎么用？
 
-编译ncnn，make install。linux/windows set/export ncnn_DIR 指向 install目录下下包含ncnnConfig.cmake 的目录
+编译ncnn，make install。linux/windows set/export ncnn_DIR 指向 install目录下包含ncnnConfig.cmake 的目录
 
 - ## android
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -111,7 +111,7 @@
 
 # 怎样添加ncnn库到项目中？cmake方式怎么用？
 
-编译ncnn，make install。linux/windows set/export ncnn_DIR 指向 isntall目录下下包含ncnnConfig.cmake 的目录
+编译ncnn，make install。linux/windows set/export ncnn_DIR 指向 install目录下下包含ncnnConfig.cmake 的目录
 
 - ## android
 


### PR DESCRIPTION
* A simple typos:
    * `isntall` -> `install`, `下下` -> `下` in `faq.md`
    * `使用` -> `Using` in `faq.en.md`