### PR TITLE
add eltwise_riscv

### DIFF
--- a/src/layer/riscv/eltwise_riscv.cpp
+++ b/src/layer/riscv/eltwise_riscv.cpp
@@ -1,0 +1,350 @@
+//
+// Copyright (C) 2025 xiaofan <xiaofan@iscas.ac.cn>. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this
+// file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#include "eltwise_riscv.h"
+
+#if __riscv_vector
+#include <riscv_vector.h>
+#include "rvv_mathfun.h"
+#endif // __riscv_vector
+
+#include "cpu.h"
+
+namespace ncnn
+{
+
+Eltwise_riscv::Eltwise_riscv()
+{
+#if __riscv_vector
+    support_packing = true;
+#endif
+#if NCNN_ZFH
+#if __riscv_vector
+    support_fp16_storage = cpu_support_riscv_zvfh();
+#else
+    support_fp16_storage = cpu_support_riscv_zfh();
+#endif
+#endif
+    support_fp16_storage = false;
+}
+
+int Eltwise_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt) const
+{
+    const Mat& bottom_top_blob = bottom_blobs[0];
+#if NCNN_ZFH
+    int elembits = bottom_top_blob.elembits();
+    if (opt.use_fp16_storage && elembits == 16)
+    {
+        // return forward_fp16s(bottom_blobs, top_blobs, opt);
+	return -1;
+    }
+#endif
+    int w = bottom_top_blob.w;
+    int h = bottom_top_blob.h;
+    int d = bottom_top_blob.d;
+    int channels = bottom_top_blob.c;
+    int elempack = bottom_top_blob.elempack;
+    int size = w * h * d * elempack;
+
+    Mat& top_blob = top_blobs[0];
+    top_blob.create_like(bottom_top_blob, opt.blob_allocator);
+
+    if (op_type == Operation_PROD)
+    {
+        // top_blob = bottom_top_blob * bottom_blobs[1]
+        const Mat& bottom_blob1 = bottom_blobs[1];
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int q = 0; q < channels; q++)
+        {
+            const float* ptr = bottom_top_blob.channel(q);
+            const float* ptr1 = bottom_blob1.channel(q);
+            float* outptr = top_blob.channel(q);
+#if __riscv_vector
+            int n = size;
+            while (n > 0)
+            {
+                size_t vl = __riscv_vsetvl_e32m8(n);
+
+                vfloat32m8_t _p = __riscv_vle32_v_f32m8(ptr, vl);
+                vfloat32m8_t _p1 = __riscv_vle32_v_f32m8(ptr1, vl);
+                _p = __riscv_vfmul_vv_f32m8(_p, _p1, vl);
+                __riscv_vse32_v_f32m8(outptr, _p, vl);
+
+                ptr += vl;
+                ptr1 += vl;
+                outptr += vl;
+                n -= vl;
+            }
+#else
+            for (int i = 0; i < size; i++)
+            {
+                outptr[i] = ptr[i] * ptr1[i];
+            }
+#endif
+        }
+
+        // top_blob *= bottom_blobs[i] for i = 2, 3, ...
+        for (size_t b = 2; b < bottom_blobs.size(); b++)
+        {
+            const Mat& bottom_blob1 = bottom_blobs[b];
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int q = 0; q < channels; q++)
+            {
+                const float* ptr = bottom_blob1.channel(q);
+                float* outptr = top_blob.channel(q);
+#if __riscv_vector
+                int n = size;
+                while (n > 0)
+                {
+                    size_t vl = __riscv_vsetvl_e32m8(n);
+
+                    vfloat32m8_t _p = __riscv_vle32_v_f32m8(ptr, vl);
+                    vfloat32m8_t _p1 = __riscv_vle32_v_f32m8(outptr, vl);
+                    _p1 = __riscv_vfmul_vv_f32m8(_p1, _p, vl);
+                    __riscv_vse32_v_f32m8(outptr, _p1, vl);
+
+                    ptr += vl;
+                    outptr += vl;
+                    n -= vl;
+                }
+#else
+                for (int i = 0; i < size; i++)
+                {
+                    outptr[i] *= ptr[i];
+                }
+#endif
+            }
+        }
+    }
+    else if (op_type == Operation_SUM)
+    {
+        if (coeffs.empty())
+        {
+            // top_blob = bottom_top_blob + bottom_blobs[1]
+            const Mat& bottom_blob1 = bottom_blobs[1];
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int q = 0; q < channels; q++)
+            {
+                const float* ptr = bottom_top_blob.channel(q);
+                const float* ptr1 = bottom_blob1.channel(q);
+                float* outptr = top_blob.channel(q);
+#if __riscv_vector
+                int n = size;
+                while (n > 0)
+                {
+                    size_t vl = __riscv_vsetvl_e32m8(n);
+
+                    vfloat32m8_t _p = __riscv_vle32_v_f32m8(ptr, vl);
+                    vfloat32m8_t _p1 = __riscv_vle32_v_f32m8(ptr1, vl);
+                    _p = __riscv_vfadd_vv_f32m8(_p, _p1, vl);
+                    __riscv_vse32_v_f32m8(outptr, _p, vl);
+
+                    ptr += vl;
+                    ptr1 += vl;
+                    outptr += vl;
+                    n -= vl;
+                }
+#else
+                for (int i = 0; i < size; i++)
+                {
+                    outptr[i] = ptr[i] + ptr1[i];
+                }
+#endif
+            }
+
+            // top_blob += bottom_blobs[i] for i = 2, 3, ...
+            for (size_t b = 2; b < bottom_blobs.size(); b++)
+            {
+                const Mat& bottom_blob1 = bottom_blobs[b];
+                #pragma omp parallel for num_threads(opt.num_threads)
+                for (int q = 0; q < channels; q++)
+                {
+                    const float* ptr = bottom_blob1.channel(q);
+                    float* outptr = top_blob.channel(q);
+#if __riscv_vector
+                    int n = size;
+                    while (n > 0)
+                    {
+                        size_t vl = __riscv_vsetvl_e32m8(n);
+
+                        vfloat32m8_t _p = __riscv_vle32_v_f32m8(ptr, vl);
+                        vfloat32m8_t _p1 = __riscv_vle32_v_f32m8(outptr, vl);
+                        _p1 = __riscv_vfadd_vv_f32m8(_p1, _p, vl);
+                        __riscv_vse32_v_f32m8(outptr, _p1, vl);
+
+                        ptr += vl;
+                        outptr += vl;
+                        n -= vl;
+                    }
+#else
+                    for (int i = 0; i < size; i++)
+                    {
+                        outptr[i] += ptr[i];
+                    }
+#endif
+                }
+            }
+        }
+        else
+        {
+            // top_blob = bottom_top_blob * coeffs[0] + bottom_blobs[1] * coeffs[1]
+            const Mat& bottom_blob1 = bottom_blobs[1];
+            float coeff0 = coeffs[0];
+            float coeff1 = coeffs[1];
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int q = 0; q < channels; q++)
+            {
+                const float* ptr = bottom_top_blob.channel(q);
+                const float* ptr1 = bottom_blob1.channel(q);
+                float* outptr = top_blob.channel(q);
+#if __riscv_vector
+                int n = size;
+                while (n > 0)
+                {
+                    size_t vl = __riscv_vsetvl_e32m8(n);
+
+                    vfloat32m8_t _p = __riscv_vle32_v_f32m8(ptr, vl);
+                    vfloat32m8_t _p1 = __riscv_vle32_v_f32m8(ptr1, vl);
+                    _p = __riscv_vfmul_vf_f32m8(_p, coeff0, vl);
+                    _p1 = __riscv_vfmul_vf_f32m8(_p1, coeff1, vl);
+                    _p = __riscv_vfadd_vv_f32m8(_p, _p1, vl);
+                    __riscv_vse32_v_f32m8(outptr, _p, vl);
+
+                    ptr += vl;
+                    ptr1 += vl;
+                    outptr += vl;
+                    n -= vl;
+                }
+#else
+                for (int i = 0; i < size; i++)
+                {
+                    outptr[i] = ptr[i] * coeff0 + ptr1[i] * coeff1;
+                }
+#endif
+            }
+
+            // top_blob += bottom_blobs[i] * coeffs[i] for i = 2, 3, ...
+            for (size_t b = 2; b < bottom_blobs.size(); b++)
+            {
+                const Mat& bottom_blob1 = bottom_blobs[b];
+                float coeff = coeffs[b];
+                #pragma omp parallel for num_threads(opt.num_threads)
+                for (int q = 0; q < channels; q++)
+                {
+                    const float* ptr = bottom_blob1.channel(q);
+                    float* outptr = top_blob.channel(q);
+#if __riscv_vector
+                    int n = size;
+                    while (n > 0)
+                    {
+                        size_t vl = __riscv_vsetvl_e32m8(n);
+
+                        vfloat32m8_t _p = __riscv_vle32_v_f32m8(ptr, vl);
+                        vfloat32m8_t _p1 = __riscv_vle32_v_f32m8(outptr, vl);
+                        _p = __riscv_vfmul_vf_f32m8(_p, coeff, vl);
+                        _p1 = __riscv_vfadd_vv_f32m8(_p1, _p, vl);
+                        __riscv_vse32_v_f32m8(outptr, _p1, vl);
+
+                        ptr += vl;
+                        outptr += vl;
+                        n -= vl;
+                    }
+#else
+                    for (int i = 0; i < size; i++)
+                    {
+                        outptr[i] += ptr[i] * coeff;
+                    }
+#endif
+                }
+            }
+        }
+    }
+    else if (op_type == Operation_MAX)
+    {
+        // top_blob = max(bottom_top_blob, bottom_blobs[1])
+        const Mat& bottom_blob1 = bottom_blobs[1];
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int q = 0; q < channels; q++)
+        {
+            const float* ptr = bottom_top_blob.channel(q);
+            const float* ptr1 = bottom_blob1.channel(q);
+            float* outptr = top_blob.channel(q);
+#if __riscv_vector
+            int n = size;
+            while (n > 0)
+            {
+                size_t vl = __riscv_vsetvl_e32m8(n);
+
+                vfloat32m8_t _p = __riscv_vle32_v_f32m8(ptr, vl);
+                vfloat32m8_t _p1 = __riscv_vle32_v_f32m8(ptr1, vl);
+                _p = __riscv_vfmax_vv_f32m8(_p, _p1, vl);
+                __riscv_vse32_v_f32m8(outptr, _p, vl);
+
+                ptr += vl;
+                ptr1 += vl;
+                outptr += vl;
+                n -= vl;
+            }
+#else
+            for (int i = 0; i < size; i++)
+            {
+                outptr[i] = std::max(ptr[i], ptr1[i]);
+            }
+#endif
+        }
+
+        // top_blob = max(top_blob, bottom_blobs[i]) for i = 2, 3, ...
+        for (size_t b = 2; b < bottom_blobs.size(); b++)
+        {
+            const Mat& bottom_blob1 = bottom_blobs[b];
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int q = 0; q < channels; q++)
+            {
+                const float* ptr = bottom_blob1.channel(q);
+                float* outptr = top_blob.channel(q);
+#if __riscv_vector
+                int n = size;
+                while (n > 0)
+                {
+                    size_t vl = __riscv_vsetvl_e32m8(n);
+
+                    vfloat32m8_t _p = __riscv_vle32_v_f32m8(ptr, vl);
+                    vfloat32m8_t _p1 = __riscv_vle32_v_f32m8(outptr, vl);
+                    _p1 = __riscv_vfmax_vv_f32m8(_p1, _p, vl);
+                    __riscv_vse32_v_f32m8(outptr, _p1, vl);
+
+                    ptr += vl;
+                    outptr += vl;
+                    n -= vl;
+                }
+#else
+                for (int i = 0; i < size; i++)
+                {
+                    outptr[i] = std::max(outptr[i], ptr[i]);
+                }
+#endif
+            }
+        }
+    }
+    else
+    {
+        fprintf(stderr, "Eltwise_riscv: unsupported operation type %d\n", op_type);
+        return -1;                   
+    }
+
+    return 0;
+}
+
+} // namespace ncnn

--- a/src/layer/riscv/eltwise_riscv.cpp
+++ b/src/layer/riscv/eltwise_riscv.cpp
@@ -125,7 +125,7 @@ int Eltwise_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat
             }
         }
     }
-    else if (op_type == Operation_SUM)
+    if (op_type == Operation_SUM)
     {
         if (coeffs.empty())
         {
@@ -268,7 +268,7 @@ int Eltwise_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat
             }
         }
     }
-    else
+    if (op_type == Operation_MAX)
     {
         // top_blob = max(bottom_top_blob, bottom_blobs[1])
         const Mat& bottom_blob1 = bottom_blobs[1];

--- a/src/layer/riscv/eltwise_riscv.cpp
+++ b/src/layer/riscv/eltwise_riscv.cpp
@@ -22,8 +22,7 @@
 
 #include "cpu.h"
 
-namespace ncnn
-{
+namespace ncnn {
 
 Eltwise_riscv::Eltwise_riscv()
 {
@@ -269,7 +268,7 @@ int Eltwise_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat
             }
         }
     }
-    else if (op_type == Operation_MAX)
+    else
     {
         // top_blob = max(bottom_top_blob, bottom_blobs[1])
         const Mat& bottom_blob1 = bottom_blobs[1];
@@ -335,11 +334,6 @@ int Eltwise_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat
 #endif
             }
         }
-    }
-    else
-    {
-        fprintf(stderr, "Eltwise_riscv: unsupported operation type %d\n", op_type);
-        return -1;                   
     }
 
     return 0;

--- a/src/layer/riscv/eltwise_riscv.h
+++ b/src/layer/riscv/eltwise_riscv.h
@@ -1,0 +1,33 @@
+//
+// Copyright (C) 2025 xiaofan <xiaofan@iscas.ac.cn>. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this
+// file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#ifndef LAYER_ELTWISE_RISCV_H
+#define LAYER_ELTWISE_RISCV_H
+
+#include "eltwise.h"
+
+namespace ncnn {
+
+class Eltwise_riscv : public Eltwise
+{
+public:
+    Eltwise_riscv();
+
+    virtual int forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt) const;    
+};
+
+} // namespace ncnn
+
+#endif // LAYER_ELTWISE_RISCV_H

--- a/src/layer/riscv/eltwise_riscv.h
+++ b/src/layer/riscv/eltwise_riscv.h
@@ -24,8 +24,12 @@ class Eltwise_riscv : public Eltwise
 {
 public:
     Eltwise_riscv();
+    virtual int forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt) const;
 
-    virtual int forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt) const;    
+protected:
+#if NCNN_ZFH
+    int forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt) const;
+#endif
 };
 
 } // namespace ncnn

--- a/src/layer/riscv/eltwise_riscv_zfh.cpp
+++ b/src/layer/riscv/eltwise_riscv_zfh.cpp
@@ -240,7 +240,7 @@ int Eltwise_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vect
             }
         }
     }
-    else if (op_type == Operation_MAX)
+    else
     {
         const Mat& bottom_blob1 = bottom_blobs[1];
         #pragma omp parallel for num_threads(opt.num_threads)
@@ -304,11 +304,6 @@ int Eltwise_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vect
 #endif
             }
         }
-    }
-    else
-    {
-        fprintf(stderr, "Eltwise_riscv: unsupported operation type %d\n", op_type);
-        return -1;
     }
 
     return 0;

--- a/src/layer/riscv/eltwise_riscv_zfh.cpp
+++ b/src/layer/riscv/eltwise_riscv_zfh.cpp
@@ -101,7 +101,7 @@ int Eltwise_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vect
             }
         }
     }
-    else if (op_type == Operation_SUM)
+    if (op_type == Operation_SUM)
     {
         if (coeffs.empty())
         {
@@ -240,7 +240,7 @@ int Eltwise_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vect
             }
         }
     }
-    else
+    if (op_type == Operation_MAX)
     {
         const Mat& bottom_blob1 = bottom_blobs[1];
         #pragma omp parallel for num_threads(opt.num_threads)


### PR DESCRIPTION
增加了eltwise_riscv

| Test                | Base Avg  | New Avg   | Improvement |
|---------------------|-----------|-----------|-------------|
| squeezenet          |     27.61 |     28.20 |      -2.09% |
| mobilenet           |     33.93 |     32.56 |      +4.21% |
| mobilenet_v2        |     42.65 |     36.72 |     +16.15% |
| mobilenet_v3        |     36.52 |     39.29 |      -7.05% |
| shufflenet          |     80.90 |     49.77 |     +62.55% |
| shufflenet_v2       |     32.40 |     29.88 |      +8.43% |
| mnasnet             |     39.10 |     40.46 |      -3.36% |
| proxylessnasnet     |     35.82 |     35.63 |      +0.53% |
| efficientnet_b0     |     45.51 |     43.50 |      +4.62% |
| efficientnetv2_b0   |     91.11 |     79.47 |     +14.65% |
| regnety_400m        |    112.58 |    111.76 |      +0.73% |
| blazeface           |     15.65 |     17.77 |     -11.93% |
| googlenet           |    102.16 |    102.94 |      -0.76% |
| resnet18            |     86.15 |     64.22 |     +34.15% |
| alexnet             |     69.58 |     68.01 |      +2.31% |
| vgg16               |    251.05 |    252.72 |      -0.66% |
| resnet50            |    287.63 |    161.12 |     +78.52% |
| squeezenet_ssd      |    115.00 |    117.97 |      -2.52% |
| mobilenet_ssd       |     68.89 |     70.88 |      -2.81% |
| mobilenet_yolo      |    308.87 |    304.68 |      +1.38% |
| mobilenetv2_yolov3  |    142.43 |    124.97 |     +13.97% |
| yolov4-tiny         |    153.13 |    157.29 |      -2.64% |
| nanodet_m           |     76.20 |     74.18 |      +2.72% |
| yolo-fastest-1.1    |     61.00 |     52.01 |     +17.29% |
| yolo-fastestv2      |     57.36 |     59.85 |      -4.16% |
| vision_transformer  |   4941.05 |   4787.39 |      +3.21% |
| FastestDet          |     52.14 |     52.71 |      -1.08% |

等FP16开发完成以后再合