### PR TITLE
riscv: implement rvv optimized tan operator

### DIFF
--- a/src/layer/riscv/unaryop_riscv.cpp
+++ b/src/layer/riscv/unaryop_riscv.cpp
@@ -164,14 +164,9 @@ struct unary_op_tan
 {
     vfloat32m8_t operator()(const vfloat32m8_t& x, const size_t& vl) const
     {
-        // TODO rvv optimize
-        std::vector<float> tmp(vl);
-        __riscv_vse32_v_f32m8(tmp.data(), x, vl);
-        for (size_t i = 0; i < vl; i++)
-        {
-            tmp[i] = tanf(tmp[i]);
-        }
-        return __riscv_vle32_v_f32m8(tmp.data(), vl);
+        vfloat32m8_t sin_x, cos_x;
+        sincos_ps(x, &sin_x, &cos_x, vl);
+        return __riscv_vfdiv_vv_f32m8(sin_x, cos_x, vl);
     }
 };
 

--- a/src/layer/riscv/unaryop_riscv_zfh.cpp
+++ b/src/layer/riscv/unaryop_riscv_zfh.cpp
@@ -236,14 +236,9 @@ struct unary_op_tan_fp16s
 #if __riscv_zvfh
     vfloat16m8_t operator()(const vfloat16m8_t& x, const size_t& vl) const
     {
-        // TODO rvv optimize
-        std::vector<__fp16> tmp(vl);
-        __riscv_vse16_v_f16m8(tmp.data(), x, vl);
-        for (size_t i = 0; i < vl; i++)
-        {
-            tmp[i] = (__fp16)tanf((float)tmp[i]);
-        }
-        return __riscv_vle16_v_f16m8(tmp.data(), vl);
+        vfloat16m8_t sin_x, cos_x;
+        sincos_ps(x, &sin_x, &cos_x, vl);
+        return __riscv_vfdiv_vv_f16m8(sin_x, cos_x, vl);
     }
 #else  // __riscv_zvfh
     __fp16 operator()(const __fp16& x) const


### PR DESCRIPTION
### Summary
This PR implements RVV optimization for the `tan` unary operator.

### Verification
- Device: SG2044 (Sophgo)
- Status: Passed `tests/test_unaryop` verification.