### PR TITLE
esp32 build doc: advise not running install.sh with sudo

### DIFF
--- a/docs/how-to-build/how-to-build.md
+++ b/docs/how-to-build/how-to-build.md
@@ -965,8 +965,13 @@ git submodule update --init --recursive
 ```
 Install esp-idf sdk and configure the environment
 ```shell
-sudo sh install.sh
+./install.sh
 source export.sh
+```
+And for Windows, you should use:
+```bash
+install.bat # or `install.ps1`
+export.bat
 ```
 Note: python>=3.8, cmake>=3.24.0
 


### PR DESCRIPTION
The existing doc recommended users to run `sudo ./install.sh`, which can lead to `esp-idf` being install in `/root/.espressif` rather than `/home/<username>/.espressif`.