### PR TITLE
Support using system CMake & Ninja

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,6 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "ninja; sys_platform != 'win32'",
-    "cmake>=3.12",
     "importlib-metadata",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import os
 import sys
 import time
 import re
+import shutil
 import subprocess
 
 from setuptools import setup, find_packages, Extension
@@ -176,6 +177,11 @@ if sys.version_info < (3, 0):
     sys.exit("Sorry, Python < 3.0 is not supported")
 
 requirements = ["numpy", "tqdm", "requests", "portalocker", "opencv-python"]
+setup_requires = []
+if shutil.which("cmake") is None:
+    setup_requires += ["cmake>=3.12"]
+if shutil.which("ninja") is None:
+    setup_requires += ["ninja; sys_platform != 'win32'"]
 
 with io.open("README.md", encoding="utf-8") as h:
     long_description = h.read()
@@ -206,6 +212,7 @@ setup(
     python_requires=">=3.5",
     packages=find_packages("python"),
     package_dir={"": "python"},
+    setup_requires=setup_requires,
     install_requires=requirements,
     ext_modules=[CMakeExtension("ncnn")],
     cmdclass={'install': InstallCommand, "build_ext": CMakeBuild},


### PR DESCRIPTION
Add the dependencies on PyPI `cmake` and `ninja` packages only if they are not available, in order to facilitate using the system tools.  This avoids unnecessarily installing third-party binaries, and improves portability by permitting users to use downstream-patched CMake.