### PR TITLE
Use platform-specific APIs for environment variables

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -163,7 +163,7 @@ __attribute__((constructor)) void ncnn_kmp_env_initializer()
     // ref KMPNativeAffinity::get_system_affinity/set_system_affinity in openmp/runtime/src/kmp_affinity.h
     // and cpu core goes offline in powersave mode on android, which triggers abort
     // disable affinity capability, we handle thread affinity for openmp threads
-#if _WIN32
+#if defined _WIN32
     _putenv_s("KMP_AFFINITY", "disabled");
 #else
     setenv("KMP_AFFINITY", "disabled", 1);
@@ -173,7 +173,7 @@ __attribute__((constructor)) void ncnn_kmp_env_initializer()
     // ref __kmp_register_library_startup in openmp/runtime/src/kmp_runtime.cpp
     // this happens when loading multiple libraries that are static linked openmp
     // just let it continue to work, it works well in most cases, at least it won't crash unexpectedly
-#if _WIN32
+#if defined _WIN32
     _putenv_s("KMP_DUPLICATE_LIB_OK", "1");
 #else
     setenv("KMP_DUPLICATE_LIB_OK", "1", 1);

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -163,13 +163,21 @@ __attribute__((constructor)) void ncnn_kmp_env_initializer()
     // ref KMPNativeAffinity::get_system_affinity/set_system_affinity in openmp/runtime/src/kmp_affinity.h
     // and cpu core goes offline in powersave mode on android, which triggers abort
     // disable affinity capability, we handle thread affinity for openmp threads
-    putenv("KMP_AFFINITY=disabled");
+#if _WIN32
+    _putenv_s("KMP_AFFINITY", "disabled");
+#else
+    setenv("KMP_AFFINITY", "disabled", 1);
+#endif
 
     // openmp initialization triggers abort when another openmp runtime detected
     // ref __kmp_register_library_startup in openmp/runtime/src/kmp_runtime.cpp
     // this happens when loading multiple libraries that are static linked openmp
     // just let it continue to work, it works well in most cases, at least it won't crash unexpectedly
-    putenv("KMP_DUPLICATE_LIB_OK=1");
+#if _WIN32
+    _putenv_s("KMP_DUPLICATE_LIB_OK", "1");
+#else
+    setenv("KMP_DUPLICATE_LIB_OK", "1", 1);
+#endif
 }
 #endif
 


### PR DESCRIPTION
The previous patch (https://github.com/Tencent/ncnn/pull/6101) used `putenv` as a quick fix for Windows compatibility. However, `putenv` is a legacy API and not the recommended choice.

This commit replaces the single `putenv` call with the most appropriate function for each platform:
- On Windows, it now uses the modern and secure `_putenv_s`.
- On Unix-like systems, it uses the standard `setenv`.