### PR TITLE
Add AVX512F implementation of atan2 in x86 targets.

### DIFF
--- a/src/layer/x86/avx512_mathfun.h
+++ b/src/layer/x86/avx512_mathfun.h
@@ -779,7 +779,8 @@ static NCNN_FORCEINLINE __m512 atan512_ps(__m512 x)
                negative_mask);
 }
 
-// MSVC 2017 x86 CI will be breaked if use NCNN_FORCEINLINE for atan2512_ps.
+// MSVC 2017 x86 CI will be broken if use NCNN_FORCEINLINE for atan2512_ps.
+// This function still be inlined compiled by MSVC 2017 even without that.
 #if _MSC_VER < 1920
 static __m512 atan2512_ps(__m512 y, __m512 x)
 #else


### PR DESCRIPTION
This implementation is based on AVX512F implementation of atan in x86 targets.

Note: Related to the implementation in https://github.com/Tencent/ncnn/pull/4633, do some workaround for MSVC 2017 for passing “windows-x86-cpu / vs2017” CI.

Formula Reference: https://mazzo.li/posts/vectorized-atan2.html

Enjoy!

Kenji Mouri