### PR TITLE
pnnx load dynamo onnx of segmentation models

### DIFF
--- a/tools/pnnx/src/load_onnx.cpp
+++ b/tools/pnnx/src/load_onnx.cpp
@@ -452,7 +452,7 @@ int load_onnx(const std::string& onnxpath, Graph& pnnx_graph)
     fprintf(stderr, "%10.2fms\n", t1 - t0);
 
     // save
-    std::fstream output("tmp2.onnx", std::ios::out | std::ios::trunc | std::ios::binary);
+    std::fstream output("debug.onnx", std::ios::out | std::ios::trunc | std::ios::binary);
     if (!model.SerializeToOstream(&output))
     {
         fprintf(stderr, "write onnx failed\n");

--- a/tools/pnnx/src/pass_ncnn/F_interpolate.cpp
+++ b/tools/pnnx/src/pass_ncnn/F_interpolate.cpp
@@ -146,6 +146,70 @@ pnnx.Output             output      1 0 out
 
 REGISTER_GLOBAL_PNNX_NCNN_GRAPH_REWRITER_PASS(F_interpolate_1, 20)
 
+class F_interpolate_2 : public GraphRewriterPass
+{
+public:
+    const char* match_pattern_graph() const
+    {
+        return R"PNNXIR(7767517
+3 2
+pnnx.Input              input       0 1 input
+F.interpolate           op_0        1 1 input out align_corners=%align_corners mode=%mode size=%size
+pnnx.Output             output      1 0 out
+)PNNXIR";
+    }
+
+    const char* type_str() const
+    {
+        return "Interp";
+    }
+
+    const char* name_str() const
+    {
+        return "interpolate";
+    }
+
+    void write(Operator* op, const std::map<std::string, Parameter>& captured_params) const
+    {
+        const std::string& mode = captured_params.at("mode").s;
+        std::vector<int> output_size;
+        if (captured_params.at("size").type == 2)
+        {
+            output_size.push_back(captured_params.at("size").i);
+        }
+        else
+        {
+            output_size = captured_params.at("size").ai;
+        }
+
+        if (mode == "nearest")
+            op->params["0"] = 1;
+        if (mode == "bilinear" || mode == "linear")
+            op->params["0"] = 2;
+        if (mode == "bicubic")
+            op->params["0"] = 3;
+
+        if (output_size.size() == 1)
+        {
+            op->params["3"] = 1.f;
+            op->params["4"] = output_size[0];
+        }
+        else if (output_size.size() == 2)
+        {
+            op->params["3"] = output_size[0];
+            op->params["4"] = output_size[1];
+        }
+        else
+        {
+            fprintf(stderr, "unsupported interpolate output_size\n");
+        }
+
+        op->params["6"] = captured_params.at("align_corners").b ? 1 : 0;
+    }
+};
+
+REGISTER_GLOBAL_PNNX_NCNN_GRAPH_REWRITER_PASS(F_interpolate_2, 20)
+
 } // namespace ncnn
 
 } // namespace pnnx

--- a/tools/pnnx/src/pass_ncnn/eliminate_output.cpp
+++ b/tools/pnnx/src/pass_ncnn/eliminate_output.cpp
@@ -20,11 +20,13 @@ namespace ncnn {
 
 void eliminate_output(Graph& graph)
 {
+    int output_index = 0;
+
     for (;;)
     {
         bool need_eliminate = false;
 
-        for (int i = (int)graph.ops.size() - 1; i >= 0; i--)
+        for (size_t i = 0; i < graph.ops.size(); i++)
         {
             Operator* op = graph.ops[i];
 
@@ -36,7 +38,8 @@ void eliminate_output(Graph& graph)
             // canonicalize output name
             for (int j = 0; j < (int)op->inputs.size(); j++)
             {
-                op->inputs[j]->name = std::string("out") + std::to_string(j);
+                op->inputs[j]->name = std::string("out") + std::to_string(output_index);
+                output_index++;
             }
 
             for (Operand* r : op->inputs)

--- a/tools/pnnx/src/pass_onnx.cpp
+++ b/tools/pnnx/src/pass_onnx.cpp
@@ -665,6 +665,9 @@ void pass_onnx(const onnx::ModelProto& model, Graph& pnnx_graph)
         {
             const std::string& input = node.input(j);
 
+            if (input.empty())
+                continue;
+
             if (modelproxy.has_initializer(input))
             {
                 // skip function weight
@@ -834,6 +837,9 @@ void pass_onnx(const onnx::ModelProto& model, Graph& pnnx_graph)
         {
             const std::string& output = node.output(j);
 
+            if (output.empty())
+                continue;
+
             Operand* op_out = 0;
 
             if (modelproxy.has_valueinfo(output))
@@ -877,9 +883,19 @@ void pass_onnx(const onnx::ModelProto& model, Graph& pnnx_graph)
 
             if (op_type == "Slice")
             {
-                // data start end dim step -> data dim start end step
-                op->inputnames = {"data", "dim", "start", "end", "step"};
-                op->inputs = {op->inputs[0], op->inputs[3], op->inputs[1], op->inputs[2], op->inputs[4]};
+                if (op->inputs.size() == 4)
+                {
+                    // data start end dim -> data dim start end
+                    op->inputnames = {"data", "dim", "start", "end"};
+                    op->inputs = {op->inputs[0], op->inputs[3], op->inputs[1], op->inputs[2]};
+                    op->params["step"] = 1;
+                }
+                else // if (op->inputs.size() == 5)
+                {
+                    // data start end dim step -> data dim start end step
+                    op->inputnames = {"data", "dim", "start", "end", "step"};
+                    op->inputs = {op->inputs[0], op->inputs[3], op->inputs[1], op->inputs[2], op->inputs[4]};
+                }
             }
 
             if (op_type == "Transpose")


### PR DESCRIPTION
### model
- [x] DeepLabV3
- [x] FCN
- [x] LRASPP
- [ ] Faster R-CNN
- [ ] FCOS
- [ ] RetinaNet
- [ ] SSD
- [ ] SSDlite
- [ ] Mask R-CNN
- [ ] Keypoint R-CNN
- [ ] RAFT

### misc
- [ ] build minimal onnxruntime
- [ ] disable onnx2pnnx by default

### onnx native op
- [ ] Abs
- [ ] Acos
- [ ] Add
- [ ] Asin
- [ ] Atan
- [ ] AveragePool
- [ ] BatchNormalization
- [ ] CeLU
- [ ] Ceil
- [ ] Clip
- [ ] Concat
- [ ] Constant
- [ ] Conv
- [ ] ConvTranspose
- [ ] Cos
- [ ] DepthToSpace
- [ ] Div
- [ ] Dropout
- [ ] Elu
- [ ] Erf
- [ ] Exp
- [ ] Flatten
- [ ] Floor
- [ ] GRU
- [ ] Gelu
- [ ] Gemm
- [ ] GlobalAveragePool
- [ ] GlobalMaxPool
- [ ] GroupNorm
- [ ] HardSigmoid
- [ ] HardSwish
- [ ] ImageScaler
- [ ] InstanceNormalization
- [ ] LRN
- [ ] LSTM
- [ ] LayerNorm
- [ ] LeakyRelu
- [ ] Log
- [ ] MatMul
- [ ] Max
- [ ] MaxPool
- [ ] Min
- [ ] Mul
- [ ] Neg
- [ ] PRelu
- [ ] Pad
- [ ] Pow
- [ ] RNN
- [ ] Reciprocal
- [ ] ReduceL1
- [ ] ReduceL2
- [ ] ReduceLogSum
- [ ] ReduceLogSumExp
- [ ] ReduceMax
- [ ] ReduceMean
- [ ] ReduceMin
- [ ] ReduceProd
- [ ] ReduceSum
- [ ] ReduceSumSquare
- [ ] Reshape
- [ ] Resize
- [ ] Shrink
- [ ] Sigmoid
- [ ] Sin
- [ ] Slice
- [ ] Softmax
- [ ] Split
- [ ] Sqrt
- [ ] Squeeze
- [ ] Sub
- [ ] Sum
- [ ] Tan
- [ ] Tanh
- [ ] Transpose
- [ ] Unsqueeze
- [ ] Upsample
