### PR TITLE
update batchnorm param

### DIFF
--- a/docs/developer-guide/operation-param-weight-table.md
+++ b/docs/developer-guide/operation-param-weight-table.md
@@ -4,8 +4,7 @@
 |AbsVal|||
 |ArgMax|0|out_max_val|0|
 ||1|topk|1|
-|BatchNorm|0|channels|0|slope mean variance bias|
-||1|eps|0.f|
+|BatchNorm|0|channels|0|slope mean variance(+eps) bias|
 |Bias|0|bias_data_size|0|
 |BinaryOp|0|op_type|0|
 ||1|with_scalar|0|


### PR DESCRIPTION
When the `BatchNorm` was imported, I found that `eps` was added to `var`. But `eps` still exists in the parameter description. It's confusing to me. Maybe it's better to delete it?