### PR TITLE
[docs] Clean comments and prints when find vulkan

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -265,18 +265,17 @@ endif()
 if(NCNN_VULKAN)
     find_package(Vulkan QUIET)
     if(NOT Vulkan_FOUND)
-        message(STATUS "=== CMAKE_SYSTEM_NAME is: ${CMAKE_SYSTEM_NAME}")
         if(DEFINED ENV{VULKAN_SDK})
             if(CMAKE_SYSTEM_NAME MATCHES "Linux")
                 list(APPEND CMAKE_MODULE_PATH "$ENV{VULKAN_SDK}/../source/VulkanTools/cmake")
             elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
                 list(APPEND CMAKE_MODULE_PATH "$ENV{VULKAN_SDK}/Samples/cmake")
             elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-                message(WARNING "Failed to find vulkan since cmake too old\n"
+                message(WARNING "Failed to find vulkan since cmake is too old\n"
                     "cmake >= 3.7 required. Consider `brew upgrade cmake`")
             endif()
         else()
-            message(FATAL_ERROR "!! CMake didn't find Vulkan. Please set VULKAN_SDK env var, e.g.:\n"
+            message(FATAL_ERROR "Error: CMake didn't find Vulkan. Please set VULKAN_SDK env var, e.g.:\n"
                 "Linux: export VULKAN_SDK=~/soft/vulkansdk/1.2.148.0/x86_64\n"
                 "Windows: set VULKAN_SDK=E:/lib/VulkanSDK/1.2.148.0\n"
                 "MacOS: export VULKAN_SDK=~/soft/vulkansdk/1.2.148.0/macOS\n"
@@ -296,7 +295,7 @@ if(NCNN_VULKAN)
         find_library(Metal NAMES Metal)
         find_library(IOKit NAMES IOKit)
         find_library(IOSurface NAMES IOSurface)
-        list(APPEND vulkan_dependec_LINK_LIBRARIES
+        list(APPEND vulkan_dependent_LINK_LIBRARIES
             ${Metal}
             ${IOKit}
             ${IOSurface}
@@ -306,7 +305,7 @@ if(NCNN_VULKAN)
             ${Foundation}
             ${CoreFoundation}
         )
-        target_link_libraries(ncnn PRIVATE ${vulkan_dependec_LINK_LIBRARIES})
+        target_link_libraries(ncnn PRIVATE ${vulkan_dependent_LINK_LIBRARIES})
     endif()
     target_include_directories(ncnn PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>)
     target_link_libraries(ncnn PRIVATE glslang SPIRV)


### PR DESCRIPTION
Hi, NiHui & ncnn Contributors

This PR do some minor cleanup work:
- Better renaming: `dependec` => `dependent`
- Better printed message
    - Remove ancient debugging prints
    - Make printed message an complete sentence

Hope it being helpful.