### PR TITLE
modify protobuf cmake

### DIFF
--- a/tools/caffe/CMakeLists.txt
+++ b/tools/caffe/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PROTOBUF REQUIRED protobuf)
 
 find_package(Protobuf)
 
@@ -12,7 +14,7 @@ if(PROTOBUF_FOUND)
         PRIVATE
             ${PROTOBUF_INCLUDE_DIR}
             ${CMAKE_CURRENT_BINARY_DIR})
-    target_link_libraries(caffe2ncnn PRIVATE ${PROTOBUF_LIBRARIES})
+    target_link_libraries(caffe2ncnn PRIVATE ${PROTOBUF_LDFLAGS})
 
     # add all caffe2ncnn tool to a virtual project group
     set_property(TARGET caffe2ncnn PROPERTY FOLDER "tools/converter")

--- a/tools/onnx/CMakeLists.txt
+++ b/tools/onnx/CMakeLists.txt
@@ -1,4 +1,5 @@
-
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PROTOBUF REQUIRED protobuf)
 find_package(Protobuf)
 
 if(PROTOBUF_FOUND)
@@ -12,7 +13,7 @@ if(PROTOBUF_FOUND)
         PRIVATE
             ${PROTOBUF_INCLUDE_DIR}
             ${CMAKE_CURRENT_BINARY_DIR})
-    target_link_libraries(onnx2ncnn PRIVATE ${PROTOBUF_LIBRARIES})
+    target_link_libraries(onnx2ncnn PRIVATE ${PROTOBUF_LDFLAGS})
 
     # add all onnx2ncnn tool to a virtual project group
     set_property(TARGET onnx2ncnn PROPERTY FOLDER "tools/converter")


### PR DESCRIPTION
新版本的protobuf（22.0以后得版本），在链接时需要链接额外链接Abseil's库，直接链接protobuf库会报错。通过pkg-config方法，获取编译信息来链接，可以避免这个问题。