### PR TITLE
fix fuse_padding_convolution asymmetric padding params being skipped

### DIFF
--- a/tools/pnnx/src/pass_ncnn/fuse_padding_convolution.cpp
+++ b/tools/pnnx/src/pass_ncnn/fuse_padding_convolution.cpp
@@ -115,14 +115,10 @@ pnnx.Output             output      1 0 out
         const int new_conv_pad_right = conv_pad_right + pad_right;
         const int new_conv_pad_bottom = conv_pad_bottom + pad_bottom;
 
-        if (new_conv_pad_left != conv_pad_left)
-            op->params["4"] = new_conv_pad_left;
-        if (new_conv_pad_top != new_conv_pad_left)
-            op->params["14"] = new_conv_pad_top;
-        if (new_conv_pad_right != new_conv_pad_left)
-            op->params["15"] = new_conv_pad_right;
-        if (new_conv_pad_bottom != new_conv_pad_top)
-            op->params["16"] = new_conv_pad_bottom;
+        op->params["4"] = new_conv_pad_left;
+        op->params["14"] = new_conv_pad_top;
+        op->params["15"] = new_conv_pad_right;
+        op->params["16"] = new_conv_pad_bottom;
 
         float padding_value = captured_params.find("op_0.5") != captured_params.end() ? captured_params.at("op_0.5").f : 0.f;
         if (padding_value != 0.f)

--- a/tools/pnnx/src/pass_ncnn/fuse_padding_convolutiondepthwise.cpp
+++ b/tools/pnnx/src/pass_ncnn/fuse_padding_convolutiondepthwise.cpp
@@ -115,14 +115,10 @@ pnnx.Output             output      1 0 out
         const int new_conv_pad_right = conv_pad_right + pad_right;
         const int new_conv_pad_bottom = conv_pad_bottom + pad_bottom;
 
-        if (new_conv_pad_left != conv_pad_left)
-            op->params["4"] = new_conv_pad_left;
-        if (new_conv_pad_top != new_conv_pad_left)
-            op->params["14"] = new_conv_pad_top;
-        if (new_conv_pad_right != new_conv_pad_left)
-            op->params["15"] = new_conv_pad_right;
-        if (new_conv_pad_bottom != new_conv_pad_top)
-            op->params["16"] = new_conv_pad_bottom;
+        op->params["4"] = new_conv_pad_left;
+        op->params["14"] = new_conv_pad_top;
+        op->params["15"] = new_conv_pad_right;
+        op->params["16"] = new_conv_pad_bottom;
 
         float padding_value = captured_params.find("op_0.5") != captured_params.end() ? captured_params.at("op_0.5").f : 0.f;
         if (padding_value != 0.f)


### PR DESCRIPTION
```
class PadConvModel(nn.Module):
    def __init__(self):
        super().__init__()
        self.conv = nn.Conv2d(
            in_channels=3, out_channels=4,
            kernel_size=5, stride=2, padding=0, bias=True,
        )

    def forward(self, x):
        # asymmetric padding: left=1, right=2, top=1, bottom=2
        x = F.pad(x, pad=(1, 2, 1, 2), mode='constant', value=0)
        x = self.conv(x)
        x = F.relu(x)
        return x
```

#### Before:
<img width="2009" height="893" alt="Clipboard_Screenshot_1775714112" src="https://github.com/user-attachments/assets/5810030f-6091-40c1-b144-beff2231457f" />

#### After:
<img width="1964" height="881" alt="Clipboard_Screenshot_1775714095" src="https://github.com/user-attachments/assets/4a0d8a89-4a67-4a0d-8943-427691a98acc" />


#### Info:
When F.pad(pad=(1,2,1,2)) (left=1, right=2, top=1, bottom=2) is fused into a Convolution layer, pad_top (param 14) can be incorrectly set to 0.

Root cause: the write() function first copies all original Convolution params (including 14=0 from padding=0), then conditionally writes the new fused padding values. The condition new_conv_pad_top != new_conv_pad_left skips writing param 14 when they are equal (e.g. both are 1), leaving the stale 14=0 from the copy.                                                                                                                     
