### PR TITLE
pnnx tnn2pnnx support Flatten operator in TNN model conversion

### DIFF
--- a/tools/pnnx/src/load_tnn.cpp
+++ b/tools/pnnx/src/load_tnn.cpp
@@ -613,6 +613,7 @@ int load_tnn(const std::string& tnnpath, Graph& pnnx_graph)
     {
         // unary
         if (op->type == "tnn.Erf") op->type = "aten::erf";
+        if (op->type == "tnn.Flatten") op->type = "Flatten";
         if (op->type == "tnn.Log") op->type = "aten::log";
         if (op->type == "tnn.ReLU") op->type = "aten::relu";
         if (op->type == "tnn.ReLU6") op->type = "aten::relu6";


### PR DESCRIPTION
## Summary
Add missing `Flatten` operator mapping in TNN to PNNX conversion.

## Changes
- Add `tnn.Flatten` to `Flatten` type conversion in operator replacement pass
- Place it under the unary operators section for better organization

## Motivation
Currently, TNN models containing `Flatten` layers fail to convert properly because the operator type mapping is missing. This PR fixes the issue by adding the necessary mapping.

## Testing
- Tested with TNN model containing Flatten operator
- Conversion completes successfully with this change