### PR TITLE
Fix yolov8.cpp larger object boundingbox error

### DIFF
--- a/examples/yolov8.cpp
+++ b/examples/yolov8.cpp
@@ -187,14 +187,14 @@ static void parse_yolov8_detections(
             float w = *bboxes_ptr++;
             float h = *bboxes_ptr;
 
-            if (i >= 6400 && i < 8000) 
+            if (i >= 6400 && i < 8000)
             {
                 x *= 2;
                 y *= 2;
                 w *= 2;
                 h *= 2;
             }
-            else if (i >= 8000 && i < 8400) 
+            else if (i >= 8000 && i < 8400)
             {
                 x *= 4;
                 y *= 4;

--- a/examples/yolov8.cpp
+++ b/examples/yolov8.cpp
@@ -187,6 +187,21 @@ static void parse_yolov8_detections(
             float w = *bboxes_ptr++;
             float h = *bboxes_ptr;
 
+            if (i >= 6400 && i < 8000) 
+            {
+                x *= 2;
+                y *= 2;
+                w *= 2;
+                h *= 2;
+            }
+            else if (i >= 8000 && i < 8400) 
+            {
+                x *= 4;
+                y *= 4;
+                w *= 4;
+                h *= 4;
+            }
+
             float x0 = clampf((x - 0.5f * w), 0.f, (float)infer_img_width);
             float y0 = clampf((y - 0.5f * h), 0.f, (float)infer_img_height);
             float x1 = clampf((x + 0.5f * w), 0.f, (float)infer_img_width);


### PR DESCRIPTION
Yolov8 has three different heads and output different size feature maps.  So the part of boundingboxs needs to be adjusted accordingly.