### PR TITLE
Ignore CMakeSettings.json, the Visual Studio CMake schema file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ build*/
 .idea
 cmake-build-debug
 cmake-build-release
+CMakeSettings.json
 
 # Compiled python
 __pycache__


### PR DESCRIPTION
Hi, NiHui & ncnn contributors

This PR add the Visual Studio generated cmake schema file `CMakeSettings.json` to gitignore list.

The content of this file is like the following:
```
{
  "configurations": [
    {
      "name": "x64-Debug",
      "generator": "Ninja",
      "configurationType": "Debug",
      "inheritEnvironments": [ "msvc_x64_x64" ],
      "buildRoot": "${projectDir}\\out\\build\\${name}",
      "installRoot": "${projectDir}\\out\\install\\${name}",
      "cmakeCommandArgs": "",
      "buildCommandArgs": "",
      "ctestCommandArgs": ""
    }
  ]
}
```

Which is considered project-ly, thus I gitignore it.