### PR TITLE
 fix the file scan error related to CRLF format

### DIFF
--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -193,7 +193,8 @@ int DataReaderFromAndroidAsset::scan(const char* format, void* p) const
             // however, it is fine to create "\nXYZ 123 abc" as sscanf will skip the leading newline silently
             newline_pos = (const char*)memchr((const char*)d->mem + 1, '\n', remain_length - 1);
         }
-        else if (remain_length > 2 && ((const char*)d->mem)[0] == '\r' && ((const char*)d->mem)[1] == '\n'){
+        else if (remain_length > 2 && ((const char*)d->mem)[0] == '\r' && ((const char*)d->mem)[1] == '\n')
+        {
             // skip the leading newline
             // however, it is fine to create "\r\nXYZ 123 abc" as sscanf will skip the leading newline silently
             newline_pos = (const char*)memchr((const char*)d->mem + 2, '\n', remain_length - 2);


### PR DESCRIPTION
# 目的
修复若使用CRLF格式换行的配置文件，调用int DataReaderFromAndroidAsset::scan(const char* format, void* p)函数导致解析异常的问题

# 问题说明
当采用Windows开发Android项目，由于git core.autocrlf 功能，会将配置文件换行转为CRLF风格的文件，导致执行DataReaderFromAndroidAsset::scan解析数据出现问题

## 问题举例
假如输入数据是 
"123\r\n456"

第一次调用 
dr.scan("%d", &a);

走else处理
```
newline_pos = (const char*)memchr((const char*)d->mem, '\n', remain_length);

size_t line_length = newline_pos ? newline_pos - (const char*)d->mem : (size_t)remain_length;
line = std::string((const char*)d->mem, line_length);
```
得 line = "123\r" 

```
int nscan = sscanf(line.c_str(), format_with_n, p, &nconsumed);
```
得到
nconsumed = 3  
p = 123
```
d->mem += nconsumed;
```
此刻 d->mem 指向的是 '\r' 后续数据就是 "\r\n456"

当第二次调用
dr.scan("%d", &a);
由于'\r'才是第一个字符，还是走的else
```
newline_pos = (const char*)memchr((const char*)d->mem, '\n', remain_length);

size_t line_length = newline_pos ? newline_pos - (const char*)d->mem : (size_t)remain_length;
line = std::string((const char*)d->mem, line_length);
```
得 line = "\r"

到这里执行解析就不正确了，这并不是我们预期的，正确处理应该是类似\n处理，跳过\r\n读后续的数据



