### PR TITLE
RFC: Add a perf class to measure performance

### DIFF
--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -81,7 +81,7 @@ private:
     std::vector<ncnn::Option> opts;
     ncnn::Perf perf;
 
-    const char *prev_comment;
+    const char* prev_comment;
     double prev_time_avg;
     int64_t prev_cpu_avg;
 };
@@ -89,15 +89,15 @@ private:
 Benchmark::Benchmark()
     :
 #if NCNN_VULKAN
-      vkdev(NULL),
-      blob_vkallocator(NULL),
-      staging_vkallocator(NULL),
+    vkdev(NULL),
+    blob_vkallocator(NULL),
+    staging_vkallocator(NULL),
 #endif
-      warmup_loop_count(8),
-      loop_count(4),
-      enable_cooling_down(true),
-      prev_comment(NULL),
-      prev_time_avg(0)
+    warmup_loop_count(8),
+    loop_count(4),
+    enable_cooling_down(true),
+    prev_comment(NULL),
+    prev_time_avg(0)
 {
     if (perf.init())
     {

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -136,7 +136,7 @@ void Perf::start()
 #endif
 }
 
-void Perf::stop(double &time, int64_t &circles)
+void Perf::stop(double& time, int64_t& circles)
 {
     time = get_current_time() - start_time;
 #ifdef __linux__

--- a/src/benchmark.h
+++ b/src/benchmark.h
@@ -27,6 +27,24 @@ NCNN_EXPORT double get_current_time();
 // sleep milliseconds
 NCNN_EXPORT void sleep(unsigned long long int milliseconds = 1000);
 
+class NCNN_EXPORT Perf
+{
+public:
+    Perf();
+
+    ~Perf();
+
+    int init();
+
+    void start();
+
+    void stop(double &time, int64_t &circles);
+
+private:
+    int fd;
+    double start_time;
+};
+
 #if NCNN_BENCHMARK
 
 NCNN_EXPORT void benchmark(const Layer* layer, double start, double end);

--- a/src/benchmark.h
+++ b/src/benchmark.h
@@ -38,7 +38,7 @@ public:
 
     void start();
 
-    void stop(double &time, int64_t &circles);
+    void stop(double& time, int64_t& circles);
 
 private:
     int fd;


### PR DESCRIPTION
Use Linux perf API on Linux and Android to measure cpu circles taking by a code block, fallback to get_current_time() otherwise.

It meant to compare the performance between different implementations, or the performance before and after optimization.