### PR TITLE
Throw errors on allocation failures

### DIFF
--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -448,6 +448,7 @@ VkBuffer VkAllocator::create_buffer(size_t size, VkBufferUsageFlags usage)
     if (ret != VK_SUCCESS)
     {
         NCNN_LOGE("vkCreateBuffer failed %d", ret);
+        throw std::runtime_error("vkCreateBuffer failed");
         return 0;
     }
 
@@ -467,6 +468,7 @@ VkDeviceMemory VkAllocator::allocate_memory(size_t size, uint32_t memory_type_in
     if (ret != VK_SUCCESS)
     {
         NCNN_LOGE("vkAllocateMemory failed %d", ret);
+        throw std::runtime_error("vkAllocateMemory failed");
         return 0;
     }
 
@@ -493,6 +495,7 @@ VkDeviceMemory VkAllocator::allocate_dedicated_memory(size_t size, uint32_t memo
     if (ret != VK_SUCCESS)
     {
         NCNN_LOGE("vkAllocateMemory failed %d", ret);
+        throw std::runtime_error("vkAllocateMemory failed");
         return 0;
     }
 

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -2420,6 +2420,7 @@ int VkCompute::submit_and_wait()
         {
             NCNN_LOGE("vkQueueSubmit failed %d", ret);
             vkdev->reclaim_queue(vkdev->info.compute_queue_family_index(), compute_queue);
+            throw std::runtime_error("vkQueueSubmit failed");
             return -1;
         }
     }
@@ -2432,6 +2433,7 @@ int VkCompute::submit_and_wait()
         if (ret != VK_SUCCESS)
         {
             NCNN_LOGE("vkWaitForFences failed %d", ret);
+            throw std::runtime_error("vkWaitForFences failed");
             return -1;
         }
     }

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -3276,6 +3276,7 @@ void VulkanDevice::reclaim_blob_allocator(VkAllocator* allocator) const
     }
 
     NCNN_LOGE("FATAL ERROR! reclaim_blob_allocator get wild allocator %p", allocator);
+    throw std::runtime_error("FATAL ERROR! reclaim_blob_allocator get wild allocator");
 }
 
 VkAllocator* VulkanDevice::acquire_staging_allocator() const


### PR DESCRIPTION
I figure this one might be controversial, and I'm open to suggestions on how to change this.

When I first made my ncnn_vulkan fork, I noticed that when memory allocation or inference failures would happen, they would just silently fail and log to the console. This made any kind of error handling on the python side impossible, as there was no error being thrown to catch and check for. There was also a specific one of these that certain users only ran into sometimes, and I needed a way to specifically handle that case.

So, my solution was to throw errors in the places that I needed to catch those errors. I have ported those here.

However, I don't know if there was maybe a different way I could have accomplished that same goal, and throwing errors in these places I'm sure could cause unexpected behavior in dependent projects. So, I figured I'd open this one as a draft in hopes that we can reach an agreement on what to do here.

For an example of how I'm using this, look [here](https://github.com/chaiNNer-org/chaiNNer/blob/9850f9cbed030a82cb20e1f87f08dbc95a58e15e/backend/src/nodes/impl/ncnn/auto_split.py#L67)