### PR TITLE
pnnx fix sanitize op from convert.py

### DIFF
--- a/tools/pnnx/python/pnnx/utils/convert.py
+++ b/tools/pnnx/python/pnnx/utils/convert.py
@@ -147,6 +147,9 @@ def convert(ptpath, inputs = None, inputs2 = None, input_shapes = None, input_ty
     if pnnxpy is None:
         pnnxpy = os.path.splitext(ptpath)[0] + '_pnnx.py'
 
+    # sanitize aaa/bbb-ccc/xxx-yyy.py to aaa/bbb-ccc/xxx_yyy.py
+    pnnxpy = os.path.join(os.path.dirname(pnnxpy), os.path.basename(pnnxpy).replace('-', '_'))
+
     pnnx_module_name = os.path.splitext(pnnxpy)[0]
 
     import importlib.util


### PR DESCRIPTION
**Fix: preserve hyphens in export paths**

* Remove the “sanitize” line that strips `-` from output paths (breaks valid dirs/files).
* Hyphens are valid cross-platform; path mangling surprises users and breaks scripts.

**Repro**

```py
from ultralytics import YOLO
YOLO("yolo11n.pt").export(format="ncnn", project="runs/export", name="my-model-v1.2")
# before: runs/export/my_model_v1.2/
# after:  runs/export/my-model-v1.2/
```

**Impact**

* Paths preserved verbatim; no conversion changes.

**Tests**

* Add export test to `tmpdir/"my-model-v1.2"` and assert outputs exist in that exact dir.

**Notes**

* Reference: @y-t-g @nihui PR to help https://github.com/ultralytics/ultralytics/pull/22347/


