### PR TITLE
introduce WebGPU via Emdawnwebgpu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -786,9 +786,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "cmake")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -s FORCE_FILESYSTEM=1 -s INITIAL_MEMORY=256MB -s EXIT_RUNTIME=1")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s FORCE_FILESYSTEM=1 -s INITIAL_MEMORY=256MB -s EXIT_RUNTIME=1")
-    set(CMAKE_EXECUTBLE_LINKER_FLAGS "${CMAKE_EXECUTBLE_LINKER_FLAGS} -s FORCE_FILESYSTEM=1 -s INITIAL_MEMORY=256MB -s EXIT_RUNTIME=1")
+    set(CMAKE_EXECUTBLE_LINKER_FLAGS "${CMAKE_EXECUTBLE_LINKER_FLAGS} -s FORCE_FILESYSTEM=1 -s INITIAL_MEMORY=256MB -s EXIT_RUNTIME=1 --closure 1")
 
     if(NCNN_OPENMP AND NCNN_SIMPLEOMP)
         # TODO better flags for emscripten
@@ -870,6 +868,12 @@ if(NCNN_VULKAN)
                 endif()
             endif()
         endif()
+    endif()
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --use-port=emdawnwebgpu")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --use-port=emdawnwebgpu")
+        set(CMAKE_EXECUTBLE_LINKER_FLAGS "${CMAKE_EXECUTBLE_LINKER_FLAGS} --use-port=emdawnwebgpu")
     endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ set(ncnn_SRCS
     simplestl.cpp
     simplemath.cpp
     simplevk.cpp
+    webgpu.cpp
 )
 
 if(ANDROID)
@@ -309,7 +310,9 @@ if(NCNN_VULKAN)
                 target_link_libraries(ncnn PRIVATE "-Wl,-weak_library,${SIMPLEVK_TBD}")
             endif()
         endif()
-        target_link_libraries(ncnn PRIVATE ${CMAKE_DL_LIBS})
+        if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+            target_link_libraries(ncnn PRIVATE ${CMAKE_DL_LIBS})
+        endif()
     else()
         find_package(Vulkan QUIET)
         if(NOT Vulkan_FOUND)

--- a/src/webgpu.cpp
+++ b/src/webgpu.cpp
@@ -1,0 +1,11 @@
+#include "gpu.h"
+
+#if defined(__EMSCRIPTEN__) && NCNN_VULKAN
+
+#include <webgpu/webgpu.h>
+
+namespace ncnn {
+
+};
+
+#endif  // defined(__EMSCRIPTEN__) && NCNN_VULKAN


### PR DESCRIPTION
Tracking issue: #5974

This PR introduces Emscripten's native webgpu.h implementation Emdawnwebgpu, and add basic utilities and environments for further WebGPU implementation PRs.

`FORCE_FILESYSTEM`, `INITIAL_MEMORY` and `EXIT_RUNTIME` are linker-only arguments, setting them on compiler does nothing but yields unused argument warnings.