### PR TITLE
RVV 1.0 Quantize Layer

### DIFF
--- a/src/layer/riscv/quantize_riscv.cpp
+++ b/src/layer/riscv/quantize_riscv.cpp
@@ -33,7 +33,6 @@ static void quantize(const float* ptr, signed char* s8ptr, const Mat& scale_data
     const int size = elemcount * elempack;
     float scale = scale_data[0];
 
-    int i = 0;
 #if __riscv_vector
     int n = size;
     while (n > 0)
@@ -47,15 +46,14 @@ static void quantize(const float* ptr, signed char* s8ptr, const Mat& scale_data
         s8ptr += vl;
         n -= vl;
     }
-
-    i += (size - n);
-#endif
-    for (; i < size; i++)
+#else  // __riscv_zvfh
+    for (int i = 0; i < size; i++)
     {
         *s8ptr = float2int8(*ptr * scale);
         ptr++;
         s8ptr++;
     }
+#endif // __riscv_zvfh
 }
 
 #if __riscv_vector
@@ -296,6 +294,7 @@ int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option&
         }
         if (elempack == packn && out_elempack == 1)
         {
+            #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
             {
                 const float* ptr = bottom_blob.channel(q);

--- a/src/layer/riscv/quantize_riscv.cpp
+++ b/src/layer/riscv/quantize_riscv.cpp
@@ -246,7 +246,7 @@ int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option&
             }
         }
 #endif // __riscv_vector
-        if (elempack == out_elempack)
+        if (elempack == 1 && out_elempack == 1)
         {
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int i = 0; i < h; i++)
@@ -307,7 +307,7 @@ int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option&
             }
         }
 #endif // __riscv_vector
-        if (elempack == out_elempack)
+        if (elempack == 1 && out_elempack == 1)
         {
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)

--- a/src/layer/riscv/quantize_riscv.cpp
+++ b/src/layer/riscv/quantize_riscv.cpp
@@ -35,24 +35,12 @@ static void quantize(const float* ptr, signed char* s8ptr, const Mat& scale_data
 
     int i = 0;
 #if __riscv_vector
-    const size_t vlm1 = __riscv_vsetvlmax_e32m1();
-    vfloat32m8_t _scale;
-    if (scale_data.w == 1)
-    {
-        _scale = __riscv_vfmv_v_f_f32m8(scale, __riscv_vsetvlmax_e32m8());
-    }
-    else if (elempack == vlm1)
-    {
-        vfloat32m1_t _s = __riscv_vle32_v_f32m1(scale_data, vlm1);
-        _scale = __riscv_vcreate_v_f32m1_f32m8(_s, _s, _s, _s, _s, _s, _s, _s);
-    }
-
     int n = size;
     while (n > 0)
     {
         size_t vl = __riscv_vsetvl_e32m8(n);
         vfloat32m8_t _v0 = __riscv_vle32_v_f32m8(ptr, vl);
-        _v0 = __riscv_vfmul_vv_f32m8(_v0, _scale, vl);
+        _v0 = __riscv_vfmul_vf_f32m8(_v0, scale, vl);
         __riscv_vse8_v_i8m2(s8ptr, float2int8(_v0, vl), vl);
 
         ptr += vl;

--- a/src/layer/riscv/quantize_riscv.cpp
+++ b/src/layer/riscv/quantize_riscv.cpp
@@ -179,7 +179,7 @@ int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option&
 
 #if __riscv_vector
     const int packn = csrr_vlenb() / 4;
-    const int pack4n = csrr_vlenb();
+    const int packn_s8 = csrr_vlenb();
 #endif
     if (dims == 1)
     {
@@ -187,7 +187,7 @@ int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option&
 #if __riscv_vector
         if (opt.use_packing_layout)
         {
-            out_elempack = w * elempack % pack4n == 0 ? pack4n : 1;
+            out_elempack = w * elempack % packn_s8 == 0 ? packn_s8 : 1;
         }
 #endif
         const int outw = w * elempack / out_elempack;
@@ -219,7 +219,7 @@ int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option&
 #if __riscv_vector
         if (opt.use_packing_layout)
         {
-            out_elempack = h * elempack % pack4n == 0 ? pack4n : 1;
+            out_elempack = h * elempack % packn_s8 == 0 ? packn_s8 : 1;
         }
 #endif // __riscv_vector
         const int outh = h * elempack / out_elempack;
@@ -229,7 +229,7 @@ int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option&
         if (top_blob.empty())
             return -100;
 #if __riscv_vector
-        if (elempack == packn && out_elempack == pack4n)
+        if (elempack == packn && out_elempack == packn_s8)
         {
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int i = 0; i < outh; i++)
@@ -279,7 +279,7 @@ int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option&
 #if __riscv_vector
         if (opt.use_packing_layout)
         {
-            out_elempack = channels * elempack % pack4n == 0 ? pack4n : 1;
+            out_elempack = channels * elempack % packn_s8 == 0 ? packn_s8 : 1;
         }
 #endif
         const int outc = channels * elempack / out_elempack;
@@ -290,7 +290,7 @@ int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option&
             return -100;
 
 #if __riscv_vector
-        if (elempack == packn && out_elempack == pack4n)
+        if (elempack == packn && out_elempack == packn_s8)
         {
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < outc; q++)

--- a/src/layer/riscv/quantize_riscv.cpp
+++ b/src/layer/riscv/quantize_riscv.cpp
@@ -1,0 +1,342 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "quantize_riscv.h"
+
+#if __riscv_vector
+#include <riscv_vector.h>
+#endif // __riscv_vector
+#include "riscv_activation.h"
+#include "riscv_usability.h"
+
+#include "cpu.h"
+
+namespace ncnn {
+
+Quantize_riscv::Quantize_riscv()
+{
+#if __riscv_vector
+    support_packing = true;
+#endif // __riscv_vector
+
+#if NCNN_ZFH
+#if __riscv_vector
+    support_fp16_storage = cpu_support_riscv_zvfh();
+#else
+    support_fp16_storage = cpu_support_riscv_zfh();
+#endif
+#endif
+}
+
+static void quantize(const float* ptr, signed char* s8ptr, const Mat& scale_data, int elemcount, int elempack)
+{
+    const int scale_data_size = scale_data.w;
+    const int size = elemcount * elempack;
+    float scale = scale_data[0];
+
+    int i = 0;
+#if __riscv_vector
+    const size_t vlm1 = __riscv_vsetvlmax_e32m1();
+    vfloat32m8_t _scale;
+    if (scale_data_size == 1)
+    {
+        _scale = __riscv_vfmv_v_f_f32m8(scale, __riscv_vsetvlmax_e32m8());
+    }
+    else if (elempack == vlm1)
+    {
+        vfloat32m1_t _s = __riscv_vle32_v_f32m1(scale_data, vlm1);
+        _scale = __riscv_vcreate_v_f32m1_f32m8(_s, _s, _s, _s, _s, _s, _s, _s);
+    }
+
+    int n = size;
+    while (n > 0)
+    {
+        size_t vl = __riscv_vsetvl_e32m8(n);
+        vfloat32m8_t _v0 = __riscv_vle32_v_f32m8(ptr, vl);
+        _v0 = __riscv_vfmul_vv_f32m8(_v0, _scale, vl);
+        __riscv_vse8_v_i8m2(s8ptr, float2int8(_v0, vl), vl);
+
+        ptr += vl;
+        s8ptr += vl;
+        n -= vl;
+    }
+
+    i += (size - n);
+#endif
+    for (; i < size; i++)
+    {
+        *s8ptr = float2int8(*ptr * scale);
+        ptr++;
+        s8ptr++;
+    }
+}
+
+#if __riscv_vector
+static void quantize_packnto4n(const float* ptr0, const float* ptr1, const float* ptr2, const float* ptr3, signed char* s8ptr, const Mat& scale_data, int elemcount)
+{
+    const size_t vlm8 = __riscv_vsetvlmax_e32m8();
+    const size_t vlm4 = __riscv_vsetvlmax_e32m4();
+    const size_t vlm1 = __riscv_vsetvlmax_e32m1();
+
+    float scale = scale_data[0];
+    vfloat32m4_t _scale0 = __riscv_vfmv_v_f_f32m4(scale, vlm4);
+    if (scale_data.w > 1)
+    {
+        _scale0 = __riscv_vle32_v_f32m4(scale_data, vlm4);
+    }
+    vfloat32m8_t _scale = __riscv_vcreate_v_f32m4_f32m8(_scale0, _scale0);
+
+    int i = 0;
+    for (; i + 1 < elemcount; i += 2)
+    {
+        vfloat32m1_t _v0 = __riscv_vle32_v_f32m1(ptr0, vlm1);
+        vfloat32m1_t _v1 = __riscv_vle32_v_f32m1(ptr1, vlm1);
+        vfloat32m1_t _v2 = __riscv_vle32_v_f32m1(ptr2, vlm1);
+        vfloat32m1_t _v3 = __riscv_vle32_v_f32m1(ptr3, vlm1);
+        vfloat32m1_t _v4 = __riscv_vle32_v_f32m1(ptr0 + vlm1, vlm1);
+        vfloat32m1_t _v5 = __riscv_vle32_v_f32m1(ptr1 + vlm1, vlm1);
+        vfloat32m1_t _v6 = __riscv_vle32_v_f32m1(ptr2 + vlm1, vlm1);
+        vfloat32m1_t _v7 = __riscv_vle32_v_f32m1(ptr3 + vlm1, vlm1);
+        vfloat32m8_t _v = __riscv_vcreate_v_f32m1_f32m8(_v0, _v1, _v2, _v3, _v4, _v5, _v6, _v7);
+        _v = __riscv_vfmul_vv_f32m8(_v, _scale, vlm8);
+        __riscv_vse8_v_i8m2(s8ptr, float2int8(_v, vlm8), vlm8);
+        ptr0 += vlm1 * 2;
+        ptr1 += vlm1 * 2;
+        ptr2 += vlm1 * 2;
+        ptr3 += vlm1 * 2;
+        s8ptr += vlm8;
+    }
+
+    for (; i < elemcount; i++)
+    {
+        vfloat32m1_t _v0 = __riscv_vle32_v_f32m1(ptr0, vlm1);
+        vfloat32m1_t _v1 = __riscv_vle32_v_f32m1(ptr1, vlm1);
+        vfloat32m1_t _v2 = __riscv_vle32_v_f32m1(ptr2, vlm1);
+        vfloat32m1_t _v3 = __riscv_vle32_v_f32m1(ptr3, vlm1);
+        vfloat32m4_t _v = __riscv_vcreate_v_f32m1_f32m4(_v0, _v1, _v2, _v3);
+        _v = __riscv_vfmul_vv_f32m4(_v, _scale0, vlm4);
+        __riscv_vse8_v_i8m1(s8ptr, float2int8(_v, vlm4), vlm4);
+        ptr0 += vlm1;
+        ptr1 += vlm1;
+        ptr2 += vlm1;
+        ptr3 += vlm1;
+        s8ptr += vlm4;
+    }
+}
+
+static void quantize_packnto1(const float* ptr, signed char* s8ptr, const Mat& scale_data, int elemcount, int stride)
+{
+    const size_t vlm8 = __riscv_vsetvlmax_e32m8();
+    const size_t vlm1 = __riscv_vsetvlmax_e32m1();
+
+    float scale = scale_data[0];
+    vfloat32m8_t _scale = __riscv_vfmv_v_f_f32m8(scale, vlm8);
+    if (scale_data.w > 1)
+    {
+        vfloat32m1_t _s = __riscv_vle32_v_f32m1(scale_data, vlm1);
+        _scale = __riscv_vcreate_v_f32m1_f32m8(_s, _s, _s, _s, _s, _s, _s, _s);
+    }
+
+    signed char tmp[vlm8];
+    int n = elemcount * vlm1;
+    while (n > 0)
+    {
+        size_t vl = __riscv_vsetvl_e32m8(n);
+        vfloat32m8_t v32 = __riscv_vle32_v_f32m8(ptr, vl);
+        v32 = __riscv_vfmul_vv_f32m8(v32, _scale, vl);
+        __riscv_vse8_v_i8m2(tmp, float2int8(v32, vl), vl);
+        for (size_t j = 0; j < (vl / vlm1); j++)
+        {
+            for (int i = 0; i < vlm1; i++)
+            {
+                s8ptr[i * stride] = tmp[j * vlm1 + i];
+            }
+            s8ptr++;
+        }
+
+        ptr += vl;
+        n -= vl;
+    }
+}
+#endif // __riscv_vector
+
+int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const
+{
+    int elembits = bottom_blob.elembits();
+
+#if NCNN_ZFH
+    if (support_fp16_storage && opt.use_fp16_storage && elembits == 16)
+    {
+        if (opt.use_fp16_arithmetic)
+            return forward_fp16sa(bottom_blob, top_blob, opt);
+        else
+            return forward_fp16s(bottom_blob, top_blob, opt);
+    }
+#endif
+
+    const int dims = bottom_blob.dims;
+    const int w = bottom_blob.w;
+    const int h = bottom_blob.h;
+    const int channels = bottom_blob.c;
+    const int elempack = bottom_blob.elempack;
+
+#if __riscv_vector
+    const int packn = csrr_vlenb() / 4;
+    const int pack4n = csrr_vlenb();
+#endif
+    if (dims == 1)
+    {
+        int out_elempack = 1;
+#if __riscv_vector
+        if (opt.use_packing_layout)
+        {
+            out_elempack = w * elempack % pack4n == 0 ? pack4n : 1;
+        }
+#endif
+        const int outw = w * elempack / out_elempack;
+        const size_t out_elemsize = out_elempack * 1u;
+
+        top_blob.create(outw, out_elemsize, out_elempack, opt.blob_allocator);
+        if (top_blob.empty())
+            return -100;
+
+        const int wp = std::max(1, w / opt.num_threads);
+        const int nn_w = (w + wp - 1) / wp;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int ii = 0; ii < nn_w; ii++)
+        {
+            const int i = ii * wp;
+
+            const float* ptr = (const float*)bottom_blob + i * elempack;
+            signed char* s8ptr = (signed char*)top_blob + i * elempack;
+            const int size = std::min(w - i, wp) * elempack;
+
+            quantize(ptr, s8ptr, scale_data, size, 1);
+        }
+    }
+
+    if (dims == 2)
+    {
+        int out_elempack = 1;
+#if __riscv_vector
+        if (opt.use_packing_layout)
+        {
+            out_elempack = h * elempack % pack4n == 0 ? pack4n : 1;
+        }
+#endif // __riscv_vector
+        const int outh = h * elempack / out_elempack;
+        const size_t out_elemsize = out_elempack * 1u;
+
+        top_blob.create(w, outh, out_elemsize, out_elempack, opt.blob_allocator);
+        if (top_blob.empty())
+            return -100;
+#if __riscv_vector
+        if (elempack == packn && out_elempack == pack4n)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int i = 0; i < outh; i++)
+            {
+                const float* ptr0 = bottom_blob.row(i * 4);
+                const float* ptr1 = bottom_blob.row(i * 4 + 1);
+                const float* ptr2 = bottom_blob.row(i * 4 + 2);
+                const float* ptr3 = bottom_blob.row(i * 4 + 3);
+                signed char* s8ptr = top_blob.row<signed char>(i);
+
+                const Mat scale_data_i = scale_data_size > 1 ? scale_data.range(i * out_elempack, out_elempack) : scale_data;
+                quantize_packnto4n(ptr0, ptr1, ptr2, ptr3, s8ptr, scale_data_i, w);
+            }
+        }
+
+        if (elempack == packn && out_elempack == 1)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int i = 0; i < h; i++)
+            {
+                const float* ptr = bottom_blob.row(i);
+                signed char* s8ptr = top_blob.row<signed char>(i * packn);
+
+                const Mat scale_data_i = scale_data_size > 1 ? scale_data.range(i * elempack, elempack) : scale_data;
+                quantize_packnto1(ptr, s8ptr, scale_data_i, w, w);
+            }
+        }
+#endif // __riscv_vector
+        if (elempack == out_elempack)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int i = 0; i < h; i++)
+            {
+                const float* ptr = bottom_blob.row(i);
+                signed char* s8ptr = top_blob.row<signed char>(i);
+
+                const Mat scale_data_i = scale_data_size > 1 ? scale_data.range(i * elempack, elempack) : scale_data;
+
+                quantize(ptr, s8ptr, scale_data_i, w, elempack);
+            }
+        }
+    }
+
+    if (dims == 3)
+    {
+        int out_elempack = 1;
+#if __riscv_vector
+        if (opt.use_packing_layout)
+        {
+            out_elempack = channels * elempack % pack4n == 0 ? pack4n : 1;
+        }
+#endif
+        const int outc = channels * elempack / out_elempack;
+        const size_t out_elemsize = out_elempack * 1u;
+
+        top_blob.create(w, h, outc, out_elemsize, out_elempack, opt.blob_allocator);
+        if (top_blob.empty())
+            return -100;
+
+#if __riscv_vector
+        if (elempack == packn && out_elempack == pack4n)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int q = 0; q < outc; q++)
+            {
+                const float* ptr0 = bottom_blob.channel(q * 4);
+                const float* ptr1 = bottom_blob.channel(q * 4 + 1);
+                const float* ptr2 = bottom_blob.channel(q * 4 + 2);
+                const float* ptr3 = bottom_blob.channel(q * 4 + 3);
+                signed char* s8ptr = top_blob.channel(q);
+
+                const Mat scale_data_q = scale_data_size > 1 ? scale_data.range(q * out_elempack, out_elempack) : scale_data;
+
+                quantize_packnto4n(ptr0, ptr1, ptr2, ptr3, s8ptr, scale_data_q, w * h);
+            }
+        }
+        if (elempack == packn && out_elempack == 1)
+        {
+            for (int q = 0; q < channels; q++)
+            {
+                const float* ptr = bottom_blob.channel(q);
+                signed char* s8ptr = top_blob.channel(q * packn);
+
+                const Mat scale_data_q = scale_data_size > 1 ? scale_data.range(q * elempack, elempack) : scale_data;
+
+                quantize_packnto1(ptr, s8ptr, scale_data_q, w * h, top_blob.cstep);
+            }
+        }
+#endif // __riscv_vector
+        if (elempack == out_elempack)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int q = 0; q < channels; q++)
+            {
+                const float* ptr = bottom_blob.channel(q);
+                signed char* s8ptr = top_blob.channel(q);
+
+                const Mat scale_data_q = scale_data_size > 1 ? scale_data.range(q * elempack, elempack) : scale_data;
+
+                quantize(ptr, s8ptr, scale_data_q, w * h, elempack);
+            }
+        }
+    }
+
+    return 0;
+}
+} // namespace ncnn

--- a/src/layer/riscv/quantize_riscv.cpp
+++ b/src/layer/riscv/quantize_riscv.cpp
@@ -30,7 +30,6 @@ Quantize_riscv::Quantize_riscv()
 
 static void quantize(const float* ptr, signed char* s8ptr, const Mat& scale_data, int elemcount, int elempack)
 {
-    const int scale_data_size = scale_data.w;
     const int size = elemcount * elempack;
     float scale = scale_data[0];
 
@@ -38,7 +37,7 @@ static void quantize(const float* ptr, signed char* s8ptr, const Mat& scale_data
 #if __riscv_vector
     const size_t vlm1 = __riscv_vsetvlmax_e32m1();
     vfloat32m8_t _scale;
-    if (scale_data_size == 1)
+    if (scale_data.w == 1)
     {
         _scale = __riscv_vfmv_v_f_f32m8(scale, __riscv_vsetvlmax_e32m8());
     }
@@ -162,10 +161,8 @@ static void quantize_packnto1(const float* ptr, signed char* s8ptr, const Mat& s
 
 int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const
 {
-    int elembits = bottom_blob.elembits();
-
 #if NCNN_ZFH
-    if (support_fp16_storage && opt.use_fp16_storage && elembits == 16)
+    if (support_fp16_storage && opt.use_fp16_storage && bottom_blob.elembits() == 16)
     {
         if (opt.use_fp16_arithmetic)
             return forward_fp16sa(bottom_blob, top_blob, opt);

--- a/src/layer/riscv/quantize_riscv.cpp
+++ b/src/layer/riscv/quantize_riscv.cpp
@@ -59,7 +59,7 @@ static void quantize(const float* ptr, signed char* s8ptr, const Mat& scale_data
 }
 
 #if __riscv_vector
-static void quantize_packnto4n(const float* ptr0, const float* ptr1, const float* ptr2, const float* ptr3, signed char* s8ptr, const Mat& scale_data, int elemcount)
+static void quantize_packnton_s8(const float* ptr0, const float* ptr1, const float* ptr2, const float* ptr3, signed char* s8ptr, const Mat& scale_data, int elemcount)
 {
     const size_t vlm8 = __riscv_vsetvlmax_e32m8();
     const size_t vlm4 = __riscv_vsetvlmax_e32m4();
@@ -229,7 +229,7 @@ int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option&
                 signed char* s8ptr = top_blob.row<signed char>(i);
 
                 const Mat scale_data_i = scale_data_size > 1 ? scale_data.range(i * out_elempack, out_elempack) : scale_data;
-                quantize_packnto4n(ptr0, ptr1, ptr2, ptr3, s8ptr, scale_data_i, w);
+                quantize_packnton_s8(ptr0, ptr1, ptr2, ptr3, s8ptr, scale_data_i, w);
             }
         }
 
@@ -291,7 +291,7 @@ int Quantize_riscv::forward(const Mat& bottom_blob, Mat& top_blob, const Option&
 
                 const Mat scale_data_q = scale_data_size > 1 ? scale_data.range(q * out_elempack, out_elempack) : scale_data;
 
-                quantize_packnto4n(ptr0, ptr1, ptr2, ptr3, s8ptr, scale_data_q, w * h);
+                quantize_packnton_s8(ptr0, ptr1, ptr2, ptr3, s8ptr, scale_data_q, w * h);
             }
         }
         if (elempack == packn && out_elempack == 1)

--- a/src/layer/riscv/quantize_riscv.h
+++ b/src/layer/riscv/quantize_riscv.h
@@ -1,0 +1,28 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef LAYER_QUANTIZE_RISCV_H
+#define LAYER_QUANTIZE_RISCV_H
+
+#include "quantize.h"
+
+namespace ncnn {
+
+// Ref: src/layer/arm/quantize_arm.cpp
+class Quantize_riscv : public Quantize
+{
+public:
+    Quantize_riscv();
+
+    virtual int forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const;
+
+protected:
+#if NCNN_ZFH
+    int forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const;
+    int forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const;
+#endif
+};
+
+} // namespace ncnn
+
+#endif // LAYER_QUANTIZE_RISCV_H

--- a/src/layer/riscv/quantize_riscv_zfh.cpp
+++ b/src/layer/riscv/quantize_riscv_zfh.cpp
@@ -46,7 +46,7 @@ static void quantize_fp16s(const __fp16* ptr, signed char* s8ptr, const Mat& sca
 }
 
 #if __riscv_vector
-static void quantize_packnto2n_fp16s(const __fp16* ptr0, const __fp16* ptr1, signed char* s8ptr, const Mat& scale_data, int elemcount)
+static void quantize_packnton_s8_fp16s(const __fp16* ptr0, const __fp16* ptr1, signed char* s8ptr, const Mat& scale_data, int elemcount)
 {
     const size_t vlm1 = __riscv_vsetvlmax_e16m1();
     const size_t vlm2 = __riscv_vsetvlmax_e16m2();
@@ -200,7 +200,7 @@ int Quantize_riscv::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const O
 
                 const Mat scale_data_i = scale_data_size > 1 ? scale_data.range(i * out_elempack, out_elempack) : scale_data;
 
-                quantize_packnto2n_fp16s(ptr0, ptr1, s8ptr, scale_data_i, w);
+                quantize_packnton_s8_fp16s(ptr0, ptr1, s8ptr, scale_data_i, w);
             }
         }
         if (elempack == packn && out_elempack == 1)
@@ -259,7 +259,7 @@ int Quantize_riscv::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const O
 
                 const Mat scale_data_q = scale_data_size > 1 ? scale_data.range(q * out_elempack, out_elempack) : scale_data;
 
-                quantize_packnto2n_fp16s(ptr0, ptr1, s8ptr, scale_data_q, w * h);
+                quantize_packnton_s8_fp16s(ptr0, ptr1, s8ptr, scale_data_q, w * h);
             }
         }
         if (elempack == packn && out_elempack == 1)
@@ -327,7 +327,7 @@ static void quantize_fp16sa(const __fp16* ptr, signed char* s8ptr, const Mat& sc
 }
 
 #if __riscv_zvfh
-static void quantize_packnto2n_fp16sa(const __fp16* ptr0, const __fp16* ptr1, signed char* s8ptr, const Mat& scale_data, int elemcount)
+static void quantize_packnton_s8_fp16sa(const __fp16* ptr0, const __fp16* ptr1, signed char* s8ptr, const Mat& scale_data, int elemcount)
 {
     const size_t vlm1 = __riscv_vsetvlmax_e16m1();
     const size_t vlm2 = __riscv_vsetvlmax_e16m2();
@@ -502,7 +502,7 @@ int Quantize_riscv::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const 
 
                 const Mat scale_data_i = scale_data_size > 1 ? scale_data.range(i * out_elempack, out_elempack) : scale_data;
 
-                quantize_packnto2n_fp16sa(ptr0, ptr1, s8ptr, scale_data_i, w);
+                quantize_packnton_s8_fp16sa(ptr0, ptr1, s8ptr, scale_data_i, w);
             }
         }
 
@@ -563,7 +563,7 @@ int Quantize_riscv::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const 
 
                 const Mat scale_data_q = scale_data_size > 1 ? scale_data.range(q * out_elempack, out_elempack) : scale_data;
 
-                quantize_packnto2n_fp16sa(ptr0, ptr1, s8ptr, scale_data_q, w * h);
+                quantize_packnton_s8_fp16sa(ptr0, ptr1, s8ptr, scale_data_q, w * h);
             }
         }
 

--- a/src/layer/riscv/quantize_riscv_zfh.cpp
+++ b/src/layer/riscv/quantize_riscv_zfh.cpp
@@ -1,0 +1,627 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "quantize_riscv.h"
+
+#if __riscv_vector
+#include <riscv_vector.h>
+#endif // __riscv_vector
+#include "riscv_activation.h"
+#include "riscv_usability.h"
+
+#include "cpu.h"
+
+namespace ncnn {
+#if NCNN_ZFH
+static void quantize_fp16s(const __fp16* ptr, signed char* s8ptr, const Mat& scale_data, int elemcount, int elempack)
+{
+    const int scale_data_size = scale_data.w;
+    const int size = elemcount * elempack;
+    float scale = scale_data[0];
+
+    int i = 0;
+#if __riscv_vector
+    const size_t vlm1 = __riscv_vsetvlmax_e32m1();
+    vfloat32m8_t _scale;
+    if (scale_data_size == 1)
+    {
+        _scale = __riscv_vfmv_v_f_f32m8(scale, __riscv_vsetvlmax_e32m8());
+    }
+    else if (elempack == vlm1)
+    {
+        vfloat32m1_t _s = __riscv_vle32_v_f32m1(scale_data, vlm1);
+        _scale = __riscv_vcreate_v_f32m1_f32m8(_s, _s, _s, _s, _s, _s, _s, _s);
+    }
+
+    int n = size;
+    while (n > 0)
+    {
+        size_t vl = __riscv_vsetvl_e16m4(n);
+        vfloat32m8_t _v0 = __riscv_vfwcvt_f_f_v_f32m8(__riscv_vle16_v_f16m4(ptr, vl), vl);
+        _v0 = __riscv_vfmul_vv_f32m8(_v0, _scale, vl);
+        __riscv_vse8_v_i8m2(s8ptr, float2int8(_v0, vl), vl);
+
+        ptr += vl;
+        s8ptr += vl;
+        n -= vl;
+    }
+
+    i += (size - n);
+#endif
+    for (; i < size; i++)
+    {
+        float v = (float)(*ptr) * scale;
+        *s8ptr = float2int8(v);
+        ptr++;
+        s8ptr++;
+    }
+}
+
+#if __riscv_vector
+static void quantize_packnto2n_fp16s(const __fp16* ptr0, const __fp16* ptr1, signed char* s8ptr, const Mat& scale_data, int elemcount)
+{
+    const size_t vlm1 = __riscv_vsetvlmax_e16m1();
+    const size_t vlm2 = __riscv_vsetvlmax_e16m2();
+    const size_t vlm4 = __riscv_vsetvlmax_e16m4();
+
+    float scale = scale_data[0];
+    vfloat32m4_t _scale0 = __riscv_vfmv_v_f_f32m4(scale, __riscv_vsetvlmax_e32m4());
+    if (scale_data.w > 1)
+    {
+        _scale0 = __riscv_vle32_v_f32m4(scale_data, __riscv_vsetvlmax_e32m4());
+    }
+    vfloat32m8_t _scale = __riscv_vcreate_v_f32m4_f32m8(_scale0, _scale0);
+
+    int i = 0;
+    for (; i + 1 < elemcount; i += 2)
+    {
+        vfloat16m1_t _v0 = __riscv_vle16_v_f16m1(ptr0, vlm1);
+        vfloat16m1_t _v1 = __riscv_vle16_v_f16m1(ptr1, vlm1);
+        vfloat16m1_t _v2 = __riscv_vle16_v_f16m1(ptr0 + vlm1, vlm1);
+        vfloat16m1_t _v3 = __riscv_vle16_v_f16m1(ptr1 + vlm1, vlm1);
+        vfloat16m4_t _v4 = __riscv_vcreate_v_f16m1_f16m4(_v0, _v1, _v2, _v3);
+        vfloat32m8_t _v = __riscv_vfwcvt_f_f_v_f32m8(_v4, vlm4);
+        _v = __riscv_vfmul_vv_f32m8(_v, _scale, vlm4);
+        __riscv_vse8_v_i8m2(s8ptr, float2int8(_v, vlm4), vlm4);
+
+        ptr0 += vlm1 * 2;
+        ptr1 += vlm1 * 2;
+        s8ptr += vlm4;
+    }
+
+    for (; i < elemcount; i++)
+    {
+        vfloat16m1_t _v0 = __riscv_vle16_v_f16m1(ptr0, vlm1);
+        vfloat16m1_t _v1 = __riscv_vle16_v_f16m1(ptr1, vlm1);
+        vfloat32m4_t _v = __riscv_vfwcvt_f_f_v_f32m4(__riscv_vcreate_v_f16m1_f16m2(_v0, _v1), vlm2);
+        _v = __riscv_vfmul_vv_f32m4(_v, _scale0, vlm2);
+        __riscv_vse8_v_i8m1(s8ptr, float2int8(_v, vlm2), vlm2);
+
+        ptr0 += vlm1;
+        ptr1 += vlm1;
+        s8ptr += vlm2;
+    }
+}
+
+static void quantize_packnto1_fp16s(const __fp16* ptr, signed char* s8ptr, const Mat& scale_data, int elemcount, int stride)
+{
+    const size_t vlm4 = __riscv_vsetvlmax_e16m4();
+    const size_t vlm1 = __riscv_vsetvlmax_e16m1();
+
+    float scale = scale_data[0];
+    vfloat32m8_t _scale = __riscv_vfmv_v_f_f32m8(scale, __riscv_vsetvlmax_e32m8());
+    if (scale_data.w > 1)
+    {
+        vfloat32m1_t _s = __riscv_vle32_v_f32m1(scale_data, __riscv_vsetvlmax_e32m1());
+        _scale = __riscv_vcreate_v_f32m1_f32m8(_s, _s, _s, _s, _s, _s, _s, _s);
+    }
+
+    signed char tmp[vlm4];
+    int n = elemcount * vlm1;
+    while (n > 0)
+    {
+        size_t vl = __riscv_vsetvl_e16m4(n);
+        vfloat32m8_t v32 = __riscv_vfwcvt_f_f_v_f32m8(__riscv_vle16_v_f16m4(ptr, vl), vl);
+        v32 = __riscv_vfmul_vv_f32m8(v32, _scale, vl);
+        __riscv_vse8_v_i8m2(tmp, float2int8(v32, vl), vl);
+        for (size_t j = 0; j < (vl / vlm1); j++)
+        {
+            for (int i = 0; i < vlm1; i++)
+            {
+                s8ptr[i * stride] = tmp[j * vlm1 + i];
+            }
+            s8ptr++;
+        }
+
+        ptr += vl;
+        n -= vl;
+    }
+}
+#endif // __riscv_vector
+
+int Quantize_riscv::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const
+{
+    const int dims = bottom_blob.dims;
+    const int w = bottom_blob.w;
+    const int h = bottom_blob.h;
+    const int channels = bottom_blob.c;
+    const int elempack = bottom_blob.elempack;
+
+#if __riscv_vector
+    const int packn = csrr_vlenb() / 2;
+    const int pack2n = csrr_vlenb();
+#endif
+
+    if (dims == 1)
+    {
+        int out_elempack = 1;
+#if __riscv_vector
+        if (opt.use_packing_layout)
+        {
+            out_elempack = w * elempack % pack2n == 0 ? pack2n : 1;
+        }
+#endif
+        const int outw = w * elempack / out_elempack;
+        const size_t out_elemsize = out_elempack * 1u;
+
+        top_blob.create(outw, out_elemsize, out_elempack, opt.blob_allocator);
+        if (top_blob.empty())
+            return -100;
+
+        const int wp = std::max(1, w / opt.num_threads);
+        const int nn_w = (w + wp - 1) / wp;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int ii = 0; ii < nn_w; ii++)
+        {
+            const int i = ii * wp;
+
+            const __fp16* ptr = (const __fp16*)bottom_blob + i * elempack;
+            signed char* s8ptr = (signed char*)top_blob + i * elempack;
+            const int size = std::min(w - i, wp) * elempack;
+
+            quantize_fp16s(ptr, s8ptr, scale_data, size, 1);
+        }
+    }
+
+    if (dims == 2)
+    {
+        int out_elempack = 1;
+#if __riscv_vector
+        if (opt.use_packing_layout)
+        {
+            out_elempack = h * elempack % pack2n == 0 ? pack2n : 1;
+        }
+#endif
+        const int outh = h * elempack / out_elempack;
+        const size_t out_elemsize = out_elempack * 1u;
+
+        top_blob.create(w, outh, out_elemsize, out_elempack, opt.blob_allocator);
+        if (top_blob.empty())
+            return -100;
+
+#if __riscv_vector
+        if (elempack == packn && out_elempack == pack2n)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int i = 0; i < outh; i++)
+            {
+                const __fp16* ptr0 = bottom_blob.row<const __fp16>(i * 2);
+                const __fp16* ptr1 = bottom_blob.row<const __fp16>(i * 2 + 1);
+                signed char* s8ptr = top_blob.row<signed char>(i);
+
+                const Mat scale_data_i = scale_data_size > 1 ? scale_data.range(i * out_elempack, out_elempack) : scale_data;
+
+                quantize_packnto2n_fp16s(ptr0, ptr1, s8ptr, scale_data_i, w);
+            }
+        }
+        if (elempack == packn && out_elempack == 1)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int i = 0; i < h; i++)
+            {
+                const __fp16* ptr = bottom_blob.row<const __fp16>(i);
+                signed char* s8ptr = top_blob.row<signed char>(i * packn);
+
+                const Mat scale_data_i = scale_data_size > 1 ? scale_data.range(i * elempack, elempack) : scale_data;
+
+                quantize_packnto1_fp16s(ptr, s8ptr, scale_data_i, w, w);
+            }
+        }
+#endif
+        if (elempack == out_elempack)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int i = 0; i < h; i++)
+            {
+                const __fp16* ptr = bottom_blob.row<const __fp16>(i);
+                signed char* s8ptr = top_blob.row<signed char>(i);
+
+                const Mat scale_data_i = scale_data_size > 1 ? scale_data.range(i * elempack, elempack) : scale_data;
+
+                quantize_fp16s(ptr, s8ptr, scale_data_i, w, elempack);
+            }
+        }
+    }
+
+    if (dims == 3)
+    {
+        int out_elempack = 1;
+#if __riscv_vector
+        if (opt.use_packing_layout)
+        {
+            out_elempack = channels * elempack % pack2n == 0 ? pack2n : 1;
+        }
+#endif
+        const int outc = channels * elempack / out_elempack;
+        const size_t out_elemsize = out_elempack * 1u;
+
+        top_blob.create(w, h, outc, out_elemsize, out_elempack, opt.blob_allocator);
+        if (top_blob.empty())
+            return -100;
+#if __riscv_vector
+        if (elempack == packn && out_elempack == pack2n)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int q = 0; q < outc; q++)
+            {
+                const __fp16* ptr0 = bottom_blob.channel(q * 2);
+                const __fp16* ptr1 = bottom_blob.channel(q * 2 + 1);
+                signed char* s8ptr = top_blob.channel(q);
+
+                const Mat scale_data_q = scale_data_size > 1 ? scale_data.range(q * out_elempack, out_elempack) : scale_data;
+
+                quantize_packnto2n_fp16s(ptr0, ptr1, s8ptr, scale_data_q, w * h);
+            }
+        }
+        if (elempack == packn && out_elempack == 1)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int q = 0; q < channels; q++)
+            {
+                const __fp16* ptr = bottom_blob.channel(q);
+                signed char* s8ptr = top_blob.channel(q * packn);
+
+                const Mat scale_data_q = scale_data_size > 1 ? scale_data.range(q * elempack, elempack) : scale_data;
+
+                quantize_packnto1_fp16s(ptr, s8ptr, scale_data_q, w * h, top_blob.cstep);
+            }
+        }
+#endif
+        if (elempack == out_elempack)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int q = 0; q < channels; q++)
+            {
+                const __fp16* ptr = bottom_blob.channel(q);
+                signed char* s8ptr = top_blob.channel(q);
+
+                const Mat scale_data_q = scale_data_size > 1 ? scale_data.range(q * elempack, elempack) : scale_data;
+
+                quantize_fp16s(ptr, s8ptr, scale_data_q, w * h, elempack);
+            }
+        }
+    }
+
+    return 0;
+}
+
+static void quantize_fp16sa(const __fp16* ptr, signed char* s8ptr, const Mat& scale_data, int elemcount, int elempack)
+{
+    const int scale_data_size = scale_data.w;
+    const int size = elemcount * elempack;
+    __fp16 scale = (__fp16)scale_data[0];
+
+    int i = 0;
+#if __riscv_zvfh
+    const size_t vlm1 = __riscv_vsetvlmax_e16m1();
+    vfloat16m8_t _scale;
+    if (scale_data_size == 1)
+    {
+        _scale = __riscv_vfmv_v_f_f16m8(scale, __riscv_vsetvlmax_e16m8());
+    }
+    else if (elempack == vlm1)
+    {
+        vfloat32m1_t _s32 = __riscv_vle32_v_f32m1(scale_data, __riscv_vsetvlmax_e32m1());
+        vfloat16m1_t _s16 = __riscv_vfncvt_f_f_w_f16m1(__riscv_vcreate_v_f32m1_f32m2(_s32, _s32), vlm1);
+        _scale = __riscv_vcreate_v_f16m1_f16m8(_s16, _s16, _s16, _s16, _s16, _s16, _s16, _s16);
+    }
+
+    int n = size;
+    while (n > 0)
+    {
+        size_t vl = __riscv_vsetvl_e16m8(n);
+        vfloat16m8_t _v0 = __riscv_vle16_v_f16m8(ptr, vl);
+        _v0 = __riscv_vfmul_vv_f16m8(_v0, _scale, vl);
+        __riscv_vse8_v_i8m4(s8ptr, float2int8(_v0, vl), vl);
+
+        ptr += vl;
+        s8ptr += vl;
+        n -= vl;
+    }
+
+    i += (size - n);
+#endif // __riscv_zvfh
+    for (; i < size; i++)
+    {
+        __fp16 v = *ptr * scale;
+        *s8ptr = float2int8(v);
+        ptr++;
+        s8ptr++;
+    }
+}
+
+#if __riscv_zvfh
+static void quantize_packnto2n_fp16sa(const __fp16* ptr0, const __fp16* ptr1, signed char* s8ptr, const Mat& scale_data, int elemcount)
+{
+    const size_t vlm1 = __riscv_vsetvlmax_e16m1();
+    const size_t vlm2 = __riscv_vsetvlmax_e16m2();
+    const size_t vlm4 = __riscv_vsetvlmax_e16m4();
+    const size_t vlm8 = __riscv_vsetvlmax_e16m8();
+
+    __fp16 scale = (__fp16)scale_data[0];
+    vfloat16m2_t _scale0 = __riscv_vfmv_v_f_f16m2(scale, __riscv_vsetvlmax_e16m2());
+    if (scale_data.w > 1)
+    {
+        vfloat32m4_t _s32 = __riscv_vle32_v_f32m4(scale_data, __riscv_vsetvlmax_e32m4());
+        _scale0 = __riscv_vfncvt_f_f_w_f16m2(_s32, vlm2);
+    }
+    vfloat16m4_t _scale1 = __riscv_vcreate_v_f16m2_f16m4(_scale0, _scale0);
+    vfloat16m8_t _scale2 = __riscv_vcreate_v_f16m4_f16m8(_scale1, _scale1);
+
+    int i = 0;
+    for (; i + 3 < elemcount; i += 4)
+    {
+        vfloat16m1_t _v0 = __riscv_vle16_v_f16m1(ptr0, vlm1);
+        vfloat16m1_t _v1 = __riscv_vle16_v_f16m1(ptr1, vlm1);
+        vfloat16m1_t _v2 = __riscv_vle16_v_f16m1(ptr0 + vlm1, vlm1);
+        vfloat16m1_t _v3 = __riscv_vle16_v_f16m1(ptr1 + vlm1, vlm1);
+        vfloat16m1_t _v4 = __riscv_vle16_v_f16m1(ptr0 + vlm1 * 2, vlm1);
+        vfloat16m1_t _v5 = __riscv_vle16_v_f16m1(ptr1 + vlm1 * 2, vlm1);
+        vfloat16m1_t _v6 = __riscv_vle16_v_f16m1(ptr0 + vlm1 * 3, vlm1);
+        vfloat16m1_t _v7 = __riscv_vle16_v_f16m1(ptr1 + vlm1 * 3, vlm1);
+        vfloat16m8_t _v = __riscv_vcreate_v_f16m1_f16m8(_v0, _v1, _v2, _v3, _v4, _v5, _v6, _v7);
+        _v = __riscv_vfmul_vv_f16m8(_v, _scale2, vlm8);
+        __riscv_vse8_v_i8m4(s8ptr, float2int8(_v, vlm8), vlm8);
+
+        ptr0 += vlm1 * 4;
+        ptr1 += vlm1 * 4;
+        s8ptr += vlm8;
+    }
+
+    for (; i + 1 < elemcount; i += 2)
+    {
+        vfloat16m1_t _v0 = __riscv_vle16_v_f16m1(ptr0, vlm1);
+        vfloat16m1_t _v1 = __riscv_vle16_v_f16m1(ptr1, vlm1);
+        vfloat16m1_t _v2 = __riscv_vle16_v_f16m1(ptr0 + vlm1, vlm1);
+        vfloat16m1_t _v3 = __riscv_vle16_v_f16m1(ptr1 + vlm1, vlm1);
+        vfloat16m4_t _v = __riscv_vcreate_v_f16m1_f16m4(_v0, _v1, _v2, _v3);
+        _v = __riscv_vfmul_vv_f16m4(_v, _scale1, vlm4);
+        __riscv_vse8_v_i8m2(s8ptr, float2int8(_v, vlm4), vlm4);
+
+        ptr0 += vlm1 * 2;
+        ptr1 += vlm1 * 2;
+        s8ptr += vlm4;
+    }
+
+    for (; i < elemcount; i++)
+    {
+        vfloat16m1_t _v0 = __riscv_vle16_v_f16m1(ptr0, vlm1);
+        vfloat16m1_t _v1 = __riscv_vle16_v_f16m1(ptr1, vlm1);
+        vfloat16m2_t _v = __riscv_vcreate_v_f16m1_f16m2(_v0, _v1);
+        _v = __riscv_vfmul_vv_f16m2(_v, _scale0, vlm2);
+        __riscv_vse8_v_i8m1(s8ptr, float2int8(_v, vlm2), vlm2);
+
+        ptr0 += vlm1;
+        ptr1 += vlm1;
+        s8ptr += vlm2;
+    }
+}
+
+static void quantize_packnto1_fp16sa(const __fp16* ptr, signed char* s8ptr, const Mat& scale_data, int elemcount, int stride)
+{
+    const size_t vlm4 = __riscv_vsetvlmax_e16m4();
+    const size_t vlm1 = __riscv_vsetvlmax_e16m1();
+
+    __fp16 scale = (__fp16)scale_data[0];
+    vfloat16m8_t _scale = __riscv_vfmv_v_f_f16m8(scale, __riscv_vsetvlmax_e16m8());
+    if (scale_data.w > 1)
+    {
+        vfloat32m1_t _s32 = __riscv_vle32_v_f32m1(scale_data, __riscv_vsetvlmax_e32m1());
+        vfloat16m1_t _s16 = __riscv_vfncvt_f_f_w_f16m1(__riscv_vcreate_v_f32m1_f32m2(_s32, _s32), vlm1);
+        _scale = __riscv_vcreate_v_f16m1_f16m8(_s16, _s16, _s16, _s16, _s16, _s16, _s16, _s16);
+    }
+
+    signed char tmp[vlm4];
+    int n = elemcount * vlm1;
+    while (n > 0)
+    {
+        size_t vl = __riscv_vsetvl_e16m8(n);
+        vfloat16m8_t v = __riscv_vle16_v_f16m8(ptr, vl);
+        v = __riscv_vfmul_vv_f16m8(v, _scale, vl);
+        __riscv_vse8_v_i8m4(tmp, float2int8(v, vl), vl);
+        for (size_t j = 0; j < (vl / vlm1); j++)
+        {
+            for (int i = 0; i < vlm1; i++)
+            {
+                s8ptr[i * stride] = tmp[j * vlm1 + i];
+            }
+            s8ptr++;
+        }
+
+        ptr += vl;
+        n -= vl;
+    }
+}
+#endif // __riscv_zvfh
+
+int Quantize_riscv::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const
+{
+    const int dims = bottom_blob.dims;
+    const int w = bottom_blob.w;
+    const int h = bottom_blob.h;
+    const int channels = bottom_blob.c;
+    const int elempack = bottom_blob.elempack;
+
+#if __riscv_zvfh
+    const int packn = csrr_vlenb() / 2;
+    const int pack2n = csrr_vlenb();
+#endif
+
+    if (dims == 1)
+    {
+        int out_elempack = 1;
+#if __riscv_zvfh
+        if (opt.use_packing_layout)
+        {
+            out_elempack = w * elempack % pack2n == 0 ? pack2n : 1;
+        }
+#endif
+        const int outw = w * elempack / out_elempack;
+        const size_t out_elemsize = out_elempack * 1u;
+
+        top_blob.create(outw, out_elemsize, out_elempack, opt.blob_allocator);
+        if (top_blob.empty())
+            return -100;
+
+        const int wp = std::max(1, w / opt.num_threads);
+        const int nn_w = (w + wp - 1) / wp;
+
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int ii = 0; ii < nn_w; ii++)
+        {
+            const int i = ii * wp;
+
+            const __fp16* ptr = (const __fp16*)bottom_blob + i * elempack;
+            signed char* s8ptr = (signed char*)top_blob + i * elempack;
+            const int size = std::min(w - i, wp) * elempack;
+
+            quantize_fp16sa(ptr, s8ptr, scale_data, size, 1);
+        }
+    }
+
+    if (dims == 2)
+    {
+        int out_elempack = 1;
+#if __riscv_zvfh
+        if (opt.use_packing_layout)
+        {
+            out_elempack = h * elempack % pack2n == 0 ? pack2n : 1;
+        }
+#endif
+        const int outh = h * elempack / out_elempack;
+        const size_t out_elemsize = out_elempack * 1u;
+
+        top_blob.create(w, outh, out_elemsize, out_elempack, opt.blob_allocator);
+        if (top_blob.empty())
+            return -100;
+#if __riscv_zvfh
+        if (elempack == packn && out_elempack == pack2n)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int i = 0; i < outh; i++)
+            {
+                const __fp16* ptr0 = bottom_blob.row<const __fp16>(i * 2);
+                const __fp16* ptr1 = bottom_blob.row<const __fp16>(i * 2 + 1);
+                signed char* s8ptr = top_blob.row<signed char>(i);
+
+                const Mat scale_data_i = scale_data_size > 1 ? scale_data.range(i * out_elempack, out_elempack) : scale_data;
+
+                quantize_packnto2n_fp16sa(ptr0, ptr1, s8ptr, scale_data_i, w);
+            }
+        }
+
+        if (elempack == packn && out_elempack == 1)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int i = 0; i < h; i++)
+            {
+                const __fp16* ptr = bottom_blob.row<const __fp16>(i);
+                signed char* s8ptr = top_blob.row<signed char>(i * packn);
+
+                const Mat scale_data_i = scale_data_size > 1 ? scale_data.range(i * elempack, elempack) : scale_data;
+
+                quantize_packnto1_fp16sa(ptr, s8ptr, scale_data_i, w, w);
+            }
+        }
+#endif
+        if (elempack == out_elempack)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int i = 0; i < h; i++)
+            {
+                const __fp16* ptr = bottom_blob.row<const __fp16>(i);
+                signed char* s8ptr = top_blob.row<signed char>(i);
+
+                const Mat scale_data_i = scale_data_size > 1 ? scale_data.range(i * elempack, elempack) : scale_data;
+
+                quantize_fp16sa(ptr, s8ptr, scale_data_i, w, elempack);
+            }
+        }
+    }
+
+    if (dims == 3)
+    {
+        int out_elempack = 1;
+#if __riscv_zvfh
+        if (opt.use_packing_layout)
+        {
+            out_elempack = channels * elempack % pack2n == 0 ? pack2n : 1;
+        }
+#endif
+        const int outc = channels * elempack / out_elempack;
+        const size_t out_elemsize = out_elempack * 1u;
+
+        top_blob.create(w, h, outc, out_elemsize, out_elempack, opt.blob_allocator);
+        if (top_blob.empty())
+            return -100;
+
+#if __riscv_zvfh
+        if (elempack == packn && out_elempack == pack2n)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int q = 0; q < outc; q++)
+            {
+                const __fp16* ptr0 = bottom_blob.channel(q * 2);
+                const __fp16* ptr1 = bottom_blob.channel(q * 2 + 1);
+                signed char* s8ptr = top_blob.channel(q);
+
+                const Mat scale_data_q = scale_data_size > 1 ? scale_data.range(q * out_elempack, out_elempack) : scale_data;
+
+                quantize_packnto2n_fp16sa(ptr0, ptr1, s8ptr, scale_data_q, w * h);
+            }
+        }
+
+        if (elempack == packn && out_elempack == 1)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int q = 0; q < channels; q++)
+            {
+                const __fp16* ptr = bottom_blob.channel(q);
+                signed char* s8ptr = top_blob.channel(q * packn);
+
+                const Mat scale_data_q = scale_data_size > 1 ? scale_data.range(q * elempack, elempack) : scale_data;
+
+                quantize_packnto1_fp16sa(ptr, s8ptr, scale_data_q, w * h, top_blob.cstep);
+            }
+        }
+#endif
+        if (elempack == out_elempack)
+        {
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int q = 0; q < channels; q++)
+            {
+                const __fp16* ptr = bottom_blob.channel(q);
+                signed char* s8ptr = top_blob.channel(q);
+
+                const Mat scale_data_q = scale_data_size > 1 ? scale_data.range(q * elempack, elempack) : scale_data;
+
+                quantize_fp16sa(ptr, s8ptr, scale_data_q, w * h, elempack);
+            }
+        }
+    }
+
+    return 0;
+}
+#endif // NCNN_ZFH
+} // namespace ncnn

--- a/src/layer/riscv/quantize_riscv_zfh.cpp
+++ b/src/layer/riscv/quantize_riscv_zfh.cpp
@@ -19,7 +19,6 @@ static void quantize_fp16s(const __fp16* ptr, signed char* s8ptr, const Mat& sca
     const int size = elemcount * elempack;
     float scale = scale_data[0];
 
-    int i = 0;
 #if __riscv_vector
     int n = size;
     while (n > 0)
@@ -33,16 +32,15 @@ static void quantize_fp16s(const __fp16* ptr, signed char* s8ptr, const Mat& sca
         s8ptr += vl;
         n -= vl;
     }
-
-    i += (size - n);
-#endif
-    for (; i < size; i++)
+#else  // __riscv_zvfh
+    for (int i = 0; i < size; i++)
     {
         float v = (float)(*ptr) * scale;
         *s8ptr = float2int8(v);
         ptr++;
         s8ptr++;
     }
+#endif // __riscv_zvfh
 }
 
 #if __riscv_vector
@@ -300,7 +298,6 @@ static void quantize_fp16sa(const __fp16* ptr, signed char* s8ptr, const Mat& sc
     const int size = elemcount * elempack;
     __fp16 scale = (__fp16)scale_data[0];
 
-    int i = 0;
 #if __riscv_zvfh
     int n = size;
     while (n > 0)
@@ -314,16 +311,15 @@ static void quantize_fp16sa(const __fp16* ptr, signed char* s8ptr, const Mat& sc
         s8ptr += vl;
         n -= vl;
     }
-
-    i += (size - n);
-#endif // __riscv_zvfh
-    for (; i < size; i++)
+#else  // __riscv_zvfh
+    for (int i = 0; i < size; i++)
     {
         __fp16 v = *ptr * scale;
         *s8ptr = float2int8(v);
         ptr++;
         s8ptr++;
     }
+#endif // __riscv_zvfh
 }
 
 #if __riscv_zvfh

--- a/src/layer/riscv/quantize_riscv_zfh.cpp
+++ b/src/layer/riscv/quantize_riscv_zfh.cpp
@@ -149,7 +149,7 @@ int Quantize_riscv::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const O
 
 #if __riscv_vector
     const int packn = csrr_vlenb() / 2;
-    const int pack2n = csrr_vlenb();
+    const int packn_s8 = csrr_vlenb();
 #endif
 
     if (dims == 1)
@@ -158,7 +158,7 @@ int Quantize_riscv::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const O
 #if __riscv_vector
         if (opt.use_packing_layout)
         {
-            out_elempack = w * elempack % pack2n == 0 ? pack2n : 1;
+            out_elempack = w * elempack % packn_s8 == 0 ? packn_s8 : 1;
         }
 #endif
         const int outw = w * elempack / out_elempack;
@@ -190,7 +190,7 @@ int Quantize_riscv::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const O
 #if __riscv_vector
         if (opt.use_packing_layout)
         {
-            out_elempack = h * elempack % pack2n == 0 ? pack2n : 1;
+            out_elempack = h * elempack % packn_s8 == 0 ? packn_s8 : 1;
         }
 #endif
         const int outh = h * elempack / out_elempack;
@@ -201,7 +201,7 @@ int Quantize_riscv::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const O
             return -100;
 
 #if __riscv_vector
-        if (elempack == packn && out_elempack == pack2n)
+        if (elempack == packn && out_elempack == packn_s8)
         {
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int i = 0; i < outh; i++)
@@ -250,7 +250,7 @@ int Quantize_riscv::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const O
 #if __riscv_vector
         if (opt.use_packing_layout)
         {
-            out_elempack = channels * elempack % pack2n == 0 ? pack2n : 1;
+            out_elempack = channels * elempack % packn_s8 == 0 ? packn_s8 : 1;
         }
 #endif
         const int outc = channels * elempack / out_elempack;
@@ -260,7 +260,7 @@ int Quantize_riscv::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const O
         if (top_blob.empty())
             return -100;
 #if __riscv_vector
-        if (elempack == packn && out_elempack == pack2n)
+        if (elempack == packn && out_elempack == packn_s8)
         {
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < outc; q++)
@@ -465,7 +465,7 @@ int Quantize_riscv::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const 
 
 #if __riscv_zvfh
     const int packn = csrr_vlenb() / 2;
-    const int pack2n = csrr_vlenb();
+    const int packn_s8 = csrr_vlenb();
 #endif
 
     if (dims == 1)
@@ -474,7 +474,7 @@ int Quantize_riscv::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const 
 #if __riscv_zvfh
         if (opt.use_packing_layout)
         {
-            out_elempack = w * elempack % pack2n == 0 ? pack2n : 1;
+            out_elempack = w * elempack % packn_s8 == 0 ? packn_s8 : 1;
         }
 #endif
         const int outw = w * elempack / out_elempack;
@@ -506,7 +506,7 @@ int Quantize_riscv::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const 
 #if __riscv_zvfh
         if (opt.use_packing_layout)
         {
-            out_elempack = h * elempack % pack2n == 0 ? pack2n : 1;
+            out_elempack = h * elempack % packn_s8 == 0 ? packn_s8 : 1;
         }
 #endif
         const int outh = h * elempack / out_elempack;
@@ -516,7 +516,7 @@ int Quantize_riscv::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const 
         if (top_blob.empty())
             return -100;
 #if __riscv_zvfh
-        if (elempack == packn && out_elempack == pack2n)
+        if (elempack == packn && out_elempack == packn_s8)
         {
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int i = 0; i < outh; i++)
@@ -566,7 +566,7 @@ int Quantize_riscv::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const 
 #if __riscv_zvfh
         if (opt.use_packing_layout)
         {
-            out_elempack = channels * elempack % pack2n == 0 ? pack2n : 1;
+            out_elempack = channels * elempack % packn_s8 == 0 ? packn_s8 : 1;
         }
 #endif
         const int outc = channels * elempack / out_elempack;
@@ -577,7 +577,7 @@ int Quantize_riscv::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const 
             return -100;
 
 #if __riscv_zvfh
-        if (elempack == packn && out_elempack == pack2n)
+        if (elempack == packn && out_elempack == packn_s8)
         {
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < outc; q++)

--- a/src/layer/riscv/quantize_riscv_zfh.cpp
+++ b/src/layer/riscv/quantize_riscv_zfh.cpp
@@ -217,7 +217,7 @@ int Quantize_riscv::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const O
             }
         }
 #endif
-        if (elempack == out_elempack)
+        if (elempack == 1 && out_elempack == 1)
         {
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int i = 0; i < h; i++)
@@ -276,7 +276,7 @@ int Quantize_riscv::forward_fp16s(const Mat& bottom_blob, Mat& top_blob, const O
             }
         }
 #endif
-        if (elempack == out_elempack)
+        if (elempack == 1 && out_elempack == 1)
         {
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -520,7 +520,7 @@ int Quantize_riscv::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const 
             }
         }
 #endif
-        if (elempack == out_elempack)
+        if (elempack == 1 && out_elempack == 1)
         {
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int i = 0; i < h; i++)
@@ -581,7 +581,7 @@ int Quantize_riscv::forward_fp16sa(const Mat& bottom_blob, Mat& top_blob, const 
             }
         }
 #endif
-        if (elempack == out_elempack)
+        if (elempack == 1 && out_elempack == 1)
         {
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)

--- a/src/layer/riscv/quantize_riscv_zfh.cpp
+++ b/src/layer/riscv/quantize_riscv_zfh.cpp
@@ -420,7 +420,7 @@ static void quantize_packnto2n_fp16sa(const __fp16* ptr0, const __fp16* ptr1, si
 
 static void quantize_packnto1_fp16sa(const __fp16* ptr, signed char* s8ptr, const Mat& scale_data, int elemcount, int stride)
 {
-    const size_t vlm4 = __riscv_vsetvlmax_e16m4();
+    const size_t vlm8 = __riscv_vsetvlmax_e16m8();
     const size_t vlm1 = __riscv_vsetvlmax_e16m1();
 
     __fp16 scale = (__fp16)scale_data[0];
@@ -432,7 +432,7 @@ static void quantize_packnto1_fp16sa(const __fp16* ptr, signed char* s8ptr, cons
         _scale = __riscv_vcreate_v_f16m1_f16m8(_s16, _s16, _s16, _s16, _s16, _s16, _s16, _s16);
     }
 
-    signed char tmp[vlm4];
+    signed char tmp[vlm8];
     int n = elemcount * vlm1;
     while (n > 0)
     {

--- a/src/layer/riscv/quantize_riscv_zfh.cpp
+++ b/src/layer/riscv/quantize_riscv_zfh.cpp
@@ -21,24 +21,12 @@ static void quantize_fp16s(const __fp16* ptr, signed char* s8ptr, const Mat& sca
 
     int i = 0;
 #if __riscv_vector
-    const size_t vlm1 = __riscv_vsetvlmax_e32m1();
-    vfloat32m8_t _scale;
-    if (scale_data_size == 1)
-    {
-        _scale = __riscv_vfmv_v_f_f32m8(scale, __riscv_vsetvlmax_e32m8());
-    }
-    else if (elempack == vlm1)
-    {
-        vfloat32m1_t _s = __riscv_vle32_v_f32m1(scale_data, vlm1);
-        _scale = __riscv_vcreate_v_f32m1_f32m8(_s, _s, _s, _s, _s, _s, _s, _s);
-    }
-
     int n = size;
     while (n > 0)
     {
         size_t vl = __riscv_vsetvl_e16m4(n);
         vfloat32m8_t _v0 = __riscv_vfwcvt_f_f_v_f32m8(__riscv_vle16_v_f16m4(ptr, vl), vl);
-        _v0 = __riscv_vfmul_vv_f32m8(_v0, _scale, vl);
+        _v0 = __riscv_vfmul_vf_f32m8(_v0, scale, vl);
         __riscv_vse8_v_i8m2(s8ptr, float2int8(_v0, vl), vl);
 
         ptr += vl;
@@ -314,25 +302,12 @@ static void quantize_fp16sa(const __fp16* ptr, signed char* s8ptr, const Mat& sc
 
     int i = 0;
 #if __riscv_zvfh
-    const size_t vlm1 = __riscv_vsetvlmax_e16m1();
-    vfloat16m8_t _scale;
-    if (scale_data_size == 1)
-    {
-        _scale = __riscv_vfmv_v_f_f16m8(scale, __riscv_vsetvlmax_e16m8());
-    }
-    else if (elempack == vlm1)
-    {
-        vfloat32m1_t _s32 = __riscv_vle32_v_f32m1(scale_data, __riscv_vsetvlmax_e32m1());
-        vfloat16m1_t _s16 = __riscv_vfncvt_f_f_w_f16m1(__riscv_vcreate_v_f32m1_f32m2(_s32, _s32), vlm1);
-        _scale = __riscv_vcreate_v_f16m1_f16m8(_s16, _s16, _s16, _s16, _s16, _s16, _s16, _s16);
-    }
-
     int n = size;
     while (n > 0)
     {
         size_t vl = __riscv_vsetvl_e16m8(n);
         vfloat16m8_t _v0 = __riscv_vle16_v_f16m8(ptr, vl);
-        _v0 = __riscv_vfmul_vv_f16m8(_v0, _scale, vl);
+        _v0 = __riscv_vfmul_vf_f16m8(_v0, scale, vl);
         __riscv_vse8_v_i8m4(s8ptr, float2int8(_v0, vl), vl);
 
         ptr += vl;

--- a/src/layer/riscv/riscv_usability.h
+++ b/src/layer/riscv/riscv_usability.h
@@ -8,7 +8,58 @@
 #include <riscv_vector.h>
 #endif // __riscv_vector
 
+static inline signed char float2int8(float v)
+{
+    int int32 = (int)roundf(v);
+    if (int32 > 127) return 127;
+    if (int32 < -127) return -127;
+    return (signed char)int32;
+}
+
 #if __riscv_vector
+static inline vint8m2_t float2int8(vfloat32m8_t v, size_t vl)
+{
+    vint32m8_t v32 = __riscv_vfcvt_x_f_v_i32m8_rm(v, __RISCV_FRM_RMM, vl);
+    v32 = __riscv_vmax_vx_i32m8(v32, -127, vl);
+    v32 = __riscv_vmin_vx_i32m8(v32, 127, vl);
+    vint16m4_t v16 = __riscv_vnclip_wx_i16m4(v32, 0, __RISCV_VXRM_RNU, vl);
+    return __riscv_vnclip_wx_i8m2(v16, 0, __RISCV_VXRM_RNU, vl);
+}
+
+static inline vint8m1_t float2int8(vfloat32m4_t v, size_t vl)
+{
+    vint32m4_t v32 = __riscv_vfcvt_x_f_v_i32m4_rm(v, __RISCV_FRM_RMM, vl);
+    v32 = __riscv_vmax_vx_i32m4(v32, -127, vl);
+    v32 = __riscv_vmin_vx_i32m4(v32, 127, vl);
+    vint16m2_t v16 = __riscv_vnclip_wx_i16m2(v32, 0, __RISCV_VXRM_RNU, vl);
+    return __riscv_vnclip_wx_i8m1(v16, 0, __RISCV_VXRM_RNU, vl);
+}
+
+#if __riscv_zvfh
+static inline vint8m4_t float2int8(vfloat16m8_t v, size_t vl)
+{
+    vint16m8_t v16 = __riscv_vfcvt_x_f_v_i16m8_rm(v, __RISCV_FRM_RMM, vl);
+    v16 = __riscv_vmax_vx_i16m8(v16, -127, vl);
+    v16 = __riscv_vmin_vx_i16m8(v16, 127, vl);
+    return __riscv_vnclip_wx_i8m4(v16, 0, __RISCV_VXRM_RNU, vl);
+}
+static inline vint8m2_t float2int8(vfloat16m4_t v, size_t vl)
+{
+    vint16m4_t v16 = __riscv_vfcvt_x_f_v_i16m4_rm(v, __RISCV_FRM_RMM, vl);
+    v16 = __riscv_vmax_vx_i16m4(v16, -127, vl);
+    v16 = __riscv_vmin_vx_i16m4(v16, 127, vl);
+    return __riscv_vnclip_wx_i8m2(v16, 0, __RISCV_VXRM_RNU, vl);
+}
+
+static inline vint8m1_t float2int8(vfloat16m2_t v, size_t vl)
+{
+    vint16m2_t v16 = __riscv_vfcvt_x_f_v_i16m2_rm(v, __RISCV_FRM_RMM, vl);
+    v16 = __riscv_vmax_vx_i16m2(v16, -127, vl);
+    v16 = __riscv_vmin_vx_i16m2(v16, 127, vl);
+    return __riscv_vnclip_wx_i8m1(v16, 0, __RISCV_VXRM_RNU, vl);
+}
+#endif // __riscv_zvfh
+
 static inline int csrr_vl()
 {
     int a = 0;

--- a/tests/test_quantize.cpp
+++ b/tests/test_quantize.cpp
@@ -42,7 +42,11 @@ static int test_quantize_0()
            || test_quantize(RandomMat(7, 9, 12), 100.f, 100.f)
            || test_quantize(RandomMat(7, 9, 12), 120.f, 140.f)
            || test_quantize(RandomMat(3, 5, 13), 100.f, 100.f)
-           || test_quantize(RandomMat(3, 5, 13), 120.f, 140.f);
+           || test_quantize(RandomMat(3, 5, 13), 120.f, 140.f)
+           || test_quantize(RandomMat(3, 3, 256), 100.f, 100.f)
+           || test_quantize(RandomMat(3, 3, 256), 120.f, 140.f)
+           || test_quantize(RandomMat(3, 3, 255), 100.f, 100.f)
+           || test_quantize(RandomMat(3, 3, 255), 120.f, 140.f);
 }
 
 static int test_quantize_1()
@@ -53,7 +57,11 @@ static int test_quantize_1()
            || test_quantize(RandomMat(17, 12), 100.f, 100.f)
            || test_quantize(RandomMat(17, 12), 120.f, 140.f)
            || test_quantize(RandomMat(19, 15), 100.f, 100.f)
-           || test_quantize(RandomMat(19, 15), 120.f, 140.f);
+           || test_quantize(RandomMat(19, 15), 120.f, 140.f)
+           || test_quantize(RandomMat(15, 256), 100.f, 100.f)
+           || test_quantize(RandomMat(15, 256), 120.f, 140.f)
+           || test_quantize(RandomMat(15, 255), 100.f, 100.f)
+           || test_quantize(RandomMat(15, 255), 120.f, 140.f);
 }
 
 static int test_quantize_2()
@@ -64,7 +72,11 @@ static int test_quantize_2()
            || test_quantize(RandomMat(124), 100.f, 100.f)
            || test_quantize(RandomMat(124), 120.f, 140.f)
            || test_quantize(RandomMat(127), 100.f, 100.f)
-           || test_quantize(RandomMat(127), 120.f, 140.f);
+           || test_quantize(RandomMat(127), 120.f, 140.f)
+           || test_quantize(RandomMat(256), 100.f, 100.f)
+           || test_quantize(RandomMat(256), 120.f, 140.f)
+           || test_quantize(RandomMat(255), 100.f, 100.f)
+           || test_quantize(RandomMat(255), 120.f, 140.f);
 }
 
 int main()


### PR DESCRIPTION
I was looking into how to make int8 optimization happen on RV, then realize we need packed & fp16s/a quantization, so here we go, Quantize layer for RVV1.0!

WIP as I'm not sure we're all happy with the current approach. I'm also not sure if it could works alongside with THead Vector. 

- [x] Packed int8 quantize
- [x] Packed fp16s/a int8 quantize
- [x] More unit test to cover longer VLEN
