### PR TITLE
Fix clang-cl.exe compatibility by using the correct cpuid intrinsics

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -365,7 +365,7 @@ static int get_hw_capability(const char* cap)
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
 static inline void x86_cpuid(int level, unsigned int out[4])
 {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
     __cpuid((int*)out, level);
 #elif defined(__clang__) || defined(__GNUC__)
     __get_cpuid(level, out, out + 1, out + 2, out + 3);


### PR DESCRIPTION
clang-cl.exe is designed to be the drop-in replacement of MSVC's cl.exe. Therefore, `_MSC_VER` preprocessor symbol is also defined by clang-cl.exe. 

However, some LLVM Clang's built-in functions (Intrinsics) are not compatible with MSVC. For example, `__cpuid()` is defined as:
```C
#if __i386__
#define __cpuid(__leaf, __eax, __ebx, __ecx, __edx) \
    __asm("cpuid" : "=a"(__eax), "=b" (__ebx), "=c"(__ecx), "=d"(__edx) \
                  : "0"(__leaf))
``` 
(Reference: https://clang.llvm.org/doxygen/cpuid_8h_source.html)


Therefore, we need to use `__get_cpuid` instead of `__cpuid` when using clang-cl.exe