### PR TITLE
Add AVX and AVX512F implementation of asin, acos and atan in x86 targets. Fix typo for SSE2 implementation of asin in x86 targets.

### DIFF
--- a/src/layer/x86/avx512_mathfun.h
+++ b/src/layer/x86/avx512_mathfun.h
@@ -541,23 +541,23 @@ static NCNN_FORCEINLINE __m512 asin512_ps(__m512 x)
 
     // is_small_input = (absolute <= 0.5f);
     __mmask16 is_small_input = _mm512_cmp_ps_mask(
-        absolute,
-        magic_half_one,
-        _CMP_LE_OQ);
+                                   absolute,
+                                   magic_half_one,
+                                   _CMP_LE_OQ);
 
     // is_big_input = (is_small_input ? 0.0f : 1.0f);
     __m512 is_big_input = _mm512_maskz_mov_ps(~is_small_input, magic_one);
 
     // big_input_approx = sqrt(0.5f * (1 - absolute));
     __m512 big_input_approx = _mm512_sqrt_ps(_mm512_mul_ps(
-        magic_half_one,
-        _mm512_sub_ps(magic_one, absolute)));
+                                  magic_half_one,
+                                  _mm512_sub_ps(magic_one, absolute)));
 
     // input_approx = (is_small_input ? absolute : big_input_approx);
     __m512 input_approx = _mm512_mask_mov_ps(
-        big_input_approx,
-        is_small_input,
-        absolute);
+                              big_input_approx,
+                              is_small_input,
+                              absolute);
 
     // square_of_input_approx = input_approx * input_approx;
     __m512 square_of_input_approx = _mm512_mul_ps(input_approx, input_approx);
@@ -565,7 +565,7 @@ static NCNN_FORCEINLINE __m512 asin512_ps(__m512 x)
     // fourth_power_of_input_approx =
     //     square_of_input_approx * square_of_input_approx;
     __m512 fourth_power_of_input_approx = _mm512_mul_ps(
-        square_of_input_approx, square_of_input_approx);
+            square_of_input_approx, square_of_input_approx);
 
     // TODO: Need more explanations.
     // x1 = ((fourth_power_of_input_approx * magic_a4) + magic_a2);
@@ -574,21 +574,21 @@ static NCNN_FORCEINLINE __m512 asin512_ps(__m512 x)
     // x4 = ((fourth_power_of_input_approx * x2) + magic_a1);
     // output_approx = ((square_of_input_approx * x4) + x3);
     __m512 output_approx = _mm512_fmadd_ps(
-        square_of_input_approx,
-        _mm512_fmadd_ps(
-            fourth_power_of_input_approx,
-            _mm512_fmadd_ps(
-                fourth_power_of_input_approx,
-                magic_a5,
-                magic_a3),
-            magic_a1),
-        _mm512_fmadd_ps(
-            fourth_power_of_input_approx,
-            _mm512_fmadd_ps(
-                fourth_power_of_input_approx,
-                magic_a4,
-                magic_a2),
-            magic_a0));
+                               square_of_input_approx,
+                               _mm512_fmadd_ps(
+                                   fourth_power_of_input_approx,
+                                   _mm512_fmadd_ps(
+                                       fourth_power_of_input_approx,
+                                       magic_a5,
+                                       magic_a3),
+                                   magic_a1),
+                               _mm512_fmadd_ps(
+                                   fourth_power_of_input_approx,
+                                   _mm512_fmadd_ps(
+                                       fourth_power_of_input_approx,
+                                       magic_a4,
+                                       magic_a2),
+                                   magic_a0));
 
     // TODO: Need more explanations.
     // x1 = ((0.5 * PI) * is_big_input);
@@ -596,9 +596,9 @@ static NCNN_FORCEINLINE __m512 asin512_ps(__m512 x)
     // x3 = (-(3.0f * is_big_input) + 1.0f);
     // final_approx = ((x2 * x3) + x1);
     __m512 final_approx = _mm512_fmadd_ps(
-        _mm512_mul_ps(output_approx, input_approx),
-        _mm512_fnmadd_ps(magic_three, is_big_input, magic_one),
-        _mm512_mul_ps(magic_half_pi, is_big_input));
+                              _mm512_mul_ps(output_approx, input_approx),
+                              _mm512_fnmadd_ps(magic_three, is_big_input, magic_one),
+                              _mm512_mul_ps(magic_half_pi, is_big_input));
 
     // return (final_approx || negative_mask);
     return _mm512_or_ps(final_approx, negative_mask);
@@ -629,20 +629,20 @@ static NCNN_FORCEINLINE __m512 acos512_ps(__m512 x)
 
     // is_small_input = (absolute <= 0.5f);
     __mmask16 is_small_input = _mm512_cmp_ps_mask(
-        absolute,
-        magic_half_one,
-        _CMP_LE_OQ);
+                                   absolute,
+                                   magic_half_one,
+                                   _CMP_LE_OQ);
 
     // big_input_approx = sqrt(0.5f * (1 - absolute));
     __m512 big_input_approx = _mm512_sqrt_ps(_mm512_mul_ps(
-        magic_half_one,
-        _mm512_sub_ps(magic_one, absolute)));
+                                  magic_half_one,
+                                  _mm512_sub_ps(magic_one, absolute)));
 
     // input_approx = (is_small_input ? absolute : big_input_approx);
     __m512 input_approx = _mm512_mask_mov_ps(
-        big_input_approx,
-        is_small_input,
-        absolute);
+                              big_input_approx,
+                              is_small_input,
+                              absolute);
 
     // square_of_input_approx = input_approx * input_approx;
     __m512 square_of_input_approx = _mm512_mul_ps(input_approx, input_approx);
@@ -650,7 +650,7 @@ static NCNN_FORCEINLINE __m512 acos512_ps(__m512 x)
     // fourth_power_of_input_approx =
     //     square_of_input_approx * square_of_input_approx;
     __m512 fourth_power_of_input_approx = _mm512_mul_ps(
-        square_of_input_approx, square_of_input_approx);
+            square_of_input_approx, square_of_input_approx);
 
     // TODO: Need more explanations.
     // x1 = ((fourth_power_of_input_approx * magic_a4) + magic_a2);
@@ -659,21 +659,21 @@ static NCNN_FORCEINLINE __m512 acos512_ps(__m512 x)
     // x4 = ((fourth_power_of_input_approx * x2) + magic_a1);
     // output_approx = ((square_of_input_approx * x4) + x3);
     __m512 output_approx = _mm512_fmadd_ps(
-        square_of_input_approx,
-        _mm512_fmadd_ps(
-            fourth_power_of_input_approx,
-            _mm512_fmadd_ps(
-                fourth_power_of_input_approx,
-                magic_a5,
-                magic_a3),
-            magic_a1),
-        _mm512_fmadd_ps(
-            fourth_power_of_input_approx,
-            _mm512_fmadd_ps(
-                fourth_power_of_input_approx,
-                magic_a4,
-                magic_a2),
-            magic_a0));
+                               square_of_input_approx,
+                               _mm512_fmadd_ps(
+                                   fourth_power_of_input_approx,
+                                   _mm512_fmadd_ps(
+                                       fourth_power_of_input_approx,
+                                       magic_a5,
+                                       magic_a3),
+                                   magic_a1),
+                               _mm512_fmadd_ps(
+                                   fourth_power_of_input_approx,
+                                   _mm512_fmadd_ps(
+                                       fourth_power_of_input_approx,
+                                       magic_a4,
+                                       magic_a2),
+                                   magic_a0));
 
     // TODO: Need more explanations.
     // x1 = (output_approx * input_approx);
@@ -682,22 +682,22 @@ static NCNN_FORCEINLINE __m512 acos512_ps(__m512 x)
     // TODO: Need more explanations.
     // small_final_approx = ((0.5 * PI) - (x1 | negative_mask));
     __m512 small_final_approx = _mm512_sub_ps(
-        magic_half_pi,
-        _mm512_or_ps(x1, negative_mask));
+                                    magic_half_pi,
+                                    _mm512_or_ps(x1, negative_mask));
 
     // TODO: Need more explanations.
     // big_final_approx = (((x < 0.0f) & PI) + ((x1 * 2) | negative_mask));
     __m512 big_final_approx = _mm512_add_ps(
-        _mm512_maskz_mov_ps(
-            _mm512_cmp_ps_mask(x, magic_zero, _CMP_LT_OQ),
-            magic_pi),
-        _mm512_or_ps(_mm512_add_ps(x1, x1), negative_mask));
+                                  _mm512_maskz_mov_ps(
+                                      _mm512_cmp_ps_mask(x, magic_zero, _CMP_LT_OQ),
+                                      magic_pi),
+                                  _mm512_or_ps(_mm512_add_ps(x1, x1), negative_mask));
 
     // return (is_small_input ? small_final_approx : big_final_approx);
     return _mm512_mask_mov_ps(
-        big_final_approx,
-        is_small_input,
-        small_final_approx);
+               big_final_approx,
+               is_small_input,
+               small_final_approx);
 }
 
 static NCNN_FORCEINLINE __m512 atan512_ps(__m512 x)
@@ -726,16 +726,16 @@ static NCNN_FORCEINLINE __m512 atan512_ps(__m512 x)
 
     // is_small_input = (1.0f < absolute);
     __mmask16 is_small_input = _mm512_cmp_ps_mask(
-        magic_one,
-        absolute,
-        _CMP_LT_OQ);
+                                   magic_one,
+                                   absolute,
+                                   _CMP_LT_OQ);
 
     // x1 = (is_small_input ? -1.0f : absolute);
     // x2 = (is_small_input ? absolute : 1.0f)
     // input_approx = x1 / x2;
     __m512 input_approx = _mm512_div_ps(
-        _mm512_mask_mov_ps(absolute, is_small_input, magic_negative_one),
-        _mm512_mask_mov_ps(magic_one, is_small_input, absolute));     
+                              _mm512_mask_mov_ps(absolute, is_small_input, magic_negative_one),
+                              _mm512_mask_mov_ps(magic_one, is_small_input, absolute));
 
     // square_of_input_approx = input_approx * input_approx;
     __m512 square_of_input_approx = _mm512_mul_ps(input_approx, input_approx);
@@ -743,7 +743,7 @@ static NCNN_FORCEINLINE __m512 atan512_ps(__m512 x)
     // fourth_power_of_input_approx =
     //     square_of_input_approx * square_of_input_approx;
     __m512 fourth_power_of_input_approx = _mm512_mul_ps(
-        square_of_input_approx, square_of_input_approx);
+            square_of_input_approx, square_of_input_approx);
 
     // TODO: Need more explanations.
     // x1 = ((fourth_power_of_input_approx * magic_a7) + magic_a5);
@@ -755,40 +755,40 @@ static NCNN_FORCEINLINE __m512 atan512_ps(__m512 x)
     // x7 = ((fourth_power_of_input_approx * x6) + magic_a0);
     // output_approx = ((square_of_input_approx * x5) + x7);
     __m512 output_approx = _mm512_fmadd_ps(
-        square_of_input_approx,
-        _mm512_fmadd_ps(
-            fourth_power_of_input_approx,
-            _mm512_fmadd_ps(
-                fourth_power_of_input_approx,
-                _mm512_fmadd_ps(
-                    fourth_power_of_input_approx,
-                    magic_a7,
-                    magic_a5),
-                magic_a3),
-            magic_a1),
-        _mm512_fmadd_ps(
-            fourth_power_of_input_approx,
-            _mm512_fmadd_ps(
-                fourth_power_of_input_approx,
-                _mm512_fmadd_ps(
-                    fourth_power_of_input_approx,
-                    _mm512_fmadd_ps(
-                        fourth_power_of_input_approx,
-                        magic_a8,
-                        magic_a6),
-                    magic_a4),
-                magic_a2),
-            magic_a0));
+                               square_of_input_approx,
+                               _mm512_fmadd_ps(
+                                   fourth_power_of_input_approx,
+                                   _mm512_fmadd_ps(
+                                       fourth_power_of_input_approx,
+                                       _mm512_fmadd_ps(
+                                           fourth_power_of_input_approx,
+                                           magic_a7,
+                                           magic_a5),
+                                       magic_a3),
+                                   magic_a1),
+                               _mm512_fmadd_ps(
+                                   fourth_power_of_input_approx,
+                                   _mm512_fmadd_ps(
+                                       fourth_power_of_input_approx,
+                                       _mm512_fmadd_ps(
+                                           fourth_power_of_input_approx,
+                                           _mm512_fmadd_ps(
+                                                   fourth_power_of_input_approx,
+                                                   magic_a8,
+                                                   magic_a6),
+                                           magic_a4),
+                                       magic_a2),
+                                   magic_a0));
 
     // TODO: Need more explanations.
     // x1 = (output_approx * input_approx);
     // if (is_small_input) x1 += (0.5 * PI);
     // return (negative_mask ? -x1 : x1);
     return _mm512_or_ps(
-        _mm512_add_ps(
-            _mm512_mul_ps(output_approx, input_approx),
-            _mm512_maskz_mov_ps(is_small_input, magic_half_pi)),
-        negative_mask);
+               _mm512_add_ps(
+                   _mm512_mul_ps(output_approx, input_approx),
+                   _mm512_maskz_mov_ps(is_small_input, magic_half_pi)),
+               negative_mask);
 }
 
 #endif // AVX512_MATHFUN_H

--- a/src/layer/x86/avx512_mathfun.h
+++ b/src/layer/x86/avx512_mathfun.h
@@ -517,4 +517,278 @@ static NCNN_FORCEINLINE __m512 atan2512_ps(__m512 a, __m512 b)
     return _mm512_loadu_ps(tmpx);
 }
 
+static NCNN_FORCEINLINE __m512 asin512_ps(__m512 x)
+{
+    const __m512 magic_negative_zero = _mm512_set1_ps(-0.0f);
+    const __m512 magic_half_one = _mm512_set1_ps(0.5f);
+    const __m512 magic_one = _mm512_set1_ps(1.0f);
+    const __m512 magic_a4 = _mm512_set1_ps(0.023994016f);
+    const __m512 magic_a5 = _mm512_set1_ps(0.042417344f);
+    const __m512 magic_a2 = _mm512_set1_ps(0.07494697f);
+    const __m512 magic_a3 = _mm512_set1_ps(0.045520633f);
+    const __m512 magic_a0 = _mm512_set1_ps(1.0f);
+    const __m512 magic_a1 = _mm512_set1_ps(0.166667819f);
+    const __m512 magic_half_pi = _mm512_set1_ps(1.5707964f);
+    const __m512 magic_three = _mm512_set1_ps(3.0f);
+
+    // negative_mask = magic_negative_zero && x;
+    __m512 negative_mask = _mm512_and_ps(magic_negative_zero, x);
+
+    // absolute = abs(x);
+    __m512 absolute = _mm512_andnot_ps(magic_negative_zero, x);
+
+    // Reference: https://en.wikipedia.org/wiki/Small-angle_approximation
+
+    // is_small_input = (absolute <= 0.5f);
+    __mmask16 is_small_input = _mm512_cmp_ps_mask(
+        absolute,
+        magic_half_one,
+        _CMP_LE_OQ);
+
+    // is_big_input = (is_small_input ? 0.0f : 1.0f);
+    __m512 is_big_input = _mm512_maskz_mov_ps(~is_small_input, magic_one);
+
+    // big_input_approx = sqrt(0.5f * (1 - absolute));
+    __m512 big_input_approx = _mm512_sqrt_ps(_mm512_mul_ps(
+        magic_half_one,
+        _mm512_sub_ps(magic_one, absolute)));
+
+    // input_approx = (is_small_input ? absolute : big_input_approx);
+    __m512 input_approx = _mm512_mask_mov_ps(
+        big_input_approx,
+        is_small_input,
+        absolute);
+
+    // square_of_input_approx = input_approx * input_approx;
+    __m512 square_of_input_approx = _mm512_mul_ps(input_approx, input_approx);
+
+    // fourth_power_of_input_approx =
+    //     square_of_input_approx * square_of_input_approx;
+    __m512 fourth_power_of_input_approx = _mm512_mul_ps(
+        square_of_input_approx, square_of_input_approx);
+
+    // TODO: Need more explanations.
+    // x1 = ((fourth_power_of_input_approx * magic_a4) + magic_a2);
+    // x2 = ((fourth_power_of_input_approx * magic_a5) + magic_a3);
+    // x3 = ((fourth_power_of_input_approx * x1) + magic_a0);
+    // x4 = ((fourth_power_of_input_approx * x2) + magic_a1);
+    // output_approx = ((square_of_input_approx * x4) + x3);
+    __m512 output_approx = _mm512_fmadd_ps(
+        square_of_input_approx,
+        _mm512_fmadd_ps(
+            fourth_power_of_input_approx,
+            _mm512_fmadd_ps(
+                fourth_power_of_input_approx,
+                magic_a5,
+                magic_a3),
+            magic_a1),
+        _mm512_fmadd_ps(
+            fourth_power_of_input_approx,
+            _mm512_fmadd_ps(
+                fourth_power_of_input_approx,
+                magic_a4,
+                magic_a2),
+            magic_a0));
+
+    // TODO: Need more explanations.
+    // x1 = ((0.5 * PI) * is_big_input);
+    // x2 = (output_approx * input_approx);
+    // x3 = (-(3.0f * is_big_input) + 1.0f);
+    // final_approx = ((x2 * x3) + x1);
+    __m512 final_approx = _mm512_fmadd_ps(
+        _mm512_mul_ps(output_approx, input_approx),
+        _mm512_fnmadd_ps(magic_three, is_big_input, magic_one),
+        _mm512_mul_ps(magic_half_pi, is_big_input));
+
+    // return (final_approx || negative_mask);
+    return _mm512_or_ps(final_approx, negative_mask);
+}
+
+static NCNN_FORCEINLINE __m512 acos512_ps(__m512 x)
+{
+    const __m512 magic_negative_zero = _mm512_set1_ps(-0.0f);
+    const __m512 magic_zero = _mm512_set1_ps(0.0f);
+    const __m512 magic_half_one = _mm512_set1_ps(0.5f);
+    const __m512 magic_one = _mm512_set1_ps(1.0f);
+    const __m512 magic_a4 = _mm512_set1_ps(0.023994016f);
+    const __m512 magic_a5 = _mm512_set1_ps(0.042417344f);
+    const __m512 magic_a2 = _mm512_set1_ps(0.07494697f);
+    const __m512 magic_a3 = _mm512_set1_ps(0.045520633f);
+    const __m512 magic_a0 = _mm512_set1_ps(1.0f);
+    const __m512 magic_a1 = _mm512_set1_ps(0.166667819f);
+    const __m512 magic_half_pi = _mm512_set1_ps(1.5707964f);
+    const __m512 magic_pi = _mm512_set1_ps(3.1415927f);
+
+    // negative_mask = magic_negative_zero && x;
+    __m512 negative_mask = _mm512_and_ps(magic_negative_zero, x);
+
+    // absolute = abs(x);
+    __m512 absolute = _mm512_andnot_ps(magic_negative_zero, x);
+
+    // Reference: https://en.wikipedia.org/wiki/Small-angle_approximation
+
+    // is_small_input = (absolute <= 0.5f);
+    __mmask16 is_small_input = _mm512_cmp_ps_mask(
+        absolute,
+        magic_half_one,
+        _CMP_LE_OQ);
+
+    // big_input_approx = sqrt(0.5f * (1 - absolute));
+    __m512 big_input_approx = _mm512_sqrt_ps(_mm512_mul_ps(
+        magic_half_one,
+        _mm512_sub_ps(magic_one, absolute)));
+
+    // input_approx = (is_small_input ? absolute : big_input_approx);
+    __m512 input_approx = _mm512_mask_mov_ps(
+        big_input_approx,
+        is_small_input,
+        absolute);
+
+    // square_of_input_approx = input_approx * input_approx;
+    __m512 square_of_input_approx = _mm512_mul_ps(input_approx, input_approx);
+
+    // fourth_power_of_input_approx =
+    //     square_of_input_approx * square_of_input_approx;
+    __m512 fourth_power_of_input_approx = _mm512_mul_ps(
+        square_of_input_approx, square_of_input_approx);
+
+    // TODO: Need more explanations.
+    // x1 = ((fourth_power_of_input_approx * magic_a4) + magic_a2);
+    // x2 = ((fourth_power_of_input_approx * magic_a5) + magic_a3);
+    // x3 = ((fourth_power_of_input_approx * x1) + magic_a0);
+    // x4 = ((fourth_power_of_input_approx * x2) + magic_a1);
+    // output_approx = ((square_of_input_approx * x4) + x3);
+    __m512 output_approx = _mm512_fmadd_ps(
+        square_of_input_approx,
+        _mm512_fmadd_ps(
+            fourth_power_of_input_approx,
+            _mm512_fmadd_ps(
+                fourth_power_of_input_approx,
+                magic_a5,
+                magic_a3),
+            magic_a1),
+        _mm512_fmadd_ps(
+            fourth_power_of_input_approx,
+            _mm512_fmadd_ps(
+                fourth_power_of_input_approx,
+                magic_a4,
+                magic_a2),
+            magic_a0));
+
+    // TODO: Need more explanations.
+    // x1 = (output_approx * input_approx);
+    __m512 x1 = _mm512_mul_ps(output_approx, input_approx);
+
+    // TODO: Need more explanations.
+    // small_final_approx = ((0.5 * PI) - (x1 | negative_mask));
+    __m512 small_final_approx = _mm512_sub_ps(
+        magic_half_pi,
+        _mm512_or_ps(x1, negative_mask));
+
+    // TODO: Need more explanations.
+    // big_final_approx = (((x < 0.0f) & PI) + ((x1 * 2) | negative_mask));
+    __m512 big_final_approx = _mm512_add_ps(
+        _mm512_maskz_mov_ps(
+            _mm512_cmp_ps_mask(x, magic_zero, _CMP_LT_OQ),
+            magic_pi),
+        _mm512_or_ps(_mm512_add_ps(x1, x1), negative_mask));
+
+    // return (is_small_input ? small_final_approx : big_final_approx);
+    return _mm512_mask_mov_ps(
+        big_final_approx,
+        is_small_input,
+        small_final_approx);
+}
+
+static NCNN_FORCEINLINE __m512 atan512_ps(__m512 x)
+{
+    const __m512 magic_negative_zero = _mm512_set1_ps(-0.0f);
+    const __m512 magic_one = _mm512_set1_ps(1.0f);
+    const __m512 magic_negative_one = _mm512_set1_ps(-1.0f);
+    const __m512 magic_half_pi = _mm512_set1_ps(1.5707964f);
+    const __m512 magic_a0 = _mm512_set1_ps(1.0f);
+    const __m512 magic_a1 = _mm512_set1_ps(-0.33333072f);
+    const __m512 magic_a2 = _mm512_set1_ps(0.1999262f);
+    const __m512 magic_a3 = _mm512_set1_ps(-0.14203644f);
+    const __m512 magic_a4 = _mm512_set1_ps(0.10640934f);
+    const __m512 magic_a5 = _mm512_set1_ps(-0.07504295f);
+    const __m512 magic_a6 = _mm512_set1_ps(0.04269152f);
+    const __m512 magic_a7 = _mm512_set1_ps(-0.01606863f);
+    const __m512 magic_a8 = _mm512_set1_ps(0.0028498897f);
+
+    // negative_mask = magic_negative_zero && x;
+    __m512 negative_mask = _mm512_and_ps(magic_negative_zero, x);
+
+    // absolute = abs(x);
+    __m512 absolute = _mm512_andnot_ps(magic_negative_zero, x);
+
+    // Reference: https://en.wikipedia.org/wiki/Small-angle_approximation
+
+    // is_small_input = (1.0f < absolute);
+    __mmask16 is_small_input = _mm512_cmp_ps_mask(
+        magic_one,
+        absolute,
+        _CMP_LT_OQ);
+
+    // x1 = (is_small_input ? -1.0f : absolute);
+    // x2 = (is_small_input ? absolute : 1.0f)
+    // input_approx = x1 / x2;
+    __m512 input_approx = _mm512_div_ps(
+        _mm512_mask_mov_ps(absolute, is_small_input, magic_negative_one),
+        _mm512_mask_mov_ps(magic_one, is_small_input, absolute));     
+
+    // square_of_input_approx = input_approx * input_approx;
+    __m512 square_of_input_approx = _mm512_mul_ps(input_approx, input_approx);
+
+    // fourth_power_of_input_approx =
+    //     square_of_input_approx * square_of_input_approx;
+    __m512 fourth_power_of_input_approx = _mm512_mul_ps(
+        square_of_input_approx, square_of_input_approx);
+
+    // TODO: Need more explanations.
+    // x1 = ((fourth_power_of_input_approx * magic_a7) + magic_a5);
+    // x2 = ((fourth_power_of_input_approx * magic_a8) + magic_a6);
+    // x3 = ((fourth_power_of_input_approx * x1) + magic_a3);
+    // x4 = ((fourth_power_of_input_approx * x2) + magic_a4);
+    // x5 = ((fourth_power_of_input_approx * x3) + magic_a1);
+    // x6 = ((fourth_power_of_input_approx * x4) + magic_a2);
+    // x7 = ((fourth_power_of_input_approx * x6) + magic_a0);
+    // output_approx = ((square_of_input_approx * x5) + x7);
+    __m512 output_approx = _mm512_fmadd_ps(
+        square_of_input_approx,
+        _mm512_fmadd_ps(
+            fourth_power_of_input_approx,
+            _mm512_fmadd_ps(
+                fourth_power_of_input_approx,
+                _mm512_fmadd_ps(
+                    fourth_power_of_input_approx,
+                    magic_a7,
+                    magic_a5),
+                magic_a3),
+            magic_a1),
+        _mm512_fmadd_ps(
+            fourth_power_of_input_approx,
+            _mm512_fmadd_ps(
+                fourth_power_of_input_approx,
+                _mm512_fmadd_ps(
+                    fourth_power_of_input_approx,
+                    _mm512_fmadd_ps(
+                        fourth_power_of_input_approx,
+                        magic_a8,
+                        magic_a6),
+                    magic_a4),
+                magic_a2),
+            magic_a0));
+
+    // TODO: Need more explanations.
+    // x1 = (output_approx * input_approx);
+    // if (is_small_input) x1 += (0.5 * PI);
+    // return (negative_mask ? -x1 : x1);
+    return _mm512_or_ps(
+        _mm512_add_ps(
+            _mm512_mul_ps(output_approx, input_approx),
+            _mm512_maskz_mov_ps(is_small_input, magic_half_pi)),
+        negative_mask);
+}
+
 #endif // AVX512_MATHFUN_H

--- a/src/layer/x86/avx_mathfun.h
+++ b/src/layer/x86/avx_mathfun.h
@@ -763,4 +763,268 @@ static NCNN_FORCEINLINE __m256 atan2256_ps(__m256 a, __m256 b)
     return _mm256_loadu_ps(tmpx);
 }
 
+static NCNN_FORCEINLINE __m256 asin256_ps(__m256 x)
+{
+    const __m256 magic_negative_zero = _mm256_set1_ps(-0.0f);
+    const __m256 magic_half_one = _mm256_set1_ps(0.5f);
+    const __m256 magic_one = _mm256_set1_ps(1.0f);
+    const __m256 magic_a4 = _mm256_set1_ps(0.023994016f);
+    const __m256 magic_a5 = _mm256_set1_ps(0.042417344f);
+    const __m256 magic_a2 = _mm256_set1_ps(0.07494697f);
+    const __m256 magic_a3 = _mm256_set1_ps(0.045520633f);
+    const __m256 magic_a0 = _mm256_set1_ps(1.0f);
+    const __m256 magic_a1 = _mm256_set1_ps(0.166667819f);
+    const __m256 magic_half_pi = _mm256_set1_ps(1.5707964f);
+    const __m256 magic_three = _mm256_set1_ps(3.0f);
+
+    // negative_mask = magic_negative_zero && x;
+    __m256 negative_mask = _mm256_and_ps(magic_negative_zero, x);
+
+    // absolute = abs(x);
+    __m256 absolute = _mm256_andnot_ps(magic_negative_zero, x);
+
+    // Reference: https://en.wikipedia.org/wiki/Small-angle_approximation
+
+    // is_small_input = (absolute <= 0.5f);
+    __m256 is_small_input = _mm256_cmp_ps(absolute, magic_half_one, _CMP_LE_OQ);
+
+    // is_big_input = (is_small_input ? 0.0f : 1.0f);
+    __m256 is_big_input = _mm256_andnot_ps(is_small_input, magic_one);
+
+    // big_input_approx = sqrt(0.5f * (1 - absolute));
+    __m256 big_input_approx = _mm256_sqrt_ps(_mm256_mul_ps(
+        magic_half_one,
+        _mm256_sub_ps(magic_one, absolute)));
+
+    // input_approx = (is_small_input ? absolute : big_input_approx);
+    __m256 input_approx = _mm256_or_ps(
+        _mm256_and_ps(is_small_input, absolute),
+        _mm256_andnot_ps(is_small_input, big_input_approx));
+
+    // square_of_input_approx = input_approx * input_approx;
+    __m256 square_of_input_approx = _mm256_mul_ps(input_approx, input_approx);
+
+    // fourth_power_of_input_approx =
+    //     square_of_input_approx * square_of_input_approx;
+    __m256 fourth_power_of_input_approx = _mm256_mul_ps(
+        square_of_input_approx, square_of_input_approx);
+
+    // TODO: Need more explanations.
+    // x1 = ((fourth_power_of_input_approx * magic_a4) + magic_a2);
+    // x2 = ((fourth_power_of_input_approx * magic_a5) + magic_a3);
+    // x3 = ((fourth_power_of_input_approx * x1) + magic_a0);
+    // x4 = ((fourth_power_of_input_approx * x2) + magic_a1);
+    // output_approx = ((square_of_input_approx * x4) + x3);
+    __m256 output_approx = _mm256_comp_fmadd_ps(
+        square_of_input_approx,
+        _mm256_comp_fmadd_ps(
+            fourth_power_of_input_approx,
+            _mm256_comp_fmadd_ps(
+                fourth_power_of_input_approx,
+                magic_a5,
+                magic_a3),
+            magic_a1),
+        _mm256_comp_fmadd_ps(
+            fourth_power_of_input_approx,
+            _mm256_comp_fmadd_ps(
+                fourth_power_of_input_approx,
+                magic_a4,
+                magic_a2),
+            magic_a0));
+
+    // TODO: Need more explanations.
+    // x1 = ((0.5 * PI) * is_big_input);
+    // x2 = (output_approx * input_approx);
+    // x3 = (-(3.0f * is_big_input) + 1.0f);
+    // final_approx = ((x2 * x3) + x1);
+    __m256 final_approx = _mm256_comp_fmadd_ps(
+        _mm256_mul_ps(output_approx, input_approx),
+        _mm256_comp_fnmadd_ps(magic_three, is_big_input, magic_one),
+        _mm256_mul_ps(magic_half_pi, is_big_input));
+
+    // return (final_approx || negative_mask);
+    return _mm256_or_ps(final_approx, negative_mask);
+}
+
+static NCNN_FORCEINLINE __m256 acos256_ps(__m256 x)
+{
+    const __m256 magic_negative_zero = _mm256_set1_ps(-0.0f);
+    const __m256 magic_zero = _mm256_set1_ps(0.0f);
+    const __m256 magic_half_one = _mm256_set1_ps(0.5f);
+    const __m256 magic_one = _mm256_set1_ps(1.0f);
+    const __m256 magic_a4 = _mm256_set1_ps(0.023994016f);
+    const __m256 magic_a5 = _mm256_set1_ps(0.042417344f);
+    const __m256 magic_a2 = _mm256_set1_ps(0.07494697f);
+    const __m256 magic_a3 = _mm256_set1_ps(0.045520633f);
+    const __m256 magic_a0 = _mm256_set1_ps(1.0f);
+    const __m256 magic_a1 = _mm256_set1_ps(0.166667819f);
+    const __m256 magic_half_pi = _mm256_set1_ps(1.5707964f);
+    const __m256 magic_pi = _mm256_set1_ps(3.1415927f);
+
+    // negative_mask = magic_negative_zero && x;
+    __m256 negative_mask = _mm256_and_ps(magic_negative_zero, x);
+
+    // absolute = abs(x);
+    __m256 absolute = _mm256_andnot_ps(magic_negative_zero, x);
+
+    // Reference: https://en.wikipedia.org/wiki/Small-angle_approximation
+
+    // is_small_input = (absolute <= 0.5f);
+    __m256 is_small_input = _mm256_cmp_ps(absolute, magic_half_one, _CMP_LE_OQ);
+
+    // big_input_approx = sqrt(0.5f * (1 - absolute));
+    __m256 big_input_approx = _mm256_sqrt_ps(_mm256_mul_ps(
+        magic_half_one,
+        _mm256_sub_ps(magic_one, absolute)));
+
+    // input_approx = (is_small_input ? absolute : big_input_approx);
+    __m256 input_approx = _mm256_or_ps(
+        _mm256_and_ps(is_small_input, absolute),
+        _mm256_andnot_ps(is_small_input, big_input_approx));
+
+    // square_of_input_approx = input_approx * input_approx;
+    __m256 square_of_input_approx = _mm256_mul_ps(input_approx, input_approx);
+
+    // fourth_power_of_input_approx =
+    //     square_of_input_approx * square_of_input_approx;
+    __m256 fourth_power_of_input_approx = _mm256_mul_ps(
+        square_of_input_approx, square_of_input_approx);
+
+    // TODO: Need more explanations.
+    // x1 = ((fourth_power_of_input_approx * magic_a4) + magic_a2);
+    // x2 = ((fourth_power_of_input_approx * magic_a5) + magic_a3);
+    // x3 = ((fourth_power_of_input_approx * x1) + magic_a0);
+    // x4 = ((fourth_power_of_input_approx * x2) + magic_a1);
+    // output_approx = ((square_of_input_approx * x4) + x3);
+    __m256 output_approx = _mm256_comp_fmadd_ps(
+        square_of_input_approx,
+        _mm256_comp_fmadd_ps(
+            fourth_power_of_input_approx,
+            _mm256_comp_fmadd_ps(
+                fourth_power_of_input_approx,
+                magic_a5,
+                magic_a3),
+            magic_a1),
+        _mm256_comp_fmadd_ps(
+            fourth_power_of_input_approx,
+            _mm256_comp_fmadd_ps(
+                fourth_power_of_input_approx,
+                magic_a4,
+                magic_a2),
+            magic_a0));
+
+    // TODO: Need more explanations.
+    // x1 = (output_approx * input_approx);
+    __m256 x1 = _mm256_mul_ps(output_approx, input_approx);
+
+    // TODO: Need more explanations.
+    // small_final_approx = ((0.5 * PI) - (x1 | negative_mask));
+    __m256 small_final_approx = _mm256_sub_ps(
+        magic_half_pi,
+        _mm256_or_ps(x1, negative_mask));
+
+    // TODO: Need more explanations.
+    // big_final_approx = (((x < 0.0f) & PI) + ((x1 * 2) | negative_mask));
+    __m256 big_final_approx = _mm256_add_ps(
+        _mm256_and_ps(_mm256_cmp_ps(x, magic_zero, _CMP_LT_OQ), magic_pi),
+        _mm256_or_ps(_mm256_add_ps(x1, x1), negative_mask));
+
+    // return (is_small_input ? small_final_approx : big_final_approx);
+    return _mm256_or_ps(
+        _mm256_and_ps(is_small_input, small_final_approx),
+        _mm256_andnot_ps(is_small_input, big_final_approx));
+}
+
+static NCNN_FORCEINLINE __m256 atan256_ps(__m256 x)
+{
+    const __m256 magic_negative_zero = _mm256_set1_ps(-0.0f);
+    const __m256 magic_one = _mm256_set1_ps(1.0f);
+    const __m256 magic_negative_one = _mm256_set1_ps(-1.0f);
+    const __m256 magic_half_pi = _mm256_set1_ps(1.5707964f);
+    const __m256 magic_a0 = _mm256_set1_ps(1.0f);
+    const __m256 magic_a1 = _mm256_set1_ps(-0.33333072f);
+    const __m256 magic_a2 = _mm256_set1_ps(0.1999262f);
+    const __m256 magic_a3 = _mm256_set1_ps(-0.14203644f);
+    const __m256 magic_a4 = _mm256_set1_ps(0.10640934f);
+    const __m256 magic_a5 = _mm256_set1_ps(-0.07504295f);
+    const __m256 magic_a6 = _mm256_set1_ps(0.04269152f);
+    const __m256 magic_a7 = _mm256_set1_ps(-0.01606863f);
+    const __m256 magic_a8 = _mm256_set1_ps(0.0028498897f);
+
+    // negative_mask = magic_negative_zero && x;
+    __m256 negative_mask = _mm256_and_ps(magic_negative_zero, x);
+
+    // absolute = abs(x);
+    __m256 absolute = _mm256_andnot_ps(magic_negative_zero, x);
+
+    // Reference: https://en.wikipedia.org/wiki/Small-angle_approximation
+
+    // is_small_input = (1.0f < absolute);
+    __m256 is_small_input = _mm256_cmp_ps(magic_one, absolute, _CMP_LT_OQ);
+
+    // x1 = (is_small_input ? -1.0f : absolute);
+    // x2 = (is_small_input ? absolute : 1.0f)
+    // input_approx = x1 / x2;
+    __m256 input_approx = _mm256_div_ps(
+        _mm256_or_ps(
+            _mm256_and_ps(is_small_input, magic_negative_one),
+            _mm256_andnot_ps(is_small_input, absolute)),
+        _mm256_or_ps(
+            _mm256_and_ps(is_small_input, absolute),
+            _mm256_andnot_ps(is_small_input, magic_one)));
+
+    // square_of_input_approx = input_approx * input_approx;
+    __m256 square_of_input_approx = _mm256_mul_ps(input_approx, input_approx);
+
+    // fourth_power_of_input_approx =
+    //     square_of_input_approx * square_of_input_approx;
+    __m256 fourth_power_of_input_approx = _mm256_mul_ps(
+        square_of_input_approx, square_of_input_approx);
+
+    // TODO: Need more explanations.
+    // x1 = ((fourth_power_of_input_approx * magic_a7) + magic_a5);
+    // x2 = ((fourth_power_of_input_approx * magic_a8) + magic_a6);
+    // x3 = ((fourth_power_of_input_approx * x1) + magic_a3);
+    // x4 = ((fourth_power_of_input_approx * x2) + magic_a4);
+    // x5 = ((fourth_power_of_input_approx * x3) + magic_a1);
+    // x6 = ((fourth_power_of_input_approx * x4) + magic_a2);
+    // x7 = ((fourth_power_of_input_approx * x6) + magic_a0);
+    // output_approx = ((square_of_input_approx * x5) + x7);
+    __m256 output_approx = _mm256_comp_fmadd_ps(
+        square_of_input_approx,
+        _mm256_comp_fmadd_ps(
+            fourth_power_of_input_approx,
+            _mm256_comp_fmadd_ps(
+                fourth_power_of_input_approx,
+                _mm256_comp_fmadd_ps(
+                    fourth_power_of_input_approx,
+                    magic_a7,
+                    magic_a5),
+                magic_a3),
+            magic_a1),
+        _mm256_comp_fmadd_ps(
+            fourth_power_of_input_approx,
+            _mm256_comp_fmadd_ps(
+                fourth_power_of_input_approx,
+                _mm256_comp_fmadd_ps(
+                    fourth_power_of_input_approx,
+                    _mm256_comp_fmadd_ps(
+                        fourth_power_of_input_approx,
+                        magic_a8,
+                        magic_a6),
+                    magic_a4),
+                magic_a2),
+            magic_a0));
+
+    // TODO: Need more explanations.
+    // x1 = (output_approx * input_approx);
+    // if (is_small_input) x1 += (0.5 * PI);
+    // return (negative_mask ? -x1 : x1);
+    return _mm256_or_ps(
+        _mm256_add_ps(
+            _mm256_mul_ps(output_approx, input_approx),
+            _mm256_and_ps(is_small_input, magic_half_pi)),
+        negative_mask);
+}
+
 #endif // AVX_MATHFUN_H

--- a/src/layer/x86/avx_mathfun.h
+++ b/src/layer/x86/avx_mathfun.h
@@ -793,13 +793,13 @@ static NCNN_FORCEINLINE __m256 asin256_ps(__m256 x)
 
     // big_input_approx = sqrt(0.5f * (1 - absolute));
     __m256 big_input_approx = _mm256_sqrt_ps(_mm256_mul_ps(
-        magic_half_one,
-        _mm256_sub_ps(magic_one, absolute)));
+                                  magic_half_one,
+                                  _mm256_sub_ps(magic_one, absolute)));
 
     // input_approx = (is_small_input ? absolute : big_input_approx);
     __m256 input_approx = _mm256_or_ps(
-        _mm256_and_ps(is_small_input, absolute),
-        _mm256_andnot_ps(is_small_input, big_input_approx));
+                              _mm256_and_ps(is_small_input, absolute),
+                              _mm256_andnot_ps(is_small_input, big_input_approx));
 
     // square_of_input_approx = input_approx * input_approx;
     __m256 square_of_input_approx = _mm256_mul_ps(input_approx, input_approx);
@@ -807,7 +807,7 @@ static NCNN_FORCEINLINE __m256 asin256_ps(__m256 x)
     // fourth_power_of_input_approx =
     //     square_of_input_approx * square_of_input_approx;
     __m256 fourth_power_of_input_approx = _mm256_mul_ps(
-        square_of_input_approx, square_of_input_approx);
+            square_of_input_approx, square_of_input_approx);
 
     // TODO: Need more explanations.
     // x1 = ((fourth_power_of_input_approx * magic_a4) + magic_a2);
@@ -816,21 +816,21 @@ static NCNN_FORCEINLINE __m256 asin256_ps(__m256 x)
     // x4 = ((fourth_power_of_input_approx * x2) + magic_a1);
     // output_approx = ((square_of_input_approx * x4) + x3);
     __m256 output_approx = _mm256_comp_fmadd_ps(
-        square_of_input_approx,
-        _mm256_comp_fmadd_ps(
-            fourth_power_of_input_approx,
-            _mm256_comp_fmadd_ps(
-                fourth_power_of_input_approx,
-                magic_a5,
-                magic_a3),
-            magic_a1),
-        _mm256_comp_fmadd_ps(
-            fourth_power_of_input_approx,
-            _mm256_comp_fmadd_ps(
-                fourth_power_of_input_approx,
-                magic_a4,
-                magic_a2),
-            magic_a0));
+                               square_of_input_approx,
+                               _mm256_comp_fmadd_ps(
+                                   fourth_power_of_input_approx,
+                                   _mm256_comp_fmadd_ps(
+                                       fourth_power_of_input_approx,
+                                       magic_a5,
+                                       magic_a3),
+                                   magic_a1),
+                               _mm256_comp_fmadd_ps(
+                                   fourth_power_of_input_approx,
+                                   _mm256_comp_fmadd_ps(
+                                       fourth_power_of_input_approx,
+                                       magic_a4,
+                                       magic_a2),
+                                   magic_a0));
 
     // TODO: Need more explanations.
     // x1 = ((0.5 * PI) * is_big_input);
@@ -838,9 +838,9 @@ static NCNN_FORCEINLINE __m256 asin256_ps(__m256 x)
     // x3 = (-(3.0f * is_big_input) + 1.0f);
     // final_approx = ((x2 * x3) + x1);
     __m256 final_approx = _mm256_comp_fmadd_ps(
-        _mm256_mul_ps(output_approx, input_approx),
-        _mm256_comp_fnmadd_ps(magic_three, is_big_input, magic_one),
-        _mm256_mul_ps(magic_half_pi, is_big_input));
+                              _mm256_mul_ps(output_approx, input_approx),
+                              _mm256_comp_fnmadd_ps(magic_three, is_big_input, magic_one),
+                              _mm256_mul_ps(magic_half_pi, is_big_input));
 
     // return (final_approx || negative_mask);
     return _mm256_or_ps(final_approx, negative_mask);
@@ -874,13 +874,13 @@ static NCNN_FORCEINLINE __m256 acos256_ps(__m256 x)
 
     // big_input_approx = sqrt(0.5f * (1 - absolute));
     __m256 big_input_approx = _mm256_sqrt_ps(_mm256_mul_ps(
-        magic_half_one,
-        _mm256_sub_ps(magic_one, absolute)));
+                                  magic_half_one,
+                                  _mm256_sub_ps(magic_one, absolute)));
 
     // input_approx = (is_small_input ? absolute : big_input_approx);
     __m256 input_approx = _mm256_or_ps(
-        _mm256_and_ps(is_small_input, absolute),
-        _mm256_andnot_ps(is_small_input, big_input_approx));
+                              _mm256_and_ps(is_small_input, absolute),
+                              _mm256_andnot_ps(is_small_input, big_input_approx));
 
     // square_of_input_approx = input_approx * input_approx;
     __m256 square_of_input_approx = _mm256_mul_ps(input_approx, input_approx);
@@ -888,7 +888,7 @@ static NCNN_FORCEINLINE __m256 acos256_ps(__m256 x)
     // fourth_power_of_input_approx =
     //     square_of_input_approx * square_of_input_approx;
     __m256 fourth_power_of_input_approx = _mm256_mul_ps(
-        square_of_input_approx, square_of_input_approx);
+            square_of_input_approx, square_of_input_approx);
 
     // TODO: Need more explanations.
     // x1 = ((fourth_power_of_input_approx * magic_a4) + magic_a2);
@@ -897,21 +897,21 @@ static NCNN_FORCEINLINE __m256 acos256_ps(__m256 x)
     // x4 = ((fourth_power_of_input_approx * x2) + magic_a1);
     // output_approx = ((square_of_input_approx * x4) + x3);
     __m256 output_approx = _mm256_comp_fmadd_ps(
-        square_of_input_approx,
-        _mm256_comp_fmadd_ps(
-            fourth_power_of_input_approx,
-            _mm256_comp_fmadd_ps(
-                fourth_power_of_input_approx,
-                magic_a5,
-                magic_a3),
-            magic_a1),
-        _mm256_comp_fmadd_ps(
-            fourth_power_of_input_approx,
-            _mm256_comp_fmadd_ps(
-                fourth_power_of_input_approx,
-                magic_a4,
-                magic_a2),
-            magic_a0));
+                               square_of_input_approx,
+                               _mm256_comp_fmadd_ps(
+                                   fourth_power_of_input_approx,
+                                   _mm256_comp_fmadd_ps(
+                                       fourth_power_of_input_approx,
+                                       magic_a5,
+                                       magic_a3),
+                                   magic_a1),
+                               _mm256_comp_fmadd_ps(
+                                   fourth_power_of_input_approx,
+                                   _mm256_comp_fmadd_ps(
+                                       fourth_power_of_input_approx,
+                                       magic_a4,
+                                       magic_a2),
+                                   magic_a0));
 
     // TODO: Need more explanations.
     // x1 = (output_approx * input_approx);
@@ -920,19 +920,19 @@ static NCNN_FORCEINLINE __m256 acos256_ps(__m256 x)
     // TODO: Need more explanations.
     // small_final_approx = ((0.5 * PI) - (x1 | negative_mask));
     __m256 small_final_approx = _mm256_sub_ps(
-        magic_half_pi,
-        _mm256_or_ps(x1, negative_mask));
+                                    magic_half_pi,
+                                    _mm256_or_ps(x1, negative_mask));
 
     // TODO: Need more explanations.
     // big_final_approx = (((x < 0.0f) & PI) + ((x1 * 2) | negative_mask));
     __m256 big_final_approx = _mm256_add_ps(
-        _mm256_and_ps(_mm256_cmp_ps(x, magic_zero, _CMP_LT_OQ), magic_pi),
-        _mm256_or_ps(_mm256_add_ps(x1, x1), negative_mask));
+                                  _mm256_and_ps(_mm256_cmp_ps(x, magic_zero, _CMP_LT_OQ), magic_pi),
+                                  _mm256_or_ps(_mm256_add_ps(x1, x1), negative_mask));
 
     // return (is_small_input ? small_final_approx : big_final_approx);
     return _mm256_or_ps(
-        _mm256_and_ps(is_small_input, small_final_approx),
-        _mm256_andnot_ps(is_small_input, big_final_approx));
+               _mm256_and_ps(is_small_input, small_final_approx),
+               _mm256_andnot_ps(is_small_input, big_final_approx));
 }
 
 static NCNN_FORCEINLINE __m256 atan256_ps(__m256 x)
@@ -966,12 +966,12 @@ static NCNN_FORCEINLINE __m256 atan256_ps(__m256 x)
     // x2 = (is_small_input ? absolute : 1.0f)
     // input_approx = x1 / x2;
     __m256 input_approx = _mm256_div_ps(
-        _mm256_or_ps(
-            _mm256_and_ps(is_small_input, magic_negative_one),
-            _mm256_andnot_ps(is_small_input, absolute)),
-        _mm256_or_ps(
-            _mm256_and_ps(is_small_input, absolute),
-            _mm256_andnot_ps(is_small_input, magic_one)));
+                              _mm256_or_ps(
+                                  _mm256_and_ps(is_small_input, magic_negative_one),
+                                  _mm256_andnot_ps(is_small_input, absolute)),
+                              _mm256_or_ps(
+                                  _mm256_and_ps(is_small_input, absolute),
+                                  _mm256_andnot_ps(is_small_input, magic_one)));
 
     // square_of_input_approx = input_approx * input_approx;
     __m256 square_of_input_approx = _mm256_mul_ps(input_approx, input_approx);
@@ -979,7 +979,7 @@ static NCNN_FORCEINLINE __m256 atan256_ps(__m256 x)
     // fourth_power_of_input_approx =
     //     square_of_input_approx * square_of_input_approx;
     __m256 fourth_power_of_input_approx = _mm256_mul_ps(
-        square_of_input_approx, square_of_input_approx);
+            square_of_input_approx, square_of_input_approx);
 
     // TODO: Need more explanations.
     // x1 = ((fourth_power_of_input_approx * magic_a7) + magic_a5);
@@ -991,40 +991,40 @@ static NCNN_FORCEINLINE __m256 atan256_ps(__m256 x)
     // x7 = ((fourth_power_of_input_approx * x6) + magic_a0);
     // output_approx = ((square_of_input_approx * x5) + x7);
     __m256 output_approx = _mm256_comp_fmadd_ps(
-        square_of_input_approx,
-        _mm256_comp_fmadd_ps(
-            fourth_power_of_input_approx,
-            _mm256_comp_fmadd_ps(
-                fourth_power_of_input_approx,
-                _mm256_comp_fmadd_ps(
-                    fourth_power_of_input_approx,
-                    magic_a7,
-                    magic_a5),
-                magic_a3),
-            magic_a1),
-        _mm256_comp_fmadd_ps(
-            fourth_power_of_input_approx,
-            _mm256_comp_fmadd_ps(
-                fourth_power_of_input_approx,
-                _mm256_comp_fmadd_ps(
-                    fourth_power_of_input_approx,
-                    _mm256_comp_fmadd_ps(
-                        fourth_power_of_input_approx,
-                        magic_a8,
-                        magic_a6),
-                    magic_a4),
-                magic_a2),
-            magic_a0));
+                               square_of_input_approx,
+                               _mm256_comp_fmadd_ps(
+                                   fourth_power_of_input_approx,
+                                   _mm256_comp_fmadd_ps(
+                                       fourth_power_of_input_approx,
+                                       _mm256_comp_fmadd_ps(
+                                           fourth_power_of_input_approx,
+                                           magic_a7,
+                                           magic_a5),
+                                       magic_a3),
+                                   magic_a1),
+                               _mm256_comp_fmadd_ps(
+                                   fourth_power_of_input_approx,
+                                   _mm256_comp_fmadd_ps(
+                                       fourth_power_of_input_approx,
+                                       _mm256_comp_fmadd_ps(
+                                           fourth_power_of_input_approx,
+                                           _mm256_comp_fmadd_ps(
+                                                   fourth_power_of_input_approx,
+                                                   magic_a8,
+                                                   magic_a6),
+                                           magic_a4),
+                                       magic_a2),
+                                   magic_a0));
 
     // TODO: Need more explanations.
     // x1 = (output_approx * input_approx);
     // if (is_small_input) x1 += (0.5 * PI);
     // return (negative_mask ? -x1 : x1);
     return _mm256_or_ps(
-        _mm256_add_ps(
-            _mm256_mul_ps(output_approx, input_approx),
-            _mm256_and_ps(is_small_input, magic_half_pi)),
-        negative_mask);
+               _mm256_add_ps(
+                   _mm256_mul_ps(output_approx, input_approx),
+                   _mm256_and_ps(is_small_input, magic_half_pi)),
+               negative_mask);
 }
 
 #endif // AVX_MATHFUN_H

--- a/src/layer/x86/sse_mathfun.h
+++ b/src/layer/x86/sse_mathfun.h
@@ -861,7 +861,7 @@ static NCNN_FORCEINLINE __m128 asin_ps(__m128 x)
     // is_small_input = (absolute <= 0.5f);
     __m128 is_small_input = _mm_cmple_ps(absolute, magic_half_one);
 
-    // is_big_input = (!is_small_input);
+    // is_big_input = (is_small_input ? 0.0f : 1.0f);
     __m128 is_big_input = _mm_andnot_ps(is_small_input, magic_one);
 
     // big_input_approx = sqrt(0.5f * (1 - absolute));

--- a/src/layer/x86/unaryop_x86.cpp
+++ b/src/layer/x86/unaryop_x86.cpp
@@ -427,18 +427,7 @@ struct unary_op_asin
 #if __AVX__
     __m256 func_pack8(const __m256& x) const
     {
-        //TODO avx optimize
-        float tmp[8];
-        _mm256_storeu_ps(tmp, x);
-        tmp[0] = asin(tmp[0]);
-        tmp[1] = asin(tmp[1]);
-        tmp[2] = asin(tmp[2]);
-        tmp[3] = asin(tmp[3]);
-        tmp[4] = asin(tmp[4]);
-        tmp[5] = asin(tmp[5]);
-        tmp[6] = asin(tmp[6]);
-        tmp[7] = asin(tmp[7]);
-        return _mm256_loadu_ps(tmp);
+        return asin256_ps(x);
     }
 #if __AVX512F__
     __m512 func_pack16(const __m512& x) const
@@ -469,18 +458,7 @@ struct unary_op_acos
 #if __AVX__
     __m256 func_pack8(const __m256& x) const
     {
-        //TODO avx optimize
-        float tmp[8];
-        _mm256_storeu_ps(tmp, x);
-        tmp[0] = acos(tmp[0]);
-        tmp[1] = acos(tmp[1]);
-        tmp[2] = acos(tmp[2]);
-        tmp[3] = acos(tmp[3]);
-        tmp[4] = acos(tmp[4]);
-        tmp[5] = acos(tmp[5]);
-        tmp[6] = acos(tmp[6]);
-        tmp[7] = acos(tmp[7]);
-        return _mm256_loadu_ps(tmp);
+        return acos256_ps(x);
     }
 #if __AVX512F__
     __m512 func_pack16(const __m512& x) const
@@ -511,18 +489,7 @@ struct unary_op_atan
 #if __AVX__
     __m256 func_pack8(const __m256& x) const
     {
-        //TODO avx optimize
-        float tmp[8];
-        _mm256_storeu_ps(tmp, x);
-        tmp[0] = atan(tmp[0]);
-        tmp[1] = atan(tmp[1]);
-        tmp[2] = atan(tmp[2]);
-        tmp[3] = atan(tmp[3]);
-        tmp[4] = atan(tmp[4]);
-        tmp[5] = atan(tmp[5]);
-        tmp[6] = atan(tmp[6]);
-        tmp[7] = atan(tmp[7]);
-        return _mm256_loadu_ps(tmp);
+        return atan256_ps(x);
     }
 #if __AVX512F__
     __m512 func_pack16(const __m512& x) const

--- a/src/layer/x86/unaryop_x86.cpp
+++ b/src/layer/x86/unaryop_x86.cpp
@@ -432,12 +432,7 @@ struct unary_op_asin
 #if __AVX512F__
     __m512 func_pack16(const __m512& x) const
     {
-        //TODO avx512 optimize
-        float tmp[16];
-        _mm512_storeu_ps(tmp, x);
-        for (int i = 0; i < 16; i++)
-            tmp[i] = asin(tmp[i]);
-        return _mm512_loadu_ps(tmp);
+        return asin512_ps(x);
     }
 #endif // __AVX512F__
 #endif // __AVX__
@@ -463,12 +458,7 @@ struct unary_op_acos
 #if __AVX512F__
     __m512 func_pack16(const __m512& x) const
     {
-        //TODO avx512 optimize
-        float tmp[16];
-        _mm512_storeu_ps(tmp, x);
-        for (int i = 0; i < 16; i++)
-            tmp[i] = acos(tmp[i]);
-        return _mm512_loadu_ps(tmp);
+        return acos512_ps(x);
     }
 #endif // __AVX512F__
 #endif // __AVX__
@@ -494,12 +484,7 @@ struct unary_op_atan
 #if __AVX512F__
     __m512 func_pack16(const __m512& x) const
     {
-        //TODO avx512 optimize
-        float tmp[16];
-        _mm512_storeu_ps(tmp, x);
-        for (int i = 0; i < 16; i++)
-            tmp[i] = atan(tmp[i]);
-        return _mm512_loadu_ps(tmp);
+        return atan512_ps(x);
     }
 #endif // __AVX512F__
 #endif // __AVX__


### PR DESCRIPTION
Huge thanks to @Yoh-Z for helping me finish the AVX512F implementation.

Enjoy!

Kenji Mouri