### PR TITLE
[fix] 文档windows编译ncnn中的小问题：编译命令中文件路径不匹配

### DIFF
--- a/docs/how-to-build/how-to-build.md
+++ b/docs/how-to-build/how-to-build.md
@@ -147,14 +147,16 @@ Download and Install Visual Studio Community 2017 from https://visualstudio.micr
 
 Start the command prompt: `Start → Programs → Visual Studio 2017 → Visual Studio Tools → x64 Native Tools Command Prompt for VS 2017`
 
+> You can also search `x64 Native Tools Command Prompt for VS 2017` directly.
+
 Download protobuf-3.11.2 from https://github.com/google/protobuf/archive/v3.11.2.zip
 
 Build protobuf library:
 
 ```shell
 cd <protobuf-root-dir>
-mkdir build
-cd build
+mkdir protobuf_build
+cd protobuf_build
 cmake -A x64 -DCMAKE_INSTALL_PREFIX=%cd%/install -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_MSVC_STATIC_RUNTIME=OFF ../cmake
 cmake --build . --config Release -j 2
 cmake --build . --config Release --target install


### PR DESCRIPTION
根据文档在windows编译ncnn的时候遇到了两个问题：
1. 下载的protobuf解压的文件中本身存在名为`BUILD`的文件，直接创建build目录会报错“子目录或文件build已经存在”
2. 在编译ncnn时依赖protobuf。而文档原来的命令中，文件路径并不匹配。会出现“<protobuf-root-dir>/protobuf_build/install/include/google/protobuf/stubs/common.h" cannot be read.”的问题。 

综上，将编译protobuf时，目录名称改为protobuf_build可以解决。