### PR TITLE
fix: bad ctc rule in ppocr

### DIFF
--- a/examples/ppocrv5.cpp
+++ b/examples/ppocrv5.cpp
@@ -345,7 +345,6 @@ void PPOCRv5::recognize(const cv::Mat& bgr, Object& object)
     ex.extract("out0", out);
 
     // 18385 x len
-
     int last_token = 0;
 
     for (int i = 0; i < out.h; i++)


### PR DESCRIPTION
CTC规定相邻index相同视为一个字符，若不识别则容易出现重字