### PR TITLE
add cross toolchain cmake config of AK3918(AK) and SS928(hisi) 

### DIFF
--- a/docs/developer-guide/glsl-extension.md
+++ b/docs/developer-guide/glsl-extension.md
@@ -398,7 +398,7 @@ void main()
 
 ncnn will define some additional convenient macros when the vulkan validation layer enabled
 
-* `ncnn_enable_validataion_layer`
+* `ncnn_enable_validation_layer`
 * `NCNN_LOGE`
 
 currently, you have to modify the `ENABLE_VALIDATION_LAYER` definition at the beginning of `src/gpu.cpp` to `1` to enable these macros.
@@ -410,7 +410,7 @@ void main()
 {
     int gx = int(gl_GlobalInvocationID.x);
 
-#if ncnn_enable_validataion_layer
+#if ncnn_enable_validation_layer
     NCNN_LOGE("gx = %d\n", gx);
 #endif
 }

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -5295,7 +5295,7 @@ int compile_spirv_module(const char* comp_data, int comp_data_size, const Option
 #if ENABLE_VALIDATION_LAYER
         if (info.support_VK_KHR_shader_non_semantic_info())
         {
-            device_defines.append("enable_validataion_layer", VK_TRUE);
+            device_defines.append("enable_validation_layer", VK_TRUE);
             custom_defines.append("NCNN_LOGE", "debugPrintfEXT");
         }
 #endif


### PR DESCRIPTION
1. add cross toolchain cmake config of AK3918(AK) and SS928(hisi) 
2. update build.sh 

增加 交叉编译配置 AK3918(安凯) SS928(海思)
更新 build.sh  文件 增加这个2个配置