### PR TITLE
Fix pnnx conversion: index out of range

### DIFF
--- a/tools/pnnx/src/pass_level5/eval_expression.cpp
+++ b/tools/pnnx/src/pass_level5/eval_expression.cpp
@@ -131,6 +131,8 @@ static std::string eval_expression(const Operator* op)
                 else
                 {
                     int bi = std::stoi(b);
+                    if (bi < 0)
+                        bi = op->inputs[input_index]->shape.size() + bi;
                     int r = op->inputs[input_index]->shape[bi];
                     if (r == -1)
                     {


### PR DESCRIPTION
pnnx will encounter index out of range at pass 5 when evauating shape expression with static input shape.