### PR TITLE
CI: Update macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -28,7 +28,7 @@ concurrency:
   group: ios-${{ github.ref }}
   cancel-in-progress: true
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.4.0.app/Contents/Developer
   IOS_DEPLOYMENT_TARGET: '13.0'
   ENABLE_BITCODE: OFF
   ENABLE_ARC: OFF
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -78,7 +78,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-ios-install-20240403
+        key: openmp-ios-install-20251004
     - name: openmp
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/mac-catalyst.yml
+++ b/.github/workflows/mac-catalyst.yml
@@ -28,7 +28,7 @@ concurrency:
   group: mac-catalyst-${{ github.ref }}
   cancel-in-progress: true
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.4.0.app/Contents/Developer
   MAC_CATALYST_DEPLOYMENT_TARGET: '13.1'
   ENABLE_BITCODE: OFF
   ENABLE_ARC: OFF
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -78,7 +78,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-mac-catalyst-install-20240403
+        key: openmp-mac-catalyst-install-20251004
     - name: openmp
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,7 @@ concurrency:
   group: macos-${{ github.ref }}
   cancel-in-progress: true
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.4.0.app/Contents/Developer
   MAC_DEPLOYMENT_TARGET: '11.0'
   ENABLE_BITCODE: OFF
   ENABLE_ARC: OFF
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -86,7 +86,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-macos-install-20240403
+        key: openmp-macos-install-20251004
     - name: openmp
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       run: |
@@ -137,7 +137,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: swiftshader-install
-        key: swiftshader-macos-install-20240622
+        key: swiftshader-macos-install-20251004
     - name: checkout-swiftshader
       if: steps.cache-swiftshader.outputs.cache-hit != 'true'
       uses: actions/checkout@v5

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,7 +26,7 @@ concurrency:
   group: python-${{ github.ref }}
   cancel-in-progress: true
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.4.0.app/Contents/Developer
   MAC_DEPLOYMENT_TARGET: '11.0'
   ENABLE_BITCODE: OFF
   ENABLE_ARC: OFF
@@ -40,7 +40,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-15-intel, windows-latest]
         python-version: [3.9, 3.12]
 
     runs-on: ${{ matrix.os }}
@@ -98,7 +98,7 @@ jobs:
         cmake -DNCNN_VULKAN=ON -DNCNN_PYTHON=ON -DNCNN_BUILD_TOOLS=OFF -DNCNN_BUILD_EXAMPLES=OFF ..
         cmake --build . -j $(nproc)
     - name: build
-      if: matrix.os == 'macos-13'
+      if: matrix.os == 'macos-15-intel'
       run: |
         mkdir build && cd build
         cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/ios.toolchain.cmake -DPLATFORM=MAC -DARCHS="x86_64" \

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.4.0.app/Contents/Developer
   MAC_DEPLOYMENT_TARGET: '11.0'
   ENABLE_BITCODE: OFF
   ENABLE_ARC: OFF
@@ -57,9 +57,9 @@ jobs:
           - { os: windows-2022,     arch: AMD64,      build: 'cp*',            build_id: cp           }
           - { os: windows-2022,     arch: AMD64,      build: 'pp*',            build_id: pp           }
           - { os: windows-2022,     arch: ARM64,      build: 'cp*',            build_id: cp           }
-          - { os: macos-13,         arch: x86_64,     build: 'cp*',            build_id: cp           }
-          - { os: macos-13,         arch: x86_64,     build: 'pp*',            build_id: pp           }
-          - { os: macos-13,         arch: arm64,      build: 'cp*',            build_id: cp           }
+          - { os: macos-15-intel,         arch: x86_64,     build: 'cp*',            build_id: cp           }
+          - { os: macos-15-intel,         arch: x86_64,     build: 'pp*',            build_id: pp           }
+          - { os: macos-15-intel,         arch: arm64,      build: 'cp*',            build_id: cp           }
           - { os: ubuntu-24.04-arm, arch: armv7l,     build: 'cp*-manylinux*', build_id: cp-manylinux }
           - { os: ubuntu-24.04-arm, arch: armv7l,     build: 'cp*-musllinux*', build_id: cp-musllinux }
           - { os: ubuntu-24.04-arm, arch: aarch64,    build: 'cp*-manylinux*', build_id: cp-manylinux }
@@ -159,17 +159,17 @@ jobs:
       with:
         output-dir: wheelhouse
 
-    # build wheels for macos-13
+    # build wheels for macos-15-intel
     - name: cache-openmp for macos
-      if: matrix.os == 'macos-13'
+      if: matrix.os == 'macos-15-intel'
       id: cache-openmp
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-macos-install-20240403
+        key: openmp-macos-install-20251004
 
     - name: openmp for macos
-      if: matrix.os == 'macos-13' && steps.cache-openmp.outputs.cache-hit != 'true'
+      if: matrix.os == 'macos-15-intel' && steps.cache-openmp.outputs.cache-hit != 'true'
       run: |
         wget https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ env.OPENMP_VERSION }}/cmake-${{ env.OPENMP_VERSION }}.src.tar.xz
         tar -xf cmake-${{ env.OPENMP_VERSION }}.src.tar.xz
@@ -183,7 +183,7 @@ jobs:
         patch -p2 -i 5c12711f9a21f41bea70566bf15a4026804d6b20.patch
 
     - name: openmp-build-x86_64 for macos
-      if: matrix.os == 'macos-13' && steps.cache-openmp.outputs.cache-hit != 'true'
+      if: matrix.os == 'macos-15-intel' && steps.cache-openmp.outputs.cache-hit != 'true'
       run: |
         cd openmp-${{ env.OPENMP_VERSION }}.src
         mkdir -p build-x86_64 && cd build-x86_64
@@ -192,7 +192,7 @@ jobs:
         cmake --build . --target install
 
     - name: openmp-build-arm64 for macos
-      if: matrix.os == 'macos-13' && steps.cache-openmp.outputs.cache-hit != 'true'
+      if: matrix.os == 'macos-15-intel' && steps.cache-openmp.outputs.cache-hit != 'true'
       run: |
         cd openmp-${{ env.OPENMP_VERSION }}.src
         mkdir -p build-arm64 && cd build-arm64
@@ -201,7 +201,7 @@ jobs:
         cmake --build . --target install
 
     - name: openmp-merge-fat-library for macos
-      if: matrix.os == 'macos-13' && steps.cache-openmp.outputs.cache-hit != 'true'
+      if: matrix.os == 'macos-15-intel' && steps.cache-openmp.outputs.cache-hit != 'true'
       run: |
         mkdir -p $GITHUB_WORKSPACE/openmp-install
         cp -a openmp-${{ env.OPENMP_VERSION }}.src/build-x86_64/install/include $GITHUB_WORKSPACE/openmp-install
@@ -212,20 +212,20 @@ jobs:
             -o $GITHUB_WORKSPACE/openmp-install/lib/libomp.a
 
     - name: install-openmp for macos
-      if: matrix.os == 'macos-13'
+      if: matrix.os == 'macos-15-intel'
       run: |
         sudo cp $GITHUB_WORKSPACE/openmp-install/include/* $DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
         sudo cp $GITHUB_WORKSPACE/openmp-install/lib/libomp.a $DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib
 
     - name: vulkansdk for macos
-      if: matrix.os == 'macos-13'
+      if: matrix.os == 'macos-15-intel'
       run: |
         wget https://sdk.lunarg.com/sdk/download/1.3.290.0/mac/vulkansdk-macos-1.3.290.0.dmg?Human=true -O vulkansdk-macos-1.3.290.0.dmg
         hdiutil attach vulkansdk-macos-1.3.290.0.dmg
         sudo /Volumes/vulkansdk-macos-1.3.290.0/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/vulkansdk-macos-1.3.290.0 --accept-licenses --default-answer --confirm-command install
 
     - name: Build wheels for macos x86_64
-      if: matrix.os == 'macos-13' && matrix.arch == 'x86_64'
+      if: matrix.os == 'macos-15-intel' && matrix.arch == 'x86_64'
       uses: pypa/cibuildwheel@v3.1.4
       env:
         CIBW_ARCHS_MACOS: ${{ matrix.arch }}
@@ -244,7 +244,7 @@ jobs:
         output-dir: wheelhouse
 
     - name: Build wheels for macos arm64
-      if: matrix.os == 'macos-13' && matrix.arch == 'arm64'
+      if: matrix.os == 'macos-15-intel' && matrix.arch == 'arm64'
       uses: pypa/cibuildwheel@v3.1.4
       env:
         CIBW_ARCHS_MACOS: ${{ matrix.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - '*'
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.4.0.app/Contents/Developer
   IOS_DEPLOYMENT_TARGET: '13.0'
   MAC_DEPLOYMENT_TARGET: '11.0'
   MAC_CATALYST_DEPLOYMENT_TARGET: '13.1'
@@ -93,7 +93,7 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   openmp-macos:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -114,7 +114,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-macos-release-18.1.2-20240403
+        key: openmp-macos-release-18.1.2-20251004
     - name: checkout
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       uses: actions/checkout@v5
@@ -171,7 +171,7 @@ jobs:
         opt:
           - { vulkan: OFF, id: macos        }
           - { vulkan: ON,  id: macos-vulkan }
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-${{ matrix.opt.id }}
       NCNN_CMAKE_OPTIONS: |
@@ -278,7 +278,7 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   openmp-ios:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -299,7 +299,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-ios-release-18.1.2-20240403
+        key: openmp-ios-release-18.1.2-20251004
     - name: checkout
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       uses: actions/checkout@v5
@@ -345,7 +345,7 @@ jobs:
         opt:
           - { vulkan: OFF, id: ios        }
           - { vulkan: ON,  id: ios-vulkan }
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-${{ matrix.opt.id }}
       NCNN_CMAKE_OPTIONS: |
@@ -440,7 +440,7 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   openmp-ios-simulator:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -461,7 +461,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-ios-simulator-release-18.1.2-20240403
+        key: openmp-ios-simulator-release-18.1.2-20251004
     - name: checkout
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       uses: actions/checkout@v5
@@ -518,7 +518,7 @@ jobs:
         opt:
           - { vulkan: OFF, id: ios-simulator        }
           - { vulkan: ON,  id: ios-simulator-vulkan }
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-${{ matrix.opt.id }}
       NCNN_CMAKE_OPTIONS: |
@@ -629,7 +629,7 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   openmp-mac-catalyst:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -650,7 +650,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-mac-catalyst-release-18.1.2-20240403
+        key: openmp-mac-catalyst-release-18.1.2-20251004
     - name: checkout
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       uses: actions/checkout@v5
@@ -707,7 +707,7 @@ jobs:
         opt:
           - { vulkan: OFF, id: mac-catalyst        }
           - { vulkan: ON,  id: mac-catalyst-vulkan }
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-${{ matrix.opt.id }}
       NCNN_CMAKE_OPTIONS: |
@@ -818,7 +818,7 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   openmp-watchos:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -839,7 +839,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-watchos-release-18.1.2-20240403
+        key: openmp-watchos-release-18.1.2-20251004
     - name: checkout
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       uses: actions/checkout@v5
@@ -891,7 +891,7 @@ jobs:
 
   watchos:
     needs: [setup, openmp-watchos]
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-watchos
       NCNN_CMAKE_OPTIONS: |
@@ -967,7 +967,7 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   openmp-watchos-simulator:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -988,7 +988,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-watchos-simulator-release-18.1.2-20240403
+        key: openmp-watchos-simulator-release-18.1.2-20251004
     - name: checkout
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       uses: actions/checkout@v5
@@ -1040,7 +1040,7 @@ jobs:
 
   watchos-simulator:
     needs: [setup, openmp-watchos-simulator]
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-watchos-simulator
       NCNN_CMAKE_OPTIONS: |
@@ -1116,7 +1116,7 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   openmp-tvos:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -1137,7 +1137,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-tvos-release-18.1.2-20240403
+        key: openmp-tvos-release-18.1.2-20251004
     - name: checkout
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       uses: actions/checkout@v5
@@ -1194,7 +1194,7 @@ jobs:
         opt:
           - { vulkan: OFF, id: tvos        }
           - { vulkan: ON,  id: tvos-vulkan }
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-${{ matrix.opt.id }}
       NCNN_CMAKE_OPTIONS: |
@@ -1305,7 +1305,7 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   openmp-tvos-simulator:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -1326,7 +1326,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-tvos-simulator-release-18.1.2-20240403
+        key: openmp-tvos-simulator-release-18.1.2-20251004
     - name: checkout
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       uses: actions/checkout@v5
@@ -1383,7 +1383,7 @@ jobs:
         opt:
           - { vulkan: OFF, id: tvos-simulator        }
           - { vulkan: ON,  id: tvos-simulator-vulkan }
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-${{ matrix.opt.id }}
       NCNN_CMAKE_OPTIONS: |
@@ -1494,7 +1494,7 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   openmp-visionos:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -1515,7 +1515,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-visionos-release-18.1.2-20240403
+        key: openmp-visionos-release-18.1.2-20251004
     - name: checkout
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       uses: actions/checkout@v5
@@ -1561,7 +1561,7 @@ jobs:
         opt:
           - { vulkan: OFF, id: visionos        }
           - { vulkan: ON,  id: visionos-vulkan }
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-${{ matrix.opt.id }}
       NCNN_CMAKE_OPTIONS: |
@@ -1656,7 +1656,7 @@ jobs:
         path: ${{ env.PACKAGENAME }}.zip
 
   openmp-visionos-simulator:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -1677,7 +1677,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-visionos-simulator-release-18.1.2-20240403
+        key: openmp-visionos-simulator-release-18.1.2-20251004
     - name: checkout
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       uses: actions/checkout@v5
@@ -1734,7 +1734,7 @@ jobs:
         opt:
           - { vulkan: OFF, id: visionos-simulator        }
           - { vulkan: ON,  id: visionos-simulator-vulkan }
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-${{ matrix.opt.id }}
       NCNN_CMAKE_OPTIONS: |
@@ -2112,11 +2112,11 @@ jobs:
 
   apple:
     needs: [setup, macos, ios, ios-simulator, mac-catalyst, watchos, watchos-simulator, tvos, tvos-simulator, visionos, visionos-simulator]
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       PACKAGENAME: ncnn-${{ needs.setup.outputs.VERSION }}-apple
     steps:
-    - run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+    - run: sudo xcode-select --switch /Applications/Xcode_16.4.0.app
     - name: download
       uses: actions/download-artifact@v5
       with:

--- a/.github/workflows/tvos.yml
+++ b/.github/workflows/tvos.yml
@@ -28,7 +28,7 @@ concurrency:
   group: tvos-${{ github.ref }}
   cancel-in-progress: true
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.4.0.app/Contents/Developer
   TVOS_DEPLOYMENT_TARGET: '11.0'
   ENABLE_BITCODE: OFF
   ENABLE_ARC: OFF
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -78,7 +78,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-tvos-install-20240403
+        key: openmp-tvos-install-20251004
     - name: openmp
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/visionos.yml
+++ b/.github/workflows/visionos.yml
@@ -26,7 +26,7 @@ concurrency:
   group: visionos-${{ github.ref }}
   cancel-in-progress: true
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.4.0.app/Contents/Developer
   VISIONOS_DEPLOYMENT_TARGET: '1.0'
   ENABLE_BITCODE: OFF
   ENABLE_ARC: OFF
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -72,7 +72,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-visionos-install-20240402
+        key: openmp-visionos-install-20251004
     - name: openmp
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/watchos.yml
+++ b/.github/workflows/watchos.yml
@@ -26,7 +26,7 @@ concurrency:
   group: watchos-${{ github.ref }}
   cancel-in-progress: true
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.4.0.app/Contents/Developer
   WATCHOS_DEPLOYMENT_TARGET: '6.0'
   ENABLE_BITCODE: OFF
   ENABLE_ARC: OFF
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       OPENMP_VERSION: '18.1.2'
       OPENMP_CMAKE_OPTIONS: |
@@ -72,7 +72,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: openmp-install
-        key: openmp-watchos-install-20240402
+        key: openmp-watchos-install-20251004
     - name: openmp
       if: steps.cache-openmp.outputs.cache-hit != 'true'
       run: |


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/13046
MacOS 13 images will be fully deprecated on December 8th, 2025.
This PR uses macos-15-intel instead.

| macOS Version        | runner.arch |
|----------------------|-------------|
| macos-13 (current)  | X64         |
| macos-15            | ARM64       |
| macos-15-intel      | X64         |

Ref: https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md