### PR TITLE
benchncnn: support running CPU and GPU tests in a single pass

### DIFF
--- a/benchmark/benchncnn.cpp
+++ b/benchmark/benchncnn.cpp
@@ -103,17 +103,17 @@ private:
 Benchmark::Benchmark()
     :
 #if NCNN_VULKAN
-      vkdev(NULL),
-      blob_vkallocator(NULL),
-      staging_vkallocator(NULL),
+    vkdev(NULL),
+    blob_vkallocator(NULL),
+    staging_vkallocator(NULL),
 #endif
-      warmup_loop_count(8),
-      loop_count(4),
-      enable_cooling_down(true),
-      prev_comment(NULL),
-      prev_time_avg(0),
-      prev_user_avg(0),
-      prev_sys_avg(0)
+    warmup_loop_count(8),
+    loop_count(4),
+    enable_cooling_down(true),
+    prev_comment(NULL),
+    prev_time_avg(0),
+    prev_user_avg(0),
+    prev_sys_avg(0)
 {
 }
 


### PR DESCRIPTION
    For example, on macOS:
         squeezenet cpu min =    5.14  max =    5.23  avg =    5.19  user =    5.18  sys =    0.00
         squeezenet gpu min =    1.30  max =    1.35  avg =    1.33  user =    0.13  sys =    0.05  speed_ratio =   3.90x  cpu_ratio =   3.48%

    Vulkan boost the speed and reduce cpu usage.

    On Android:
         squeezenet cpu min =    4.88  max =    5.06  avg =    4.98  user =   20.88  sys =    3.93
         squeezenet gpu min =   17.44  max =   19.18  avg =   18.47  user =    3.90  sys =    1.26  speed_ratio =   0.27x  cpu_ratio =  20.77%

    Vulkan doesn't boost the speed but reduce cpu usage, which can be useful too.