### PR TITLE
fix compile warning with gcc 9.1.0 including simplestl.h file

### DIFF
--- a/src/simplestl.h
+++ b/src/simplestl.h
@@ -508,7 +508,7 @@ protected:
         {
             capacity_ = new_size * 2;
             T* new_data = (T*)new char[capacity_ * sizeof(T)];
-            memset(new_data, 0, capacity_ * sizeof(T));
+            memset(static_cast<void *>(new_data), 0, capacity_ * sizeof(T));
             if (data_)
             {
                 memmove(new_data, data_, sizeof(T) * size_);

--- a/src/simplestl.h
+++ b/src/simplestl.h
@@ -508,7 +508,7 @@ protected:
         {
             capacity_ = new_size * 2;
             T* new_data = (T*)new char[capacity_ * sizeof(T)];
-            memset(static_cast<void *>(new_data), 0, capacity_ * sizeof(T));
+            memset(static_cast<void*>(new_data), 0, capacity_ * sizeof(T));
             if (data_)
             {
                 memmove(new_data, data_, sizeof(T) * size_);


### PR DESCRIPTION
It is normal to compile with gcc 7.5.0, but a warning is reported using gcc 9.1.0.

> simplestl.h:511:19: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct std::pair<float, int>’; use assignment or value-initialization instead [-Wclass-memaccess]
  511 |    memset(new_data, 0, capacity_ * sizeof(T));
      |    ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
simplestl.h:72:8: note: ‘struct std::pair<float, int>’ declared here
   72 | struct pair
      |        ^~~~

This change will fix the warnning.