### PR TITLE
Don't silently ignore errors in VkCompute::submit_and_wait

### DIFF
--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -1878,9 +1878,7 @@ int VulkanDevicePrivate::create_dummy_buffer_image()
     cmd.record_dummy_readonly(dummy_image_readonly);
 #endif
 
-    cmd.submit_and_wait();
-
-    return 0;
+    return cmd.submit_and_wait();
 }
 
 void VulkanDevicePrivate::destroy_dummy_buffer_image()


### PR DESCRIPTION
We had a problem when there was "vkQueueSubmit failed" error printed in console but ncnn::Extractor::extract doesn't return any error because return value of submit_and_wait isn't checked.