### PR TITLE
docs: update Chinese glsl-extension documentation

### DIFF
--- a/docs/developer-guide/glsl-extension.md
+++ b/docs/developer-guide/glsl-extension.md
@@ -398,7 +398,7 @@ void main()
 
 ncnn will define some additional convenient macros when the vulkan validation layer enabled
 
-* `ncnn_enable_validataion_layer`
+* `ncnn_enable_validation_layer`
 * `NCNN_LOGE`
 
 currently, you have to modify the `ENABLE_VALIDATION_LAYER` definition at the beginning of `src/gpu.cpp` to `1` to enable these macros.
@@ -410,7 +410,7 @@ void main()
 {
     int gx = int(gl_GlobalInvocationID.x);
 
-#if ncnn_enable_validataion_layer
+#if ncnn_enable_validation_layer
     NCNN_LOGE("gx = %d\n", gx);
 #endif
 }

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -5295,7 +5295,7 @@ int compile_spirv_module(const char* comp_data, int comp_data_size, const Option
 #if ENABLE_VALIDATION_LAYER
         if (info.support_VK_KHR_shader_non_semantic_info())
         {
-            device_defines.append("enable_validataion_layer", VK_TRUE);
+            device_defines.append("enable_validation_layer", VK_TRUE);
             custom_defines.append("NCNN_LOGE", "debugPrintfEXT");
         }
 #endif


### PR DESCRIPTION
更新 GLSL 扩展中文文档 
Fixes #6135
## 变更内容
1. 完整同步英文文档最新内容至中文版
2. 修正英文文档拼写错误：
   - `ncnn_enable_validataion_layer` → `ncnn_enable_validation_layer`
3. 移除中文文档的条件编译指令，英文文档中已经删除，保持一致：
   ```glsl
   #if NCNN_fp16_storage
   #extension GL_EXT_shader_16bit_storage: require
   #endif
   #if NCNN_fp16_arithmetic
   #extension GL_EXT_shader_explicit_arithmetic_types_float16: require
   #endif
