### PR TITLE
fix macos vulkan instance create failed when vulkan sdk version >= 1.…

### DIFF
--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -235,6 +235,7 @@ public:
     int support_VK_KHR_maintenance2;
     int support_VK_KHR_maintenance3;
     int support_VK_KHR_multiview;
+    int support_VK_KHR_portability_subset;
     int support_VK_KHR_push_descriptor;
     int support_VK_KHR_sampler_ycbcr_conversion;
     int support_VK_KHR_shader_float16_int8;
@@ -578,6 +579,11 @@ int GpuInfo::support_VK_KHR_maintenance3() const
 int GpuInfo::support_VK_KHR_multiview() const
 {
     return d->support_VK_KHR_multiview;
+}
+
+int GpuInfo::support_VK_KHR_portability_subset() const
+{
+    return d->support_VK_KHR_portability_subset;
 }
 
 int GpuInfo::support_VK_KHR_push_descriptor() const
@@ -1322,6 +1328,7 @@ int create_gpu_instance()
         gpu_info.support_VK_KHR_maintenance2 = 0;
         gpu_info.support_VK_KHR_maintenance3 = 0;
         gpu_info.support_VK_KHR_multiview = 0;
+        gpu_info.support_VK_KHR_portability_subset= 0;
         gpu_info.support_VK_KHR_push_descriptor = 0;
         gpu_info.support_VK_KHR_sampler_ycbcr_conversion = 0;
         gpu_info.support_VK_KHR_shader_float16_int8 = 0;
@@ -1364,6 +1371,8 @@ int create_gpu_instance()
                 gpu_info.support_VK_KHR_maintenance3 = exp.specVersion;
             else if (strcmp(exp.extensionName, "VK_KHR_multiview") == 0)
                 gpu_info.support_VK_KHR_multiview = exp.specVersion;
+            else if (strcmp(exp.extensionName, "VK_KHR_portability_subset") == 0)
+                gpu_info.support_VK_KHR_portability_subset = exp.specVersion;
             else if (strcmp(exp.extensionName, "VK_KHR_push_descriptor") == 0)
                 gpu_info.support_VK_KHR_push_descriptor = exp.specVersion;
             else if (strcmp(exp.extensionName, "VK_KHR_sampler_ycbcr_conversion") == 0)
@@ -1933,6 +1942,8 @@ VulkanDevice::VulkanDevice(int device_index)
         enabledExtensions.push_back("VK_KHR_maintenance3");
     if (info.support_VK_KHR_multiview())
         enabledExtensions.push_back("VK_KHR_multiview");
+    if (info.support_VK_KHR_portability_subset())
+        enabledExtensions.push_back("VK_KHR_portability_subset");
     if (info.support_VK_KHR_push_descriptor())
         enabledExtensions.push_back("VK_KHR_push_descriptor");
     if (info.support_VK_KHR_sampler_ycbcr_conversion())

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -1009,11 +1009,9 @@ int create_gpu_instance()
     VkInstanceCreateInfo instanceCreateInfo;
     instanceCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     instanceCreateInfo.pNext = 0;
-#if __APPLE__
-    instanceCreateInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
-#else
     instanceCreateInfo.flags = 0;
-#endif
+    if (support_VK_KHR_portability_enumeration)
+        instanceCreateInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
     instanceCreateInfo.pApplicationInfo = &applicationInfo;
     instanceCreateInfo.enabledLayerCount = enabledLayers.size();
     instanceCreateInfo.ppEnabledLayerNames = enabledLayers.data();

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -103,6 +103,7 @@ int support_VK_KHR_get_physical_device_properties2 = 0;
 int support_VK_KHR_get_surface_capabilities2 = 0;
 int support_VK_KHR_surface = 0;
 int support_VK_EXT_debug_utils = 0;
+int support_VK_KHR_portability_enumeration = 0;
 #if __ANDROID_API__ >= 26
 int support_VK_KHR_android_surface = 0;
 #endif // __ANDROID_API__ >= 26
@@ -935,6 +936,7 @@ int create_gpu_instance()
     support_VK_KHR_get_surface_capabilities2 = 0;
     support_VK_KHR_surface = 0;
     support_VK_EXT_debug_utils = 0;
+    support_VK_KHR_portability_enumeration = 0;
 #if __ANDROID_API__ >= 26
     support_VK_KHR_android_surface = 0;
 #endif // __ANDROID_API__ >= 26
@@ -953,6 +955,8 @@ int create_gpu_instance()
             support_VK_KHR_surface = exp.specVersion;
         else if (strcmp(exp.extensionName, "VK_EXT_debug_utils") == 0)
             support_VK_EXT_debug_utils = exp.specVersion;
+        else if (strcmp(exp.extensionName, "VK_KHR_portability_enumeration") == 0)
+            support_VK_KHR_portability_enumeration = exp.specVersion;
 #if __ANDROID_API__ >= 26
         else if (strcmp(exp.extensionName, "VK_KHR_android_surface") == 0)
             support_VK_KHR_android_surface = exp.specVersion;
@@ -975,6 +979,11 @@ int create_gpu_instance()
     if (support_VK_KHR_android_surface)
         enabledExtensions.push_back("VK_KHR_android_surface");
 #endif // __ANDROID_API__ >= 26
+
+#if __APPLE__
+    if (support_VK_KHR_portability_enumeration)
+        enabledExtensions.push_back("VK_KHR_portability_enumeration");
+#endif
 
     uint32_t instance_api_version = VK_MAKE_VERSION(1, 0, 0);
     typedef VkResult(VKAPI_PTR * PFN_vkEnumerateInstanceVersion)(uint32_t * pApiVersion);
@@ -1003,7 +1012,11 @@ int create_gpu_instance()
     VkInstanceCreateInfo instanceCreateInfo;
     instanceCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     instanceCreateInfo.pNext = 0;
+#if __APPLE__
+    instanceCreateInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+#else
     instanceCreateInfo.flags = 0;
+#endif
     instanceCreateInfo.pApplicationInfo = &applicationInfo;
     instanceCreateInfo.enabledLayerCount = enabledLayers.size();
     instanceCreateInfo.ppEnabledLayerNames = enabledLayers.data();

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -101,9 +101,9 @@ static const int layer_shader_registry_entry_count = sizeof(layer_shader_registr
 int support_VK_KHR_external_memory_capabilities = 0;
 int support_VK_KHR_get_physical_device_properties2 = 0;
 int support_VK_KHR_get_surface_capabilities2 = 0;
+int support_VK_KHR_portability_enumeration = 0;
 int support_VK_KHR_surface = 0;
 int support_VK_EXT_debug_utils = 0;
-int support_VK_KHR_portability_enumeration = 0;
 #if __ANDROID_API__ >= 26
 int support_VK_KHR_android_surface = 0;
 #endif // __ANDROID_API__ >= 26
@@ -934,9 +934,9 @@ int create_gpu_instance()
 
     support_VK_KHR_get_physical_device_properties2 = 0;
     support_VK_KHR_get_surface_capabilities2 = 0;
+    support_VK_KHR_portability_enumeration = 0;
     support_VK_KHR_surface = 0;
     support_VK_EXT_debug_utils = 0;
-    support_VK_KHR_portability_enumeration = 0;
 #if __ANDROID_API__ >= 26
     support_VK_KHR_android_surface = 0;
 #endif // __ANDROID_API__ >= 26
@@ -951,12 +951,12 @@ int create_gpu_instance()
             support_VK_KHR_get_physical_device_properties2 = exp.specVersion;
         else if (strcmp(exp.extensionName, "VK_KHR_get_surface_capabilities2") == 0)
             support_VK_KHR_get_surface_capabilities2 = exp.specVersion;
+        else if (strcmp(exp.extensionName, "VK_KHR_portability_enumeration") == 0)
+            support_VK_KHR_portability_enumeration = exp.specVersion;
         else if (strcmp(exp.extensionName, "VK_KHR_surface") == 0)
             support_VK_KHR_surface = exp.specVersion;
         else if (strcmp(exp.extensionName, "VK_EXT_debug_utils") == 0)
             support_VK_EXT_debug_utils = exp.specVersion;
-        else if (strcmp(exp.extensionName, "VK_KHR_portability_enumeration") == 0)
-            support_VK_KHR_portability_enumeration = exp.specVersion;
 #if __ANDROID_API__ >= 26
         else if (strcmp(exp.extensionName, "VK_KHR_android_surface") == 0)
             support_VK_KHR_android_surface = exp.specVersion;
@@ -969,6 +969,8 @@ int create_gpu_instance()
         enabledExtensions.push_back("VK_KHR_get_physical_device_properties2");
     if (support_VK_KHR_get_surface_capabilities2)
         enabledExtensions.push_back("VK_KHR_get_surface_capabilities2");
+    if (support_VK_KHR_portability_enumeration)
+        enabledExtensions.push_back("VK_KHR_portability_enumeration");
     if (support_VK_KHR_surface)
         enabledExtensions.push_back("VK_KHR_surface");
 #if ENABLE_VALIDATION_LAYER
@@ -979,11 +981,6 @@ int create_gpu_instance()
     if (support_VK_KHR_android_surface)
         enabledExtensions.push_back("VK_KHR_android_surface");
 #endif // __ANDROID_API__ >= 26
-
-#if __APPLE__
-    if (support_VK_KHR_portability_enumeration)
-        enabledExtensions.push_back("VK_KHR_portability_enumeration");
-#endif
 
     uint32_t instance_api_version = VK_MAKE_VERSION(1, 0, 0);
     typedef VkResult(VKAPI_PTR * PFN_vkEnumerateInstanceVersion)(uint32_t * pApiVersion);

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -1328,7 +1328,7 @@ int create_gpu_instance()
         gpu_info.support_VK_KHR_maintenance2 = 0;
         gpu_info.support_VK_KHR_maintenance3 = 0;
         gpu_info.support_VK_KHR_multiview = 0;
-        gpu_info.support_VK_KHR_portability_subset= 0;
+        gpu_info.support_VK_KHR_portability_subset = 0;
         gpu_info.support_VK_KHR_push_descriptor = 0;
         gpu_info.support_VK_KHR_sampler_ycbcr_conversion = 0;
         gpu_info.support_VK_KHR_shader_float16_int8 = 0;

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -176,6 +176,7 @@ public:
     int support_VK_KHR_maintenance2() const;
     int support_VK_KHR_maintenance3() const;
     int support_VK_KHR_multiview() const;
+    int support_VK_KHR_portability_subset() const;
     int support_VK_KHR_push_descriptor() const;
     int support_VK_KHR_sampler_ycbcr_conversion() const;
     int support_VK_KHR_shader_float16_int8() const;

--- a/src/vulkan_header_fix.h
+++ b/src/vulkan_header_fix.h
@@ -248,4 +248,11 @@ typedef struct VkPhysicalDeviceCooperativeMatrixPropertiesNV
 typedef VkResult(VKAPI_PTR* PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV)(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount, VkCooperativeMatrixPropertiesNV* pProperties);
 #endif // VK_HEADER_VERSION < 101
 
+#if VK_HEADER_VERSION < 208
+typedef enum VkInstanceCreateFlagBits {
+    VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR = 0x00000001,
+    VK_INSTANCE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
+} VkInstanceCreateFlagBits;
+#endif // VK_HEADER_VERSION < 208
+
 #endif // NCNN_VULKAN_HEADER_FIX_H


### PR DESCRIPTION
As this [doc](https://vulkan-tutorial.com/Drawing_a_triangle/Setup/Instance#:~:text=If%20using%20MacOS%20with%20the%20latest%20MoltenVK%20sdk%2C%20you%20may%20get%20VK_ERROR_INCOMPATIBLE_DRIVER%20returned%20from%20vkCreateInstance.%20According%20to%20the%20Getting%20Start%20Notes.%20Beginning%20with%20the%201.3.216%20Vulkan%20SDK%2C%20the%20VK_KHR_PORTABILITY_subset%20extension%20is%20mandatory.) says 
> Beginning with the 1.3.216 Vulkan SDK, the VK_KHR_PORTABILITY_subset extension is mandatory on macos. 

This pull request addresses an issue where using versions of the Vulkan SDK starting with 1.3.216 causes the error "vkCreateInstance failed" on macos due to the mandatory use of the VK_KHR_PORTABILITY_subset extension. 
![3721673605525_.pic.jpg](https://s2.loli.net/2023/01/13/VAtm8dTPFCOjx2Z.png) 
This pull request resolves this issue and has been tested on vulkan-sdk-1.3.211.0 and vulkan-sdk-1.3.236 on intel macbookpro.