### PR TITLE
test conv1d update

### DIFF
--- a/tests/test_convolution1d.cpp
+++ b/tests/test_convolution1d.cpp
@@ -77,7 +77,7 @@ static int test_convolution1d_0()
         const int s = kdsp[i][2];
         const int p = kdsp[i][3];
         const int b0 = i % 2;
-        const int b1 = 1 - b1;
+        const int b1 = 1 - b0;
 
         int ret = 0
                   || test_convolution1d(9, 1, 1, k, d, s, p, b0)


### PR DESCRIPTION
in my tests, b1 may become an unpredictable value. As a bias term, I think it should be either 0 or 1.