### PR TITLE
c_api return null on null layer

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -1028,8 +1028,14 @@ ncnn_layer_t ncnn_layer_create()
 
 ncnn_layer_t ncnn_layer_create_by_typeindex(int typeindex)
 {
+    void* pthis = (void*)(ncnn::create_layer(typeindex));
+    if (!pthis)
+    {
+        return 0;
+    }
+
     ncnn_layer_t layer = (ncnn_layer_t)malloc(sizeof(__ncnn_layer_t));
-    layer->pthis = (void*)(ncnn::create_layer(typeindex));
+    layer->pthis = pthis;
     layer->load_param = __ncnn_layer_load_param;
     layer->load_model = __ncnn_layer_load_model;
     layer->create_pipeline = __ncnn_layer_create_pipeline;
@@ -1044,8 +1050,14 @@ ncnn_layer_t ncnn_layer_create_by_typeindex(int typeindex)
 #if NCNN_STRING
 ncnn_layer_t ncnn_layer_create_by_type(const char* type)
 {
+    void* pthis = (void*)(ncnn::create_layer(type));
+    if (!pthis)
+    {
+        return 0;
+    }
+
     ncnn_layer_t layer = (ncnn_layer_t)malloc(sizeof(__ncnn_layer_t));
-    layer->pthis = (void*)(ncnn::create_layer(type));
+    layer->pthis = pthis;
     layer->load_param = __ncnn_layer_load_param;
     layer->load_model = __ncnn_layer_load_model;
     layer->create_pipeline = __ncnn_layer_create_pipeline;


### PR DESCRIPTION
Adds a check to `ncnn_layer_create_by_typeindex` and `ncnn_layer_create_by_type` to return null if the index or name don't match any known layer.

This is mostly to move segmentation faults deriving from a wrong typeindex/name near the source callsite.
