### PR TITLE
Correct README links about build and Add compatibility introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,19 +201,19 @@ ncnn 目前已在腾讯多款应用中使用，如：QQ，Qzone，微信，天�
 
 ## HowTo
 
-**[how to build ncnn library](https://github.com/Tencent/ncnn/wiki/how-to-build) on Linux / Windows / macOS / Raspberry Pi3 / Android / NVIDIA Jetson / iOS / WebAssembly / AllWinner D1 / Loongson 2K1000**
+**[how to build ncnn library](https://github.com/Tencent/ncnn/wiki/how-to-build) on Linux / Windows / macOS / Raspberry Pi3, Pi4 / Android / NVIDIA Jetson / iOS / WebAssembly / AllWinner D1 / Loongson 2K1000**
 
-- [Build for Linux / NVIDIA Jetson / Raspberry Pi 3](https://github.com/Tencent/ncnn/wiki/how-to-build#pass-for-linux)
-- [Build for Windows x64 using VS2017](https://github.com/Tencent/ncnn/wiki/how-to-build#pass-for-windows-x64-using-visual-studio-community-2017)
-- [Build for macOS](https://github.com/Tencent/ncnn/wiki/how-to-build#pass-for-macos)
-- [Build for ARM Cortex-A family with cross-compiling](https://github.com/Tencent/ncnn/wiki/how-to-build#pass-for-arm-cortex-a-family-with-cross-compiling)
-- [Build for Hisilicon platform with cross-compiling](https://github.com/Tencent/ncnn/wiki/how-to-build#pass-for-hisilicon-platform-with-cross-compiling)
-- [Build for Android](https://github.com/Tencent/ncnn/wiki/how-to-build#pass-for-android)
-- [Build for iOS on macOS with xcode](https://github.com/Tencent/ncnn/wiki/how-to-build#pass-for-ios-on-macos-with-xcode)
-- [Build for WebAssembly](https://github.com/Tencent/ncnn/wiki/how-to-build#pass-for-webassembly)
-- [Build for AllWinner D1](https://github.com/Tencent/ncnn/wiki/how-to-build#pass-for-allwinner-d1)
-- [Build for Loongson 2K1000](https://github.com/Tencent/ncnn/wiki/how-to-build#pass-for-loongson-2k1000)
-- [Build for Termux on Android](https://github.com/Tencent/ncnn/wiki/how-to-build#pass-for-termux-on-android)
+- [Build for Linux / NVIDIA Jetson / Raspberry Pi3, Pi4](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-linux)
+- [Build for Windows x64 using VS2017](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-windows-x64-using-visual-studio-community-2017)
+- [Build for macOS](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-macos)
+- [Build for ARM Cortex-A family with cross-compiling](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-arm-cortex-a-family-with-cross-compiling)
+- [Build for Hisilicon platform with cross-compiling](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-hisilicon-platform-with-cross-compiling)
+- [Build for Android](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-android)
+- [Build for iOS on macOS with xcode](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-ios-on-macos-with-xcode)
+- [Build for WebAssembly](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-webassembly)
+- [Build for AllWinner D1](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-allwinner-d1)
+- [Build for Loongson 2K1000](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-loongson-2k1000)
+- [Build for Termux on Android](https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-termux-on-android)
 
 **[download prebuild binary package for android and ios](https://github.com/Tencent/ncnn/releases)**
 


### PR DESCRIPTION
1. The correctly link is `how-to-build#build-for-linux` not `#pass-for-linux`, and so on other `#`
2. Add compatibility introduction for Raspberry Pi 4 (build pass)