### PR TITLE
Using snprintf instead of sprintf for a tools

### DIFF
--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -111,8 +111,9 @@ int DataReaderFromMemory::scan(const char* format, void* p) const
 {
     size_t fmtlen = strlen(format);
 
-    char* format_with_n = new char[fmtlen + 4];
-    sprintf(format_with_n, "%s%%n", format);
+    const size_t nlen = fmtlen + 4;
+    char* format_with_n = new char[nlen];
+    snprintf(format_with_n, nlen, "%s%%n", format);
 
     int nconsumed = 0;
     int nscan = sscanf((const char*)d->mem, format_with_n, p, &nconsumed);

--- a/tools/caffe/caffe2ncnn.cpp
+++ b/tools/caffe/caffe2ncnn.cpp
@@ -240,7 +240,7 @@ int main(int argc, char** argv)
                 bottom_reference[blob_name] = refidx;
 
                 char splitsuffix[256];
-                sprintf(splitsuffix, "_splitncnn_%d", refidx);
+                snprintf(splitsuffix, 256, "_splitncnn_%d", refidx);
                 blob_name = blob_name + splitsuffix;
             }
 
@@ -1127,7 +1127,7 @@ int main(int argc, char** argv)
                 if (refcount > 1)
                 {
                     char splitname[256];
-                    sprintf(splitname, "splitncnn_%d", internal_split);
+                    snprintf(splitname, 256, "splitncnn_%d", internal_split);
                     fprintf(pp, "%-16s %-16s %d %d", "Split", splitname, 1, refcount);
                     fprintf(pp, " %s", blob_name.c_str());
 
@@ -1152,7 +1152,7 @@ int main(int argc, char** argv)
                     if (refcount > 1)
                     {
                         char splitname[256];
-                        sprintf(splitname, "splitncnn_%d", internal_split);
+                        snprintf(splitname, 256, "splitncnn_%d", internal_split);
                         fprintf(pp, "%-16s %-16s %d %d", "Split", splitname, 1, refcount);
                         fprintf(pp, " %s", blob_name.c_str());
 

--- a/tools/mlir/mlir2ncnn.cpp
+++ b/tools/mlir/mlir2ncnn.cpp
@@ -539,7 +539,7 @@ int main(int argc, char** argv)
         }
 
         char splitname[256];
-        sprintf(splitname, "splitncnn_%d", internal_split);
+        snprintf(splitname, 256, "splitncnn_%d", internal_split);
         fprintf(pp, "%-16s %-24s %d %d", "Split", splitname, 1, refcount);
 
         fprintf(pp, " %s", input_name.c_str());
@@ -768,7 +768,7 @@ int main(int argc, char** argv)
         }
 
         char opid_name[64];
-        sprintf(opid_name, "op_%d", opid);
+        snprintf(opid_name, 64, "op_%d", opid);
 
         fprintf(pp, " %-24s %d %d", opid_name, num_input, num_output);
 
@@ -788,7 +788,7 @@ int main(int argc, char** argv)
                 split_node_reference[input_name] = refidx;
 
                 char splitsuffix[256];
-                sprintf(splitsuffix, "_splitncnn_%d", refidx);
+                snprintf(splitsuffix, 256, "_splitncnn_%d", refidx);
                 input_name = input_name + splitsuffix;
             }
 
@@ -1784,7 +1784,7 @@ int main(int argc, char** argv)
                 if (refcount > 1)
                 {
                     char splitname[256];
-                    sprintf(splitname, "splitncnn_%d", internal_split);
+                    snprintf(splitname, 256, "splitncnn_%d", internal_split);
                     fprintf(pp, "%-16s %-24s %d %d", "Split", splitname, 1, refcount);
 
                     fprintf(pp, " %s", output_name.c_str());

--- a/tools/mxnet/mxnet2ncnn.cpp
+++ b/tools/mxnet/mxnet2ncnn.cpp
@@ -428,7 +428,7 @@ static bool read_mxnet_json(const char* jsonpath, std::vector<MXNetNode>& nodes)
                 {
                     // assign default unknown name
                     char unknownname[256];
-                    sprintf(unknownname, "unknownncnn_%d", internal_unknown);
+                    snprintf(unknownname, 256, "unknownncnn_%d", internal_unknown);
 
                     n.name = unknownname;
 
@@ -438,7 +438,7 @@ static bool read_mxnet_json(const char* jsonpath, std::vector<MXNetNode>& nodes)
                 {
                     // workaround for potential duplicated _plus0
                     char underscorename[256];
-                    sprintf(underscorename, "underscorencnn_%d%s", internal_underscore, n.name.c_str());
+                    snprintf(underscorename, 256, "underscorencnn_%d%s", internal_underscore, n.name.c_str());
 
                     n.name = underscorename;
 
@@ -857,7 +857,7 @@ static void fuse_shufflechannel(std::vector<MXNetNode>& nodes, std::vector<MXNet
             new_node.name = n3.name;
             new_node.output_size = n3.output_size;
             char group[16];
-            sprintf(group, "%d", shape[2]);
+            snprintf(group, 16, "%d", shape[2]);
             new_node.attrs["group"] = group;
             new_node.inputs = n.inputs;
             new_node.subinputs = n.subinputs;
@@ -914,8 +914,8 @@ static void fuse_hardsigmoid_hardswish(std::vector<MXNetNode>& nodes, std::vecto
                 new_node.name = n2.name;
                 new_node.output_size = n2.output_size;
                 char alpha[16], beta[16];
-                sprintf(alpha, "%f", 1.f / 6.f);
-                sprintf(beta, "%f", 3.f / 6.f);
+                snprintf(alpha, 16, "%f", 1.f / 6.f);
+                snprintf(beta, 16, "%f", 3.f / 6.f);
                 new_node.attrs["alpha"] = alpha;
                 new_node.attrs["beta"] = beta;
                 new_node.inputs = n.inputs;
@@ -940,8 +940,8 @@ static void fuse_hardsigmoid_hardswish(std::vector<MXNetNode>& nodes, std::vecto
                 new_node.name = n3.name;
                 new_node.output_size = n3.output_size;
                 char alpha[16], beta[16];
-                sprintf(alpha, "%f", 1.f / 6.f);
-                sprintf(beta, "%f", 3.f / 6.f);
+                snprintf(alpha, 16, "%f", 1.f / 6.f);
+                snprintf(beta, 16, "%f", 3.f / 6.f);
                 new_node.attrs["alpha"] = alpha;
                 new_node.attrs["beta"] = beta;
                 new_node.inputs = n.inputs;
@@ -1004,7 +1004,7 @@ int main(int argc, char** argv)
 
             // non-unique name detected, append index as suffix
             char suffix[32];
-            sprintf(suffix, "_%d", (int)i);
+            snprintf(suffix, 32, "_%d", (int)i);
             n.name = n.name + std::string(suffix);
         }
     }
@@ -1094,7 +1094,7 @@ int main(int argc, char** argv)
             if (subinput_index != 0)
             {
                 char subinputsuffix[256];
-                sprintf(subinputsuffix, "_subncnn_%d", subinput_index);
+                snprintf(subinputsuffix, 256, "_subncnn_%d", subinput_index);
                 input_name = input_name + subinputsuffix;
             }
 
@@ -1118,7 +1118,7 @@ int main(int argc, char** argv)
         for (int j = 1; j < n.output_size; j++)
         {
             char subinputsuffix[256];
-            sprintf(subinputsuffix, "_%d", j);
+            snprintf(subinputsuffix, 256, "_%d", j);
             std::string output_name_j = output_name + subinputsuffix;
             blob_names.insert(output_name_j);
         }
@@ -1576,7 +1576,7 @@ int main(int argc, char** argv)
             if (subinput_index != 0)
             {
                 char subinputsuffix[256];
-                sprintf(subinputsuffix, "_subncnn_%d", subinput_index);
+                snprintf(subinputsuffix, 256, "_subncnn_%d", subinput_index);
                 input_name = input_name + subinputsuffix;
             }
 
@@ -1587,7 +1587,7 @@ int main(int argc, char** argv)
                 node_reference[input_uid] = refidx;
 
                 char splitsuffix[256];
-                sprintf(splitsuffix, "_splitncnn_%d", refidx);
+                snprintf(splitsuffix, 256, "_splitncnn_%d", refidx);
                 input_name = input_name + splitsuffix;
             }
 
@@ -2735,7 +2735,7 @@ int main(int argc, char** argv)
                     std::string output_name = n.name;
 
                     char splitname[256];
-                    sprintf(splitname, "splitncnn_%d", internal_split);
+                    snprintf(splitname, 256, "splitncnn_%d", internal_split);
                     fprintf(pp, "%-16s %-32s %d %d", "Split", splitname, 1, refcount);
                     if (j == 0)
                     {

--- a/tools/onnx/onnx2ncnn.cpp
+++ b/tools/onnx/onnx2ncnn.cpp
@@ -3464,7 +3464,7 @@ For more information, please refer to https://github.com/pnnx/pnnx\n");
         }
 
         char splitname[256];
-        sprintf(splitname, "splitncnn_input%d", j);
+        snprintf(splitname, 256, "splitncnn_input%d", j);
         fprintf(pp, "%-16s %-24s %d %d", "Split", splitname, 1, refcount);
         fprintf(pp, " %s", trunc_name(input_name).c_str());
 
@@ -3533,7 +3533,7 @@ For more information, please refer to https://github.com/pnnx/pnnx\n");
         }
 
         char splitname[256];
-        sprintf(splitname, "splitncnn_%d", internal_split);
+        snprintf(splitname, 256, "splitncnn_%d", internal_split);
         fprintf(pp, "%-16s %-24s %d %d", "Split", splitname, 1, refcount);
 
         fprintf(pp, " %s", trunc_name(input_name).c_str());
@@ -3998,7 +3998,7 @@ For more information, please refer to https://github.com/pnnx/pnnx\n");
                 split_node_reference[input_name] = refidx;
 
                 char splitsuffix[256];
-                sprintf(splitsuffix, "_splitncnn_%d", refidx);
+                snprintf(splitsuffix, 256, "_splitncnn_%d", refidx);
                 input_name = input_name + splitsuffix;
             }
 
@@ -6116,7 +6116,7 @@ For more information, please refer to https://github.com/pnnx/pnnx\n");
                 if (refcount > 1)
                 {
                     char splitname[256];
-                    sprintf(splitname, "splitncnn_%d", internal_split);
+                    snprintf(splitname, 256, "splitncnn_%d", internal_split);
                     fprintf(pp, "%-16s %-24s %d %d", "Split", splitname, 1, refcount);
 
                     fprintf(pp, " %s", trunc_name(output_name).c_str());

--- a/tools/pnnx/src/ir.cpp
+++ b/tools/pnnx/src/ir.cpp
@@ -458,7 +458,7 @@ std::string Parameter::encode_to_string(const Parameter& param)
     if (param.type == 10)
     {
         char buf[128];
-        sprintf(buf, "%e+%ej", param.c.real(), param.c.imag());
+        snprintf(buf, 128, "%e+%ej", param.c.real(), param.c.imag());
         return std::string(buf);
     }
     if (param.type == 11)
@@ -467,7 +467,7 @@ std::string Parameter::encode_to_string(const Parameter& param)
         for (size_t i = 0; i < param.ac.size(); i++)
         {
             char buf[128];
-            sprintf(buf, "%e+%ej", param.ac[i].real(), param.ac[i].imag());
+            snprintf(buf, 128, "%e+%ej", param.ac[i].real(), param.ac[i].imag());
             s += std::string(buf);
             if (i + 1 != param.ac.size())
                 s += std::string(",");

--- a/tools/pnnx/src/pass_level1.cpp
+++ b/tools/pnnx/src/pass_level1.cpp
@@ -69,7 +69,7 @@ void pass_level1(const torch::jit::Module& mod, const std::shared_ptr<torch::jit
         const auto& in = g->inputs()[i];
 
         char name[32];
-        sprintf(name, "pnnx_input_%d", i - 1);
+        snprintf(name, 32, "pnnx_input_%d", i - 1);
 
         Operator* op = pg.new_operator("pnnx.Input", name);
         Operand* r = pg.new_operand(in);
@@ -151,7 +151,7 @@ void pass_level1(const torch::jit::Module& mod, const std::shared_ptr<torch::jit
         else if (n->kind() == c10::prim::Constant) // || n->kind() == c10::prim::ListConstruct)
         {
             char name[32];
-            sprintf(name, "pnnx_%d", pnnx_unknown_index++);
+            snprintf(name, 32, "pnnx_%d", pnnx_unknown_index++);
 
             Operator* op = pg.new_operator(n->kind().toDisplayString(), name);
 
@@ -321,7 +321,7 @@ void pass_level1(const torch::jit::Module& mod, const std::shared_ptr<torch::jit
                     for (auto attr : constant_attr_nodes)
                     {
                         char name[32];
-                        sprintf(name, "pnnx_%02d", pnnx_moduleop_unknown_index);
+                        snprintf(name, 32, "pnnx_%02d", pnnx_moduleop_unknown_index);
                         op->attrs[name] = attr.second->t(torch::jit::attr::value);
                         pnnx_moduleop_unknown_index++;
                     }
@@ -395,7 +395,7 @@ void pass_level1(const torch::jit::Module& mod, const std::shared_ptr<torch::jit
         else
         {
             char name[32];
-            sprintf(name, "pnnx_%d", pnnx_unknown_index++);
+            snprintf(name, 32, "pnnx_%d", pnnx_unknown_index++);
 
             Operator* op = pg.new_operator(n->kind().toDisplayString(), name);
 
@@ -422,7 +422,7 @@ void pass_level1(const torch::jit::Module& mod, const std::shared_ptr<torch::jit
         const auto& in = g->outputs()[i];
 
         char name[32];
-        sprintf(name, "pnnx_output_%d", i);
+        snprintf(name, 32, "pnnx_output_%d", i);
         Operator* op = pg.new_operator("pnnx.Output", name);
         Operand* r = pg.get_operand(in->debugName());
         r->consumers.push_back(op);

--- a/tools/pnnx/src/pass_level3/fuse_expression.cpp
+++ b/tools/pnnx/src/pass_level3/fuse_expression.cpp
@@ -207,7 +207,7 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
         else if (param.type == 2)
         {
             char tmp[32];
-            sprintf(tmp, "%d", param.i);
+            snprintf(tmp, 32, "%d", param.i);
             expr += tmp;
         }
         else if (param.type == 3)
@@ -225,7 +225,7 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
             for (int i = 0; i < (int)param.ai.size(); i++)
             {
                 char tmp[32];
-                sprintf(tmp, "%d", param.ai[i]);
+                snprintf(tmp, 32, "%d", param.ai[i]);
                 expr += tmp;
                 if (i != (int)param.ai.size() - 1)
                     expr += ",";
@@ -247,7 +247,7 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
         else if (param.type == 10)
         {
             char tmp[32];
-            sprintf(tmp, "%e%+ej", param.c.real(), param.c.imag());
+            snprintf(tmp, 32, "%e%+ej", param.c.real(), param.c.imag());
             expr += tmp;
         }
         else
@@ -277,7 +277,7 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
             else if (data.type == 4)
             {
                 char tmp[32];
-                sprintf(tmp, "%d", ((const int*)data.data.data())[0]);
+                snprintf(tmp, 32, "%d", ((const int*)data.data.data())[0]);
                 expr += tmp;
             }
             else if (data.type == 5)
@@ -287,25 +287,25 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
                 if (v == std::numeric_limits<int64_t>::min()) v = INT_MIN;
 
                 char tmp[32];
-                sprintf(tmp, "%d", (int)v);
+                snprintf(tmp, 32, "%d", (int)v);
                 expr += tmp;
             }
             else if (data.type == 6)
             {
                 char tmp[32];
-                sprintf(tmp, "%d", ((const short*)data.data.data())[0]);
+                snprintf(tmp, 32, "%d", ((const short*)data.data.data())[0]);
                 expr += tmp;
             }
             else if (data.type == 7)
             {
                 char tmp[32];
-                sprintf(tmp, "%d", ((const signed char*)data.data.data())[0]);
+                snprintf(tmp, 32, "%d", ((const signed char*)data.data.data())[0]);
                 expr += tmp;
             }
             else if (data.type == 8)
             {
                 char tmp[32];
-                sprintf(tmp, "%u", ((const unsigned char*)data.data.data())[0]);
+                snprintf(tmp, 32, "%u", ((const unsigned char*)data.data.data())[0]);
                 expr += tmp;
             }
             else if (data.type == 9)
@@ -361,7 +361,7 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
                 else if (data.type == 4)
                 {
                     char tmp[32];
-                    sprintf(tmp, "%d", ((const int*)data.data.data())[si]);
+                    snprintf(tmp, 32, "%d", ((const int*)data.data.data())[si]);
                     expr += tmp;
                 }
                 else if (data.type == 5)
@@ -371,25 +371,25 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
                     if (v == std::numeric_limits<int64_t>::min()) v = INT_MIN;
 
                     char tmp[32];
-                    sprintf(tmp, "%d", (int)v);
+                    snprintf(tmp, 32, "%d", (int)v);
                     expr += tmp;
                 }
                 else if (data.type == 6)
                 {
                     char tmp[32];
-                    sprintf(tmp, "%d", ((const short*)data.data.data())[si]);
+                    snprintf(tmp, 32, "%d", ((const short*)data.data.data())[si]);
                     expr += tmp;
                 }
                 else if (data.type == 7)
                 {
                     char tmp[32];
-                    sprintf(tmp, "%d", ((const signed char*)data.data.data())[si]);
+                    snprintf(tmp, 32, "%d", ((const signed char*)data.data.data())[si]);
                     expr += tmp;
                 }
                 else if (data.type == 8)
                 {
                     char tmp[32];
-                    sprintf(tmp, "%u", ((const unsigned char*)data.data.data())[si]);
+                    snprintf(tmp, 32, "%u", ((const unsigned char*)data.data.data())[si]);
                     expr += tmp;
                 }
                 else if (data.type == 9)
@@ -439,7 +439,7 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
                 zip.read_file(operand->name, (char*)&v);
 
                 char tmp[32];
-                sprintf(tmp, "%d", v);
+                snprintf(tmp, 32, "%d", v);
                 expr += tmp;
             }
             else if (operand->type == 5)
@@ -451,7 +451,7 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
                 if (v == std::numeric_limits<int64_t>::min()) v = INT_MIN;
 
                 char tmp[32];
-                sprintf(tmp, "%ld", v);
+                snprintf(tmp, 32, "%ld", v);
                 expr += tmp;
             }
             else if (operand->type == 6)
@@ -460,7 +460,7 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
                 zip.read_file(operand->name, (char*)&v);
 
                 char tmp[32];
-                sprintf(tmp, "%d", v);
+                snprintf(tmp, 32, "%d", v);
                 expr += tmp;
             }
             else if (operand->type == 7)
@@ -469,7 +469,7 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
                 zip.read_file(operand->name, (char*)&v);
 
                 char tmp[32];
-                sprintf(tmp, "%d", v);
+                snprintf(tmp, 32, "%d", v);
                 expr += tmp;
             }
             else if (operand->type == 8)
@@ -478,7 +478,7 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
                 zip.read_file(operand->name, (char*)&v);
 
                 char tmp[32];
-                sprintf(tmp, "%u", v);
+                snprintf(tmp, 32, "%u", v);
                 expr += tmp;
             }
             else if (operand->type == 9)
@@ -496,7 +496,7 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
                 {
                     // tensor
                     char tmp[32];
-                    sprintf(tmp, "@%d", (int)inputs.size());
+                    snprintf(tmp, 32, "@%d", (int)inputs.size());
                     expr += tmp;
 
                     inputs.push_back(operand);
@@ -505,7 +505,7 @@ static void fuse_expression(Graph& graph, Operand* operand, std::string& expr, s
                 {
                     // tensor
                     char tmp[32];
-                    sprintf(tmp, "@%d", (int)(it - inputs.begin()));
+                    snprintf(tmp, 32, "@%d", (int)(it - inputs.begin()));
                     expr += tmp;
                 }
             }
@@ -786,7 +786,7 @@ DEFAULT:
     {
         // tensor
         char tmp[32];
-        sprintf(tmp, "@%d", (int)inputs.size());
+        snprintf(tmp, 32, "@%d", (int)inputs.size());
         expr += tmp;
 
         inputs.push_back(operand);
@@ -795,7 +795,7 @@ DEFAULT:
     {
         // tensor
         char tmp[32];
-        sprintf(tmp, "@%d", (int)(it - inputs.begin()));
+        snprintf(tmp, 32, "@%d", (int)(it - inputs.begin()));
         expr += tmp;
     }
 }
@@ -913,7 +913,7 @@ void fuse_expression(Graph& graph, const std::set<std::string>& foldable_constan
 
                 // lets rewrite graph
                 char name[32];
-                sprintf(name, "pnnx_expr_%d", pnnx_expr_index++);
+                snprintf(name, 32, "pnnx_expr_%d", pnnx_expr_index++);
 
                 op->type = "pnnx.Expression";
                 op->name = name;

--- a/tools/pnnx/src/pass_level5/fuse_slice_indices.cpp
+++ b/tools/pnnx/src/pass_level5/fuse_slice_indices.cpp
@@ -177,18 +177,18 @@ void fuse_slice_indices(Graph& graph)
                         char tmp[32];
                         if (sop->params.at("start").type == 0)
                         {
-                            sprintf(tmp, "0");
+                            snprintf(tmp, 32, "0");
                         }
                         else
                         {
-                            sprintf(tmp, "%d", sop->params.at("start").i);
+                            snprintf(tmp, 32, "%d", sop->params.at("start").i);
                         }
                         starts_indexes.push_back(tmp);
                     }
                     else
                     {
                         char tmp[32];
-                        sprintf(tmp, "@%d", (int)op_starts->inputs.size());
+                        snprintf(tmp, 32, "@%d", (int)op_starts->inputs.size());
                         starts_indexes.push_back(tmp);
                         Operand* start = sop->named_input("start");
                         op_starts->inputs.push_back(start);
@@ -205,18 +205,18 @@ void fuse_slice_indices(Graph& graph)
                         char tmp[32];
                         if (sop->params.at("end").type == 0)
                         {
-                            sprintf(tmp, "%d", INT_MAX);
+                            snprintf(tmp, 32, "%d", INT_MAX);
                         }
                         else
                         {
-                            sprintf(tmp, "%d", sop->params.at("end").i);
+                            snprintf(tmp, 32, "%d", sop->params.at("end").i);
                         }
                         ends_indexes.push_back(tmp);
                     }
                     else
                     {
                         char tmp[32];
-                        sprintf(tmp, "@%d", (int)op_ends->inputs.size());
+                        snprintf(tmp, 32, "@%d", (int)op_ends->inputs.size());
                         ends_indexes.push_back(tmp);
                         Operand* end = sop->named_input("end");
                         op_ends->inputs.push_back(end);
@@ -233,18 +233,18 @@ void fuse_slice_indices(Graph& graph)
                         char tmp[32];
                         if (sop->params.at("step").type == 0)
                         {
-                            sprintf(tmp, "1");
+                            snprintf(tmp, 32, "1");
                         }
                         else
                         {
-                            sprintf(tmp, "%d", sop->params.at("step").i);
+                            snprintf(tmp, 32, "%d", sop->params.at("step").i);
                         }
                         steps_indexes.push_back(tmp);
                     }
                     else
                     {
                         char tmp[32];
-                        sprintf(tmp, "@%d", (int)op_steps->inputs.size());
+                        snprintf(tmp, 32, "@%d", (int)op_steps->inputs.size());
                         steps_indexes.push_back(tmp);
                         Operand* step = sop->named_input("step");
                         op_steps->inputs.push_back(step);
@@ -259,7 +259,7 @@ void fuse_slice_indices(Graph& graph)
                     else
                     {
                         char tmp[32];
-                        sprintf(tmp, "%d", INT_MAX);
+                        snprintf(tmp, 32, "%d", INT_MAX);
                         selects_indexes.push_back(tmp);
                     }
                 }
@@ -301,18 +301,18 @@ void fuse_slice_indices(Graph& graph)
                         char tmp[32];
                         if (sop->params.at("index").type == 0)
                         {
-                            sprintf(tmp, "0");
+                            snprintf(tmp, 32, "0");
                         }
                         else
                         {
-                            sprintf(tmp, "%d", sop->params.at("index").i);
+                            snprintf(tmp, 32, "%d", sop->params.at("index").i);
                         }
                         selects_indexes.push_back(tmp);
                     }
                     else
                     {
                         char tmp[32];
-                        sprintf(tmp, "@%d", (int)op_selects->inputs.size());
+                        snprintf(tmp, 32, "@%d", (int)op_selects->inputs.size());
                         selects_indexes.push_back(tmp);
                         Operand* index = sop->named_input("index");
                         op_selects->inputs.push_back(index);
@@ -350,18 +350,18 @@ void fuse_slice_indices(Graph& graph)
                     char tmp[32];
                     if (op->params.at("start").type == 0)
                     {
-                        sprintf(tmp, "0");
+                        snprintf(tmp, 32, "0");
                     }
                     else
                     {
-                        sprintf(tmp, "%d", op->params.at("start").i);
+                        snprintf(tmp, 32, "%d", op->params.at("start").i);
                     }
                     starts_indexes.push_back(tmp);
                 }
                 else
                 {
                     char tmp[32];
-                    sprintf(tmp, "@%d", (int)op_starts->inputs.size());
+                    snprintf(tmp, 32, "@%d", (int)op_starts->inputs.size());
                     starts_indexes.push_back(tmp);
                     Operand* start = op->named_input("start");
                     op_starts->inputs.push_back(start);
@@ -378,18 +378,18 @@ void fuse_slice_indices(Graph& graph)
                     char tmp[32];
                     if (op->params.at("end").type == 0)
                     {
-                        sprintf(tmp, "%d", INT_MAX);
+                        snprintf(tmp, 32, "%d", INT_MAX);
                     }
                     else
                     {
-                        sprintf(tmp, "%d", op->params.at("end").i);
+                        snprintf(tmp, 32, "%d", op->params.at("end").i);
                     }
                     ends_indexes.push_back(tmp);
                 }
                 else
                 {
                     char tmp[32];
-                    sprintf(tmp, "@%d", (int)op_ends->inputs.size());
+                    snprintf(tmp, 32, "@%d", (int)op_ends->inputs.size());
                     ends_indexes.push_back(tmp);
                     Operand* end = op->named_input("end");
                     op_ends->inputs.push_back(end);
@@ -406,18 +406,18 @@ void fuse_slice_indices(Graph& graph)
                     char tmp[32];
                     if (op->params.at("step").type == 0)
                     {
-                        sprintf(tmp, "1");
+                        snprintf(tmp, 32, "1");
                     }
                     else
                     {
-                        sprintf(tmp, "%d", op->params.at("step").i);
+                        snprintf(tmp, 32, "%d", op->params.at("step").i);
                     }
                     steps_indexes.push_back(tmp);
                 }
                 else
                 {
                     char tmp[32];
-                    sprintf(tmp, "@%d", (int)op_steps->inputs.size());
+                    snprintf(tmp, 32, "@%d", (int)op_steps->inputs.size());
                     steps_indexes.push_back(tmp);
                     Operand* step = op->named_input("step");
                     op_steps->inputs.push_back(step);
@@ -432,7 +432,7 @@ void fuse_slice_indices(Graph& graph)
                 else if (op->has_param("index"))
                 {
                     char tmp[32];
-                    sprintf(tmp, "%d", INT_MAX);
+                    snprintf(tmp, 32, "%d", INT_MAX);
                     selects_indexes.push_back(tmp);
                 }
             }
@@ -474,18 +474,18 @@ void fuse_slice_indices(Graph& graph)
                     char tmp[32];
                     if (op->params.at("index").type == 0)
                     {
-                        sprintf(tmp, "0");
+                        snprintf(tmp, 32, "0");
                     }
                     else
                     {
-                        sprintf(tmp, "%d", op->params.at("index").i);
+                        snprintf(tmp, 32, "%d", op->params.at("index").i);
                     }
                     selects_indexes.push_back(tmp);
                 }
                 else
                 {
                     char tmp[32];
-                    sprintf(tmp, "@%d", (int)op_selects->inputs.size());
+                    snprintf(tmp, 32, "@%d", (int)op_selects->inputs.size());
                     selects_indexes.push_back(tmp);
                     Operand* index = op->named_input("index");
                     op_selects->inputs.push_back(index);

--- a/tools/quantize/ncnn2int8.cpp
+++ b/tools/quantize/ncnn2int8.cpp
@@ -150,7 +150,7 @@ int NetQuantize::quantize_convolution()
             continue;
 
         char key[256];
-        sprintf(key, "%s_param_0", layers[i]->name.c_str());
+        snprintf(key, 256, "%s_param_0", layers[i]->name.c_str());
 
         std::map<std::string, ncnn::Mat>::iterator iter = weight_int8scale_table.find(key);
         if (iter == weight_int8scale_table.end())
@@ -208,7 +208,7 @@ int NetQuantize::quantize_convolutiondepthwise()
             continue;
 
         char key[256];
-        sprintf(key, "%s_param_0", layers[i]->name.c_str());
+        snprintf(key, 256, "%s_param_0", layers[i]->name.c_str());
 
         std::map<std::string, ncnn::Mat>::iterator iter = weight_int8scale_table.find(key);
         if (iter == weight_int8scale_table.end())
@@ -270,7 +270,7 @@ int NetQuantize::quantize_innerproduct()
             continue;
 
         char key[256];
-        sprintf(key, "%s_param_0", layers[i]->name.c_str());
+        snprintf(key, 256, "%s_param_0", layers[i]->name.c_str());
 
         std::map<std::string, ncnn::Mat>::iterator iter = weight_int8scale_table.find(key);
         if (iter == weight_int8scale_table.end())


### PR DESCRIPTION
HI, @nihui and team.

I have fixed several compile warnings with a sprintf. Could you review and accept a my changes?

[764/770] Building CXX object tools/quantize/CMakeFiles/ncnn2int8.dir/ncnn2int8.cpp.o ../tools/quantize/ncnn2int8.cpp:153:9: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  153 |         sprintf(key, "%s_param_0", layers[i]->name.c_str());
      |         ^

Best regards, Evgeny Proydakov.