### PR TITLE
fix _mm512_i32gather_epi32 and other scatter/gather routines have incorrect signature.

### DIFF
--- a/src/layer/x86/convolution_packed_int8.h
+++ b/src/layer/x86/convolution_packed_int8.h
@@ -169,22 +169,22 @@ static void convolution_transform_kernel_packed_int8(const Mat& kernel, Mat& ker
 
             for (int k = 0; k < maxk; k++)
             {
-                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr0 + k, sizeof(signed char)));
-                __m128i _w1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr1 + k, sizeof(signed char)));
-                __m128i _w2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr2 + k, sizeof(signed char)));
-                __m128i _w3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr3 + k, sizeof(signed char)));
-                __m128i _w4 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr4 + k, sizeof(signed char)));
-                __m128i _w5 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr5 + k, sizeof(signed char)));
-                __m128i _w6 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr6 + k, sizeof(signed char)));
-                __m128i _w7 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr7 + k, sizeof(signed char)));
-                __m128i _w8 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr8 + k, sizeof(signed char)));
-                __m128i _w9 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr9 + k, sizeof(signed char)));
-                __m128i _wa = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptra + k, sizeof(signed char)));
-                __m128i _wb = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptrb + k, sizeof(signed char)));
-                __m128i _wc = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptrc + k, sizeof(signed char)));
-                __m128i _wd = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptrd + k, sizeof(signed char)));
-                __m128i _we = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptre + k, sizeof(signed char)));
-                __m128i _wf = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptrf + k, sizeof(signed char)));
+                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr0 + k), sizeof(signed char)));
+                __m128i _w1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr1 + k), sizeof(signed char)));
+                __m128i _w2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr2 + k), sizeof(signed char)));
+                __m128i _w3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr3 + k), sizeof(signed char)));
+                __m128i _w4 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr4 + k), sizeof(signed char)));
+                __m128i _w5 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr5 + k), sizeof(signed char)));
+                __m128i _w6 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr6 + k), sizeof(signed char)));
+                __m128i _w7 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr7 + k), sizeof(signed char)));
+                __m128i _w8 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr8 + k), sizeof(signed char)));
+                __m128i _w9 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr9 + k), sizeof(signed char)));
+                __m128i _wa = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptra + k), sizeof(signed char)));
+                __m128i _wb = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptrb + k), sizeof(signed char)));
+                __m128i _wc = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptrc + k), sizeof(signed char)));
+                __m128i _wd = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptrd + k), sizeof(signed char)));
+                __m128i _we = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptre + k), sizeof(signed char)));
+                __m128i _wf = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptrf + k), sizeof(signed char)));
 
                 transpose8x16_epi16(_w0, _w1, _w2, _w3, _w4, _w5, _w6, _w7, _w8, _w9, _wa, _wb, _wc, _wd, _we, _wf);
 
@@ -296,8 +296,8 @@ static void convolution_transform_kernel_packed_int8(const Mat& kernel, Mat& ker
             __m512i _vindex = _mm512_inserti64x4(_mm512_castsi256_si512(_vindex01), _vindex23, 1);
             for (int k = 0; k < maxk; k++)
             {
-                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr0 + k, sizeof(signed char)));
-                __m128i _w1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr8 + k, sizeof(signed char)));
+                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr0 + k), sizeof(signed char)));
+                __m128i _w1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr8 + k), sizeof(signed char)));
 
                 _mm_storeu_si128((__m128i*)g00, _w0);
                 _mm_storeu_si128((__m128i*)(g00 + 16), _w1);
@@ -313,7 +313,7 @@ static void convolution_transform_kernel_packed_int8(const Mat& kernel, Mat& ker
             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(inch * maxk));
             for (int k = 0; k < maxk; k++)
             {
-                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr0 + k, sizeof(signed char)));
+                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr0 + k), sizeof(signed char)));
                 _mm_storeu_si128((__m128i*)g00, _w0);
                 g00 += 16;
             }
@@ -346,14 +346,14 @@ static void convolution_transform_kernel_packed_int8(const Mat& kernel, Mat& ker
 
             for (int k = 0; k < maxk; k++)
             {
-                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr0 + k, sizeof(signed char)));
-                __m128i _w1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr1 + k, sizeof(signed char)));
-                __m128i _w2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr2 + k, sizeof(signed char)));
-                __m128i _w3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr3 + k, sizeof(signed char)));
-                __m128i _w4 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr4 + k, sizeof(signed char)));
-                __m128i _w5 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr5 + k, sizeof(signed char)));
-                __m128i _w6 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr6 + k, sizeof(signed char)));
-                __m128i _w7 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr7 + k, sizeof(signed char)));
+                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr0 + k), sizeof(signed char)));
+                __m128i _w1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr1 + k), sizeof(signed char)));
+                __m128i _w2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr2 + k), sizeof(signed char)));
+                __m128i _w3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr3 + k), sizeof(signed char)));
+                __m128i _w4 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr4 + k), sizeof(signed char)));
+                __m128i _w5 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr5 + k), sizeof(signed char)));
+                __m128i _w6 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr6 + k), sizeof(signed char)));
+                __m128i _w7 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr7 + k), sizeof(signed char)));
 
                 transpose8x8_epi16(_w0, _w1, _w2, _w3, _w4, _w5, _w6, _w7);
 
@@ -446,7 +446,7 @@ static void convolution_transform_kernel_packed_int8(const Mat& kernel, Mat& ker
             for (int k = 0; k < maxk; k++)
             {
 #if __AVX512F__
-                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr0 + k, sizeof(signed char)));
+                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr0 + k), sizeof(signed char)));
 #else
                 __m256i _w01 = _mm256_shuffle_epi8(_mm256_i32gather_epi32((const int*)(kptr0 + k), _vindex01, sizeof(signed char)), _sindex88);
                 __m256i _w23 = _mm256_shuffle_epi8(_mm256_i32gather_epi32((const int*)(kptr4 + k), _vindex01, sizeof(signed char)), _sindex88);
@@ -670,8 +670,8 @@ static void convolution_transform_kernel_packed_int8(const Mat& kernel, Mat& ker
 
             for (int k = 0; k < maxk; k++)
             {
-                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr0 + k, sizeof(signed char)));
-                __m128i _w1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr1 + k, sizeof(signed char)));
+                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr0 + k), sizeof(signed char)));
+                __m128i _w1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr1 + k), sizeof(signed char)));
 
                 _mm_storeu_si128((__m128i*)g00, _w0);
                 _mm_storeu_si128((__m128i*)(g00 + 16), _w1);
@@ -699,7 +699,7 @@ static void convolution_transform_kernel_packed_int8(const Mat& kernel, Mat& ker
             for (int k = 0; k < maxk; k++)
             {
 #if __AVX512F__
-                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr0 + k, sizeof(signed char)));
+                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr0 + k), sizeof(signed char)));
                 _mm_storeu_si128((__m128i*)g00, _w0);
 #elif __AVX2__
                 __m256i _w00 = _mm256_shuffle_epi8(_mm256_i32gather_epi32((const int*)(kptr0 + k), _vindex0, sizeof(signed char)), _sindex88);
@@ -805,7 +805,7 @@ static void convolution_transform_kernel_packed_int8(const Mat& kernel, Mat& ker
 
             for (int k = 0; k < maxk; k++)
             {
-                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr + k, sizeof(signed char)));
+                __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(kptr + k), sizeof(signed char)));
 
                 _mm_storeu_si128((__m128i*)g00, _w0);
                 g00 += 16;
@@ -1029,10 +1029,10 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                     {
                         __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                         _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                        _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
-                        _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
-                        _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r2s, sizeof(signed char)));
-                        _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r3s, sizeof(signed char)));
+                        _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
+                        _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r1s), sizeof(signed char)));
+                        _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r2s), sizeof(signed char)));
+                        _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r3s), sizeof(signed char)));
                     }
 
                     __m256i _rr0 = _mm256_cvtepi8_epi16(_r0);
@@ -1394,8 +1394,8 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                     {
                         __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                         _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                        _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
-                        _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
+                        _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
+                        _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r1s), sizeof(signed char)));
                     }
 
                     __m256i _rr0 = _mm256_cvtepi8_epi16(_r0);
@@ -1649,7 +1649,7 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                     {
                         __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                         _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                        _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
+                        _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
                     }
 
                     __m256i _rr0 = _mm256_cvtepi8_epi16(_r0);
@@ -1910,10 +1910,10 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                         {
                             __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
-                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
-                            _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r2s, sizeof(signed char)));
-                            _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r3s, sizeof(signed char)));
+                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
+                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r1s), sizeof(signed char)));
+                            _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r2s), sizeof(signed char)));
+                            _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r3s), sizeof(signed char)));
                         }
 
                         __m256i _rr0 = _mm256_cvtepi8_epi16(_r0);
@@ -2317,8 +2317,8 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                         {
                             __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
-                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
+                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
+                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r1s), sizeof(signed char)));
                         }
 
                         __m256i _rr0 = _mm256_cvtepi8_epi16(_r0);
@@ -2601,7 +2601,7 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                         {
                             __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
+                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
                         }
 
                         __m256i _rr0 = _mm256_cvtepi8_epi16(_r0);
@@ -2882,10 +2882,10 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                         {
                             __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
-                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
-                            _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r2s, sizeof(signed char)));
-                            _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r3s, sizeof(signed char)));
+                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
+                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r1s), sizeof(signed char)));
+                            _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r2s), sizeof(signed char)));
+                            _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r3s), sizeof(signed char)));
                         }
 
                         __m256i _rr0 = _mm256_cvtepi8_epi16(_r0);
@@ -3337,8 +3337,8 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                         {
                             __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
-                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
+                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
+                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r1s), sizeof(signed char)));
                         }
 
                         __m256i _rr0 = _mm256_cvtepi8_epi16(_r0);
@@ -3669,7 +3669,7 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                         {
                             __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
+                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
                         }
 
                         __m256i _rr0 = _mm256_cvtepi8_epi16(_r0);
@@ -3986,10 +3986,10 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                         {
                             __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
-                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
-                            _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r2s, sizeof(signed char)));
-                            _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r3s, sizeof(signed char)));
+                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
+                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r1s), sizeof(signed char)));
+                            _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r2s), sizeof(signed char)));
+                            _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r3s), sizeof(signed char)));
                         }
 
                         __m256i _val0 = _mm256_cvtepi8_epi16(_r0);
@@ -4324,8 +4324,8 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                         {
                             __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
-                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
+                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
+                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r1s), sizeof(signed char)));
                         }
 
                         __m256i _val0 = _mm256_cvtepi8_epi16(_r0);
@@ -4562,7 +4562,7 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                         {
                             __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
+                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
                         }
 
                         __m256i _val = _mm256_cvtepi8_epi16(_r0);
@@ -4790,10 +4790,10 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                             __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
 
-                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
-                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
-                            _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r2s, sizeof(signed char)));
-                            _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r3s, sizeof(signed char)));
+                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
+                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r1s), sizeof(signed char)));
+                            _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r2s), sizeof(signed char)));
+                            _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r3s), sizeof(signed char)));
                         }
 
                         __m256i _val0 = _mm256_cvtepi8_epi16(_r0);
@@ -5071,8 +5071,8 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                             __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
 
-                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
-                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
+                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
+                            _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r1s), sizeof(signed char)));
                         }
 
                         __m256i _val0 = _mm256_cvtepi8_epi16(_r0);
@@ -5264,7 +5264,7 @@ static void convolution_packed_int8(const Mat& bottom_blob, Mat& top_blob, const
                         {
                             __m512i _vindex = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
                             _vindex = _mm512_mullo_epi32(_vindex, _mm512_set1_epi32(N));
-                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
+                            _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, (const int*)(r0s), sizeof(signed char)));
                         }
 
                         __m256i _val = _mm256_cvtepi8_epi16(_r0);


### PR DESCRIPTION
Errors may occur in gcc versions below 7.0, with the following logs:

```
[ 56%] Building CXX object src/CMakeFiles/ncnn.dir/layer/deconvolution.cpp.o
/root/ncnn/src/layer/x86/convolution_packed_int8.h:673:114: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                 __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr0 + k, sizeof(signed char)));
                                                                                                                  ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:674:114: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                 __m128i _w1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr1 + k, sizeof(signed char)));
                                                                                                                  ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:702:114: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                 __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr0 + k, sizeof(signed char)));
                                                                                                                  ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:808:113: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                 __m128i _w0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, kptr + k, sizeof(signed char)));
                                                                                                                 ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h: In function 'void ncnn::convolution_packed_int8(const ncnn::Mat&, ncnn::Mat&, const ncnn::Mat&, int, int, int, int, int, int, const ncnn::Option&)':
/root/ncnn/src/layer/x86/convolution_packed_int8.h:1032:108: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                         _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                            ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:1033:108: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                         _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
                                                                                                            ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:1034:108: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                         _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r2s, sizeof(signed char)));
                                                                                                            ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:1035:108: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                         _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r3s, sizeof(signed char)));
                                                                                                            ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:1397:108: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                         _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                            ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:1398:108: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                         _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
                                                                                                            ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:1652:108: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                         _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                            ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:1913:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:1914:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:1915:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r2s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:1916:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r3s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:2320:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:2321:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:2604:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:2885:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:2886:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:2887:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r2s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:2888:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r3s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:3340:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:3341:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:3672:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:3989:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:3990:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:3991:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r2s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:3992:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r3s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:4327:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:4328:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:4565:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:4793:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:4794:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:4795:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r2s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:4796:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r3s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:5074:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:5075:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r1s, sizeof(signed char)));
                                                                                                                ^
/root/ncnn/src/layer/x86/convolution_packed_int8.h:5267:112: error: cannot convert 'const signed char*' to 'const int*' for argument '2' to '__m512i _mm512_i32gather_epi32(__m512i, const int*, int)'
                             _r0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_vindex, r0s, sizeof(signed char)));
                                                                                                                ^
[ 56%] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/deconvolution_x86.cpp.o
[ 56%] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/deconvolution_x86_avx512.cpp.o
[ 56%] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/deconvolution_x86_fma.cpp.o
[ 57%] Building CXX object src/CMakeFiles/ncnn.dir/layer/x86/deconvolution_x86_avx.cpp.o
src/CMakeFiles/ncnn.dir/build.make:2366: recipe for target 'src/CMakeFiles/ncnn.dir/layer/x86/convolution_x86_avx512.cpp.o' failed
make[2]: *** [src/CMakeFiles/ncnn.dir/layer/x86/convolution_x86_avx512.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
CMakeFiles/Makefile2:118: recipe for target 'src/CMakeFiles/ncnn.dir/all' failed
make[1]: *** [src/CMakeFiles/ncnn.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
root@virtual-machine:~/ncnn/build# gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/5/lto-wrapper
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 5.4.0-6ubuntu1~16.04.12' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.12)
```

But we can find a solution here:

[https://gcc.gnu.org/bugzilla/show_bug.cgi?id=76731](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=76731)