### PR TITLE
fix (vulkan) fallback invalid subgroupSize (0/non-power-of-two) to avoid infinite loop (#6457)

### DIFF
--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -1015,18 +1015,18 @@ void GpuInfoPrivate::query_extension_features()
 
 static int get_vendor_default_subgroup_size(uint32_t vendorID)
 {
-    int default_size = 64;         // default to 64
-    if (vendorID == 0x5143)        // qcom adreno
+    int default_size = 64;  // default to 64
+    if (vendorID == 0x5143) // qcom adreno
         default_size = 128;
-    else if (vendorID == 0x13b5)   // arm mali
+    else if (vendorID == 0x13b5) // arm mali
         default_size = 16;
-    else if (vendorID == 0x1010)   // imgtec powervr
+    else if (vendorID == 0x1010) // imgtec powervr
         default_size = 32;
-    else if (vendorID == 0x1002)   // amd
+    else if (vendorID == 0x1002) // amd
         default_size = 64;
-    else if (vendorID == 0x10de)   // nvidia
+    else if (vendorID == 0x10de) // nvidia
         default_size = 32;
-    else if (vendorID == 0x8086)   // intel
+    else if (vendorID == 0x8086) // intel
         default_size = 32;
     return default_size;
 }


### PR DESCRIPTION
### 本次 PR 解决的问题
修复 Issue #6457 中反馈的：荣耀V10（Mali-G72 MP12）使用 ncnn Vulkan 后端时，因 `subgroupSize` 非法（0 ）导致 `load_model` 死循环的问题。

### 问题根因
1. **设备场景**：荣耀V10（Mali-G72 MP12）虽支持 Vulkan 1.1+，但 GPU 驱动未实现 Subgroup 相关扩展，返回 `subgroupSize=0`；
2. **代码缺陷**：ncnn 原有逻辑未对 `subgroupSize` 做合法性校验，仅 Vulkan <1.1 分支有兜底，1.1+ 分支完全依赖驱动返回值，当值为 0 或非2的幂时，`adjust_xyz` 函数中 `while ((1 << target_n) != subgroup_size)` 会陷入死循环；
3. **无副作用**：本次修复仅在驱动查询后增加合法性校验和兜底，不修改原有扩展链表、其他属性查询逻辑。

### 核心修改点
1. 在 `vkGetPhysicalDeviceProperties2KHR` 调用后，新增 `subgroupSize` 合法性校验：判断值是否 >0 且为 2 的幂；
2. 当 `subgroupSize` 非法时，复用 Vulkan <1.1 分支的兜底规则（Mali 赋值 16、Adreno 赋值 128 等），保证逻辑一致性；
3. 校验逻辑覆盖「值为 0」和「非2的幂」两类非法场景，避免潜在死循环。

### 测试验证
| 测试设备                | Vulkan 版本 | 修复前状态                | 修复后状态                  |
|-------------------------|-------------|---------------------------|-----------------------------|
| 荣耀V10（Mali-G72 MP12）| 1.1         | subgroupSize=0，死循环    | subgroupSize=16，加载模型正常 |
| 华为mate40（Mali-G78）| 1.1         | subgroupSize=16（合法）| 保持 16，无性能影响        |

### 关联 Issue
 #6457