### PR TITLE
fix(pybind11): build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ else()
     option(NCNN_BUILD_EXAMPLES "build examples" ON)
 endif()
 
-if(ANDROID OR IOS OR LINUX OR NCNN_SIMPLESTL)
+if(ANDROID OR IOS OR NCNN_SIMPLESTL)
     option(NCNN_DISABLE_EXCEPTION "disable exception" ON)
 else()
     option(NCNN_DISABLE_EXCEPTION "disable exception" OFF)

--- a/python/README.md
+++ b/python/README.md
@@ -43,7 +43,7 @@ git submodule init && git submodule update
 ```bash
 mkdir build
 cd build
-cmake -DNCNN_PYTHON=ON -DNCNN_DISABLE_EXCEPTION=OFF ..
+cmake -DNCNN_PYTHON=ON ..
 make
 ```
 

--- a/python/README.md
+++ b/python/README.md
@@ -43,7 +43,7 @@ git submodule init && git submodule update
 ```bash
 mkdir build
 cd build
-cmake -DNCNN_PYTHON=ON ..
+cmake -DNCNN_PYTHON=ON -DNCNN_DISABLE_EXCEPTION=OFF ..
 make
 ```
 


### PR DESCRIPTION
我们的 CI 里有 pyncnn 源码 build， 目前因 `-fno-exceptions` 报错：

```bash
[100%] Building CXX object python/CMakeFiles/pyncnn.dir/src/main.cpp.o
cd /home/runner/work/mmdeploy/mmdeploy-dep/ncnn/build/python && /usr/bin/c++ -DVERSION_INFO=\"1.0.20221125\" -Dpyncnn_EXPORTS -I/home/runner/work/mmdeploy/mmdeploy-dep/ncnn/src -I/home/runner/work/mmdeploy/mmdeploy
-dep/ncnn/build/src -isystem /home/runner/work/mmdeploy/mmdeploy-dep/ncnn/python/pybind11/include -isystem /opt/hostedtoolcache/Python/3.7.15/x64/include/python3.7m -O3 -DNDEBUG -fPIC -fvisibility=hidden -flto -fno
-fat-lto-objects -fno-exceptions -fopenmp -pthread -std=gnu++11 -MD -MT python/CMakeFiles/pyncnn.dir/src/main.cpp.o -MF CMakeFiles/pyncnn.dir/src/main.cpp.o.d -o CMakeFiles/pyncnn.dir/src/main.cpp.o -c /home/runner
/work/mmdeploy/mmdeploy-dep/ncnn/python/src/main.cpp
In file included from /home/runner/work/mmdeploy/mmdeploy-dep/ncnn/python/pybind11/include/pybind11/attr.h:13,
                 from /home/runner/work/mmdeploy/mmdeploy-dep/ncnn/python/pybind11/include/pybind11/detail/class.h:12,
                 from /home/runner/work/mmdeploy/mmdeploy-dep/ncnn/python/pybind11/include/pybind11/pybind11.h:13,
                 from /home/runner/work/mmdeploy/mmdeploy-dep/ncnn/python/src/main.cpp:16:
/home/runner/work/mmdeploy/mmdeploy-dep/ncnn/python/pybind11/include/pybind11/detail/common.h: In function ‘void pybind11::pybind11_fail(const char*)’:
/home/runner/work/mmdeploy/mmdeploy-dep/ncnn/python/pybind11/include/pybind11/detail/common.h:947:36: error: exception handling disabled, use ‘-fexceptions’ to enable
  947 |     throw std::runtime_error(reason);
```


是因为 CMakeListst.txt 命中 Linux 就 `option(NCNN_DISABLE_EXCEPTION "disable exception" ON)`

Android/iOS 不需要 pyncnn 可以关，linux 是需要的。