### PR TITLE
fix build with new protobuf target for pnnx

### DIFF
--- a/tools/pnnx/CMakeLists.txt
+++ b/tools/pnnx/CMakeLists.txt
@@ -39,6 +39,21 @@ set(TorchVision_INSTALL_DIR "/home/nihui/osd/vision/build/install" CACHE STRING 
 #set(Torch_DIR "${Torch_INSTALL_DIR}/share/cmake/Torch")
 set(TorchVision_DIR "${TorchVision_INSTALL_DIR}/share/cmake/TorchVision")
 
+find_package(protobuf CONFIG)
+
+if(protobuf_FOUND)
+    set(PROTOBUF_FOUND ${protobuf_FOUND})
+    set(PROTOBUF_VERSION ${protobuf_VERSION})
+else()
+    # fallback to system
+    find_package(Protobuf)
+    set(PROTOBUF_FOUND ${Protobuf_FOUND})
+    set(PROTOBUF_VERSION ${Protobuf_VERSION})
+    if(TARGET protobuf::protoc)
+        set_target_properties(protobuf::protoc PROPERTIES IMPORTED_LOCATION_RELEASE "${PROTOBUF_PROTOC_EXECUTABLE}")
+    endif()
+endif()
+
 find_package(Python3 COMPONENTS Interpreter Development)
 
 PNNXProbeForPyTorchInstall()

--- a/tools/pnnx/src/CMakeLists.txt
+++ b/tools/pnnx/src/CMakeLists.txt
@@ -592,7 +592,7 @@ if(PROTOBUF_FOUND)
         message(STATUS "Building with onnx-zero")
     endif()
 else()
-    message(WARNING "Building without onnx-zer")
+    message(STATUS "Building without onnx-zero")
 endif()
 
 set(pnnx_SRCS

--- a/tools/pnnx/src/CMakeLists.txt
+++ b/tools/pnnx/src/CMakeLists.txt
@@ -557,25 +557,42 @@ set(pnnx_pass_ncnn_SRCS
     pass_ncnn/torchvision_DeformConv2d.cpp
 )
 
-find_package(Protobuf)
 if(PROTOBUF_FOUND)
-    protobuf_generate_cpp(ONNX_PROTO_SRCS ONNX_PROTO_HDRS onnx.proto)
+    if(DEFINED PROTOBUF_VERSION AND PROTOBUF_VERSION VERSION_GREATER_EQUAL 3.22)
+        set(CMAKE_CXX_STANDARD 17)
+    endif()
 
-    add_library(pnnx2onnx STATIC
-        save_onnx.cpp
-        save_onnx_cxxabi_bridge.cpp
-        ${ONNX_PROTO_SRCS} ${ONNX_PROTO_HDRS}
-    )
+    if(Protobuf_FOUND OR protobuf_MODULE_COMPATIBLE)
+        protobuf_generate_cpp(ONNX_PROTO_SRCS ONNX_PROTO_HDRS onnx.proto)
 
-    target_include_directories(pnnx2onnx PRIVATE ${PROTOBUF_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-    target_link_libraries(pnnx2onnx PRIVATE ${PROTOBUF_LIBRARIES})
+        add_library(pnnx2onnx STATIC
+            save_onnx.cpp
+            save_onnx_cxxabi_bridge.cpp
+            ${ONNX_PROTO_SRCS} ${ONNX_PROTO_HDRS}
+        )
 
-    # libtorch is usually compiled with old cxx11 abi
-    set_source_files_properties(save_onnx_cxxabi_bridge.cpp PROPERTIES COMPILE_FLAGS "${TORCH_CXX_FLAGS}")
+        target_include_directories(pnnx2onnx PRIVATE ${PROTOBUF_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+        target_link_libraries(pnnx2onnx PRIVATE ${PROTOBUF_LIBRARIES})
 
-    message(STATUS "Building with onnx-zero")
+        # libtorch is usually compiled with old cxx11 abi
+        set_source_files_properties(save_onnx_cxxabi_bridge.cpp PROPERTIES COMPILE_FLAGS "${TORCH_CXX_FLAGS}")
+
+        message(STATUS "Building with onnx-zero")
+    else()
+
+            add_library(pnnx2onnx STATIC
+            save_onnx.cpp
+            save_onnx_cxxabi_bridge.cpp
+            onnx.proto
+        )
+        set_source_files_properties(save_onnx_cxxabi_bridge.cpp PROPERTIES COMPILE_FLAGS "${TORCH_CXX_FLAGS}")
+        target_include_directories(pnnx2onnx PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+        protobuf_generate(TARGET pnnx2onnx)
+        target_link_libraries(pnnx2onnx PRIVATE protobuf::libprotobuf)
+        message(STATUS "Building with onnx-zero")
+    endif()
 else()
-    message(STATUS "Building without onnx-zero")
+    message(WARNING "Building without onnx-zer")
 endif()
 
 set(pnnx_SRCS

--- a/tools/pnnx/src/CMakeLists.txt
+++ b/tools/pnnx/src/CMakeLists.txt
@@ -580,7 +580,7 @@ if(PROTOBUF_FOUND)
         message(STATUS "Building with onnx-zero")
     else()
 
-            add_library(pnnx2onnx STATIC
+        add_library(pnnx2onnx STATIC
             save_onnx.cpp
             save_onnx_cxxabi_bridge.cpp
             onnx.proto


### PR DESCRIPTION
nihui，您好！
1.我发现您没有修改相关的PNNX的Cmake，以支持最新的protobuf，我参考[#4955](https://github.com/Tencent/ncnn/pull/4955)对CMakeLists文件进行了修改。
2.我把find_package(protobuf)相关的代码从src/CMakeLists.txt下移动到pnnx目录下的CMakeLists.txt，这点主要是因为find_package(Torch REQUIRED)加载TorchConfig.cmake，这个cmake里定义了protobuf的相关目标，所以必须放在find_package(Torch REQUIRED)它前面，不然会有目标重复定义的错误。