### PR TITLE
Fix #5741 don't crash when vkCreateDevice fails

### DIFF
--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -2321,7 +2321,8 @@ void VulkanDevicePrivate::destroy_dummy_buffer_image()
     dummy_image_readonly.release();
 #endif
 
-    if (dummy_allocator) {
+    if (dummy_allocator)
+    {
         delete dummy_allocator;
         dummy_allocator = 0;
     }

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -336,6 +336,7 @@ public:
     const GpuInfo& info;
 
     VkDevice vkdevice() const;
+    bool is_valid() const;
 
     VkShaderModule compile_shader_module(const uint32_t* spv_data, size_t spv_data_size) const;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1677,7 +1677,7 @@ int Net::load_param_bin(const DataReader& dr)
     if (opt.use_vulkan_compute)
     {
         if (!d->vkdev) d->vkdev = get_gpu_device();
-        if (!d->vkdev) opt.use_vulkan_compute = false; // no vulkan device, fallback to cpu
+        if (!d->vkdev || !d->vkdev->is_valid()) opt.use_vulkan_compute = false; // no valid vulkan device, fallback to cpu
     }
     if (opt.use_vulkan_compute)
     {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1381,7 +1381,7 @@ int Net::load_param(const DataReader& dr)
     if (opt.use_vulkan_compute)
     {
         if (!d->vkdev) d->vkdev = get_gpu_device();
-        if (!d->vkdev) opt.use_vulkan_compute = false; // no vulkan device, fallback to cpu
+        if (!d->vkdev || !d->vkdev->is_valid()) opt.use_vulkan_compute = false; // no valid vulkan device, fallback to cpu
     }
     if (opt.use_vulkan_compute)
     {


### PR DESCRIPTION
This patch should fix #5741 and prevent crash if vkCreateDevice fails or unable to create dummy buffer image.