### PR TITLE
Update onnx2ncnn.cpp

### DIFF
--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -5955,6 +5955,8 @@ int main(int argc, char** argv)
                     fprintf(pp, " 0=4"); // h c w
                 else if (perm[1] == 3 && perm[2] == 2 && perm[3] == 1)
                     fprintf(pp, " 0=5"); // c h w
+                else
+                    fprintf(stderr, "Unsupported transpose type !\n");
             }
             else if (perm.size() == 5)
             {


### PR DESCRIPTION
permute perm.size()==4时 仅考虑了perm[0]==0的情况 实际转换时有可能出错却没有提示 导致inference的时候结果对不上