### PR TITLE
WIP: add read npy for ncnn2table

### DIFF
--- a/docs/how-to-use-and-FAQ/quantized-int8-inference.md
+++ b/docs/how-to-use-and-FAQ/quantized-int8-inference.md
@@ -14,6 +14,8 @@ Example with mobilenet, just need three steps.
 
 ### 2. Create the calibration table file
 
+#### 2.1 From image
+
 We suggest that using the verification dataset for calibration, which is more than 5000 images.
 
 Some imagenet sample images here https://github.com/nihui/imagenet-sample-images
@@ -41,6 +43,47 @@ If your model has multiple input nodes, you can use multiple list files and othe
 ```shell
 ./ncnn2table mobilenet-opt.param mobilenet-opt.bin imagelist-bgr.txt,imagelist-depth.txt mobilenet.table mean=[104,117,123],[128] norm=[0.017,0.017,0.017],[0.0078125] shape=[224,224,3],[224,224,1] pixel=BGR,GRAY thread=8 method=kl
 ```
+
+#### 2.2 From npy
+
+We suggest that using the validation(development) set for calibration.
+
+Use the same preprocessing as the training set to get the input vectors, in the case of batchsize=1, store each input vector as an npy file, n inputs correspond to n npy files, the actual stored vectors to remove the batch dimension.
+
+
+test net, shape is in NCHW format, but there's no `N`.
+in0, shape=[512]
+in1, shape=[2, 1, 64]
+in2, shape=[2, 1, 64]
+
+filelist_in0.txt
+```txt
+0_in0.npy
+1_in0.npy
+2_in0.npy
+...
+```
+
+filelist_in1.txt
+```txt
+0_in1.npy
+1_in1.npy
+2_in1.npy
+...
+```
+
+filelist_in2.txt
+```txt
+0_in2.npy
+1_in2.npy
+2_in2.npy
+...
+```
+
+```shell
+./ncnn2table test.param test.bin filelist_in0.txt,filelist_in1.txt,filelist_in2.txt test.table shape=[512],[64,1,2],[64,1,2] thread=8 method=kl type=1
+```
+**Here shape is WHC, because the order of the arguments to `ncnn::Mat`.**
 
 ### 3. Quantize model
 

--- a/docs/how-to-use-and-FAQ/quantized-int8-inference.md
+++ b/docs/how-to-use-and-FAQ/quantized-int8-inference.md
@@ -52,9 +52,11 @@ Use the same preprocessing as the training set to get the input vectors, in the 
 
 
 test net, shape is in NCHW format, but there's no `N`.
+```txt
 in0, shape=[512]
 in1, shape=[2, 1, 64]
 in2, shape=[2, 1, 64]
+```
 
 filelist_in0.txt
 ```txt

--- a/tests/test_cpu.cpp
+++ b/tests/test_cpu.cpp
@@ -1,3 +1,17 @@
+// Tencent is pleased to support the open source community by making ncnn available.
+//
+// Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
 #include <stdio.h>
 
 #include "cpu.h"

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -216,8 +216,34 @@ void QuantNet::print_quant_info() const
 
 inline ncnn::Mat read_npy(const std::vector<int>& shape, const std::string& npypath)
 {
-    npy::npy_data<float> d = npy::read_npy<float>(npypath);
+    npy::npy_data<float> d;
+    try
+    {
+        d = npy::read_npy<float>(npypath);
+    }
+    catch (const std::exception& e)
+    {
+        fprintf(stderr, "npy::read_npy exception: %s\n", e.what());
+        std::exit(EXIT_FAILURE);
+    }
+
+    std::vector<unsigned long> npy_shape = d.shape;
     size_t dims = shape.size();
+
+    if (dims != npy_shape.size())
+    {
+        fprintf(stderr, "expect %d dims, but got: %d, npy file:%s\n", dims, npy_shape.size(), npypath);
+        std::exit(EXIT_FAILURE);
+    }
+
+    for (size_t i = 0; i < dims; ++i)
+    {
+        if (static_cast<unsigned long>(shape[i]) != npy_shape[dims-1-i])
+        {
+            fprintf(stderr, "shape mismatch!\n");
+            std::exit(EXIT_FAILURE);
+        }
+    }
 
     switch (dims)
     {

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -232,7 +232,7 @@ inline ncnn::Mat read_npy(const std::vector<int>& shape, const std::string& npyp
 
     if (dims != npy_shape.size())
     {
-        fprintf(stderr, "expect %d dims, but got: %d, npy file:%s\n", dims, npy_shape.size(), npypath);
+        fprintf(stderr, "expect %d dims, but got: %d, npy file:%s\n", (int)dims, (int)npy_shape.size(), npypath);
         std::exit(EXIT_FAILURE);
     }
 
@@ -256,7 +256,7 @@ inline ncnn::Mat read_npy(const std::vector<int>& shape, const std::string& npyp
     case 4:
         return ncnn::Mat(shape[0] * shape[1] * shape[2] * shape[3], (void*)(d.data.data())).reshape(shape[0], shape[1], shape[2], shape[3]).clone();
     default:
-        fprintf(stderr, "dims:%ld illegal!", dims);
+        fprintf(stderr, "dims:%d illegal!", (int)dims);
         return ncnn::Mat();
     }
 }

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -232,7 +232,7 @@ inline ncnn::Mat read_npy(const std::vector<int>& shape, const std::string& npyp
 
     if (dims != npy_shape.size())
     {
-        fprintf(stderr, "expect %d dims, but got: %d, npy file:%s\n", (int)dims, (int)npy_shape.size(), npypath);
+        fprintf(stderr, "expect %d dims, but got: %d\n", (int)dims, (int)npy_shape.size());
         std::exit(EXIT_FAILURE);
     }
 

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -39,6 +39,9 @@
 #include <string>
 #include <vector>
 
+// npy format header
+#include "npy.hpp"
+
 // ncnn public header
 #include "benchmark.h"
 #include "cpu.h"
@@ -86,6 +89,7 @@ public:
     std::vector<std::vector<int> > shapes;
     std::vector<int> type_to_pixels;
     int quantize_num_threads;
+    int file_type;
 
 public:
     int init();
@@ -159,6 +163,8 @@ int QuantNet::save_table(const char* tablepath)
     const int conv_layer_count = (int)conv_layers.size();
     const int conv_bottom_blob_count = (int)conv_bottom_blobs.size();
 
+    fprintf(stdout, "param:%d\n", conv_layer_count);
+
     for (int i = 0; i < conv_layer_count; i++)
     {
         const ncnn::Mat& weight_scale = weight_scales[i];
@@ -199,6 +205,34 @@ void QuantNet::print_quant_info() const
         float scale = 127 / stat.threshold;
 
         fprintf(stderr, "%-40s : max = %-15f  threshold = %-15f  scale = %-15f\n", layers[conv_layers[i]]->name.c_str(), stat.absmax, stat.threshold, scale);
+    }
+}
+
+/**
+ * Read npy file
+ * shape is input as [w,h,...]
+ * @return ncnn::Mat
+ */
+
+inline ncnn::Mat read_npy(const std::vector<int>& shape, const std::string& npypath)
+{
+    npy::npy_data<float> d = npy::read_npy<float>(npypath);
+    // std::vector<unsigned long> npy_shape = d.shape; // shape check ?
+    size_t dims = shape.size();
+
+    switch (dims)
+    {
+    case 1:
+        return ncnn::Mat(shape[0], (void*)(d.data.data())).clone();
+    case 2:
+        return ncnn::Mat(shape[0], shape[1], (void*)(d.data.data())).clone();
+    case 3:
+        return ncnn::Mat(shape[0], shape[1], shape[2], (void*)(d.data.data())).clone();
+    case 4:
+        return ncnn::Mat(shape[0], shape[1], shape[2], shape[3], (void*)(d.data.data())).clone();
+    default:
+        fprintf(stderr, "dims:%ld illegal!", dims);
+        return ncnn::Mat();
     }
 }
 
@@ -256,7 +290,7 @@ int QuantNet::quantize_KL()
     const int input_blob_count = (int)input_blobs.size();
     const int conv_layer_count = (int)conv_layers.size();
     const int conv_bottom_blob_count = (int)conv_bottom_blobs.size();
-    const int image_count = (int)listspaths[0].size();
+    const int file_count = (int)listspaths[0].size();
 
     const int num_histogram_bins = 2048;
 
@@ -363,11 +397,11 @@ int QuantNet::quantize_KL()
 
     // count the absmax
     #pragma omp parallel for num_threads(quantize_num_threads) schedule(static, 1)
-    for (int i = 0; i < image_count; i++)
+    for (int i = 0; i < file_count; i++)
     {
         if (i % 100 == 0)
         {
-            fprintf(stderr, "count the absmax %.2f%% [ %d / %d ]\n", i * 100.f / image_count, i, image_count);
+            fprintf(stderr, "count the absmax %.2f%% [ %d / %d ]\n", i * 100.f / file_count, i, file_count);
         }
 
         ncnn::Extractor ex = create_extractor();
@@ -379,19 +413,26 @@ int QuantNet::quantize_KL()
 
         for (int j = 0; j < input_blob_count; j++)
         {
-            const int type_to_pixel = type_to_pixels[j];
-            const std::vector<float>& mean_vals = means[j];
-            const std::vector<float>& norm_vals = norms[j];
+            ncnn::Mat in;
 
-            int pixel_convert_type = ncnn::Mat::PIXEL_BGR;
-            if (type_to_pixel != pixel_convert_type)
+            if (0 == file_type)
             {
-                pixel_convert_type = pixel_convert_type | (type_to_pixel << ncnn::Mat::PIXEL_CONVERT_SHIFT);
+                const int type_to_pixel = type_to_pixels[j];
+                const std::vector<float>& mean_vals = means[j];
+                const std::vector<float>& norm_vals = norms[j];
+
+                int pixel_convert_type = ncnn::Mat::PIXEL_BGR;
+                if (type_to_pixel != pixel_convert_type)
+                {
+                    pixel_convert_type = pixel_convert_type | (type_to_pixel << ncnn::Mat::PIXEL_CONVERT_SHIFT);
+                }
+                in = read_and_resize_image(shapes[j], listspaths[j][i], pixel_convert_type);
+                in.substract_mean_normalize(mean_vals.data(), norm_vals.data());
             }
-
-            ncnn::Mat in = read_and_resize_image(shapes[j], listspaths[j][i], pixel_convert_type);
-
-            in.substract_mean_normalize(mean_vals.data(), norm_vals.data());
+            else
+            {
+                in = read_npy(shapes[j], listspaths[j][i]);
+            }
 
             ex.input(input_blobs[j], in);
         }
@@ -437,11 +478,11 @@ int QuantNet::quantize_KL()
 
     // build histogram
     #pragma omp parallel for num_threads(quantize_num_threads) schedule(static, 1)
-    for (int i = 0; i < image_count; i++)
+    for (int i = 0; i < file_count; i++)
     {
         if (i % 100 == 0)
         {
-            fprintf(stderr, "build histogram %.2f%% [ %d / %d ]\n", i * 100.f / image_count, i, image_count);
+            fprintf(stderr, "build histogram %.2f%% [ %d / %d ]\n", i * 100.f / file_count, i, file_count);
         }
 
         ncnn::Extractor ex = create_extractor();
@@ -453,19 +494,26 @@ int QuantNet::quantize_KL()
 
         for (int j = 0; j < input_blob_count; j++)
         {
-            const int type_to_pixel = type_to_pixels[j];
-            const std::vector<float>& mean_vals = means[j];
-            const std::vector<float>& norm_vals = norms[j];
+            ncnn::Mat in;
 
-            int pixel_convert_type = ncnn::Mat::PIXEL_BGR;
-            if (type_to_pixel != pixel_convert_type)
+            if (0 == file_type)
             {
-                pixel_convert_type = pixel_convert_type | (type_to_pixel << ncnn::Mat::PIXEL_CONVERT_SHIFT);
+                const int type_to_pixel = type_to_pixels[j];
+                const std::vector<float>& mean_vals = means[j];
+                const std::vector<float>& norm_vals = norms[j];
+
+                int pixel_convert_type = ncnn::Mat::PIXEL_BGR;
+                if (type_to_pixel != pixel_convert_type)
+                {
+                    pixel_convert_type = pixel_convert_type | (type_to_pixel << ncnn::Mat::PIXEL_CONVERT_SHIFT);
+                }
+                in = read_and_resize_image(shapes[j], listspaths[j][i], pixel_convert_type);
+                in.substract_mean_normalize(mean_vals.data(), norm_vals.data());
             }
-
-            ncnn::Mat in = read_and_resize_image(shapes[j], listspaths[j][i], pixel_convert_type);
-
-            in.substract_mean_normalize(mean_vals.data(), norm_vals.data());
+            else
+            {
+                in = read_npy(shapes[j], listspaths[j][i]);
+            }
 
             ex.input(input_blobs[j], in);
         }
@@ -720,7 +768,7 @@ int QuantNet::quantize_ACIQ()
     const int input_blob_count = (int)input_blobs.size();
     const int conv_layer_count = (int)conv_layers.size();
     const int conv_bottom_blob_count = (int)conv_bottom_blobs.size();
-    const int image_count = (int)listspaths[0].size();
+    const int file_count = (int)listspaths[0].size();
 
     std::vector<ncnn::UnlockedPoolAllocator> blob_allocators(quantize_num_threads);
     std::vector<ncnn::UnlockedPoolAllocator> workspace_allocators(quantize_num_threads);
@@ -829,11 +877,11 @@ int QuantNet::quantize_ACIQ()
 
     // count the absmax
     #pragma omp parallel for num_threads(quantize_num_threads) schedule(static, 1)
-    for (int i = 0; i < image_count; i++)
+    for (int i = 0; i < file_count; i++)
     {
         if (i % 100 == 0)
         {
-            fprintf(stderr, "count the absmax %.2f%% [ %d / %d ]\n", i * 100.f / image_count, i, image_count);
+            fprintf(stderr, "count the absmax %.2f%% [ %d / %d ]\n", i * 100.f / file_count, i, file_count);
         }
 
         ncnn::Extractor ex = create_extractor();
@@ -845,19 +893,26 @@ int QuantNet::quantize_ACIQ()
 
         for (int j = 0; j < input_blob_count; j++)
         {
-            const int type_to_pixel = type_to_pixels[j];
-            const std::vector<float>& mean_vals = means[j];
-            const std::vector<float>& norm_vals = norms[j];
+            ncnn::Mat in;
 
-            int pixel_convert_type = ncnn::Mat::PIXEL_BGR;
-            if (type_to_pixel != pixel_convert_type)
+            if (0 == file_type)
             {
-                pixel_convert_type = pixel_convert_type | (type_to_pixel << ncnn::Mat::PIXEL_CONVERT_SHIFT);
+                const int type_to_pixel = type_to_pixels[j];
+                const std::vector<float>& mean_vals = means[j];
+                const std::vector<float>& norm_vals = norms[j];
+
+                int pixel_convert_type = ncnn::Mat::PIXEL_BGR;
+                if (type_to_pixel != pixel_convert_type)
+                {
+                    pixel_convert_type = pixel_convert_type | (type_to_pixel << ncnn::Mat::PIXEL_CONVERT_SHIFT);
+                }
+                in = read_and_resize_image(shapes[j], listspaths[j][i], pixel_convert_type);
+                in.substract_mean_normalize(mean_vals.data(), norm_vals.data());
             }
-
-            ncnn::Mat in = read_and_resize_image(shapes[j], listspaths[j][i], pixel_convert_type);
-
-            in.substract_mean_normalize(mean_vals.data(), norm_vals.data());
+            else
+            {
+                in = read_npy(shapes[j], listspaths[j][i]);
+            }
 
             ex.input(input_blobs[j], in);
         }
@@ -1049,7 +1104,7 @@ int QuantNet::quantize_EQ()
     std::vector<ncnn::UnlockedPoolAllocator> workspace_allocators(quantize_num_threads);
 
     // max 50 images for EQ
-    const int image_count = std::min((int)listspaths[0].size(), 50);
+    const int file_count = std::min((int)listspaths[0].size(), 50);
 
     const float scale_range_lower = 0.5f;
     const float scale_range_upper = 2.0f;
@@ -1073,11 +1128,11 @@ int QuantNet::quantize_EQ()
             std::vector<double> avgsims(search_steps, 0.0);
 
             #pragma omp parallel for num_threads(quantize_num_threads) schedule(static, 1)
-            for (int ii = 0; ii < image_count; ii++)
+            for (int ii = 0; ii < file_count; ii++)
             {
                 if (ii % 100 == 0)
                 {
-                    fprintf(stderr, "search weight scale %.2f%% [ %d / %d ] for %d / %d of %d / %d\n", ii * 100.f / image_count, ii, image_count, j, weight_scale.w, i, conv_layer_count);
+                    fprintf(stderr, "search weight scale %.2f%% [ %d / %d ] for %d / %d of %d / %d\n", ii * 100.f / file_count, ii, file_count, j, weight_scale.w, i, conv_layer_count);
                 }
 
                 ncnn::Extractor ex = create_extractor();
@@ -1089,21 +1144,28 @@ int QuantNet::quantize_EQ()
 
                 for (int jj = 0; jj < input_blob_count; jj++)
                 {
-                    const int type_to_pixel = type_to_pixels[jj];
-                    const std::vector<float>& mean_vals = means[jj];
-                    const std::vector<float>& norm_vals = norms[jj];
+                    ncnn::Mat in;
 
-                    int pixel_convert_type = ncnn::Mat::PIXEL_BGR;
-                    if (type_to_pixel != pixel_convert_type)
+                    if (0 == file_type)
                     {
-                        pixel_convert_type = pixel_convert_type | (type_to_pixel << ncnn::Mat::PIXEL_CONVERT_SHIFT);
+                        const int type_to_pixel = type_to_pixels[j];
+                        const std::vector<float>& mean_vals = means[j];
+                        const std::vector<float>& norm_vals = norms[j];
+
+                        int pixel_convert_type = ncnn::Mat::PIXEL_BGR;
+                        if (type_to_pixel != pixel_convert_type)
+                        {
+                            pixel_convert_type = pixel_convert_type | (type_to_pixel << ncnn::Mat::PIXEL_CONVERT_SHIFT);
+                        }
+                        in = read_and_resize_image(shapes[j], listspaths[j][i], pixel_convert_type);
+                        in.substract_mean_normalize(mean_vals.data(), norm_vals.data());
+                    }
+                    else
+                    {
+                        in = read_npy(shapes[j], listspaths[j][i]);
                     }
 
-                    ncnn::Mat in = read_and_resize_image(shapes[jj], listspaths[jj][ii], pixel_convert_type);
-
-                    in.substract_mean_normalize(mean_vals.data(), norm_vals.data());
-
-                    ex.input(input_blobs[jj], in);
+                    ex.input(input_blobs[j], in);
                 }
 
                 ncnn::Mat in;
@@ -1183,11 +1245,11 @@ int QuantNet::quantize_EQ()
             std::vector<double> avgsims(search_steps, 0.0);
 
             #pragma omp parallel for num_threads(quantize_num_threads) schedule(static, 1)
-            for (int ii = 0; ii < image_count; ii++)
+            for (int ii = 0; ii < file_count; ii++)
             {
                 if (ii % 100 == 0)
                 {
-                    fprintf(stderr, "search bottom blob scale %.2f%% [ %d / %d ] for %d / %d of %d / %d\n", ii * 100.f / image_count, ii, image_count, j, bottom_blob_scale.w, i, conv_layer_count);
+                    fprintf(stderr, "search bottom blob scale %.2f%% [ %d / %d ] for %d / %d of %d / %d\n", ii * 100.f / file_count, ii, file_count, j, bottom_blob_scale.w, i, conv_layer_count);
                 }
 
                 ncnn::Extractor ex = create_extractor();
@@ -1199,21 +1261,28 @@ int QuantNet::quantize_EQ()
 
                 for (int jj = 0; jj < input_blob_count; jj++)
                 {
-                    const int type_to_pixel = type_to_pixels[jj];
-                    const std::vector<float>& mean_vals = means[jj];
-                    const std::vector<float>& norm_vals = norms[jj];
+                    ncnn::Mat in;
 
-                    int pixel_convert_type = ncnn::Mat::PIXEL_BGR;
-                    if (type_to_pixel != pixel_convert_type)
+                    if (0 == file_type)
                     {
-                        pixel_convert_type = pixel_convert_type | (type_to_pixel << ncnn::Mat::PIXEL_CONVERT_SHIFT);
+                        const int type_to_pixel = type_to_pixels[j];
+                        const std::vector<float>& mean_vals = means[j];
+                        const std::vector<float>& norm_vals = norms[j];
+
+                        int pixel_convert_type = ncnn::Mat::PIXEL_BGR;
+                        if (type_to_pixel != pixel_convert_type)
+                        {
+                            pixel_convert_type = pixel_convert_type | (type_to_pixel << ncnn::Mat::PIXEL_CONVERT_SHIFT);
+                        }
+                        in = read_and_resize_image(shapes[j], listspaths[j][i], pixel_convert_type);
+                        in.substract_mean_normalize(mean_vals.data(), norm_vals.data());
+                    }
+                    else
+                    {
+                        in = read_npy(shapes[j], listspaths[j][i]);
                     }
 
-                    ncnn::Mat in = read_and_resize_image(shapes[jj], listspaths[jj][ii], pixel_convert_type);
-
-                    in.substract_mean_normalize(mean_vals.data(), norm_vals.data());
-
-                    ex.input(input_blobs[jj], in);
+                    ex.input(input_blobs[j], in);
                 }
 
                 ncnn::Mat in;
@@ -1586,7 +1655,10 @@ static void show_usage()
     fprintf(stderr, "  pixel=RAW/RGB/BGR/GRAY/RGBA/BGRA,...\n");
     fprintf(stderr, "  thread=8\n");
     fprintf(stderr, "  method=kl/aciq/eq\n");
-    fprintf(stderr, "Sample usage: ncnn2table squeezenet.param squeezenet.bin imagelist.txt squeezenet.table mean=[104.0,117.0,123.0] norm=[1.0,1.0,1.0] shape=[227,227,3] pixel=BGR method=kl\n");
+    fprintf(stderr, "  type=0/1, 0:image,1:npy\n");
+    fprintf(stderr, "Sample usage:\n");
+    fprintf(stderr, "  ncnn2table squeezenet.param squeezenet.bin filelist.txt squeezenet.table mean=[104.0,117.0,123.0] norm=[1.0,1.0,1.0] shape=[227,227,3] pixel=BGR method=kl\n");
+    fprintf(stderr, "  ncnn2table test.param test.bin filelist.txt squeezenet.table shape=[227,227,3] method=kl type=1\n");
 }
 
 int main(int argc, char** argv)
@@ -1629,6 +1701,7 @@ int main(int argc, char** argv)
     net.listspaths = parse_comma_path_list(lists);
 
     std::string method = "kl";
+    net.file_type = 0;
 
     for (int i = 5; i < argc; i++)
     {
@@ -1660,6 +1733,8 @@ int main(int argc, char** argv)
             net.quantize_num_threads = atoi(value);
         if (memcmp(key, "method", 6) == 0)
             method = std::string(value);
+        if (memcmp(key, "type", 4) == 0)
+            net.file_type = atoi(value);
     }
 
     // sanity check
@@ -1669,12 +1744,12 @@ int main(int argc, char** argv)
         fprintf(stderr, "expect %d lists, but got %d\n", (int)input_blob_count, (int)net.listspaths.size());
         return -1;
     }
-    if (net.means.size() != input_blob_count)
+    if ((0 == net.file_type) && (net.means.size() != input_blob_count))
     {
         fprintf(stderr, "expect %d means, but got %d\n", (int)input_blob_count, (int)net.means.size());
         return -1;
     }
-    if (net.norms.size() != input_blob_count)
+    if ((0 == net.file_type) && (net.norms.size() != input_blob_count))
     {
         fprintf(stderr, "expect %d norms, but got %d\n", (int)input_blob_count, (int)net.norms.size());
         return -1;
@@ -1684,7 +1759,7 @@ int main(int argc, char** argv)
         fprintf(stderr, "expect %d shapes, but got %d\n", (int)input_blob_count, (int)net.shapes.size());
         return -1;
     }
-    if (net.type_to_pixels.size() != input_blob_count)
+    if ((0 == net.file_type) && (net.type_to_pixels.size() != input_blob_count))
     {
         fprintf(stderr, "expect %d pixels, but got %d\n", (int)input_blob_count, (int)net.type_to_pixels.size());
         return -1;

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -217,19 +217,18 @@ void QuantNet::print_quant_info() const
 inline ncnn::Mat read_npy(const std::vector<int>& shape, const std::string& npypath)
 {
     npy::npy_data<float> d = npy::read_npy<float>(npypath);
-    // std::vector<unsigned long> npy_shape = d.shape; // shape check ?
     size_t dims = shape.size();
 
     switch (dims)
     {
     case 1:
-        return ncnn::Mat(shape[0], (void*)(d.data.data())).clone();
+        return ncnn::Mat(shape[0], (void*)(d.data.data())).reshape(shape[0]).clone();
     case 2:
-        return ncnn::Mat(shape[0], shape[1], (void*)(d.data.data())).clone();
+        return ncnn::Mat(shape[0] * shape[1], (void*)(d.data.data())).reshape(shape[0], shape[1]).clone();
     case 3:
-        return ncnn::Mat(shape[0], shape[1], shape[2], (void*)(d.data.data())).clone();
+        return ncnn::Mat(shape[0] * shape[1] * shape[2], (void*)(d.data.data())).reshape(shape[0], shape[1], shape[2]).clone();
     case 4:
-        return ncnn::Mat(shape[0], shape[1], shape[2], shape[3], (void*)(d.data.data())).clone();
+        return ncnn::Mat(shape[0] * shape[1] * shape[2] * shape[3], (void*)(d.data.data())).reshape(shape[0], shape[1], shape[2], shape[3]).clone();
     default:
         fprintf(stderr, "dims:%ld illegal!", dims);
         return ncnn::Mat();

--- a/tools/quantize/npy.hpp
+++ b/tools/quantize/npy.hpp
@@ -1,0 +1,600 @@
+/*
+   Copyright 2017-2023 Leon Merten Lohse
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#ifndef NPY_HPP_
+#define NPY_HPP_
+
+#include <algorithm>
+#include <array>
+#include <complex>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <typeindex>
+#include <typeinfo>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace npy {
+
+/* Compile-time test for byte order.
+   If your compiler does not define these per default, you may want to define
+   one of these constants manually.
+   Defaults to little endian order. */
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN || defined(__BIG_ENDIAN__) || defined(__ARMEB__) || \
+    defined(__THUMBEB__) || defined(__AARCH64EB__) || defined(_MIBSEB) || defined(__MIBSEB) || defined(__MIBSEB__)
+const bool big_endian = true;
+#else
+const bool big_endian = false;
+#endif
+
+const size_t magic_string_length = 6;
+const std::array<char, magic_string_length> magic_string = {'\x93', 'N', 'U', 'M', 'P', 'Y'};
+
+const char little_endian_char = '<';
+const char big_endian_char = '>';
+const char no_endian_char = '|';
+
+constexpr std::array<char, 3> endian_chars = {little_endian_char, big_endian_char, no_endian_char};
+constexpr std::array<char, 4> numtype_chars = {'f', 'i', 'u', 'c'};
+
+constexpr char host_endian_char = (big_endian ? big_endian_char : little_endian_char);
+
+/* npy array length */
+using ndarray_len_t = unsigned long int;
+using shape_t = std::vector<ndarray_len_t>;
+
+using version_t = std::pair<char, char>;
+
+struct dtype_t {
+  char byteorder;
+  char kind;
+  unsigned int itemsize;
+
+  inline std::string str() const {
+    std::stringstream ss;
+    ss << byteorder << kind << itemsize;
+    return ss.str();
+  }
+
+  inline std::tuple<const char, const char, const unsigned int> tie() const {
+    return std::tie(byteorder, kind, itemsize);
+  }
+};
+
+struct header_t {
+  dtype_t dtype;
+  bool fortran_order;
+  shape_t shape;
+};
+
+inline void write_magic(std::ostream &ostream, version_t version) {
+  ostream.write(magic_string.data(), magic_string_length);
+  ostream.put(version.first);
+  ostream.put(version.second);
+}
+
+inline version_t read_magic(std::istream &istream) {
+  std::array<char, magic_string_length + 2> buf{};
+  istream.read(buf.data(), sizeof(buf));
+
+  if (!istream) {
+    throw std::runtime_error("io error: failed reading file");
+  }
+
+  if (!std::equal(magic_string.begin(), magic_string.end(), buf.begin()))
+    throw std::runtime_error("this file does not have a valid npy format.");
+
+  version_t version;
+  version.first = buf[magic_string_length];
+  version.second = buf[magic_string_length + 1];
+
+  return version;
+}
+
+const std::unordered_map<std::type_index, dtype_t> dtype_map = {
+    {std::type_index(typeid(float)), {host_endian_char, 'f', sizeof(float)}},
+    {std::type_index(typeid(double)), {host_endian_char, 'f', sizeof(double)}},
+    {std::type_index(typeid(long double)), {host_endian_char, 'f', sizeof(long double)}},
+    {std::type_index(typeid(char)), {no_endian_char, 'i', sizeof(char)}},
+    {std::type_index(typeid(signed char)), {no_endian_char, 'i', sizeof(signed char)}},
+    {std::type_index(typeid(short)), {host_endian_char, 'i', sizeof(short)}},
+    {std::type_index(typeid(int)), {host_endian_char, 'i', sizeof(int)}},
+    {std::type_index(typeid(long)), {host_endian_char, 'i', sizeof(long)}},
+    {std::type_index(typeid(long long)), {host_endian_char, 'i', sizeof(long long)}},
+    {std::type_index(typeid(unsigned char)), {no_endian_char, 'u', sizeof(unsigned char)}},
+    {std::type_index(typeid(unsigned short)), {host_endian_char, 'u', sizeof(unsigned short)}},
+    {std::type_index(typeid(unsigned int)), {host_endian_char, 'u', sizeof(unsigned int)}},
+    {std::type_index(typeid(unsigned long)), {host_endian_char, 'u', sizeof(unsigned long)}},
+    {std::type_index(typeid(unsigned long long)), {host_endian_char, 'u', sizeof(unsigned long long)}},
+    {std::type_index(typeid(std::complex<float>)), {host_endian_char, 'c', sizeof(std::complex<float>)}},
+    {std::type_index(typeid(std::complex<double>)), {host_endian_char, 'c', sizeof(std::complex<double>)}},
+    {std::type_index(typeid(std::complex<long double>)), {host_endian_char, 'c', sizeof(std::complex<long double>)}}};
+
+// helpers
+inline bool is_digits(const std::string &str) { return std::all_of(str.begin(), str.end(), ::isdigit); }
+
+template <typename T, size_t N>
+inline bool in_array(T val, const std::array<T, N> &arr) {
+  return std::find(std::begin(arr), std::end(arr), val) != std::end(arr);
+}
+
+inline dtype_t parse_descr(std::string typestring) {
+  if (typestring.length() < 3) {
+    throw std::runtime_error("invalid typestring (length)");
+  }
+
+  char byteorder_c = typestring.at(0);
+  char kind_c = typestring.at(1);
+  std::string itemsize_s = typestring.substr(2);
+
+  if (!in_array(byteorder_c, endian_chars)) {
+    throw std::runtime_error("invalid typestring (byteorder)");
+  }
+
+  if (!in_array(kind_c, numtype_chars)) {
+    throw std::runtime_error("invalid typestring (kind)");
+  }
+
+  if (!is_digits(itemsize_s)) {
+    throw std::runtime_error("invalid typestring (itemsize)");
+  }
+  unsigned int itemsize = std::stoul(itemsize_s);
+
+  return {byteorder_c, kind_c, itemsize};
+}
+
+namespace pyparse {
+
+/**
+  Removes leading and trailing whitespaces
+  */
+inline std::string trim(const std::string &str) {
+  const std::string whitespace = " \t";
+  auto begin = str.find_first_not_of(whitespace);
+
+  if (begin == std::string::npos) return "";
+
+  auto end = str.find_last_not_of(whitespace);
+
+  return str.substr(begin, end - begin + 1);
+}
+
+inline std::string get_value_from_map(const std::string &mapstr) {
+  size_t sep_pos = mapstr.find_first_of(":");
+  if (sep_pos == std::string::npos) return "";
+
+  std::string tmp = mapstr.substr(sep_pos + 1);
+  return trim(tmp);
+}
+
+/**
+   Parses the string representation of a Python dict
+
+   The keys need to be known and may not appear anywhere else in the data.
+ */
+inline std::unordered_map<std::string, std::string> parse_dict(std::string in, const std::vector<std::string> &keys) {
+  std::unordered_map<std::string, std::string> map;
+
+  if (keys.size() == 0) return map;
+
+  in = trim(in);
+
+  // unwrap dictionary
+  if ((in.front() == '{') && (in.back() == '}'))
+    in = in.substr(1, in.length() - 2);
+  else
+    throw std::runtime_error("Not a Python dictionary.");
+
+  std::vector<std::pair<size_t, std::string>> positions;
+
+  for (auto const &value : keys) {
+    size_t pos = in.find("'" + value + "'");
+
+    if (pos == std::string::npos) throw std::runtime_error("Missing '" + value + "' key.");
+
+    std::pair<size_t, std::string> position_pair{pos, value};
+    positions.push_back(position_pair);
+  }
+
+  // sort by position in dict
+  std::sort(positions.begin(), positions.end());
+
+  for (size_t i = 0; i < positions.size(); ++i) {
+    std::string raw_value;
+    size_t begin{positions[i].first};
+    size_t end{std::string::npos};
+
+    std::string key = positions[i].second;
+
+    if (i + 1 < positions.size()) end = positions[i + 1].first;
+
+    raw_value = in.substr(begin, end - begin);
+
+    raw_value = trim(raw_value);
+
+    if (raw_value.back() == ',') raw_value.pop_back();
+
+    map[key] = get_value_from_map(raw_value);
+  }
+
+  return map;
+}
+
+/**
+  Parses the string representation of a Python boolean
+  */
+inline bool parse_bool(const std::string &in) {
+  if (in == "True") return true;
+  if (in == "False") return false;
+
+  throw std::runtime_error("Invalid python boolan.");
+}
+
+/**
+  Parses the string representation of a Python str
+  */
+inline std::string parse_str(const std::string &in) {
+  if ((in.front() == '\'') && (in.back() == '\'')) return in.substr(1, in.length() - 2);
+
+  throw std::runtime_error("Invalid python string.");
+}
+
+/**
+  Parses the string represenatation of a Python tuple into a vector of its items
+ */
+inline std::vector<std::string> parse_tuple(std::string in) {
+  std::vector<std::string> v;
+  const char seperator = ',';
+
+  in = trim(in);
+
+  if ((in.front() == '(') && (in.back() == ')'))
+    in = in.substr(1, in.length() - 2);
+  else
+    throw std::runtime_error("Invalid Python tuple.");
+
+  std::istringstream iss(in);
+
+  for (std::string token; std::getline(iss, token, seperator);) {
+    v.push_back(token);
+  }
+
+  return v;
+}
+
+template <typename T>
+inline std::string write_tuple(const std::vector<T> &v) {
+  if (v.size() == 0) return "()";
+
+  std::ostringstream ss;
+  ss.imbue(std::locale("C"));
+
+  if (v.size() == 1) {
+    ss << "(" << v.front() << ",)";
+  } else {
+    const std::string delimiter = ", ";
+    // v.size() > 1
+    ss << "(";
+    std::copy(v.begin(), v.end() - 1, std::ostream_iterator<T>(ss, delimiter.c_str()));
+    ss << v.back();
+    ss << ")";
+  }
+
+  return ss.str();
+}
+
+inline std::string write_boolean(bool b) {
+  if (b)
+    return "True";
+  else
+    return "False";
+}
+
+}  // namespace pyparse
+
+inline header_t parse_header(std::string header) {
+  /*
+     The first 6 bytes are a magic string: exactly "x93NUMPY".
+     The next 1 byte is an unsigned byte: the major version number of the file
+     format, e.g. x01. The next 1 byte is an unsigned byte: the minor version
+     number of the file format, e.g. x00. Note: the version of the file format
+     is not tied to the version of the numpy package. The next 2 bytes form a
+     little-endian unsigned short int: the length of the header data HEADER_LEN.
+     The next HEADER_LEN bytes form the header data describing the array's
+     format. It is an ASCII string which contains a Python literal expression of
+     a dictionary. It is terminated by a newline ('n') and padded with spaces
+     ('x20') to make the total length of the magic string + 4 + HEADER_LEN be
+     evenly divisible by 16 for alignment purposes. The dictionary contains
+     three keys:
+
+     "descr" : dtype.descr
+     An object that can be passed as an argument to the numpy.dtype()
+     constructor to create the array's dtype. "fortran_order" : bool Whether the
+     array data is Fortran-contiguous or not. Since Fortran-contiguous arrays
+     are a common form of non-C-contiguity, we allow them to be written directly
+     to disk for efficiency. "shape" : tuple of int The shape of the array. For
+     repeatability and readability, this dictionary is formatted using
+     pprint.pformat() so the keys are in alphabetic order.
+   */
+
+  // remove trailing newline
+  if (header.back() != '\n') throw std::runtime_error("invalid header");
+  header.pop_back();
+
+  // parse the dictionary
+  std::vector<std::string> keys{"descr", "fortran_order", "shape"};
+  auto dict_map = npy::pyparse::parse_dict(header, keys);
+
+  if (dict_map.size() == 0) throw std::runtime_error("invalid dictionary in header");
+
+  std::string descr_s = dict_map["descr"];
+  std::string fortran_s = dict_map["fortran_order"];
+  std::string shape_s = dict_map["shape"];
+
+  std::string descr = npy::pyparse::parse_str(descr_s);
+  dtype_t dtype = parse_descr(descr);
+
+  // convert literal Python bool to C++ bool
+  bool fortran_order = npy::pyparse::parse_bool(fortran_s);
+
+  // parse the shape tuple
+  auto shape_v = npy::pyparse::parse_tuple(shape_s);
+
+  shape_t shape;
+  for (auto item : shape_v) {
+    auto dim = static_cast<ndarray_len_t>(std::stoul(item));
+    shape.push_back(dim);
+  }
+
+  return {dtype, fortran_order, shape};
+}
+
+inline std::string write_header_dict(const std::string &descr, bool fortran_order, const shape_t &shape) {
+  std::string s_fortran_order = npy::pyparse::write_boolean(fortran_order);
+  std::string shape_s = npy::pyparse::write_tuple(shape);
+
+  return "{'descr': '" + descr + "', 'fortran_order': " + s_fortran_order + ", 'shape': " + shape_s + ", }";
+}
+
+inline void write_header(std::ostream &out, const header_t &header) {
+  std::string header_dict = write_header_dict(header.dtype.str(), header.fortran_order, header.shape);
+
+  size_t length = magic_string_length + 2 + 2 + header_dict.length() + 1;
+
+  version_t version{1, 0};
+  if (length >= 255 * 255) {
+    length = magic_string_length + 2 + 4 + header_dict.length() + 1;
+    version = {2, 0};
+  }
+  size_t padding_len = 16 - length % 16;
+  std::string padding(padding_len, ' ');
+
+  // write magic
+  write_magic(out, version);
+
+  // write header length
+  if (version == version_t{1, 0}) {
+    auto header_len = static_cast<uint16_t>(header_dict.length() + padding.length() + 1);
+
+    std::array<uint8_t, 2> header_len_le16{static_cast<uint8_t>((header_len >> 0) & 0xff),
+                                           static_cast<uint8_t>((header_len >> 8) & 0xff)};
+    out.write(reinterpret_cast<char *>(header_len_le16.data()), 2);
+  } else {
+    auto header_len = static_cast<uint32_t>(header_dict.length() + padding.length() + 1);
+
+    std::array<uint8_t, 4> header_len_le32{
+        static_cast<uint8_t>((header_len >> 0) & 0xff), static_cast<uint8_t>((header_len >> 8) & 0xff),
+        static_cast<uint8_t>((header_len >> 16) & 0xff), static_cast<uint8_t>((header_len >> 24) & 0xff)};
+    out.write(reinterpret_cast<char *>(header_len_le32.data()), 4);
+  }
+
+  out << header_dict << padding << '\n';
+}
+
+inline std::string read_header(std::istream &istream) {
+  // check magic bytes an version number
+  version_t version = read_magic(istream);
+
+  uint32_t header_length = 0;
+  if (version == version_t{1, 0}) {
+    std::array<uint8_t, 2> header_len_le16{};
+    istream.read(reinterpret_cast<char *>(header_len_le16.data()), 2);
+    header_length = (header_len_le16[0] << 0) | (header_len_le16[1] << 8);
+
+    if ((magic_string_length + 2 + 2 + header_length) % 16 != 0) {
+      // TODO(llohse): display warning
+    }
+  } else if (version == version_t{2, 0}) {
+    std::array<uint8_t, 4> header_len_le32{};
+    istream.read(reinterpret_cast<char *>(header_len_le32.data()), 4);
+
+    header_length =
+        (header_len_le32[0] << 0) | (header_len_le32[1] << 8) | (header_len_le32[2] << 16) | (header_len_le32[3] << 24);
+
+    if ((magic_string_length + 2 + 4 + header_length) % 16 != 0) {
+      // TODO(llohse): display warning
+    }
+  } else {
+    throw std::runtime_error("unsupported file format version");
+  }
+
+  auto buf_v = std::vector<char>(header_length);
+  istream.read(buf_v.data(), header_length);
+  std::string header(buf_v.data(), header_length);
+
+  return header;
+}
+
+inline ndarray_len_t comp_size(const shape_t &shape) {
+  ndarray_len_t size = 1;
+  for (ndarray_len_t i : shape) size *= i;
+
+  return size;
+}
+
+template <typename Scalar>
+struct npy_data {
+  std::vector<Scalar> data = {};
+  shape_t shape = {};
+  bool fortran_order = false;
+};
+
+template <typename Scalar>
+struct npy_data_ptr {
+  const Scalar *data_ptr = nullptr;
+  shape_t shape = {};
+  bool fortran_order = false;
+};
+
+template <typename Scalar>
+inline npy_data<Scalar> read_npy(std::istream &in) {
+  std::string header_s = read_header(in);
+
+  // parse header
+  header_t header = parse_header(header_s);
+
+  // check if the typestring matches the given one
+  const dtype_t dtype = dtype_map.at(std::type_index(typeid(Scalar)));
+
+  if (header.dtype.tie() != dtype.tie()) {
+    throw std::runtime_error("formatting error: typestrings not matching");
+  }
+
+  // compute the data size based on the shape
+  auto size = static_cast<size_t>(comp_size(header.shape));
+
+  npy_data<Scalar> data;
+
+  data.shape = header.shape;
+  data.fortran_order = header.fortran_order;
+
+  data.data.resize(size);
+
+  // read the data
+  in.read(reinterpret_cast<char *>(data.data.data()), sizeof(Scalar) * size);
+
+  return data;
+}
+
+template <typename Scalar>
+inline npy_data<Scalar> read_npy(const std::string &filename) {
+  std::ifstream stream(filename, std::ifstream::binary);
+  if (!stream) {
+    throw std::runtime_error("io error: failed to open a file.");
+  }
+
+  return read_npy<Scalar>(stream);
+}
+
+template <typename Scalar>
+inline void write_npy(std::ostream &out, const npy_data<Scalar> &data) {
+  //  static_assert(has_typestring<Scalar>::value, "scalar type not
+  //  understood");
+  const dtype_t dtype = dtype_map.at(std::type_index(typeid(Scalar)));
+
+  header_t header{dtype, data.fortran_order, data.shape};
+  write_header(out, header);
+
+  auto size = static_cast<size_t>(comp_size(data.shape));
+
+  out.write(reinterpret_cast<const char *>(data.data.data()), sizeof(Scalar) * size);
+}
+
+template <typename Scalar>
+inline void write_npy(const std::string &filename, const npy_data<Scalar> &data) {
+  std::ofstream stream(filename, std::ofstream::binary);
+  if (!stream) {
+    throw std::runtime_error("io error: failed to open a file.");
+  }
+
+  write_npy<Scalar>(stream, data);
+}
+
+template <typename Scalar>
+inline void write_npy(std::ostream &out, const npy_data_ptr<Scalar> &data_ptr) {
+  const dtype_t dtype = dtype_map.at(std::type_index(typeid(Scalar)));
+
+  header_t header{dtype, data_ptr.fortran_order, data_ptr.shape};
+  write_header(out, header);
+
+  auto size = static_cast<size_t>(comp_size(data_ptr.shape));
+
+  out.write(reinterpret_cast<const char *>(data_ptr.data_ptr), sizeof(Scalar) * size);
+}
+
+template <typename Scalar>
+inline void write_npy(const std::string &filename, const npy_data_ptr<Scalar> &data_ptr) {
+  std::ofstream stream(filename, std::ofstream::binary);
+  if (!stream) {
+    throw std::runtime_error("io error: failed to open a file.");
+  }
+
+  write_npy<Scalar>(stream, data_ptr);
+}
+
+// old interface
+
+// NOLINTBEGIN(*-avoid-c-arrays)
+template <typename Scalar>
+inline void SaveArrayAsNumpy(const std::string &filename, bool fortran_order, unsigned int n_dims,
+                             const unsigned long shape[], const Scalar *data) {
+  const npy_data_ptr<Scalar> ptr{data, {shape, shape + n_dims}, fortran_order};
+
+  write_npy<Scalar>(filename, ptr);
+}
+
+template <typename Scalar>
+inline void SaveArrayAsNumpy(const std::string &filename, bool fortran_order, unsigned int n_dims,
+                             const unsigned long shape[], const std::vector<Scalar> &data) {
+  SaveArrayAsNumpy(filename, fortran_order, n_dims, shape, data.data());
+}
+
+template <typename Scalar>
+inline void LoadArrayFromNumpy(const std::string &filename, std::vector<unsigned long> &shape, bool &fortran_order,
+                               std::vector<Scalar> &data) {
+  const npy_data<Scalar> n_data = read_npy<Scalar>(filename);
+
+  shape = n_data.shape;
+  fortran_order = n_data.fortran_order;
+
+  std::copy(n_data.data.begin(), n_data.data.end(), std::back_inserter(data));
+}
+
+template <typename Scalar>
+inline void LoadArrayFromNumpy(const std::string &filename, std::vector<unsigned long> &shape,
+                               std::vector<Scalar> &data) {
+  bool fortran_order = false;
+  LoadArrayFromNumpy<Scalar>(filename, shape, fortran_order, data);
+}
+// NOLINTEND(*-avoid-c-arrays)
+
+}  // namespace npy
+
+#endif  // NPY_HPP_


### PR DESCRIPTION
- 内容概述
ncnn2table增加读npy功能
- 实现方式
命令增加一个参数type，type为0时和原来一样，可省略
type为1时，以npy格式读文件，读npy引用(https://github.com/llohse/libnpy)实现。
  ```bash
  ncnn2table test.param test.bin filelist.txt squeezenet.table shape=[227,227,3] method=kl type=1
  ```
- 测试结果
单个input blob测试通过，多个未测试（没资源）