### PR TITLE
feat: add cmake print ver support

### DIFF
--- a/cmake/ncnnConfig.cmake.in
+++ b/cmake/ncnnConfig.cmake.in
@@ -1,3 +1,4 @@
+set(NCNN_VERSION @NCNN_VERSION@)
 set(NCNN_OPENMP @NCNN_OPENMP@)
 set(NCNN_THREADS @NCNN_THREADS@)
 set(NCNN_VULKAN @NCNN_VULKAN@)
@@ -44,3 +45,10 @@ if(NCNN_VULKAN)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/ncnn.cmake)
+
+if(TARGET ncnn)
+    set(ncnn_FOUND TRUE)
+    if(NOT ncnn_FIND_QUIETLY)
+        message(STATUS "Found ncnn: ${NCNN_VERSION}")
+    endif()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -717,6 +717,13 @@ add_dependencies(ncnn ncnn-generate-spirv)
 if(NCNN_INSTALL_SDK)
     include(GNUInstallDirs)
 
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/ncnnConfigVersion.cmake
+        VERSION ${NCNN_VERSION}
+        COMPATIBILITY AnyNewerVersion
+    )
+
     install(TARGETS ncnn EXPORT ncnn
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -756,7 +763,10 @@ if(NCNN_INSTALL_SDK)
     )
     install(EXPORT ncnn DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ncnn)
     configure_file(${CMAKE_CURRENT_LIST_DIR}/../cmake/ncnnConfig.cmake.in ncnnConfig.cmake @ONLY)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ncnnConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ncnn)
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/ncnnConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/ncnnConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ncnn)
     # pkgconfig
     configure_file(ncnn.pc.in ${CMAKE_CURRENT_BINARY_DIR}/ncnn.pc @ONLY)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ncnn.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)


### PR DESCRIPTION
# feat: add cmake print ver support(#6139 )

## Main changes
- Modified `./cmake/ncnnConfig.cmake.in` to print `ncnn` version to the console when `find_package(ncnn)` is called.
- Follow the `QUIET` argument of the `find_package` command. When using `QUIET`, users will not get the version message.

> There are multiple version variables in `./CMakeLists.txt` and I'm not sure if just printing the date information is enough.

## 主要修改
- 修改了 `cmake/ncnnConfig.cmake.in` 文件，使得当 `find_package(ncnn)` 成功执行时，会在 console 打印 ncnn 的版本信息。
- 遵循 `find_package` 命令的 `QUIET` 参数，在静默模式下不输出版本信息。

> 在 `./CMakeLists.txt` 中有多个关于版本的变量，我不确定只打印这个日期信息是否是足够的。

![image](https://github.com/user-attachments/assets/1ce6443a-6ad9-413f-a163-7f073ae4fa02)