### PR TITLE
CMake: Force enable MSVC multi-processor build (/MP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,14 @@ endif()
 
 project(ncnn)
 
-if(MSVC AND NOT CMAKE_VERSION VERSION_LESS "3.15")
-    option(NCNN_BUILD_WITH_STATIC_CRT "Enables use of statically linked CRT for statically linked ncnn" OFF)
-    if(NCNN_BUILD_WITH_STATIC_CRT)
-        # cmake before version 3.15 not work
-        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+if(MSVC)
+    add_compile_options(/MP)
+    if(NOT CMAKE_VERSION VERSION_LESS "3.15")
+        option(NCNN_BUILD_WITH_STATIC_CRT "Enables use of statically linked CRT for statically linked ncnn" OFF)
+        if(NCNN_BUILD_WITH_STATIC_CRT)
+            # cmake before version 3.15 not work
+            set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
## Force enable MSVC multi-processor build (/MP)

<img width="786" height="548" alt="圖片" src="https://github.com/user-attachments/assets/aa650c81-6647-4edd-b620-39bc04100e13" />
