### PR TITLE
Add support for Windows XP (x86)

### DIFF
--- a/.github/workflows/windows-xp.yml
+++ b/.github/workflows/windows-xp.yml
@@ -1,0 +1,85 @@
+name: windows-xp
+on:
+  push:
+    branches: [master]
+    paths:
+    - '.github/workflows/windows-xp.yml'
+    - 'toolchains/windows-xp.toolchain.cmake'
+    - 'CMakeLists.txt'
+    - 'cmake/**'
+    - 'src/*'
+    - 'src/layer/*'
+    - 'src/layer/x86/**'
+    - 'tests/**'
+    - 'tools/**'
+    - '!tools/pnnx/**'
+    - 'examples/**'
+    - 'benchmark/**'
+  pull_request:
+    branches: [master]
+    paths:
+    - '.github/workflows/windows-xp.yml'
+    - 'toolchains/windows-xp.toolchain.cmake'
+    - 'CMakeLists.txt'
+    - 'cmake/**'
+    - 'src/*'
+    - 'src/layer/*'
+    - 'src/layer/x86/**'
+    - 'tests/**'
+    - 'tools/**'
+    - '!tools/pnnx/**'
+    - 'examples/**'
+    - 'benchmark/**'
+concurrency:
+  group: windows-xp-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+
+jobs:
+  windows-xp:
+    name: Windows XP Compatibility
+    runs-on: windows-2022
+
+    env:
+      UseMultiToolTask: true
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: x86 (Windows XP compatible)
+      run: |
+        mkdir build-xp; cd build-xp
+        
+        cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/windows-xp.toolchain.cmake \
+              -DNCNN_VULKAN=OFF \
+              -DNCNN_SIMPLEOCV=ON \
+              -DCMAKE_BUILD_TYPE=Release \
+              -G "MinGW Makefiles" ..
+        
+        cmake --build . --config Release -j 2
+
+    - name: x86-test (Windows XP compatible)
+      run: |
+        cd build-xp
+        ctest -C Release --output-on-failure -j 2
+
+    - name: Verify XP Compatibility
+      run: |
+        cd build-xp
+        
+        Get-ChildItem -Path "tests\Release" -Filter "*.exe" | ForEach-Object {
+          Write-Host "Testing $($_.Name)..."
+          if (Test-Path $_.FullName) {
+            Write-Host "✓ $($_.Name) exists"
+          }
+        }
+        
+        Get-ChildItem -Path "src\Release" -Filter "*.dll" | ForEach-Object {
+          Write-Host "Testing $($_.Name)..."
+          if (Test-Path $_.FullName) {
+            Write-Host "✓ $($_.Name) exists"
+          }
+        }

--- a/docs/developer-guide/build-ncnn-on-windows-xp.zh.md
+++ b/docs/developer-guide/build-ncnn-on-windows-xp.zh.md
@@ -1,0 +1,185 @@
+# Build ncnn on Windows XP
+
+## 0. 环境准备
+
+#### 0.1 虚拟机设置
+
+我使用的是[我的MSDN](https://www.imsdn.cn/)提供的[Windows XP SP3 x64版本](https://www.imsdn.cn/operating-systems/windows-xp/)。虚拟机使用Oracle VM VirtualBox，内存4GB，存储空间64GB（C盘16GB，D盘48GB）。
+
+**在虚拟机关机的情况下**，点击虚拟机管理器界面的"设置"-"网络"-"高级"，将控制芯片改为PCnet-FAST III，混杂模式设置为拒绝，勾选接入网线，点击"OK"保存。重启虚拟机就可以连接上网络了。
+
+点击虚拟机界面的"设备"-"安装增强功能..."，在虚拟机中进入"我的电脑"，刷新后出现"VirtualBox Guest Additions (D: )"，右键选择"自动播放"，完成安装后重启。
+
+点击虚拟机界面的"设备"-"共享粘贴板"，设置为"双向"。点击"设备"-"共享文件夹"-"共享文件夹.."，点击右侧加号，在"共享文件夹路径"中选择"其他..."，然后选择需要共享的主机文件夹。勾选"自动挂载"和"固定分配"，点击"OK"保存。在虚拟机中进入"我的电脑"，刷新后出现'VBoxSvr' 上的 <主机文件夹名称>，双击进入就可以双向传输文件了。
+
+#### 0.2 开发环境配置
+
+浏览器推荐[Mypal 68](https://www.mypal-browser.org/download.html)，注意要选择32位版本。Windows XP自带ZIP文件解压。安装后就可以访问互联网了。
+
+从Github下载[w64devkit](https://github.com/skeeto/w64devkit)，选择x86版本。这里下载的是一个自解压的7z文件，在虚拟机中解压即可。
+
+在"开始"-"控制面板"-"切换到经典视图"-"系统"-"高级"-"环境变量"-"系统变量"中，选择Path，点击"编辑"，在字符串末尾加入一个分号(;)，然后粘贴w64devkit下bin文件夹的目录。点击"确定"保存之后可以打开命令提示符输入例如c++的命令验证是否成功加入环境变量。
+
+由于年代过于久远，Git的官方release已经没有兼容Windows XP的版本了。最后一个兼容的版本(1.9.5)可以在[这里](https://www.xiazaiba.com/html/29352.html)下载。
+
+为了使用Git，需要安装[Win32 OpenSSL](https://slproweb.com/products/Win32OpenSSL.html)。选择Win32 OpenSSL Light版本。这个过程中会附带安装VC++ 2022运行时库。
+
+如果因为协议、代理等问题不能在虚拟机中使用Git，也可以下载ZIP版本后在虚拟机中解压。
+
+需要手动下载[CMake最后支持Windows XP的版本](https://github.com/Kitware/CMake/releases/download/v3.10.3/cmake-3.10.3-win32-x86.zip)。建议解压在C:\Program Files下，并且需要设置系统变量，到CMake目录下的bin文件夹。具体可以参考上面w64devkit的方法。
+
+## 1. 编译
+
+#### 1.1 修改头文件
+
+在这一步，需要打开src目录下的platform.h.in进行修改。将原有的
+
+在
+
+```cpp
+#define WIN32_LEAN_AND_MEAN
+```
+
+和
+
+```cpp
+#include <windows.h>
+#include <process.h>
+```
+
+之间添加
+
+```cpp
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0501
+#endif
+```
+
+来确保使用Windows XP的API。之后，将
+
+```cpp
+#if NCNN_THREADS
+#if defined _WIN32
+```
+
+下方原有的
+
+```cpp
+class NCNN_EXPORT Mutex
+```
+
+中的内容替换为
+
+```cpp
+public:
+Mutex() { InitializeCriticalSection(&cs); }
+~Mutex() { DeleteCriticalSection(&cs); }
+void lock() { EnterCriticalSection(&cs); }
+void unlock() { LeaveCriticalSection(&cs); }
+private:
+friend class ConditionVariable;
+CRITICAL_SECTION cs;
+```
+
+再下方的
+
+```cpp
+class NCNN_EXPORT ConditionVariable
+```
+
+中的内容替换为
+
+```cpp
+public:
+ConditionVariable() { event = CreateEvent(NULL, TRUE, FALSE, NULL); }
+~ConditionVariable() { CloseHandle(event); }
+void wait(Mutex& mutex) { LeaveCriticalSection(&mutex.cs); WaitForSingleObject(event, INFINITE); EnterCriticalSection(&mutex.cs); }
+void broadcast() { SetEvent(event); ResetEvent(event); }
+void signal() { SetEvent(event); ResetEvent(event); }
+private:
+HANDLE event;
+```
+
+然后保存。
+
+#### 1.2 cmake
+
+运行
+
+```bash
+cd <ncnn-root-dir>
+mkdir build
+cd build
+cmake -DNCNN_VULKAN=OFF -DNCNN_SIMPLEOCU=ON -DCMAKE_BUILD_TYPE=Release -G "MinGW Makefiles" ..
+```
+
+由于平台性能的限制，Vulkan SDK 最低要求 Windows 7 SP1，XP 无法安装官方驱动和工具链，因此需要关闭Vulkan选项。同时需要使用简化版 OpenCV 替代库NCNN_SIMPLEOCV。
+
+#### 1.3 make
+
+由于所使用的CMake 3.10.3版本中`-j`（并行编译）参数依赖Ninja生成器，所以改用make。
+
+运行
+
+```bash
+make -j2
+make install
+```
+
+# 2. 测试
+
+#### 2.1 benchncnn
+
+将benchmark目录下的所有文件复制到build/benchmark目录下。在命令提示符中cd到build/benchmark， 然后运行
+
+```bash
+benchncnn [测试的循环次数] [线程数] [节能模式]
+```
+
+其中，节能模式取值为0时关闭，为1时打开。
+
+#### 2.2 examples
+
+从[这里](https://github.com/nihui/ncnn-assets/tree/master/models)可以下载到所有需要的param和bin文件。需要注意的是，ZF_faster_rcnn_final.bin开头的三个文件（.zip，.z01，.z02）最好先放在主机上解压出bin文件再传进虚拟机。
+
+把这些文件放在build/examples目录下。
+
+我写了一个bat脚本来批量测试这些模型：
+
+```batch
+@echo off
+setlocal enabledelayedexpansion
+
+set EXAMPLES_DIR=<ncnn-root-dir>\BUILD\EXAMPLES
+set IMAGE_PATH=<ncnn-root-dir>\IMAGES\256-ncnn.png
+set LOG_FILE=test_results.log
+
+echo NCNN Examples Test Results > %LOG_FILE%
+echo ========================= >> %LOG_FILE%
+echo Test started: %date% %time% >> %LOG_FILE%
+echo. >> %LOG_FILE%
+
+for %%f in ("%EXAMPLES_DIR%\*.exe") do (
+    set EXE_NAME=%%~nf
+    set EXE_PATH=%%f
+    echo Testing: !EXE_NAME! >> %LOG_FILE%
+    echo -------------------------------- >> %LOG_FILE%
+
+    !EXE_PATH! "%IMAGE_PATH%" >> %LOG_FILE% 2>&1
+
+    if errorlevel 1 (
+        echo [ERROR] !EXE_NAME! failed to run. >> %LOG_FILE%
+    ) else (
+        echo [SUCCESS] !EXE_NAME! completed. >> %LOG_FILE%
+    )
+    echo. >> %LOG_FILE%
+)
+
+echo Test finished: %date% %time% >> %LOG_FILE%
+echo Results saved to %LOG_FILE%
+endlocal
+```
+
+把这个bat脚本放在build/examples目录下，替换掉所有的`<ncnn-root-dir>`，双击运行。通过生成的test_results.log即可查看所有模型的结果。
+
+通过修改`set IMAGE_PATH=<ncnn-root-dir>\IMAGES\256-ncnn.png`中的路径来更换需要测试的文件。

--- a/docs/how-to-build/how-to-build.md
+++ b/docs/how-to-build/how-to-build.md
@@ -16,6 +16,7 @@ git submodule update --init
   - [Verification](#verification)
 - [Build for Windows x64 using Visual Studio Community 2017](#build-for-windows-x64-using-visual-studio-community-2017)
 - [Build for Windows x64 using MinGW-w64](#build-for-windows-x64-using-mingw-w64)
+- [Build for Windows XP(x86) using MinGW-w64](#build-for-windows-xp-x86-using-mingw-w64)
 - [Build for macOS](#build-for-macos)
 - [Build for ARM Cortex-A family with cross-compiling](#build-for-arm-cortex-a-family-with-cross-compiling)
 - [Build for Hisilicon platform with cross-compiling](#build-for-hisilicon-platform-with-cross-compiling)
@@ -260,6 +261,29 @@ cmake -DNCNN_VULKAN=ON -G "MinGW Makefiles" ..
 cmake --build . --config Release -j 4
 cmake --build . --config Release --target install
 ```
+
+***
+
+### Build for Windows XP (x86) using MinGW-w64
+
+Download MinGW-w64 x86 toolchain from [w64devkit](https://github.com/skeeto/w64devkit), add `bin` folder to environment variables.
+
+Build ncnn library for Windows XP:
+
+```shell
+cd <ncnn-root-dir>
+mkdir build
+cd build
+cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/windows-xp.toolchain.cmake \
+      -DNCNN_VULKAN=OFF \
+      -DNCNN_SIMPLEOCV=ON \
+      -DCMAKE_BUILD_TYPE=Release \
+      -G "MinGW Makefiles" ..
+make -j2
+make install
+```
+
+Note: You can also use `cmake --build . --config Release -j 2` instead of `make -j2` if higher version of CMake that supports `-j` is available.
 
 ***
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -338,6 +338,11 @@ endif()
 
 if(WIN32)
     target_compile_definitions(ncnn PUBLIC NOMINMAX)
+    
+    # Add Windows XP compatibility definitions
+    # _WIN32_WINNT=0x0501 for Windows XP
+    # WINVER=0x0501 for Windows XP
+    target_compile_definitions(ncnn PUBLIC _WIN32_WINNT=0x0501 WINVER=0x0501)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES "MSVC" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT MATCHES "MSVC"))

--- a/src/platform.h.in
+++ b/src/platform.h.in
@@ -67,6 +67,9 @@
 #if NCNN_THREADS
 #if defined _WIN32
 #define WIN32_LEAN_AND_MEAN
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0501
+#endif
 #include <windows.h>
 #include <process.h>
 #else
@@ -87,26 +90,32 @@ namespace ncnn {
 class NCNN_EXPORT Mutex
 {
 public:
-    Mutex() { InitializeSRWLock(&srwlock); }
-    ~Mutex() {}
-    void lock() { AcquireSRWLockExclusive(&srwlock); }
-    void unlock() { ReleaseSRWLockExclusive(&srwlock); }
+    public:
+    Mutex() { InitializeCriticalSection(&cs); }
+    ~Mutex() { DeleteCriticalSection(&cs); }
+    void lock() { EnterCriticalSection(&cs); }
+    void unlock() { LeaveCriticalSection(&cs); }
 private:
     friend class ConditionVariable;
-    // NOTE SRWLock is available from windows vista
-    SRWLOCK srwlock;
+    //use CRITICAL_SECTION to make it work on XP
+    CRITICAL_SECTION cs;
 };
 
 class NCNN_EXPORT ConditionVariable
 {
+    //use event to make it work on XP
 public:
-    ConditionVariable() { InitializeConditionVariable(&condvar); }
-    ~ConditionVariable() {}
-    void wait(Mutex& mutex) { SleepConditionVariableSRW(&condvar, &mutex.srwlock, INFINITE, 0); }
-    void broadcast() { WakeAllConditionVariable(&condvar); }
-    void signal() { WakeConditionVariable(&condvar); }
+    ConditionVariable() { event = CreateEvent(NULL, TRUE, FALSE, NULL); }
+    ~ConditionVariable() { CloseHandle(event); }
+    void wait(Mutex& mutex) {
+        LeaveCriticalSection(&mutex.cs);
+        WaitForSingleObject(event, INFINITE);
+        EnterCriticalSection(&mutex.cs);
+    }
+    void broadcast() { SetEvent(event); ResetEvent(event); }
+    void signal() { SetEvent(event); ResetEvent(event); }
 private:
-    CONDITION_VARIABLE condvar;
+    HANDLE event;
 };
 
 static unsigned __stdcall start_wrapper(void* args);

--- a/toolchains/windows-xp.toolchain.cmake
+++ b/toolchains/windows-xp.toolchain.cmake
@@ -1,0 +1,31 @@
+# using MinGW-w64 with appropriate flags
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86)
+set(CMAKE_C_COMPILER "gcc")
+set(CMAKE_CXX_COMPILER "g++")
+set(CMAKE_C_FLAGS "-DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0501 -DWINVER=0x0501 ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "-DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0501 -DWINVER=0x0501 ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+
+set(NCNN_RUNTIME_CPU OFF CACHE BOOL "Disable runtime CPU dispatch for XP compatibility" FORCE)
+set(NCNN_AVX OFF CACHE BOOL "Disable AVX for XP compatibility" FORCE)
+set(NCNN_AVX2 OFF CACHE BOOL "Disable AVX2 for XP compatibility" FORCE)
+set(NCNN_AVX512 OFF CACHE BOOL "Disable AVX512 for XP compatibility" FORCE)
+set(NCNN_FMA OFF CACHE BOOL "Disable FMA for XP compatibility" FORCE)
+set(NCNN_F16C OFF CACHE BOOL "Disable F16C for XP compatibility" FORCE)
+
+set(NCNN_SSE2 ON CACHE BOOL "Enable SSE2 for XP compatibility" FORCE)
+set(NCNN_VULKAN OFF CACHE BOOL "Disable Vulkan for XP compatibility" FORCE)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static-libgcc -static-libstdc++")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libgcc -static-libstdc++")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+
+set(CMAKE_GENERATOR_PLATFORM Win32 CACHE STRING "Force 32-bit build for XP compatibility" FORCE) 


### PR DESCRIPTION
通过将src/platform.h.in中的SRW Lock替换为CRITICAL_SECTION，将ConditionalVariable通过Event模拟实现，修改CMakeLists，添加新的toolchain实现了ncnn在Windows XP上的运行。
成功跑通benchncnn和examples。
benchncnn指令参数：`benchncnn 4 1 0`
结果：
<img width="2560" height="1332" alt="VirtualBox_XP_11_07_2025_23_47_29" src="https://github.com/user-attachments/assets/a0c48b52-5f50-4715-8a91-67f14bfec7c4" />
<img width="2560" height="1332" alt="VirtualBox_XP_11_07_2025_23_53_23" src="https://github.com/user-attachments/assets/8852ffb3-eca2-4c16-b982-5492cf445d53" />
报告：
[benchncnn.txt](https://github.com/user-attachments/files/21194399/benchncnn.txt)
examples报告：
[test_results.log](https://github.com/user-attachments/files/21194419/test_results.log)

将工作过程同步到了docs/developer-guide/build-ncnn-on-windows-xp.zh.md，以及[个人博客](https://www.jianshu.com/p/70982155e223)。同时在docs/how-to-build/how-to-build.md中添加了对应的指导。