### PR TITLE
shader: use #extension GL_GOOGLE_include_directive: enable for compatibility

### DIFF
--- a/src/layer/vulkan/shader/convolution_1x1s1d1_cm.comp
+++ b/src/layer/vulkan/shader/convolution_1x1s1d1_cm.comp
@@ -3,7 +3,7 @@
 
 #version 450
 
-#extension GL_GOOGLE_include_directive: require
+#extension GL_GOOGLE_include_directive: enable
 #include "vulkan_activation.comp"
 
 #extension GL_EXT_control_flow_attributes: require

--- a/src/layer/vulkan/shader/convolution_gemm_cm.comp
+++ b/src/layer/vulkan/shader/convolution_gemm_cm.comp
@@ -3,7 +3,7 @@
 
 #version 450
 
-#extension GL_GOOGLE_include_directive: require
+#extension GL_GOOGLE_include_directive: enable
 #include "vulkan_activation.comp"
 
 #extension GL_EXT_control_flow_attributes: require

--- a/src/layer/vulkan/shader/convolution_winograd_gemm_cm.comp
+++ b/src/layer/vulkan/shader/convolution_winograd_gemm_cm.comp
@@ -3,7 +3,7 @@
 
 #version 450
 
-#extension GL_GOOGLE_include_directive: require
+#extension GL_GOOGLE_include_directive: enable
 #include "vulkan_activation.comp"
 
 #extension GL_EXT_control_flow_attributes: require

--- a/src/layer/vulkan/shader/deconvolution_gemm_cm.comp
+++ b/src/layer/vulkan/shader/deconvolution_gemm_cm.comp
@@ -3,7 +3,7 @@
 
 #version 450
 
-#extension GL_GOOGLE_include_directive: require
+#extension GL_GOOGLE_include_directive: enable
 #include "vulkan_activation.comp"
 
 #extension GL_EXT_control_flow_attributes: require


### PR DESCRIPTION
## shader changes

This PR modifies the directive in ```/src/layer/vulkan/shader/***.comp``` from ```#extension GL_GOOGLE_include_directive : require``` to ```#extension GL_GOOGLE_include_directive : enable```  for compatibility. 


## why do this change

Some Vulkan drivers—especially those not based on Google's implementation—do not support the require level for this extension, which can lead to shader compilation failures. Switching to enable improves compatibility across platforms while preserving functionality where the extension is supported.
This change does not affect shader logic and only adjusts the extension declaration to be more tolerant.