### PR TITLE
fix param parsing issue when layer/blob name exceeds 255

### DIFF
--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -2930,6 +2930,30 @@ static void fuse_binaryop_with_scalar(onnx::GraphProto* mutable_graph, std::map<
     }
 }
 
+// truncate layer/blob names when they exceed 255, which is the upper length limit when parsing param in src/net.cpp
+static std::string trunc_name(std::string name)
+{      
+    static int trunc_idx = 0;
+    static std::map<std::string, std::string> name_trunc_map;
+
+    const int max_len = 255;
+    if (name.size() <= max_len)
+    {
+        return name;
+    }
+    if (name_trunc_map.count(name)) 
+    {
+        return name_trunc_map[name];
+    }
+
+    std::string concat_name = name + "_t" + std::to_string(trunc_idx);
+    std::string trunc_name = concat_name.substr(concat_name.size() - max_len);
+    trunc_idx += 1;
+    name_trunc_map[name] = trunc_name;
+
+    return trunc_name;
+}
+
 int main(int argc, char** argv)
 {
     if (!(argc == 2 || argc == 4))
@@ -3433,7 +3457,7 @@ int main(int argc, char** argv)
         if (weights.find(input_name) != weights.end())
             continue;
 
-        fprintf(pp, "%-16s %-24s 0 1 %s\n", "Input", input_name.c_str(), input_name.c_str());
+        fprintf(pp, "%-16s %-24s 0 1 %s\n", "Input", trunc_name(input_name).c_str(), trunc_name(input_name).c_str());
 
         int refcount = node_reference[input_name];
         if (refcount <= 1)
@@ -3444,11 +3468,12 @@ int main(int argc, char** argv)
         char splitname[256];
         sprintf(splitname, "splitncnn_input%d", j);
         fprintf(pp, "%-16s %-24s %d %d", "Split", splitname, 1, refcount);
-        fprintf(pp, " %s", input_name.c_str());
+        fprintf(pp, " %s", trunc_name(input_name).c_str());
 
         for (int k = 0; k < refcount; k++)
         {
-            fprintf(pp, " %s_splitncnn_%d", input_name.c_str(), k);
+            std::string split_name = input_name + "_splitncnn_" + std::to_string(k);
+            fprintf(pp, " %s", trunc_name(split_name).c_str());
         }
         fprintf(pp, "\n");
     }
@@ -3464,7 +3489,7 @@ int main(int argc, char** argv)
             continue;
         }
 
-        fprintf(pp, "%-16s %-24s 0 1 %s", "MemoryData", input_name.c_str(), input_name.c_str());
+        fprintf(pp, "%-16s %-24s 0 1 %s", "MemoryData", trunc_name(input_name).c_str(), trunc_name(input_name).c_str());
 
         const onnx::TensorProto& M = weights[input_name];
 
@@ -3513,11 +3538,12 @@ int main(int argc, char** argv)
         sprintf(splitname, "splitncnn_%d", internal_split);
         fprintf(pp, "%-16s %-24s %d %d", "Split", splitname, 1, refcount);
 
-        fprintf(pp, " %s", input_name.c_str());
+        fprintf(pp, " %s", trunc_name(input_name).c_str());
 
         for (int k = 0; k < refcount; k++)
         {
-            fprintf(pp, " %s_splitncnn_%d", input_name.c_str(), k);
+            std::string split_name = input_name + "_splitncnn_" + std::to_string(k);
+            fprintf(pp, " %s", trunc_name(split_name).c_str());
         }
         fprintf(pp, "\n");
 
@@ -3939,7 +3965,7 @@ int main(int argc, char** argv)
             fprintf(pp, "%-16s", op.c_str());
         }
 
-        fprintf(pp, " %-24s %d %d", name.c_str(), input_size, output_size);
+        fprintf(pp, " %-24s %d %d", trunc_name(name).c_str(), input_size, output_size);
 
         for (int j = 0; j < (int)node.input_size(); j++)
         {
@@ -3966,14 +3992,14 @@ int main(int argc, char** argv)
                 input_name = input_name + splitsuffix;
             }
 
-            fprintf(pp, " %s", input_name.c_str());
+            fprintf(pp, " %s", trunc_name(input_name).c_str());
         }
 
         for (int j = 0; j < output_size; j++)
         {
             const std::string& output_name = node.output(j);
 
-            fprintf(pp, " %s", output_name.c_str());
+            fprintf(pp, " %s", trunc_name(output_name).c_str());
         }
 
         if (op == "Abs")
@@ -6064,11 +6090,12 @@ int main(int argc, char** argv)
                     sprintf(splitname, "splitncnn_%d", internal_split);
                     fprintf(pp, "%-16s %-24s %d %d", "Split", splitname, 1, refcount);
 
-                    fprintf(pp, " %s", output_name.c_str());
+                    fprintf(pp, " %s", trunc_name(output_name).c_str());
 
                     for (int k = 0; k < refcount; k++)
                     {
-                        fprintf(pp, " %s_splitncnn_%d", output_name.c_str(), k);
+                        std::string split_name = output_name + "_splitncnn_" + std::to_string(k);
+                        fprintf(pp, " %s", trunc_name(split_name).c_str());
                     }
                     fprintf(pp, "\n");
 

--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -2932,7 +2932,7 @@ static void fuse_binaryop_with_scalar(onnx::GraphProto* mutable_graph, std::map<
 
 // truncate layer/blob names when they exceed 255, which is the upper length limit when parsing param in src/net.cpp
 static std::string trunc_name(std::string name)
-{      
+{
     static int trunc_idx = 0;
     static std::map<std::string, std::string> name_trunc_map;
 
@@ -2941,7 +2941,7 @@ static std::string trunc_name(std::string name)
     {
         return name;
     }
-    if (name_trunc_map.count(name)) 
+    if (name_trunc_map.count(name))
     {
         return name_trunc_map[name];
     }


### PR DESCRIPTION
# 描述
在对`.param`解析时，由于为`layer_name`和`blob_name`预分配的长度为255，因此当它们的长度超过255时，会发生网络解析失败。
```cpp
// src/net.cpp
char layer_name[256];
SCAN_VALUE("%255s", layer_type)
...
char bottom_name[256];
SCAN_VALUE("%255s", bottom_name)
```
# 复现
该问题可基于以下模型和步骤复现：

**原始ONNX模型**：[movenet.onnx](https://drive.google.com/file/d/1XzqSbH9z20E6AqxV7wj7lrhOl0AN5u4K/view?usp=sharing)，是由Google提供的预训练[movenet tflite](https://tfhub.dev/google/lite-model/movenet/singlepose/lightning/3)经[tensorflow-onnx](https://github.com/onnx/tensorflow-onnx)转换得到（并进一步去除了前后处理算子）

1. 使用`onnx2ncnn`转换为ncnn模型
```bash
onnx2ncnn movenet.onnx movenet.param movenet.bin
```
得到[movenet.param](https://drive.google.com/file/d/158ka1hILmcZyYu4o950xTmWOG-q-u0Gl/view?usp=sharing)和[movenet.bin](https://drive.google.com/file/d/1R5WFJXcSPPGxF-i-GeUFKAYpL7KHf2Wa/view?usp=sharing)。

2. 使用`ncnnoptimze`优化模型
```bash
ncnnoptimize movenet.param movenet.bin movenet_opt.param movenet_opt.bin 0
```
此时会发生模型解析错误：
```bash
parse bottom_count failed
load_model error at layer 2, parameter file has inconsistent content.
```
# 修改
定位问题在于，第一步转化得到的`movenet.param`文件中，多数层的layer_name和blob_name超过255，导致第二步`.param`文件无法正常解析。故对`onnx2ncnn.cpp`做以下修改：

1. 对每一个超出255长度的layer_name和blob_name进行截断；
2. 截断的同时增加后缀截断编号`trunc_idx`，以避免截断后重名。总长维持在255。

# 结果
使用修改后的`onnx2ncnn`，保证生成的`.param`文件中，layer_name和blob_name长度均在255内。网络解析和`ncnnoptimize`可正常进行，得到的ncnn模型成功应用在项目：https://github.com/ZhangGe6/sports_counting_by_pose_estimation

