### PR TITLE
fix typo in PNNX groupnorm error message

### DIFF
--- a/tools/pnnx/src/pass_level1/nn_GroupNorm.cpp
+++ b/tools/pnnx/src/pass_level1/nn_GroupNorm.cpp
@@ -57,7 +57,7 @@ public:
         }
         else
         {
-            fprintf(stderr, "Cannot resolve GroupNorm num_channels when affint=False\n");
+            fprintf(stderr, "Cannot resolve GroupNorm num_channels when affine=False\n");
         }
     }
 };


### PR DESCRIPTION
I guess this is an typo.
If it is not an typo, feel free to close it.