### PR TITLE
修复onnx gemm转化成ncnn后导致尺寸和推理结果错误的问题（将本质为fc层但不规范的onnx gemm转ncnn inner product，比如从mxnet/paddle转过来的onnx）

### DIFF
--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -4591,22 +4591,22 @@ For more information, please refer to https://github.com/pnnx/pnnx\n");
                 // InnerProduct-like A * B + C
                 const onnx::TensorProto& B = weights[node.input(1)];
                 const onnx::TensorProto& C = weights[node.input(2)];
-            
+
                 fprintf(pp, " 0=%d", get_tensor_proto_data_size(C));
                 fprintf(pp, " 1=1");
                 fprintf(pp, " 2=%d", get_tensor_proto_data_size(B));
-            
+
                 int weight_data_size = get_tensor_proto_data_size(B);
                 int num_output = B.dims(B.dims_size() - 1);
                 int num_input = weight_data_size / num_output;
-            
+
                 int quantize_tag = 0;
                 fwrite(&quantize_tag, sizeof(int), 1, bp);
-            
+
                 // reorder num_input-num_output to num_output-num_input
                 {
                     const float* bptr = B.has_raw_data() ? (const float*)B.raw_data().data() : B.float_data().data();
-            
+
                     for (int j = 0; j < num_output; j++)
                     {
                         for (int k = 0; k < num_input; k++)
@@ -4617,7 +4617,6 @@ For more information, please refer to https://github.com/pnnx/pnnx\n");
                     }
                 }
                 fwrite_tensor_proto_data(C, bp);
-            
             }
             else
             {


### PR DESCRIPTION
修复onnx gemm转化成ncnn后导致尺寸和推理结果错误的问题。将本质为fc层但不规范的onnx gemm转ncnn inner product，比如从mxnet/paddle转过来的onnx

在 https://github.com/Tencent/ncnn/issues/4546 亦有记载
参考了https://blog.csdn.net/u012505617/article/details/131002019 进行了修改

ps：虽然pnnx好用，但并不是所有模型都来自pytorch嘛
附模型前后对比，
[model.zip](https://github.com/user-attachments/files/20383115/model.zip)

