### PR TITLE
Fuse pixel unshuffle

### DIFF
--- a/tools/pnnx/src/CMakeLists.txt
+++ b/tools/pnnx/src/CMakeLists.txt
@@ -319,6 +319,7 @@ set(pnnx_pass_level5_SRCS
     pass_level5/fuse_linear_batchnorm1d.cpp
     pass_level5/fuse_pad_conv1d.cpp
     pass_level5/fuse_pad_conv2d.cpp
+    pass_level5/fuse_pixel_unshuffle.cpp
     pass_level5/fuse_select_to_unbind.cpp
     pass_level5/fuse_slice_copy.cpp
     pass_level5/fuse_slice_indices.cpp

--- a/tools/pnnx/src/pass_level5.cpp
+++ b/tools/pnnx/src/pass_level5.cpp
@@ -51,6 +51,7 @@
 #include "pass_level4/dead_code_elimination.h"
 #include "pass_level4/canonicalize.h"
 #include "pass_level3/fuse_index_expression.h"
+#include "pass_level5/fuse_pixel_unshuffle.h"
 
 namespace pnnx {
 
@@ -113,6 +114,8 @@ void pass_level5(Graph& g, const std::set<std::string>& foldable_constants, cons
     eliminate_noop_view_reshape(g);
 
     fuse_channel_shuffle(g);
+
+    fuse_pixel_unshuffle(g);
 
     fuse_index_expression(g);
 

--- a/tools/pnnx/src/pass_level5.cpp
+++ b/tools/pnnx/src/pass_level5.cpp
@@ -109,13 +109,14 @@ void pass_level5(Graph& g, const std::set<std::string>& foldable_constants, cons
 
     fuse_contiguous_view(g);
 
+    // need to execute before fuse_adjacent_reshape
+    fuse_pixel_unshuffle(g);
+
     fuse_adjacent_reshape(g);
 
     eliminate_noop_view_reshape(g);
 
     fuse_channel_shuffle(g);
-
-    fuse_pixel_unshuffle(g);
 
     fuse_index_expression(g);
 

--- a/tools/pnnx/src/pass_level5/fuse_pixel_unshuffle.cpp
+++ b/tools/pnnx/src/pass_level5/fuse_pixel_unshuffle.cpp
@@ -56,7 +56,7 @@ pnnx.Output             output      1 0 out
         int downscale_factor = shape[size - 1];
 
         bool match_reshape = downscale_factor == shape[size - 3] && shape[size - 2] == shape2[size2 - 1] && shape[size - 4] == shape2[size2 - 2]
-            && shape2[size2 - 3] == downscale_factor * downscale_factor * shape[size - 5];
+                             && shape2[size2 - 3] == downscale_factor * downscale_factor * shape[size - 5];
         bool match_permute = dims == std::vector<int>{0, 1, 3, 5, 2, 4};
 
         return match_reshape & match_permute;

--- a/tools/pnnx/src/pass_level5/fuse_pixel_unshuffle.cpp
+++ b/tools/pnnx/src/pass_level5/fuse_pixel_unshuffle.cpp
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making ncnn available.
 //
-// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+// Copyright (C) 2023 THL A29 Limited, a Tencent company. All rights reserved.
 //
 // Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/tools/pnnx/src/pass_level5/fuse_pixel_unshuffle.cpp
+++ b/tools/pnnx/src/pass_level5/fuse_pixel_unshuffle.cpp
@@ -1,0 +1,83 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "fuse_pixel_unshuffle.h"
+
+#include "pass_level2.h"
+
+namespace pnnx {
+
+class fuse_pixel_unshuffle_pass : public GraphRewriterPass
+{
+public:
+    const char* match_pattern_graph() const
+    {
+        return R"PNNXIR(7767517
+5 4
+pnnx.Input              input       0 1 input
+Tensor.reshape          op_1        1 1 input 1 shape=%shape
+torch.permute           op_2        1 1 1 2 dims=%dims
+Tensor.reshape          op_3        1 1 2 out shape=%shape2
+pnnx.Output             output      1 0 out
+)PNNXIR";
+    }
+
+    const char* type_str() const
+    {
+        return "nn.PixelUnshuffle";
+    }
+
+    const char* name_str() const
+    {
+        return "pixelunshuffle";
+    }
+
+    bool match(const std::map<std::string, Parameter>& captured_params) const
+    {
+        const std::vector<int>& shape = captured_params.at("shape").ai;
+        const std::vector<int>& shape2 = captured_params.at("shape2").ai;
+        const std::vector<int>& dims = captured_params.at("dims").ai;
+        int size = shape.size();
+        int size2 = shape2.size();
+
+        if (shape.size() < 3 || shape2.size() < 3 || shape.size() != shape2.size() + 2) return false;
+
+        int downscale_factor = shape[size - 1];
+
+        bool match_reshape = downscale_factor == shape[size - 3] && shape[size - 2] == shape2[size2 - 1] && shape[size - 4] == shape2[size2 - 2]
+            && shape2[size2 - 3] == downscale_factor * downscale_factor * shape[size - 5];
+        bool match_permute = dims == std::vector<int>{0, 1, 3, 5, 2, 4};
+
+        return match_reshape & match_permute;
+    }
+
+    void write(Operator* op, const std::map<std::string, Parameter>& captured_params) const
+    {
+        const std::vector<int>& shape = captured_params.at("shape").ai;
+
+        int downscale_factor = shape.back();
+
+        op->params["downscale_factor"] = downscale_factor;
+    }
+};
+
+void fuse_pixel_unshuffle(Graph& graph)
+{
+    fuse_pixel_unshuffle_pass a;
+    int opindex = 0;
+
+    pnnx_graph_rewrite(graph, &a, opindex);
+}
+
+} // namespace pnnx

--- a/tools/pnnx/src/pass_level5/fuse_pixel_unshuffle.h
+++ b/tools/pnnx/src/pass_level5/fuse_pixel_unshuffle.h
@@ -1,0 +1,21 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2023 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "ir.h"
+
+namespace pnnx {
+
+void fuse_pixel_unshuffle(Graph& graph);
+
+} // namespace pnnx

--- a/tools/pnnx/tests/CMakeLists.txt
+++ b/tools/pnnx/tests/CMakeLists.txt
@@ -295,7 +295,7 @@ pnnx_add_test(pnnx_fuse_slice_to_tensor_split)
 pnnx_add_test(pnnx_fuse_adjacent_reshape)
 pnnx_add_test(pnnx_fuse_pad_conv1d)
 pnnx_add_test(pnnx_fuse_pad_conv2d)
-pnnx_add_test(pnnx_fuse_PixelUnshuffle)
+pnnx_add_test(pnnx_fuse_pixel_unshuffle)
 
 if(Torch_VERSION VERSION_GREATER_EQUAL "1.9")
     pnnx_add_test(F_mish)

--- a/tools/pnnx/tests/CMakeLists.txt
+++ b/tools/pnnx/tests/CMakeLists.txt
@@ -295,6 +295,7 @@ pnnx_add_test(pnnx_fuse_slice_to_tensor_split)
 pnnx_add_test(pnnx_fuse_adjacent_reshape)
 pnnx_add_test(pnnx_fuse_pad_conv1d)
 pnnx_add_test(pnnx_fuse_pad_conv2d)
+pnnx_add_test(pnnx_fuse_PixelUnshuffle)
 
 if(Torch_VERSION VERSION_GREATER_EQUAL "1.9")
     pnnx_add_test(F_mish)

--- a/tools/pnnx/tests/test_pnnx_fuse_PixelUnshuffle.py
+++ b/tools/pnnx/tests/test_pnnx_fuse_PixelUnshuffle.py
@@ -1,0 +1,71 @@
+# Tencent is pleased to support the open source community by making ncnn available.
+#
+# Copyright (C) 2023 THL A29 Limited, a Tencent company. All rights reserved.
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class pixel_unshuffle(nn.Module):
+    def __init__(self, scale=2):
+        super(pixel_unshuffle, self).__init__()
+        self.scale = scale
+                                
+    def forward(self, x):
+        n, c, h, w = x.shape
+        x = torch.reshape(x, (n, c, h // self.scale, self.scale, w // self.scale, self.scale))
+        x = x.permute((0, 1, 3, 5, 2, 4))
+        x = torch.reshape(x, (n, c * self.scale * self.scale, h // self.scale, w // self.scale))
+
+        return x
+
+class Model(nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+
+        self.down_0 = pixel_unshuffle(2)
+        self.down_1 = pixel_unshuffle(4)
+
+    def forward(self, x):
+        x = self.down_0(x)
+        x = self.down_1(x)
+        return x
+
+def test():
+    net = Model()
+    net.eval()
+
+    torch.manual_seed(0)
+    x = torch.rand(1, 3, 128, 128)
+
+    a0 = net(x)
+
+    # export torchscript
+    mod = torch.jit.trace(net, x)
+    mod.save("test_pnnx_fuse_PixelUnshuffle.pt")
+
+    # torchscript to pnnx
+    import os
+    os.system("pnnx test_pnnx_fuse_PixelUnshuffle.pt inputshape=[1,3,128,128]")
+
+    # ncnn inference
+    import test_pnnx_fuse_PixelUnshuffle_pnnx
+    b0 = test_pnnx_fuse_PixelUnshuffle_pnnx.test_inference()
+
+    return torch.allclose(a0, b0, 1e-4, 1e-4)
+
+if __name__ == "__main__":
+    if test():
+        exit(0)
+    else:
+        exit(1)

--- a/tools/pnnx/tests/test_pnnx_fuse_pixel_unshuffle.py
+++ b/tools/pnnx/tests/test_pnnx_fuse_pixel_unshuffle.py
@@ -56,7 +56,7 @@ def test():
 
     # torchscript to pnnx
     import os
-    os.system("pnnx test_pnnx_fuse_pixel_unshuffle.pt inputshape=[1,3,128,128]")
+    os.system("../src/pnnx test_pnnx_fuse_pixel_unshuffle.pt inputshape=[1,3,128,128]")
 
     # ncnn inference
     import test_pnnx_fuse_pixel_unshuffle_pnnx

--- a/tools/pnnx/tests/test_pnnx_fuse_pixel_unshuffle.py
+++ b/tools/pnnx/tests/test_pnnx_fuse_pixel_unshuffle.py
@@ -52,17 +52,17 @@ def test():
 
     # export torchscript
     mod = torch.jit.trace(net, x)
-    mod.save("test_pnnx_fuse_PixelUnshuffle.pt")
+    mod.save("test_pnnx_fuse_pixel_unshuffle.pt")
 
     # torchscript to pnnx
     import os
-    os.system("pnnx test_pnnx_fuse_PixelUnshuffle.pt inputshape=[1,3,128,128]")
+    os.system("pnnx test_pnnx_fuse_pixel_unshuffle.pt inputshape=[1,3,128,128]")
 
     # ncnn inference
     import test_pnnx_fuse_PixelUnshuffle_pnnx
     b0 = test_pnnx_fuse_PixelUnshuffle_pnnx.test_inference()
 
-    return torch.allclose(a0, b0, 1e-4, 1e-4)
+    return torch.equal(a0, b0)
 
 if __name__ == "__main__":
     if test():

--- a/tools/pnnx/tests/test_pnnx_fuse_pixel_unshuffle.py
+++ b/tools/pnnx/tests/test_pnnx_fuse_pixel_unshuffle.py
@@ -59,8 +59,8 @@ def test():
     os.system("pnnx test_pnnx_fuse_pixel_unshuffle.pt inputshape=[1,3,128,128]")
 
     # ncnn inference
-    import test_pnnx_fuse_PixelUnshuffle_pnnx
-    b0 = test_pnnx_fuse_PixelUnshuffle_pnnx.test_inference()
+    import test_pnnx_fuse_pixel_unshuffle_pnnx
+    b0 = test_pnnx_fuse_pixel_unshuffle_pnnx.test_inference()
 
     return torch.equal(a0, b0)
 

--- a/tools/pnnx/tests/test_pnnx_fuse_pixel_unshuffle.py
+++ b/tools/pnnx/tests/test_pnnx_fuse_pixel_unshuffle.py
@@ -58,7 +58,7 @@ def test():
     import os
     os.system("../src/pnnx test_pnnx_fuse_pixel_unshuffle.pt inputshape=[1,3,128,128]")
 
-    # ncnn inference
+    # pnnx inference
     import test_pnnx_fuse_pixel_unshuffle_pnnx
     b0 = test_pnnx_fuse_pixel_unshuffle_pnnx.test_inference()
 


### PR DESCRIPTION
fuse this old implementation
```
class pixel_unshuffle(nn.Module):
    def __init__(self, scale=1):
        super(pixel_unshuffle, self).__init__()
        self.scale = scale
                                
    def forward(self, x):
        n, c, h, w = x.shape
        x = torch.reshape(x, (n, c, h // self.scale, self.scale, w // self.scale, self.scale))
        x = x.permute((0, 1, 3, 5, 2, 4))
        x = torch.reshape(x, (n, c * self.scale * self.scale, h // self.scale, w // self.scale))

        return x

```