### PR TITLE
fix errors while build in Android Open Source Code"arm_usability.h:20…

### DIFF
--- a/src/layer/arm/cast_arm_bf16.cpp
+++ b/src/layer/arm/cast_arm_bf16.cpp
@@ -14,7 +14,7 @@
 
 #include "cpu.h"
 #include "mat.h"
-
+#include <math.h>
 namespace ncnn {
 
 #include "cast_bf16.h"


### PR DESCRIPTION
…:17 use of undeclared identifier 'round'"

error info:
In file included from vendor/hxxxsilicon/subsystem/ai/third-party/ncnn-20230223/src/layer/arm/cast_arm_bf16.cpp:20:
In file included from vendor/hxxxsilicon/subsystem/ai/third-party/ncnn-20230223/src/layer/arm/cast_bf16.h:14:
vendor/hxxxsilicon/subsystem/ai/third-party/ncnn-20230223/src/layer/arm/arm_usability.h:20:17: error: use of undeclared identifier 'round'
    int int32 = round(v);
                ^
vendor/hxxxsilicon/subsystem/ai/third-party/ncnn-20230223/src/layer/arm/arm_usability.h:128:17: error: use of undeclared identifier 'round'
    int int32 = round(v);

2 errors generated.