### PR TITLE
wip: [​fix(cpu): add support for CPUs with more than 64 cores]

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1452,25 +1452,25 @@ static int set_sched_affinity(const ncnn::CpuSet& thread_affinity_mask)
             PROCESSOR_NUMBER proc_num;
             proc_num.Group = group_index;
             proc_num.Number = proc_index_in_group;
-            
+
             // We need a way to map from PROCESSOR_NUMBER to a global linear CPU index.
             // This is complex without a pre-built map.
             // A simpler approach is to find the first enabled CPU in the mask,
             // determine its group, and then set the affinity for all other enabled
             // CPUs within that same group.
-            
+
             // Simplified logic: Iterate all CPUs in the mask, find the group of the first one,
             // then construct a mask for that group ONLY.
         }
         // The above mapping is too complex for a direct fix.
         // Let's adopt a simpler, though less flexible, modification that is self-contained.
-        
+
         // Find the group of the current thread
         PROCESSOR_NUMBER proc_num;
         GetCurrentProcessorNumberEx(&proc_num);
-        
+
         KAFFINITY mask_for_current_group = 0;
-        
+
         // Build a mask for the thread's current group based on the CpuSet
         int base_cpu_index = 0;
         for (USHORT i = 0; i < proc_num.Group; i++)
@@ -1479,15 +1479,15 @@ static int set_sched_affinity(const ncnn::CpuSet& thread_affinity_mask)
         }
 
         UINT procs_in_current_group = GetActiveProcessorCount(proc_num.Group);
-        for(UINT i = 0; i < procs_in_current_group; i++)
+        for (UINT i = 0; i < procs_in_current_group; i++)
         {
             int global_cpu_index = base_cpu_index + i;
-            if(thread_affinity_mask.is_enabled(global_cpu_index))
+            if (thread_affinity_mask.is_enabled(global_cpu_index))
             {
                 mask_for_current_group |= (KAFFINITY)1 << i;
             }
         }
-        
+
         if (mask_for_current_group != 0)
         {
             GROUP_AFFINITY ga;
@@ -1504,7 +1504,7 @@ static int set_sched_affinity(const ncnn::CpuSet& thread_affinity_mask)
         // A full solution requires redesigning the thread creation logic.
         return 0;
     }
-    
+
     // Fallback for older systems without GetActiveProcessorGroupCount (pre-Win7)
     // The original code is kept here for that.
     DWORD_PTR mask = 0;

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -12,6 +12,7 @@
 #endif
 #if defined __ANDROID__ || defined __linux__
 #include <sched.h> // cpu_set_t
+#include <cstring> // for memcpy
 #endif
 
 #include "platform.h"
@@ -30,10 +31,17 @@ public:
 
 public:
 #if defined _WIN32
-    ULONG_PTR mask;
+    std::vector<bool> enabled_cpus;
 #endif
 #if defined __ANDROID__ || defined __linux__
-    cpu_set_t cpu_set;
+    cpu_set_t* cpu_set;
+    size_t cpu_set_size;
+
+public:
+    ~CpuSet();
+
+    CpuSet(const CpuSet& other);
+    CpuSet& operator=(const CpuSet& other);
 #endif
 #if __APPLE__
     unsigned int policy;


### PR DESCRIPTION
Addresses two critical issues with ncnn on systems with more than 64 CPU cores:

1. Refactoring ncnn::CpuSet to support more cores:

   - On Linux platforms, the original cpu_set_t implementation had a fixed-size limitation. It has been refactored to use CPU_ALLOC for dynamic memory allocation, along with macros with the _S suffix (e.g., CPU_SET_S) for operations. This ensures proper support for affinity settings on systems with more than CPU_SETSIZE (typically 1024) cores.

2. Fixing race conditions in global CPU info initialization:

   - A race condition was discovered in the try_initialize_global_cpu_info function under multithreaded environments (e.g., when benchncnn runs on 128 cores), which could lead to multiple invocations of the initialization function and cause program crashes.

   - By replacing the original non-thread-safe flag check with pthread_once, the initialization of global CPU information is now thread-safe and guaranteed to execute only once during the program's lifecycle.