### PR TITLE
feat(benchmark/benchncnn.cpp): support user defined case

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,7 +4,7 @@ Only the network definition files (ncnn param) are required.
 
 The large model binary files (ncnn bin) are not loaded but generated randomly for speed test.
 
-More model networks may be added later.
+If no model specified, it would benchmark default list. More model networks may be added later.
 
 ---
 Build
@@ -23,7 +23,7 @@ make -j4
 Usage
 ```shell
 # copy all param files to the current directory
-./benchncnn [loop count] [num threads] [powersave] [gpu device] [cooling down]
+./benchncnn [loop count] [num threads] [powersave] [gpu device] [cooling down] [model w h c]
 ```
 run benchncnn on android device
 ```shell
@@ -34,7 +34,7 @@ adb shell
 
 # executed in android adb shell
 cd /data/local/tmp/
-./benchncnn [loop count] [num threads] [powersave] [gpu device] [cooling down]
+./benchncnn [loop count] [num threads] [powersave] [gpu device] [cooling down] [model w h c]
 ```
 
 Parameter
@@ -46,7 +46,10 @@ Parameter
 |powersave|0=all cores, 1=little cores only, 2=big cores only|0|
 |gpu device|-1=cpu-only, 0=gpu0, 1=gpu1 ...|-1|
 |cooling down|0=disable, 1=enable|1|
-
+|model|user specified .param filename, optional|nullptr|
+|w|1~N|-|
+|h|1~N|-|
+|c|1~N|-|
 
 Tips: Disable android UI server and set CPU and GPU to max frequency
 ```shell
@@ -4329,6 +4332,17 @@ cooling_down = 0
            nanodet_m  min =   17.41  max =   18.13  avg =   17.78
     yolo-fastest-1.1  min =   13.91  max =   14.18  avg =   14.03
       yolo-fastestv2  min =   15.94  max =   16.02  avg =   15.97
+```
+### Intel(R) Core(TM) i5-11320H @ 3.20GHz
+```bash
+$ ./benchncnn 4 1 0 -1 1 squeezenet.param 227 227 3
+loop_count = 4
+num_threads = 1
+powersave = 0
+gpu_device = -1
+cooling_down = 1
+
+          squeezenet  min =   45.02  max =   46.32  avg =   45.47
 ```
 
 ### nVIDIA RTX2060 of Notebook

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -23,7 +23,9 @@ make -j4
 Usage
 ```shell
 # copy all param files to the current directory
-./benchncnn [loop count] [num threads] [powersave] [gpu device] [cooling down] [model w h c]
+./benchncnn [loop count] [num threads] [powersave] [gpu device] [cooling down] [(key=value)...]
+  param=model.param
+  shape=[227,227,3],..
 ```
 run benchncnn on android device
 ```shell
@@ -34,7 +36,9 @@ adb shell
 
 # executed in android adb shell
 cd /data/local/tmp/
-./benchncnn [loop count] [num threads] [powersave] [gpu device] [cooling down] [model w h c]
+./benchncnn [loop count] [num threads] [powersave] [gpu device] [cooling down] [(key=value)...]
+  param=model.param
+  shape=[227,227,3],..
 ```
 
 Parameter
@@ -46,10 +50,8 @@ Parameter
 |powersave|0=all cores, 1=little cores only, 2=big cores only|0|
 |gpu device|-1=cpu-only, 0=gpu0, 1=gpu1 ...|-1|
 |cooling down|0=disable, 1=enable|1|
-|model|user specified .param filename, optional|nullptr|
-|w|1~N|-|
-|h|1~N|-|
-|c|1~N|-|
+|param|ncnn model.param filepath|-|
+|shape|model input shapes with, whc format|-|
 
 Tips: Disable android UI server and set CPU and GPU to max frequency
 ```shell
@@ -4332,17 +4334,6 @@ cooling_down = 0
            nanodet_m  min =   17.41  max =   18.13  avg =   17.78
     yolo-fastest-1.1  min =   13.91  max =   14.18  avg =   14.03
       yolo-fastestv2  min =   15.94  max =   16.02  avg =   15.97
-```
-### Intel(R) Core(TM) i5-11320H @ 3.20GHz
-```bash
-$ ./benchncnn 4 1 0 -1 1 squeezenet.param 227 227 3
-loop_count = 4
-num_threads = 1
-powersave = 0
-gpu_device = -1
-cooling_down = 1
-
-          squeezenet  min =   45.02  max =   46.32  avg =   45.47
 ```
 
 ### nVIDIA RTX2060 of Notebook

--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -370,75 +370,75 @@ int main(int argc, char** argv)
         // run default cases
         benchmark("squeezenet", {ncnn::Mat(227, 227, 3)}, opt);
 
-        // benchmark("squeezenet_int8", ncnn::Mat(227, 227, 3), opt);
+        benchmark("squeezenet_int8", {ncnn::Mat(227, 227, 3)}, opt);
 
-        // benchmark("mobilenet", ncnn::Mat(224, 224, 3), opt);
+        benchmark("mobilenet", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("mobilenet_int8", ncnn::Mat(224, 224, 3), opt);
+        benchmark("mobilenet_int8", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("mobilenet_v2", ncnn::Mat(224, 224, 3), opt);
+        benchmark("mobilenet_v2", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // // benchmark("mobilenet_v2_int8", ncnn::Mat(224, 224, 3), opt);
+        // benchmark("mobilenet_v2_int8", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("mobilenet_v3", ncnn::Mat(224, 224, 3), opt);
+        benchmark("mobilenet_v3", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("shufflenet", ncnn::Mat(224, 224, 3), opt);
+        benchmark("shufflenet", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("shufflenet_v2", ncnn::Mat(224, 224, 3), opt);
+        benchmark("shufflenet_v2", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("mnasnet", ncnn::Mat(224, 224, 3), opt);
+        benchmark("mnasnet", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("proxylessnasnet", ncnn::Mat(224, 224, 3), opt);
+        benchmark("proxylessnasnet", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("efficientnet_b0", ncnn::Mat(224, 224, 3), opt);
+        benchmark("efficientnet_b0", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("efficientnetv2_b0", ncnn::Mat(224, 224, 3), opt);
+        benchmark("efficientnetv2_b0", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("regnety_400m", ncnn::Mat(224, 224, 3), opt);
+        benchmark("regnety_400m", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("blazeface", ncnn::Mat(128, 128, 3), opt);
+        benchmark("blazeface", {ncnn::Mat(128, 128, 3)}, opt);
 
-        // benchmark("googlenet", ncnn::Mat(224, 224, 3), opt);
+        benchmark("googlenet", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("googlenet_int8", ncnn::Mat(224, 224, 3), opt);
+        benchmark("googlenet_int8", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("resnet18", ncnn::Mat(224, 224, 3), opt);
+        benchmark("resnet18", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("resnet18_int8", ncnn::Mat(224, 224, 3), opt);
+        benchmark("resnet18_int8", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("alexnet", ncnn::Mat(227, 227, 3), opt);
+        benchmark("alexnet", {ncnn::Mat(227, 227, 3)}, opt);
 
-        // benchmark("vgg16", ncnn::Mat(224, 224, 3), opt);
+        benchmark("vgg16", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("vgg16_int8", ncnn::Mat(224, 224, 3), opt);
+        benchmark("vgg16_int8", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("resnet50", ncnn::Mat(224, 224, 3), opt);
+        benchmark("resnet50", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("resnet50_int8", ncnn::Mat(224, 224, 3), opt);
+        benchmark("resnet50_int8", {ncnn::Mat(224, 224, 3)}, opt);
 
-        // benchmark("squeezenet_ssd", ncnn::Mat(300, 300, 3), opt);
+        benchmark("squeezenet_ssd", {ncnn::Mat(300, 300, 3)}, opt);
 
-        // benchmark("squeezenet_ssd_int8", ncnn::Mat(300, 300, 3), opt);
+        benchmark("squeezenet_ssd_int8", {ncnn::Mat(300, 300, 3)}, opt);
 
-        // benchmark("mobilenet_ssd", ncnn::Mat(300, 300, 3), opt);
+        benchmark("mobilenet_ssd", {ncnn::Mat(300, 300, 3)}, opt);
 
-        // benchmark("mobilenet_ssd_int8", ncnn::Mat(300, 300, 3), opt);
+        benchmark("mobilenet_ssd_int8", {ncnn::Mat(300, 300, 3)}, opt);
 
-        // benchmark("mobilenet_yolo", ncnn::Mat(416, 416, 3), opt);
+        benchmark("mobilenet_yolo", {ncnn::Mat(416, 416, 3)}, opt);
 
-        // benchmark("mobilenetv2_yolov3", ncnn::Mat(352, 352, 3), opt);
+        benchmark("mobilenetv2_yolov3", {ncnn::Mat(352, 352, 3)}, opt);
 
-        // benchmark("yolov4-tiny", ncnn::Mat(416, 416, 3), opt);
+        benchmark("yolov4-tiny", {ncnn::Mat(416, 416, 3)}, opt);
 
-        // benchmark("nanodet_m", ncnn::Mat(320, 320, 3), opt);
+        benchmark("nanodet_m", {ncnn::Mat(320, 320, 3)}, opt);
 
-        // benchmark("yolo-fastest-1.1", ncnn::Mat(320, 320, 3), opt);
+        benchmark("yolo-fastest-1.1", {ncnn::Mat(320, 320, 3)}, opt);
 
-        // benchmark("yolo-fastestv2", ncnn::Mat(352, 352, 3), opt);
+        benchmark("yolo-fastestv2", {ncnn::Mat(352, 352, 3)}, opt);
 
-        // benchmark("vision_transformer", ncnn::Mat(384, 384, 3), opt);
+        benchmark("vision_transformer", {ncnn::Mat(384, 384, 3)}, opt);
 
-        // benchmark("FastestDet", ncnn::Mat(352, 352, 3), opt);
+        benchmark("FastestDet", {ncnn::Mat(352, 352, 3)}, opt);
     }
 #if NCNN_VULKAN
     delete g_blob_vkallocator;

--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -246,7 +246,7 @@ int main(int argc, char** argv)
 
     for (int i = 1; i < argc; i++)
     {
-        if (argv[i][0] == '-')
+        if (argv[i][0] == '-' && argv[i][1] == 'h')
         {
             show_usage();
             return -1;

--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -56,7 +56,6 @@ static ncnn::VkAllocator* g_staging_vkallocator = 0;
 
 void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncnn::Option& opt, bool fix_path = true)
 {
-
     g_blob_pool_allocator.clear();
     g_workspace_pool_allocator.clear();
 
@@ -108,7 +107,8 @@ void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncn
         ncnn::sleep(10 * 1000);
     }
 
-    if (input_names.size() > _in.size()) {
+    if (input_names.size() > _in.size())
+    {
         fprintf(stderr, "input %ld tensors while model has %ld inputs\n", _in.size(), input_names.size());
         return;
     }
@@ -116,13 +116,15 @@ void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncn
     for (int i = 0; i < g_warmup_loop_count; i++)
     {
         ncnn::Extractor ex = net.create_extractor();
-        for (size_t j = 0; j < input_names.size(); ++j) {
+        for (size_t j = 0; j < input_names.size(); ++j)
+        {
             ncnn::Mat in = _in[j];
             in.fill(0.01f);
             ex.input(input_names[j], in);
         }
 
-        for (size_t j = 0; j < output_names.size(); ++j) {
+        for (size_t j = 0; j < output_names.size(); ++j)
+        {
             ncnn::Mat out;
             ex.extract(output_names[0], out);
         }
@@ -138,13 +140,15 @@ void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncn
 
         {
             ncnn::Extractor ex = net.create_extractor();
-            for (size_t j = 0; j < input_names.size(); ++j) {
+            for (size_t j = 0; j < input_names.size(); ++j)
+            {
                 ncnn::Mat in = _in[j];
                 in.fill(0.01f);
                 ex.input(input_names[j], in);
             }
 
-            for (size_t j = 0; j < output_names.size(); ++j) {
+            for (size_t j = 0; j < output_names.size(); ++j)
+            {
                 ncnn::Mat out;
                 ex.extract(output_names[0], out);
             }
@@ -179,7 +183,6 @@ static std::vector<ncnn::Mat> parse_shape_list(char* s)
     char* pch = strtok(s, "[]");
     while (pch != NULL)
     {
-
         // parse a,b,c
         int v;
         int nconsumed = 0;
@@ -209,7 +212,8 @@ static std::vector<ncnn::Mat> parse_shape_list(char* s)
         pch = strtok(NULL, "[]");
     }
 
-    for (size_t i = 0; i < shapes.size(); ++i) {
+    for (size_t i = 0; i < shapes.size(); ++i)
+    {
         const std::vector<int>& shape = shapes[i];
         switch (shape.size())
         {
@@ -293,7 +297,8 @@ int main(int argc, char** argv)
             inputs = parse_shape_list(value);
     }
 
-    if (model != nullptr && inputs.empty()) {
+    if (model != nullptr && inputs.empty())
+    {
         fprintf(stderr, "input tensor shape empty!\n");
         return -1;
     }

--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -320,11 +320,11 @@ int main(int argc, char** argv)
         benchmark("yolo-fastest-1.1", ncnn::Mat(320, 320, 3), opt);
 
         benchmark("yolo-fastestv2", ncnn::Mat(352, 352, 3), opt);
+
+        benchmark("vision_transformer", ncnn::Mat(384, 384, 3), opt);
+
+        benchmark("FastestDet", ncnn::Mat(352, 352, 3), opt);
     }
-
-    benchmark("vision_transformer", ncnn::Mat(384, 384, 3), opt);
-
-    benchmark("FastestDet", ncnn::Mat(352, 352, 3), opt);
 #if NCNN_VULKAN
     delete g_blob_vkallocator;
     delete g_staging_vkallocator;

--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -147,7 +147,6 @@ void benchmark(const char* comment, const ncnn::Mat& _in, const ncnn::Option& op
     fprintf(stderr, "%20s  min = %7.2f  max = %7.2f  avg = %7.2f\n", comment, time_min, time_max, time_avg);
 }
 
-
 int main(int argc, char** argv)
 {
     int loop_count = 4;

--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -119,7 +119,7 @@ void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncn
         ncnn::Mat in = _in[j];
         in.fill(0.01f);
     }
-        
+
     // warm up
     for (int i = 0; i < g_warmup_loop_count; i++)
     {

--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -166,7 +166,7 @@ void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncn
     fprintf(stderr, "%20s  min = %7.2f  max = %7.2f  avg = %7.2f\n", comment, time_min, time_max, time_avg);
 }
 
-void benchmark(const char* comment, ncnn::Mat _in, const ncnn::Option& opt, bool fixed_path = true)
+void benchmark(const char* comment, const ncnn::Mat& _in, const ncnn::Option& opt, bool fixed_path = true)
 {
     std::vector<ncnn::Mat> inputs;
     inputs.push_back(_in);
@@ -376,7 +376,7 @@ int main(int argc, char** argv)
     fprintf(stderr, "gpu_device = %d\n", gpu_device);
     fprintf(stderr, "cooling_down = %d\n", (int)g_enable_cooling_down);
 
-    if (model != nullptr)
+    if (model != 0)
     {
         // run user defined benchmark
         benchmark(model, inputs, opt, false);

--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -112,6 +112,14 @@ void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncn
         fprintf(stderr, "input %ld tensors while model has %ld inputs\n", _in.size(), input_names.size());
         return;
     }
+
+    // initialize input
+    for (size_t j = 0; j < input_names.size(); ++j)
+    {
+        ncnn::Mat in = _in[j];
+        in.fill(0.01f);
+    }
+        
     // warm up
     for (int i = 0; i < g_warmup_loop_count; i++)
     {
@@ -136,7 +144,6 @@ void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncn
     for (int i = 0; i < g_loop_count; i++)
     {
         double start = ncnn::get_current_time();
-
         {
             ncnn::Extractor ex = net.create_extractor();
             for (size_t j = 0; j < input_names.size(); ++j)

--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -54,7 +54,7 @@ static ncnn::VkAllocator* g_blob_vkallocator = 0;
 static ncnn::VkAllocator* g_staging_vkallocator = 0;
 #endif // NCNN_VULKAN
 
-void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncnn::Option& opt, bool fix_path = true)
+void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncnn::Option& opt, bool fixed_path = true)
 {
     g_blob_pool_allocator.clear();
     g_workspace_pool_allocator.clear();
@@ -84,7 +84,7 @@ void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncn
 #define MODEL_DIR ""
 #endif
 
-    if (fix_path)
+    if (fixed_path)
     {
         char parampath[256];
         sprintf(parampath, MODEL_DIR "%s.param", comment);
@@ -119,14 +119,13 @@ void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncn
         for (size_t j = 0; j < input_names.size(); ++j)
         {
             ncnn::Mat in = _in[j];
-            in.fill(0.01f);
             ex.input(input_names[j], in);
         }
 
         for (size_t j = 0; j < output_names.size(); ++j)
         {
             ncnn::Mat out;
-            ex.extract(output_names[0], out);
+            ex.extract(output_names[j], out);
         }
     }
 
@@ -143,14 +142,13 @@ void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncn
             for (size_t j = 0; j < input_names.size(); ++j)
             {
                 ncnn::Mat in = _in[j];
-                in.fill(0.01f);
                 ex.input(input_names[j], in);
             }
 
             for (size_t j = 0; j < output_names.size(); ++j)
             {
                 ncnn::Mat out;
-                ex.extract(output_names[0], out);
+                ex.extract(output_names[j], out);
             }
         }
 
@@ -166,6 +164,13 @@ void benchmark(const char* comment, const std::vector<ncnn::Mat>& _in, const ncn
     time_avg /= g_loop_count;
 
     fprintf(stderr, "%20s  min = %7.2f  max = %7.2f  avg = %7.2f\n", comment, time_min, time_max, time_avg);
+}
+
+void benchmark(const char* comment, ncnn::Mat _in, const ncnn::Option& opt, bool fixed_path = true)
+{
+    std::vector<ncnn::Mat> inputs;
+    inputs.push_back(_in);
+    return benchmark(comment, inputs, opt, fixed_path);
 }
 
 void show_usage()
@@ -241,12 +246,18 @@ int main(int argc, char** argv)
     int powersave = 2;
     int gpu_device = -1;
     int cooling_down = 1;
-    char* model = nullptr;
+    char* model = 0;
     std::vector<ncnn::Mat> inputs;
 
     for (int i = 1; i < argc; i++)
     {
         if (argv[i][0] == '-' && argv[i][1] == 'h')
+        {
+            show_usage();
+            return -1;
+        }
+
+        if (strcmp(argv[i], "--help") == 0)
         {
             show_usage();
             return -1;
@@ -297,7 +308,7 @@ int main(int argc, char** argv)
             inputs = parse_shape_list(value);
     }
 
-    if (model != nullptr && inputs.empty())
+    if (model && inputs.empty())
     {
         fprintf(stderr, "input tensor shape empty!\n");
         return -1;
@@ -373,77 +384,77 @@ int main(int argc, char** argv)
     else
     {
         // run default cases
-        benchmark("squeezenet", {ncnn::Mat(227, 227, 3)}, opt);
+        benchmark("squeezenet", ncnn::Mat(227, 227, 3), opt);
 
-        benchmark("squeezenet_int8", {ncnn::Mat(227, 227, 3)}, opt);
+        benchmark("squeezenet_int8", ncnn::Mat(227, 227, 3), opt);
 
-        benchmark("mobilenet", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("mobilenet", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("mobilenet_int8", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("mobilenet_int8", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("mobilenet_v2", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("mobilenet_v2", ncnn::Mat(224, 224, 3), opt);
 
-        // benchmark("mobilenet_v2_int8", {ncnn::Mat(224, 224, 3)}, opt);
+        // benchmark("mobilenet_v2_int8", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("mobilenet_v3", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("mobilenet_v3", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("shufflenet", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("shufflenet", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("shufflenet_v2", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("shufflenet_v2", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("mnasnet", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("mnasnet", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("proxylessnasnet", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("proxylessnasnet", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("efficientnet_b0", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("efficientnet_b0", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("efficientnetv2_b0", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("efficientnetv2_b0", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("regnety_400m", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("regnety_400m", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("blazeface", {ncnn::Mat(128, 128, 3)}, opt);
+        benchmark("blazeface", ncnn::Mat(128, 128, 3), opt);
 
-        benchmark("googlenet", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("googlenet", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("googlenet_int8", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("googlenet_int8", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("resnet18", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("resnet18", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("resnet18_int8", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("resnet18_int8", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("alexnet", {ncnn::Mat(227, 227, 3)}, opt);
+        benchmark("alexnet", ncnn::Mat(227, 227, 3), opt);
 
-        benchmark("vgg16", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("vgg16", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("vgg16_int8", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("vgg16_int8", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("resnet50", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("resnet50", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("resnet50_int8", {ncnn::Mat(224, 224, 3)}, opt);
+        benchmark("resnet50_int8", ncnn::Mat(224, 224, 3), opt);
 
-        benchmark("squeezenet_ssd", {ncnn::Mat(300, 300, 3)}, opt);
+        benchmark("squeezenet_ssd", ncnn::Mat(300, 300, 3), opt);
 
-        benchmark("squeezenet_ssd_int8", {ncnn::Mat(300, 300, 3)}, opt);
+        benchmark("squeezenet_ssd_int8", ncnn::Mat(300, 300, 3), opt);
 
-        benchmark("mobilenet_ssd", {ncnn::Mat(300, 300, 3)}, opt);
+        benchmark("mobilenet_ssd", ncnn::Mat(300, 300, 3), opt);
 
-        benchmark("mobilenet_ssd_int8", {ncnn::Mat(300, 300, 3)}, opt);
+        benchmark("mobilenet_ssd_int8", ncnn::Mat(300, 300, 3), opt);
 
-        benchmark("mobilenet_yolo", {ncnn::Mat(416, 416, 3)}, opt);
+        benchmark("mobilenet_yolo", ncnn::Mat(416, 416, 3), opt);
 
-        benchmark("mobilenetv2_yolov3", {ncnn::Mat(352, 352, 3)}, opt);
+        benchmark("mobilenetv2_yolov3", ncnn::Mat(352, 352, 3), opt);
 
-        benchmark("yolov4-tiny", {ncnn::Mat(416, 416, 3)}, opt);
+        benchmark("yolov4-tiny", ncnn::Mat(416, 416, 3), opt);
 
-        benchmark("nanodet_m", {ncnn::Mat(320, 320, 3)}, opt);
+        benchmark("nanodet_m", ncnn::Mat(320, 320, 3), opt);
 
-        benchmark("yolo-fastest-1.1", {ncnn::Mat(320, 320, 3)}, opt);
+        benchmark("yolo-fastest-1.1", ncnn::Mat(320, 320, 3), opt);
 
-        benchmark("yolo-fastestv2", {ncnn::Mat(352, 352, 3)}, opt);
+        benchmark("yolo-fastestv2", ncnn::Mat(352, 352, 3), opt);
 
-        benchmark("vision_transformer", {ncnn::Mat(384, 384, 3)}, opt);
+        benchmark("vision_transformer", ncnn::Mat(384, 384, 3), opt);
 
-        benchmark("FastestDet", {ncnn::Mat(352, 352, 3)}, opt);
+        benchmark("FastestDet", ncnn::Mat(352, 352, 3), opt);
     }
 #if NCNN_VULKAN
     delete g_blob_vkallocator;


### PR DESCRIPTION
`benchncnn` 支持指定 param 文件
## 1. 兼容原行为
```bash
$ ./benchncnn
$ ./benchncnn  8
..
$ ./benchncnn 1 8 0 -1 1 param=vgg16.param "shape=[112,112,3]"
loop_count = 1
num_threads = 8
powersave = 0
gpu_device = -1
cooling_down = 1
         vgg16.param  min =   28.64  max =   28.64  avg =   28.64
```

## 2. 发现输入 `-h` 或者 `--help` 打印 usage
```bash
$ ./benchncnn -h
Usage: benchncnn [loop count] [num threads] [powersave] [gpu device] [cooling down] [(key=value)...]
  param=model.param
  shape=[227,227,3],...
```

```bash
$ ./benchncnn 12 --help
Usage: benchncnn [loop count] [num threads] [powersave] [gpu device] [cooling down] [(key=value)...]
  param=model.param
  shape=[227,227,3],...
```

## 3. 增加指定 param 和 shape
shape 用 whc 格式
```bash
$ ./benchncnn 1 8 0 0 1 param=squeezenet.param "shape=[224,224,3]"
loop_count = 1
num_threads = 8
powersave = 0
gpu_device = 0
cooling_down = 1
    squeezenet.param  min =   11.40  max =   11.40  avg =   11.40
```

##  4. 异常处理：没输入shape
```bash
$ ./benchncnn 1 8 0 0 1 param=squeezenet.param                    
input tensor shape empty!
```

##  5. 异常处理：shape 输入了 4 维
```bash
$ ./benchncnn 1 8 0 0 1 param=squeezenet.param "shape=[224,224,3,1]"
unsupported input shape size 4
input tensor shape empty!
```

##  6. 模型只需要 1 个输入，输入了 2 个 shape
正常运行，此时取第一个 shape
```bash
$ ./benchncnn 1 8 0 0 1 param=squeezenet.param "shape=[224,224,3],[666]" 
loop_count = 1
num_threads = 8
powersave = 0
gpu_device = 0
cooling_down = 1
    squeezenet.param  min =    9.09  max =    9.09  avg =    9.09
```
