### PR TITLE
clear warning: unused variable [-Wunused-variable] while building on x86-wsl platform.

### DIFF
--- a/src/layer/fold.cpp
+++ b/src/layer/fold.cpp
@@ -41,7 +41,6 @@ int Fold::load_param(const ParamDict& pd)
 
 int Fold::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const
 {
-    const int size = bottom_blob.w;
     const int max_channels = bottom_blob.h;
     size_t elemsize = bottom_blob.elemsize;
 

--- a/src/layer/x86/deformableconv2d_pack16.h
+++ b/src/layer/x86/deformableconv2d_pack16.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack16_avx512(const std::vector<Mat>& bottom_blobs,
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 16;

--- a/src/layer/x86/deformableconv2d_pack16to1.h
+++ b/src/layer/x86/deformableconv2d_pack16to1.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack16to1_avx512(const std::vector<Mat>& bottom_blo
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 16;

--- a/src/layer/x86/deformableconv2d_pack16to4.h
+++ b/src/layer/x86/deformableconv2d_pack16to4.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack16to4_avx512(const std::vector<Mat>& bottom_blo
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 16;

--- a/src/layer/x86/deformableconv2d_pack16to8.h
+++ b/src/layer/x86/deformableconv2d_pack16to8.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack16to8_avx512(const std::vector<Mat>& bottom_blo
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 16;

--- a/src/layer/x86/deformableconv2d_pack1to16.h
+++ b/src/layer/x86/deformableconv2d_pack1to16.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack1to16_avx512(const std::vector<Mat>& bottom_blo
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 1;

--- a/src/layer/x86/deformableconv2d_pack1to4.h
+++ b/src/layer/x86/deformableconv2d_pack1to4.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack1to4_sse(const std::vector<Mat>& bottom_blobs, 
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 1;

--- a/src/layer/x86/deformableconv2d_pack1to8.h
+++ b/src/layer/x86/deformableconv2d_pack1to8.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack1to8_avx(const std::vector<Mat>& bottom_blobs, 
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 1;

--- a/src/layer/x86/deformableconv2d_pack4.h
+++ b/src/layer/x86/deformableconv2d_pack4.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack4_sse(const std::vector<Mat>& bottom_blobs, Mat
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 4;

--- a/src/layer/x86/deformableconv2d_pack4to1.h
+++ b/src/layer/x86/deformableconv2d_pack4to1.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack4to1_sse(const std::vector<Mat>& bottom_blobs, 
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 4;

--- a/src/layer/x86/deformableconv2d_pack4to16.h
+++ b/src/layer/x86/deformableconv2d_pack4to16.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack4to16_avx512(const std::vector<Mat>& bottom_blo
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 4;

--- a/src/layer/x86/deformableconv2d_pack4to8.h
+++ b/src/layer/x86/deformableconv2d_pack4to8.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack4to8_avx(const std::vector<Mat>& bottom_blobs, 
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 4;

--- a/src/layer/x86/deformableconv2d_pack8.h
+++ b/src/layer/x86/deformableconv2d_pack8.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack8_avx(const std::vector<Mat>& bottom_blobs, Mat
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 8;

--- a/src/layer/x86/deformableconv2d_pack8to1.h
+++ b/src/layer/x86/deformableconv2d_pack8to1.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack8to1_avx(const std::vector<Mat>& bottom_blobs, 
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 8;

--- a/src/layer/x86/deformableconv2d_pack8to16.h
+++ b/src/layer/x86/deformableconv2d_pack8to16.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack8to16_avx512(const std::vector<Mat>& bottom_blo
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 8;

--- a/src/layer/x86/deformableconv2d_pack8to4.h
+++ b/src/layer/x86/deformableconv2d_pack8to4.h
@@ -27,8 +27,6 @@ static void deformableconv2d_pack8to4_avx(const std::vector<Mat>& bottom_blobs, 
     int outw = top_blob.w;
     int outh = top_blob.h;
     int outch = top_blob.c;
-    const int size = outw * outh;
-    const int maxk = kernel_w * kernel_h;
 
     const float* bias_data_ptr = bias_data;
     const int elempack = 8;

--- a/src/layer/x86/deformableconv2d_x86.cpp
+++ b/src/layer/x86/deformableconv2d_x86.cpp
@@ -265,8 +265,6 @@ int DeformableConv2D_x86::forward(const std::vector<Mat>& bottom_blobs, std::vec
     if (top_blob.empty())
         return -100;
 
-    const int num_input = channels * elempack;
-
     if (opt.use_sgemm_convolution)
     {
         const int size = outw * outh;


### PR DESCRIPTION
clear warning: unused variable [-Wunused-variable] while building on x86-wsl platform.l platform without protobuf. <3