### PR TITLE
Fix for torch.mean(keepdim=True)

### DIFF
--- a/src/layer/binaryop.cpp
+++ b/src/layer/binaryop.cpp
@@ -921,7 +921,12 @@ struct binary_op_rdiv
 int BinaryOp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt) const
 {
     const Mat& bottom_blob = bottom_blobs[0];
-    const Mat& bottom_blob1 = bottom_blobs[1];
+    Mat bottom_blob1 = bottom_blobs[1];
+    if (bottom_blob1.dims == 2 and bottom_blob1.w == 1)
+    {
+      // fix for torch.mean(keepdim=True)
+      bottom_blob1 = bottom_blob1.reshape(bottom_blob1.h);
+    }
 
     Mat& top_blob = top_blobs[0];
 

--- a/src/layer/binaryop.cpp
+++ b/src/layer/binaryop.cpp
@@ -924,8 +924,8 @@ int BinaryOp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& to
     Mat bottom_blob1 = bottom_blobs[1];
     if (bottom_blob1.dims == 2 and bottom_blob1.w == 1)
     {
-      // fix for torch.mean(keepdim=True)
-      bottom_blob1 = bottom_blob1.reshape(bottom_blob1.h);
+        // fix for torch.mean(keepdim=True)
+        bottom_blob1 = bottom_blob1.reshape(bottom_blob1.h);
     }
 
     Mat& top_blob = top_blobs[0];


### PR DESCRIPTION
This PR is to fix the following issue.

If x is an n-d (n>=2) tensor, ncnn cannot handle the following case:
```
        scale = torch.mean(x, dim=-1, keepdim=True)
        print(x.shape, scale.shape)
        return x * scale
```

I committed a similar fix in my own branch for speech recognition:
https://github.com/csukuangfj/ncnn/commit/ece9ba5f309b0be390f33dcd4f7b99b43d6f169c

---


Code to reproduce:

```python3
#!/usr/bin/env python3

import torch


class Foo(torch.nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, x):
        """
        Args:
          x:
            A tensor of shape (N, T, C)
        """
        scale = torch.mean(x, dim=-1, keepdim=True)
        print(x.shape, scale.shape)
        return x * scale


def main():
    f = Foo()
    x = torch.rand(1, 10, 2)
    y = f(x)
    print("y", y.shape)
    m = torch.jit.trace(f, x)
    print(m.graph)
    m.save("m.pt")


if __name__ == "__main__":
    main()
```

```
pnnx ./m.pt
```

```python3
#!/usr/bin/env python3

import ncnn
import torch

@torch.no_grad()
def main():
    m = torch.jit.load("m.pt")
    num_features = 2

    T = 3
    x = torch.rand(1, T, num_features)

    y = m(x).squeeze(0)

    print(x.shape)
    print(y.shape)

    param = "m.ncnn.param"
    model = "m.ncnn.bin"
    with ncnn.Net() as net:
        net.opt.use_packing_layout = False
        net.load_param(param)
        net.load_model(model)

        with net.create_extractor() as ex:
            ex.input("in0", ncnn.Mat(x.squeeze(0).numpy()).clone())

            ret, ncnn_out0 = ex.extract("out0")

            ncnn_y = torch.from_numpy(ncnn_out0.numpy()).clone()
            print("y", y.shape, ncnn_y.shape)
            assert torch.allclose(y, ncnn_y, atol=1e-3), (y - ncnn_y).abs().max()


if __name__ == "__main__":
    torch.manual_seed(20221128)
    main()
```