### PR TITLE
Add more GPU-related python bindings

### DIFF
--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -1277,7 +1277,8 @@ PYBIND11_MODULE(ncnn, m)
     .def("pipeline_cache_uuid", [](GpuInfo& gpuinfo) {
         return py::memoryview::from_buffer(gpuinfo.pipeline_cache_uuid(), {VK_UUID_SIZE}, {sizeof(uint8_t) * VK_UUID_SIZE});
     })
-    .def("type", &GpuInfo::type);
+    .def("type", &GpuInfo::type)
+    .def("device_name", &GpuInfo::device_name);
 
     py::class_<VulkanDevice>(m, "VulkanDevice")
     .def(py::init<int>(), py::arg("device_index") = 0)
@@ -1285,7 +1286,12 @@ PYBIND11_MODULE(ncnn, m)
     "info", [](VulkanDevice& dev) {
         return &dev.info;
     },
-    py::return_value_policy::reference_internal);
+    py::return_value_policy::reference_internal)
+    .def("acquire_blob_allocator", &VulkanDevice::acquire_blob_allocator)
+    .def("reclaim_blob_allocator", &VulkanDevice::reclaim_blob_allocator, py::arg("vkallocator"))
+    .def("acquire_staging_allocator", &VulkanDevice::acquire_staging_allocator)
+    .def("reclaim_staging_allocator", &VulkanDevice::reclaim_staging_allocator, py::arg("vkallocator"))
+    .def("get_heap_budget", &VulkanDevice::get_heap_budget);
 #endif // NCNN_VULKAN
 
     m.doc() = R"pbdoc(


### PR DESCRIPTION
This PR adds a few extra GPU-related bindings:

- "device_name" to GpuInfo
- acquire & reclaim blob & heap allocators to VulkanDevice
- "get_heap_budget" to VulkanDevice