### PR TITLE
Support mac platform static library compilation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -287,7 +287,7 @@ if(NCNN_VULKAN)
 
     target_link_libraries(ncnn PUBLIC Vulkan::Vulkan)
     # Support mac platform static library compilation
-    if(NOT NCNN_SHARED_LIB AND APPLE)
+    if(NOT NCNN_SHARED_LIB AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
         find_library(CoreFoundation NAMES CoreFoundation)
         find_library(Foundation NAMES Foundation)
         find_library(QuartzCore NAMES QuartzCore)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -287,7 +287,7 @@ if(NCNN_VULKAN)
 
     target_link_libraries(ncnn PUBLIC Vulkan::Vulkan)
     # Support mac platform static library compilation
-    if(NOT NCNN_SHARED_LIB AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    if(NOT NCNN_SHARED_LIB AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "iOS")
         find_library(CoreFoundation NAMES CoreFoundation)
         find_library(Foundation NAMES Foundation)
         find_library(QuartzCore NAMES QuartzCore)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -286,7 +286,28 @@ if(NCNN_VULKAN)
     endif()
 
     target_link_libraries(ncnn PUBLIC Vulkan::Vulkan)
-
+    # Support mac platform static library compilation
+    if(NOT NCNN_SHARED_LIB AND APPLE)
+        find_library(CoreFoundation NAMES CoreFoundation)
+        find_library(Foundation NAMES Foundation)
+        find_library(QuartzCore NAMES QuartzCore)
+        find_library(CoreGraphics NAMES CoreGraphics)
+        find_library(Cocoa NAMES Cocoa)
+        find_library(Metal NAMES Metal)
+        find_library(IOKit NAMES IOKit)
+        find_library(IOSurface NAMES IOSurface)
+        list(APPEND vulkan_dependec_LINK_LIBRARIES
+            ${Metal}
+            ${IOKit}
+            ${IOSurface}
+            ${QuartzCore}
+            ${CoreGraphics}
+            ${Cocoa}
+            ${Foundation}
+            ${CoreFoundation}
+        )
+        target_link_libraries(ncnn PRIVATE ${vulkan_dependec_LINK_LIBRARIES})
+    endif()
     target_include_directories(ncnn PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>)
     target_link_libraries(ncnn PRIVATE glslang SPIRV)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -287,7 +287,7 @@ if(NCNN_VULKAN)
 
     target_link_libraries(ncnn PUBLIC Vulkan::Vulkan)
     # Support mac platform static library compilation
-    if(NOT NCNN_SHARED_LIB AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+    if(NOT NCNN_SHARED_LIB AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
         find_library(CoreFoundation NAMES CoreFoundation)
         find_library(Foundation NAMES Foundation)
         find_library(QuartzCore NAMES QuartzCore)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -287,7 +287,7 @@ if(NCNN_VULKAN)
 
     target_link_libraries(ncnn PUBLIC Vulkan::Vulkan)
     # Support mac platform static library compilation
-    if(NOT NCNN_SHARED_LIB AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "iOS")
+    if(NOT NCNN_SHARED_LIB AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
         find_library(CoreFoundation NAMES CoreFoundation)
         find_library(Foundation NAMES Foundation)
         find_library(QuartzCore NAMES QuartzCore)


### PR DESCRIPTION
修复mac设备编译vulkan静态库时缺少相关依赖的问题
```log
Undefined symbols for architecture arm64:
  "_CACurrentMediaTime", referenced from:
      MVKSwapchain::recordPresentTime(MVKImagePresentInfo const&, unsigned long long) in libMoltenVK.a(libMoltenVK.a-arm64-master.o)
Undefined symbols for architecture arm64:
  "_CACurrentMediaTime", referenced from:
      MVKSwapchain::recordPresentTime(MVKImagePresentInfo const&, unsigned long long) in libMoltenVK.a(libMoltenVK.a-arm64-master.o)
  "_CFArrayAppendValue", referenced from:
      MVKImage::useIOSurface(__IOSurface*) in libMoltenVK.a(libMoltenVK.a-arm64-master.o)
Undefined symbols for architecture arm64:
  "_CACurrentMediaTime", referenced from:
Undefined symbols for architecture arm64:
  "_CACurrentMediaTime", referenced from:
      MVKSwapchain::recordPresentTime(MVKImagePresentInfo const&, unsigned long long) in libMoltenVK.a(libMoltenVK.a-arm64-master.o)
      MVKSwapchain::recordPresentTime(MVKImagePresentInfo const&, unsigned long long) in libMoltenVK.a(libMoltenVK.a-arm64-master.o)
  "_CFArrayCreateMutable", referenced from:
  "_CFArrayAppendValue", referenced from:
      MVKImage::useIOSurface(__IOSurface*) in libMoltenVK.a(libMoltenVK.a-arm64-master.o)
      MVKImage::useIOSurface(__IOSurface*) in libMoltenVK.a(libMoltenVK.a-arm64-master.o)
...
   ```
   添加后，可成功编译为静态库，可被用于其它应用调用，而无需像vkpeak里那样使项目代码和ncnn代码夹杂在同一个目录里。