### PR TITLE
[WIP] added erf support

### DIFF
--- a/docs/developer-guide/operators.md
+++ b/docs/developer-guide/operators.md
@@ -1781,4 +1781,3 @@ Operation type:
 - 17 = LOG10
 - 18 = ROUND
 - 19 = TRUNC
-- 20 = ERF

--- a/docs/developer-guide/operators.md
+++ b/docs/developer-guide/operators.md
@@ -1781,3 +1781,4 @@ Operation type:
 - 17 = LOG10
 - 18 = ROUND
 - 19 = TRUNC
+- 20 = ERF

--- a/src/layer/arm/unaryop_arm.cpp
+++ b/src/layer/arm/unaryop_arm.cpp
@@ -481,10 +481,9 @@ struct unary_op_erf
 #if __ARM_NEON
     float32x4_t func_pack4(const float32x4_t& x) const
     {
-    float norm_x = x / sqrt(2.0f);
+    float32x4_t norm_x_vec = x / vsqrtq_f32(vdupq_n_f32(2.0f));
     float32x4_t erf_approx = vmovq_n_f32(1.0f);
-    float32x4_t norm_x_vec = vdupq_n_f32(norm_x);
-    float32x4_t tanh_x = tanh(vmulq_f32(pi, norm_x_vec));
+    float32x4_t tanh_x = tanh_ps(vmulq_f32(pi, norm_x_vec));
     return vsubq_f32(erf_approx, vmulq_f32(0.5f, tanh_x));
     }
 #endif // __ARM_NEON

--- a/src/layer/arm/unaryop_arm.cpp
+++ b/src/layer/arm/unaryop_arm.cpp
@@ -472,6 +472,24 @@ struct unary_op_trunc
 #endif // __ARM_NEON
 };
 
+struct unary_op_erf
+{
+    float func(const float& x) const
+    {
+        return (float)erf(x);
+    }
+#if __ARM_NEON
+    float32x4_t func_pack4(const float32x4_t& x) const
+    {
+    float norm_x = x / sqrt(2.0f);
+    float32x4_t erf_approx = vmovq_n_f32(1.0f);
+    float32x4_t norm_x_vec = vdupq_n_f32(norm_x);
+    float32x4_t tanh_x = tanh(vmulq_f32(pi, norm_x_vec));
+    return vsubq_f32(erf_approx, vmulq_f32(0.5f, tanh_x));
+    }
+#endif // __ARM_NEON
+};
+
 } // namespace UnaryOp_arm_functor
 
 int UnaryOp_arm::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
@@ -549,6 +567,9 @@ int UnaryOp_arm::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
 
     if (op_type == Operation_TRUNC)
         return unary_op_inplace<unary_op_trunc>(bottom_top_blob, opt);
+
+    if (op_type == Operation_ERF)
+        return unary_op_inplace<unary_op_erf>(bottom_top_blob, opt);
 
     return 0;
 }
@@ -685,6 +706,9 @@ int UnaryOp_arm::forward_inplace_bf16s(Mat& bottom_top_blob, const Option& opt) 
 
     if (op_type == Operation_TRUNC)
         return unary_op_inplace_bf16s<unary_op_trunc>(bottom_top_blob, opt);
+
+    if (op_type == Operation_ERF)
+        return unary_op_inplace_bf16s<unary_op_erf>(bottom_top_blob, opt);
 
     return 0;
 }

--- a/src/layer/unaryop.cpp
+++ b/src/layer/unaryop.cpp
@@ -218,6 +218,14 @@ struct unary_op_trunc
     }
 };
 
+struct unary_op_erf
+{
+    float operator()(const float& x) const
+    {
+        return (float)erf(x);
+    }
+};
+
 int UnaryOp::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
 {
     if (op_type == Operation_ABS)
@@ -279,6 +287,9 @@ int UnaryOp::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
 
     if (op_type == Operation_TRUNC)
         return unary_op_inplace<unary_op_trunc>(bottom_top_blob, opt);
+
+    if (op_type == Operation_ERF)
+        return unary_op_inplace<unary_op_erf>(bottom_top_blob, opt);
 
     return 0;
 }

--- a/src/layer/unaryop.h
+++ b/src/layer/unaryop.h
@@ -49,7 +49,8 @@ public:
         Operation_TANH = 16,
         Operation_LOG10 = 17,
         Operation_ROUND = 18,
-        Operation_TRUNC = 19
+        Operation_TRUNC = 19,
+Operation_ERF = 20
     };
 
 public:

--- a/src/layer/vulkan/shader/unaryop.comp
+++ b/src/layer/vulkan/shader/unaryop.comp
@@ -89,6 +89,7 @@ void main()
     if (op_type == 17) res = log(v) * afp(0.434294481903);
     if (op_type == 18) res = round(v);
     if (op_type == 19) res = trunc(v);
+    if (op_type == 20) res = erf(v);
 
 #if NCNN_image_shader
     image3d_st1(top_blob_3d, ivec3(gx, gy, gz), res);

--- a/src/layer/vulkan/shader/unaryop_pack4.comp
+++ b/src/layer/vulkan/shader/unaryop_pack4.comp
@@ -89,6 +89,7 @@ void main()
     if (op_type == 17) res = log(v) * afp(0.434294481903);
     if (op_type == 18) res = round(v);
     if (op_type == 19) res = trunc(v);
+    if (op_type == 20) res = erf(v);
 
 #if NCNN_image_shader
     image3d_st4(top_blob_3d, ivec3(gx, gy, gz), res);

--- a/src/layer/vulkan/shader/unaryop_pack8.comp
+++ b/src/layer/vulkan/shader/unaryop_pack8.comp
@@ -171,6 +171,11 @@ void main()
         res[0] = trunc(v[0]);
         res[1] = trunc(v[1]);
     }
+    if (op_type == 20)
+    {
+        res[0] = erf(v[0]);
+        res[1] = erf(v[1]);
+    }
 
 #if NCNN_image_shader
     image3d_st8(top_blob_3d, ivec3(gx, gy, gz), res);

--- a/src/layer/x86/unaryop_x86.cpp
+++ b/src/layer/x86/unaryop_x86.cpp
@@ -19,6 +19,7 @@
 #include <math.h>
 
 #if __SSE2__
+#include <xmmintrin.h>
 #include <emmintrin.h>
 #include "sse_mathfun.h"
 #if __SSE4_1__

--- a/src/layer/x86/unaryop_x86.cpp
+++ b/src/layer/x86/unaryop_x86.cpp
@@ -642,6 +642,32 @@ struct unary_op_trunc
 #endif // __SSE2__
 };
 
+struct unary_op_erf
+{
+    float func(const float& x) const
+    {
+        return (float)erf(x);
+    }
+#if __SSE2__
+    __m128 func_pack4(const __m128& x) const
+    {
+        return _mm_erf_ps(x);
+    }
+#if __AVX__
+    __m256 func_pack8(const __m256& x) const
+    {
+        return _mm256_erf_ps(x);
+    }
+#if __AVX512F__
+    __m512 func_pack16(const __m512& x) const
+    {
+        return _mm512_erf_ps(x);
+    }
+#endif // __AVX512F__
+#endif // __AVX__
+#endif // __SSE2__
+};
+
 } // namespace UnaryOp_x86_functor
 
 int UnaryOp_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
@@ -706,6 +732,9 @@ int UnaryOp_x86::forward_inplace(Mat& bottom_top_blob, const Option& opt) const
 
     if (op_type == Operation_TRUNC)
         return unary_op_inplace<unary_op_trunc>(bottom_top_blob, opt);
+
+    if (op_type == Operation_ERF)
+        return unary_op_inplace<unary_op_erf>(bottom_top_blob, opt);
 
     return 0;
 }

--- a/tests/test_unaryop.cpp
+++ b/tests/test_unaryop.cpp
@@ -15,7 +15,7 @@
 #include "layer/unaryop.h"
 #include "testutil.h"
 
-#define OP_TYPE_MAX 20
+#define OP_TYPE_MAX 21
 
 static int op_type = 0;
 

--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -3714,6 +3714,10 @@ int main(int argc, char** argv)
         {
             fprintf(pp, "%-16s", "EmbedLayerNormalization");
         }
+else if (op == "Erf")
+        {
+            fprintf(pp, "%-16s", "UnaryOp");
+        }
         else if (op == "Exp")
         {
             fprintf(pp, "%-16s", "UnaryOp");
@@ -4509,6 +4513,11 @@ int main(int argc, char** argv)
             fwrite(&quantize_tag, sizeof(int), 1, bp);
 
             fwrite_tensor_proto_data(B, bp);
+        }
+        else if (op == "Erf")
+        {
+            int op_type = 20;
+            fprintf(pp, " 0=%d", op_type);
         }
         else if (op == "Exp")
         {


### PR DESCRIPTION
hi,
the first operator that I would like to contribute is erf
pytorch by itself breaks gelu when the model is converted to onnx by torch.onnx.export into peaces
for loongarch etc, I don't know about their instruction sets, and how I can implement it.
I will be adding more and more.
with this, wav2vec2, etc can be easily exported to ncnn from onnx
if there is anything I should add/fix, let me know and I will update this pull until everything works out.