### PR TITLE
c_api: expose Mat border processing api

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1419,25 +1419,25 @@ int ncnn_extractor_extract_index(ncnn_extractor_t ex, int index, ncnn_mat_t* mat
 
 void ncnn_copy_make_border(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int type, float v, const ncnn_option_t opt)
 {
-    const Option _opt = opt == nullptr ? Option() : *((const Option*)opt);
+    const Option _opt = opt ? *((const Option*)opt) : Option();
     copy_make_border(*(const Mat*)src, *(Mat*)dst, top, bottom, left, right, type, v, _opt);
 }
 
 void ncnn_copy_make_border_3d(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int front, int behind, int type, float v, const ncnn_option_t opt)
 {
-    const Option _opt = opt == nullptr ? Option() : *((const Option*)opt);
+    const Option _opt = opt ? *((const Option*)opt) : Option();
     copy_make_border_3d(*(const Mat*)src, *(Mat*)dst, top, bottom, left, right, front, behind, type, v, _opt);
 }
 
 void ncnn_copy_cut_border(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, const ncnn_option_t opt)
 {
-    const Option _opt = opt == nullptr ? Option() : *((const Option*)opt);
+    const Option _opt = opt ? *((const Option*)opt) : Option();
     copy_cut_border(*(const Mat*)src, *(Mat*)dst, top, bottom, left, right, _opt);
 }
 
 void ncnn_copy_cut_border_3d(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int front, int behind, const ncnn_option_t opt)
 {
-    const Option _opt = opt == nullptr ? Option() : *((const Option*)opt);
+    const Option _opt = opt ? *((const Option*)opt) : Option();
     copy_cut_border_3d(*(const Mat*)src, *(Mat*)dst, top, bottom, left, right, front, behind, _opt);
 }
 

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1417,6 +1417,30 @@ int ncnn_extractor_extract_index(ncnn_extractor_t ex, int index, ncnn_mat_t* mat
     return ret;
 }
 
+void ncnn_copy_make_border(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int type, float v, const ncnn_option_t opt)
+{
+    const Option _opt = opt == nullptr ? Option() : *((const Option*)opt);
+    copy_make_border(*(const Mat*)src, *(Mat*)dst, top, bottom, left, right, type, v, _opt);
+}
+
+void ncnn_copy_make_border_3d(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int front, int behind, int type, float v, const ncnn_option_t opt)
+{
+    const Option _opt = opt == nullptr ? Option() : *((const Option*)opt);
+    copy_make_border_3d(*(const Mat*)src, *(Mat*)dst, top, bottom, left, right, front, behind, type, v, _opt);
+}
+
+void ncnn_copy_cut_border(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, const ncnn_option_t opt)
+{
+    const Option _opt = opt == nullptr ? Option() : *((const Option*)opt);
+    copy_cut_border(*(const Mat*)src, *(Mat*)dst, top, bottom, left, right, _opt);
+}
+
+void ncnn_copy_cut_border_3d(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int front, int behind, const ncnn_option_t opt)
+{
+    const Option _opt = opt == nullptr ? Option() : *((const Option*)opt);
+    copy_cut_border_3d(*(const Mat*)src, *(Mat*)dst, top, bottom, left, right, front, behind, _opt);
+}
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/c_api.h
+++ b/src/c_api.h
@@ -327,6 +327,16 @@ NCNN_EXPORT int ncnn_extractor_extract(ncnn_extractor_t ex, const char* name, nc
 NCNN_EXPORT int ncnn_extractor_input_index(ncnn_extractor_t ex, int index, const ncnn_mat_t mat);
 NCNN_EXPORT int ncnn_extractor_extract_index(ncnn_extractor_t ex, int index, ncnn_mat_t* mat);
 
+/* mat process api */
+#define NCNN_BORDER_CONSTANT = 0,
+#define NCNN_BORDER_REPLICATE = 1,
+#define NCNN_BORDER_REFLECT = 2,
+#define NCNN_BORDER_TRANSPARENT = -233,
+NCNN_EXPORT void ncnn_copy_make_border(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int type, float v, const ncnn_option_t opt);
+NCNN_EXPORT void ncnn_copy_make_border_3d(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int front, int behind, int type, float v, const ncnn_option_t opt);
+NCNN_EXPORT void ncnn_copy_cut_border(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, const ncnn_option_t opt);
+NCNN_EXPORT void ncnn_copy_cut_border_3d(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int front, int behind, const ncnn_option_t opt);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/c_api.h
+++ b/src/c_api.h
@@ -328,9 +328,9 @@ NCNN_EXPORT int ncnn_extractor_input_index(ncnn_extractor_t ex, int index, const
 NCNN_EXPORT int ncnn_extractor_extract_index(ncnn_extractor_t ex, int index, ncnn_mat_t* mat);
 
 /* mat process api */
-#define NCNN_BORDER_CONSTANT 0
-#define NCNN_BORDER_REPLICATE 1
-#define NCNN_BORDER_REFLECT 2
+#define NCNN_BORDER_CONSTANT    0
+#define NCNN_BORDER_REPLICATE   1
+#define NCNN_BORDER_REFLECT     2
 #define NCNN_BORDER_TRANSPARENT -233
 NCNN_EXPORT void ncnn_copy_make_border(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int type, float v, const ncnn_option_t opt);
 NCNN_EXPORT void ncnn_copy_make_border_3d(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int front, int behind, int type, float v, const ncnn_option_t opt);

--- a/src/c_api.h
+++ b/src/c_api.h
@@ -328,10 +328,10 @@ NCNN_EXPORT int ncnn_extractor_input_index(ncnn_extractor_t ex, int index, const
 NCNN_EXPORT int ncnn_extractor_extract_index(ncnn_extractor_t ex, int index, ncnn_mat_t* mat);
 
 /* mat process api */
-#define NCNN_BORDER_CONSTANT = 0,
-#define NCNN_BORDER_REPLICATE = 1,
-#define NCNN_BORDER_REFLECT = 2,
-#define NCNN_BORDER_TRANSPARENT = -233,
+#define NCNN_BORDER_CONSTANT 0
+#define NCNN_BORDER_REPLICATE 1
+#define NCNN_BORDER_REFLECT 2
+#define NCNN_BORDER_TRANSPARENT -233
 NCNN_EXPORT void ncnn_copy_make_border(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int type, float v, const ncnn_option_t opt);
 NCNN_EXPORT void ncnn_copy_make_border_3d(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, int front, int behind, int type, float v, const ncnn_option_t opt);
 NCNN_EXPORT void ncnn_copy_cut_border(const ncnn_mat_t src, ncnn_mat_t dst, int top, int bottom, int left, int right, const ncnn_option_t opt);


### PR DESCRIPTION
Adds `ncnn_copy_make_border`, `ncnn_copy_make_border_3d`, `ncnn_copy_cut_border` and `ncnn_copy_cut_border_3d` to the C api