### PR TITLE
Fixe Security Issue

### DIFF
--- a/.github/workflows/compare-binary-size.yml
+++ b/.github/workflows/compare-binary-size.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   compare-size:
+  # 🚫 Skip fork PRs (unsafe)
+  # ✅ Run only if PR originates from a branch on this repository
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
     - name: checkout-pr-branch


### PR DESCRIPTION
Security Issue

The workflow is triggered using `pull_request_target`, which runs with the **base repository's permissions** and a **privileged GITHUB_TOKEN**.


