### PR TITLE
[Fix]: modified the param index of expanddims's axes in modelwriter.h

### DIFF
--- a/tools/modelwriter.h
+++ b/tools/modelwriter.h
@@ -1569,7 +1569,7 @@ int ModelWriter::save(const char* parampath, const char* binpath)
             fprintf_param_value(" 1=%d", expand_h)
             fprintf_param_value(" 2=%d", expand_c)
             {
-                if (!op->axes.empty()) fprintf_param_int_array(0, op->axes, pp);
+                if (!op->axes.empty()) fprintf_param_int_array(3, op->axes, pp);
             }
         }
         else if (layer->type == "GELU")


### PR DESCRIPTION
Hi, thank you for your excellent job.

Motivation:
When I use `ncnn2int8` the `ExpandDims` with the fourth param `axes` and its index is `-23303`, but after quantizing it change to `0` instead of `3`.I found the problem was `modelwriter.h` -> `fprintf_param_int_array(0, op->axes, pp)`.So I modified it to `fprintf_param_int_array(3, op->axes, pp)`.