### PR TITLE
create_gpu_instance: do not perform destroy_gpu_instance()

### DIFF
--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -1150,8 +1150,6 @@ static int find_default_vulkan_device_index()
 
 int create_gpu_instance(const char* driver_path)
 {
-    destroy_gpu_instance();
-
     MutexLockGuard lock(g_instance_lock);
 
     if (g_instance.created != 0)


### PR DESCRIPTION
When performing destroy_gpu_instance(), g_instance.created is always 0.