### PR TITLE
Optimize x86 BF16 GEMM micro kernels: replace vpalignr with vpshufd and add instruction scheduling

### DIFF
--- a/src/layer/x86/convolution_im2col_gemm_bf16s.h
+++ b/src/layer/x86/convolution_im2col_gemm_bf16s.h
@@ -528,11 +528,11 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
                 __m256i _pBB = _mm256_loadu_si256((const __m256i*)pB);
                 __m512i _pB0 = combine8x2_epi32(_pBB, _pBB);
 
-                __m512i _pA1 = _mm512_alignr_epi8(_pA0, _pA0, 8);
+                __m512i _pA1 = _mm512_shuffle_epi32(_pA0, _MM_PERM_BADC);
 
-                __m512i _pB1 = _mm512_alignr_epi8(_pB0, _pB0, 4);
+                __m512i _pB1 = _mm512_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 __m512i _pB2 = _mm512_permutex_epi64(_pB0, _MM_SHUFFLE(1, 0, 3, 2));
-                __m512i _pB3 = _mm512_alignr_epi8(_pB2, _pB2, 4);
+                __m512i _pB3 = _mm512_shuffle_epi32(_pB2, _MM_PERM_ADCB);
 
                 _sum0 = _mm512_dpbf16_ps(_sum0, (__m512bh)_pA0, (__m512bh)_pB0);
                 _sum1 = _mm512_dpbf16_ps(_sum1, (__m512bh)_pA0, (__m512bh)_pB1);
@@ -818,8 +818,8 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
             {
                 __m512i _pA0 = _mm512_loadu_si512((const __m512i*)pA);
                 __m512i _pB0 = _mm512_broadcast_i32x4(_mm_loadu_si128((const __m128i*)pB));
-                __m512i _pA1 = _mm512_alignr_epi8(_pA0, _pA0, 8);
-                __m512i _pB1 = _mm512_alignr_epi8(_pB0, _pB0, 4);
+                __m512i _pA1 = _mm512_shuffle_epi32(_pA0, _MM_PERM_BADC);
+                __m512i _pB1 = _mm512_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm512_dpbf16_ps(_sum0, (__m512bh)_pA0, (__m512bh)_pB0);
                 _sum1 = _mm512_dpbf16_ps(_sum1, (__m512bh)_pA0, (__m512bh)_pB1);
                 _sum2 = _mm512_dpbf16_ps(_sum2, (__m512bh)_pA1, (__m512bh)_pB0);
@@ -1126,10 +1126,10 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
             {
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m256i _pB0 = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA1 = _mm256_alignr_epi8(_pA0, _pA0, 8);
-                __m256i _pB1 = _mm256_alignr_epi8(_pB0, _pB0, 4);
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_PERM_BADC);
+                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 __m256i _pB2 = _mm256_permute4x64_epi64(_pB0, _MM_SHUFFLE(1, 0, 3, 2));
-                __m256i _pB3 = _mm256_alignr_epi8(_pB2, _pB2, 4);
+                __m256i _pB3 = _mm256_shuffle_epi32(_pB2, _MM_PERM_ADCB);
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB0);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA0, (__m256bh)_pB1);
                 _sum2 = _mm256_dpbf16_ps(_sum2, (__m256bh)_pA1, (__m256bh)_pB0);
@@ -1349,8 +1349,8 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m128i _pB = _mm_loadu_si128((const __m128i*)pB);
                 __m256i _pB0 = combine4x2_epi32(_pB, _pB);
-                __m256i _pA1 = _mm256_alignr_epi8(_pA0, _pA0, 8);
-                __m256i _pB1 = _mm256_alignr_epi8(_pB0, _pB0, 4);
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_PERM_BADC);
+                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB0);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA0, (__m256bh)_pB1);
                 _sum2 = _mm256_dpbf16_ps(_sum2, (__m256bh)_pA1, (__m256bh)_pB0);
@@ -1593,8 +1593,8 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
                 __m128i _pA0 = _mm_loadu_si128((const __m128i*)pA);
                 __m256i _pA00 = combine4x2_epi32(_pA0, _pA0);
                 __m256i _pB01 = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA11 = _mm256_alignr_epi8(_pA00, _pA00, 8);
-                __m256i _pB23 = _mm256_alignr_epi8(_pB01, _pB01, 4);
+                __m256i _pA11 = _mm256_shuffle_epi32(_pA00, _MM_PERM_BADC);
+                __m256i _pB23 = _mm256_shuffle_epi32(_pB01, _MM_PERM_ADCB);
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA00, (__m256bh)_pB01);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA11, (__m256bh)_pB01);
                 _sum2 = _mm256_dpbf16_ps(_sum2, (__m256bh)_pA00, (__m256bh)_pB23);
@@ -1846,8 +1846,8 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
             {
                 __m128i _pA0 = _mm_loadu_si128((const __m128i*)pA);
                 __m128i _pB0 = _mm_loadu_si128((const __m128i*)pB);
-                __m128i _pA1 = _mm_alignr_epi8(_pA0, _pA0, 8);
-                __m128i _pB1 = _mm_alignr_epi8(_pB0, _pB0, 4);
+                __m128i _pA1 = _mm_shuffle_epi32(_pA0, _MM_PERM_BADC);
+                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm_dpbf16_ps(_sum0, (__m128bh)_pA0, (__m128bh)_pB0);
                 _sum1 = _mm_dpbf16_ps(_sum1, (__m128bh)_pA0, (__m128bh)_pB1);
                 _sum2 = _mm_dpbf16_ps(_sum2, (__m128bh)_pA1, (__m128bh)_pB0);
@@ -2041,7 +2041,7 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
             {
                 __m256i _pA0 = _mm256_castpd_si256(_mm256_broadcast_sd((const double*)pA));
                 __m256i _pB = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA1 = _mm256_alignr_epi8(_pA0, _pA0, 4);
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_PERM_ADCB);
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA1, (__m256bh)_pB);
                 pA += 4;
@@ -2214,7 +2214,7 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
             {
                 __m128i _pA = _mm_castpd_si128(_mm_load1_pd((const double*)pA));
                 __m128i _pB0 = _mm_loadu_si128((const __m128i*)pB);
-                __m128i _pB1 = _mm_alignr_epi8(_pB0, _pB0, 4);
+                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm_dpbf16_ps(_sum0, (__m128bh)_pA, (__m128bh)_pB0);
                 _sum1 = _mm_dpbf16_ps(_sum1, (__m128bh)_pA, (__m128bh)_pB1);
                 pA += 4;

--- a/src/layer/x86/convolution_im2col_gemm_bf16s.h
+++ b/src/layer/x86/convolution_im2col_gemm_bf16s.h
@@ -1126,7 +1126,7 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
             {
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m256i _pB0 = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(2, 3, 0, 1));
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(1, 0, 3, 2));
                 __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 __m256i _pB2 = _mm256_permute4x64_epi64(_pB0, _MM_SHUFFLE(1, 0, 3, 2));
                 __m256i _pB3 = _mm256_shuffle_epi32(_pB2, _MM_SHUFFLE(0, 3, 2, 1));
@@ -1349,7 +1349,7 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m128i _pB = _mm_loadu_si128((const __m128i*)pB);
                 __m256i _pB0 = combine4x2_epi32(_pB, _pB);
-                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(2, 3, 0, 1));
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(1, 0, 3, 2));
                 __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB0);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA0, (__m256bh)_pB1);
@@ -1593,7 +1593,7 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
                 __m128i _pA0 = _mm_loadu_si128((const __m128i*)pA);
                 __m256i _pA00 = combine4x2_epi32(_pA0, _pA0);
                 __m256i _pB01 = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA11 = _mm256_shuffle_epi32(_pA00, _MM_SHUFFLE(2, 3, 0, 1));
+                __m256i _pA11 = _mm256_shuffle_epi32(_pA00, _MM_SHUFFLE(1, 0, 3, 2));
                 __m256i _pB23 = _mm256_shuffle_epi32(_pB01, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA00, (__m256bh)_pB01);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA11, (__m256bh)_pB01);
@@ -1846,7 +1846,7 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
             {
                 __m128i _pA0 = _mm_loadu_si128((const __m128i*)pA);
                 __m128i _pB0 = _mm_loadu_si128((const __m128i*)pB);
-                __m128i _pA1 = _mm_shuffle_epi32(_pA0, _MM_SHUFFLE(2, 3, 0, 1));
+                __m128i _pA1 = _mm_shuffle_epi32(_pA0, _MM_SHUFFLE(1, 0, 3, 2));
                 __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm_dpbf16_ps(_sum0, (__m128bh)_pA0, (__m128bh)_pB0);
                 _sum1 = _mm_dpbf16_ps(_sum1, (__m128bh)_pA0, (__m128bh)_pB1);

--- a/src/layer/x86/convolution_im2col_gemm_bf16s.h
+++ b/src/layer/x86/convolution_im2col_gemm_bf16s.h
@@ -1126,10 +1126,10 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
             {
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m256i _pB0 = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_PERM_BADC);
-                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_PERM_ADCB);
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(2, 3, 0, 1));
+                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 __m256i _pB2 = _mm256_permute4x64_epi64(_pB0, _MM_SHUFFLE(1, 0, 3, 2));
-                __m256i _pB3 = _mm256_shuffle_epi32(_pB2, _MM_PERM_ADCB);
+                __m256i _pB3 = _mm256_shuffle_epi32(_pB2, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB0);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA0, (__m256bh)_pB1);
                 _sum2 = _mm256_dpbf16_ps(_sum2, (__m256bh)_pA1, (__m256bh)_pB0);
@@ -1349,8 +1349,8 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m128i _pB = _mm_loadu_si128((const __m128i*)pB);
                 __m256i _pB0 = combine4x2_epi32(_pB, _pB);
-                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_PERM_BADC);
-                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_PERM_ADCB);
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(2, 3, 0, 1));
+                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB0);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA0, (__m256bh)_pB1);
                 _sum2 = _mm256_dpbf16_ps(_sum2, (__m256bh)_pA1, (__m256bh)_pB0);
@@ -1593,8 +1593,8 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
                 __m128i _pA0 = _mm_loadu_si128((const __m128i*)pA);
                 __m256i _pA00 = combine4x2_epi32(_pA0, _pA0);
                 __m256i _pB01 = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA11 = _mm256_shuffle_epi32(_pA00, _MM_PERM_BADC);
-                __m256i _pB23 = _mm256_shuffle_epi32(_pB01, _MM_PERM_ADCB);
+                __m256i _pA11 = _mm256_shuffle_epi32(_pA00, _MM_SHUFFLE(2, 3, 0, 1));
+                __m256i _pB23 = _mm256_shuffle_epi32(_pB01, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA00, (__m256bh)_pB01);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA11, (__m256bh)_pB01);
                 _sum2 = _mm256_dpbf16_ps(_sum2, (__m256bh)_pA00, (__m256bh)_pB23);
@@ -1846,8 +1846,8 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
             {
                 __m128i _pA0 = _mm_loadu_si128((const __m128i*)pA);
                 __m128i _pB0 = _mm_loadu_si128((const __m128i*)pB);
-                __m128i _pA1 = _mm_shuffle_epi32(_pA0, _MM_PERM_BADC);
-                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_PERM_ADCB);
+                __m128i _pA1 = _mm_shuffle_epi32(_pA0, _MM_SHUFFLE(2, 3, 0, 1));
+                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm_dpbf16_ps(_sum0, (__m128bh)_pA0, (__m128bh)_pB0);
                 _sum1 = _mm_dpbf16_ps(_sum1, (__m128bh)_pA0, (__m128bh)_pB1);
                 _sum2 = _mm_dpbf16_ps(_sum2, (__m128bh)_pA1, (__m128bh)_pB0);
@@ -2041,7 +2041,7 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
             {
                 __m256i _pA0 = _mm256_castpd_si256(_mm256_broadcast_sd((const double*)pA));
                 __m256i _pB = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_PERM_ADCB);
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA1, (__m256bh)_pB);
                 pA += 4;
@@ -2214,7 +2214,7 @@ static void convolution_gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const 
             {
                 __m128i _pA = _mm_castpd_si128(_mm_load1_pd((const double*)pA));
                 __m128i _pB0 = _mm_loadu_si128((const __m128i*)pB);
-                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_PERM_ADCB);
+                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm_dpbf16_ps(_sum0, (__m128bh)_pA, (__m128bh)_pB0);
                 _sum1 = _mm_dpbf16_ps(_sum1, (__m128bh)_pA, (__m128bh)_pB1);
                 pA += 4;

--- a/src/layer/x86/gemm_bf16s.h
+++ b/src/layer/x86/gemm_bf16s.h
@@ -2630,10 +2630,10 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m256i _pB0 = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_PERM_BADC);
-                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_PERM_ADCB);
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(2, 3, 0, 1));
+                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 __m256i _pB2 = _mm256_permute4x64_epi64(_pB0, _MM_SHUFFLE(1, 0, 3, 2));
-                __m256i _pB3 = _mm256_shuffle_epi32(_pB2, _MM_PERM_ADCB);
+                __m256i _pB3 = _mm256_shuffle_epi32(_pB2, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB0);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA0, (__m256bh)_pB1);
                 _sum2 = _mm256_dpbf16_ps(_sum2, (__m256bh)_pA1, (__m256bh)_pB0);
@@ -2704,8 +2704,8 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m128i _pB = _mm_loadu_si128((const __m128i*)pB);
                 __m256i _pB0 = combine4x2_epi32(_pB, _pB);
-                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_PERM_BADC);
-                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_PERM_ADCB);
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(2, 3, 0, 1));
+                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB0);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA0, (__m256bh)_pB1);
                 _sum2 = _mm256_dpbf16_ps(_sum2, (__m256bh)_pA1, (__m256bh)_pB0);
@@ -2757,7 +2757,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m256i _pA = _mm256_loadu_si256((const __m256i*)pA);
                 __m256i _pB0 = _mm256_castpd_si256(_mm256_broadcast_sd((const double*)pB));
-                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_PERM_ADCB);
+                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA, (__m256bh)_pB0);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA, (__m256bh)_pB1);
                 pA += 16;
@@ -2931,8 +2931,8 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
                 __m128i _pA0 = _mm_loadu_si128((const __m128i*)pA);
                 __m256i _pA00 = combine4x2_epi32(_pA0, _pA0);
                 __m256i _pB01 = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA11 = _mm256_shuffle_epi32(_pA00, _MM_PERM_BADC);
-                __m256i _pB23 = _mm256_shuffle_epi32(_pB01, _MM_PERM_ADCB);
+                __m256i _pA11 = _mm256_shuffle_epi32(_pA00, _MM_SHUFFLE(2, 3, 0, 1));
+                __m256i _pB23 = _mm256_shuffle_epi32(_pB01, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA00, (__m256bh)_pB01);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA11, (__m256bh)_pB01);
                 _sum2 = _mm256_dpbf16_ps(_sum2, (__m256bh)_pA00, (__m256bh)_pB23);
@@ -3019,8 +3019,8 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m128i _pA0 = _mm_loadu_si128((const __m128i*)pA);
                 __m128i _pB0 = _mm_loadu_si128((const __m128i*)pB);
-                __m128i _pA1 = _mm_shuffle_epi32(_pA0, _MM_PERM_BADC);
-                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_PERM_ADCB);
+                __m128i _pA1 = _mm_shuffle_epi32(_pA0, _MM_SHUFFLE(2, 3, 0, 1));
+                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm_dpbf16_ps(_sum0, (__m128bh)_pA0, (__m128bh)_pB0);
                 _sum1 = _mm_dpbf16_ps(_sum1, (__m128bh)_pA0, (__m128bh)_pB1);
                 _sum2 = _mm_dpbf16_ps(_sum2, (__m128bh)_pA1, (__m128bh)_pB0);
@@ -3071,7 +3071,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m128i _pA = _mm_loadu_si128((const __m128i*)pA);
                 __m128i _pB0 = _mm_castpd_si128(_mm_load1_pd((const double*)pB));
-                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_PERM_ADCB);
+                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm_dpbf16_ps(_sum0, (__m128bh)_pA, (__m128bh)_pB0);
                 _sum1 = _mm_dpbf16_ps(_sum1, (__m128bh)_pA, (__m128bh)_pB1);
                 pA += 8;
@@ -3217,7 +3217,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m256i _pA0 = _mm256_castpd_si256(_mm256_broadcast_sd((const double*)pA));
                 __m256i _pB = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_PERM_ADCB);
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA1, (__m256bh)_pB);
                 pA += 4;
@@ -3281,7 +3281,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m128i _pA = _mm_castpd_si128(_mm_load1_pd((const double*)pA));
                 __m128i _pB0 = _mm_loadu_si128((const __m128i*)pB);
-                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_PERM_ADCB);
+                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm_dpbf16_ps(_sum0, (__m128bh)_pA, (__m128bh)_pB0);
                 _sum1 = _mm_dpbf16_ps(_sum1, (__m128bh)_pA, (__m128bh)_pB1);
                 pA += 4;

--- a/src/layer/x86/gemm_bf16s.h
+++ b/src/layer/x86/gemm_bf16s.h
@@ -2630,7 +2630,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m256i _pB0 = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(2, 3, 0, 1));
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(1, 0, 3, 2));
                 __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 __m256i _pB2 = _mm256_permute4x64_epi64(_pB0, _MM_SHUFFLE(1, 0, 3, 2));
                 __m256i _pB3 = _mm256_shuffle_epi32(_pB2, _MM_SHUFFLE(0, 3, 2, 1));
@@ -2704,7 +2704,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m128i _pB = _mm_loadu_si128((const __m128i*)pB);
                 __m256i _pB0 = combine4x2_epi32(_pB, _pB);
-                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(2, 3, 0, 1));
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_SHUFFLE(1, 0, 3, 2));
                 __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB0);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA0, (__m256bh)_pB1);
@@ -2931,7 +2931,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
                 __m128i _pA0 = _mm_loadu_si128((const __m128i*)pA);
                 __m256i _pA00 = combine4x2_epi32(_pA0, _pA0);
                 __m256i _pB01 = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA11 = _mm256_shuffle_epi32(_pA00, _MM_SHUFFLE(2, 3, 0, 1));
+                __m256i _pA11 = _mm256_shuffle_epi32(_pA00, _MM_SHUFFLE(1, 0, 3, 2));
                 __m256i _pB23 = _mm256_shuffle_epi32(_pB01, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA00, (__m256bh)_pB01);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA11, (__m256bh)_pB01);
@@ -3019,7 +3019,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m128i _pA0 = _mm_loadu_si128((const __m128i*)pA);
                 __m128i _pB0 = _mm_loadu_si128((const __m128i*)pB);
-                __m128i _pA1 = _mm_shuffle_epi32(_pA0, _MM_SHUFFLE(2, 3, 0, 1));
+                __m128i _pA1 = _mm_shuffle_epi32(_pA0, _MM_SHUFFLE(1, 0, 3, 2));
                 __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_SHUFFLE(0, 3, 2, 1));
                 _sum0 = _mm_dpbf16_ps(_sum0, (__m128bh)_pA0, (__m128bh)_pB0);
                 _sum1 = _mm_dpbf16_ps(_sum1, (__m128bh)_pA0, (__m128bh)_pB1);

--- a/src/layer/x86/gemm_bf16s.h
+++ b/src/layer/x86/gemm_bf16s.h
@@ -2204,29 +2204,28 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
                 __m512i _pA0 = _mm512_loadu_si512((const __m512i*)pA);
                 __m512i _pB0 = _mm512_loadu_si512((const __m512i*)pB);
 
-                __m512i _pA1 = _mm512_alignr_epi8(_pA0, _pA0, 8);
+                __m512i _pA1 = _mm512_shuffle_epi32(_pA0, _MM_PERM_BADC);
                 __m512i _pA2 = _mm512_shuffle_i32x4(_pA0, _pA0, _MM_SHUFFLE(2, 3, 0, 1));
-                __m512i _pA3 = _mm512_alignr_epi8(_pA2, _pA2, 8);
-
-                __m512i _pB1 = _mm512_alignr_epi8(_pB0, _pB0, 4);
                 __m512i _pB2 = _mm512_shuffle_i32x4(_pB0, _pB0, _MM_SHUFFLE(1, 0, 3, 2));
-                __m512i _pB3 = _mm512_alignr_epi8(_pB2, _pB2, 4);
+                __m512i _pB1 = _mm512_shuffle_epi32(_pB0, _MM_PERM_ADCB);
 
                 _sum0 = _mm512_dpbf16_ps(_sum0, (__m512bh)_pA0, (__m512bh)_pB0);
+                __m512i _pA3 = _mm512_shuffle_epi32(_pA2, _MM_PERM_BADC);
                 _sum1 = _mm512_dpbf16_ps(_sum1, (__m512bh)_pA0, (__m512bh)_pB1);
                 _sum2 = _mm512_dpbf16_ps(_sum2, (__m512bh)_pA1, (__m512bh)_pB0);
                 _sum3 = _mm512_dpbf16_ps(_sum3, (__m512bh)_pA1, (__m512bh)_pB1);
-                _sum4 = _mm512_dpbf16_ps(_sum4, (__m512bh)_pA0, (__m512bh)_pB2);
-                _sum5 = _mm512_dpbf16_ps(_sum5, (__m512bh)_pA0, (__m512bh)_pB3);
-                _sum6 = _mm512_dpbf16_ps(_sum6, (__m512bh)_pA1, (__m512bh)_pB2);
-                _sum7 = _mm512_dpbf16_ps(_sum7, (__m512bh)_pA1, (__m512bh)_pB3);
                 _sum8 = _mm512_dpbf16_ps(_sum8, (__m512bh)_pA2, (__m512bh)_pB0);
                 _sum9 = _mm512_dpbf16_ps(_sum9, (__m512bh)_pA2, (__m512bh)_pB1);
+                __m512i _pB3 = _mm512_shuffle_epi32(_pB2, _MM_PERM_ADCB);
+                _sum4 = _mm512_dpbf16_ps(_sum4, (__m512bh)_pA0, (__m512bh)_pB2);
+                _sum6 = _mm512_dpbf16_ps(_sum6, (__m512bh)_pA1, (__m512bh)_pB2);
                 _suma = _mm512_dpbf16_ps(_suma, (__m512bh)_pA3, (__m512bh)_pB0);
                 _sumb = _mm512_dpbf16_ps(_sumb, (__m512bh)_pA3, (__m512bh)_pB1);
                 _sumc = _mm512_dpbf16_ps(_sumc, (__m512bh)_pA2, (__m512bh)_pB2);
-                _sumd = _mm512_dpbf16_ps(_sumd, (__m512bh)_pA2, (__m512bh)_pB3);
                 _sume = _mm512_dpbf16_ps(_sume, (__m512bh)_pA3, (__m512bh)_pB2);
+                _sum5 = _mm512_dpbf16_ps(_sum5, (__m512bh)_pA0, (__m512bh)_pB3);
+                _sum7 = _mm512_dpbf16_ps(_sum7, (__m512bh)_pA1, (__m512bh)_pB3);
+                _sumd = _mm512_dpbf16_ps(_sumd, (__m512bh)_pA2, (__m512bh)_pB3);
                 _sumf = _mm512_dpbf16_ps(_sumf, (__m512bh)_pA3, (__m512bh)_pB3);
 
                 pA += 32;
@@ -2317,11 +2316,11 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
                 __m256i _pBB = _mm256_loadu_si256((const __m256i*)pB);
                 __m512i _pB0 = combine8x2_epi32(_pBB, _pBB);
 
-                __m512i _pA1 = _mm512_alignr_epi8(_pA0, _pA0, 8);
+                __m512i _pA1 = _mm512_shuffle_epi32(_pA0, _MM_PERM_BADC);
 
-                __m512i _pB1 = _mm512_alignr_epi8(_pB0, _pB0, 4);
+                __m512i _pB1 = _mm512_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 __m512i _pB2 = _mm512_permutex_epi64(_pB0, _MM_SHUFFLE(1, 0, 3, 2));
-                __m512i _pB3 = _mm512_alignr_epi8(_pB2, _pB2, 4);
+                __m512i _pB3 = _mm512_shuffle_epi32(_pB2, _MM_PERM_ADCB);
 
                 _sum0 = _mm512_dpbf16_ps(_sum0, (__m512bh)_pA0, (__m512bh)_pB0);
                 _sum1 = _mm512_dpbf16_ps(_sum1, (__m512bh)_pA0, (__m512bh)_pB1);
@@ -2394,8 +2393,8 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m512i _pA0 = _mm512_loadu_si512((const __m512i*)pA);
                 __m512i _pB0 = _mm512_broadcast_i32x4(_mm_loadu_si128((const __m128i*)pB));
-                __m512i _pA1 = _mm512_alignr_epi8(_pA0, _pA0, 8);
-                __m512i _pB1 = _mm512_alignr_epi8(_pB0, _pB0, 4);
+                __m512i _pA1 = _mm512_shuffle_epi32(_pA0, _MM_PERM_BADC);
+                __m512i _pB1 = _mm512_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm512_dpbf16_ps(_sum0, (__m512bh)_pA0, (__m512bh)_pB0);
                 _sum1 = _mm512_dpbf16_ps(_sum1, (__m512bh)_pA0, (__m512bh)_pB1);
                 _sum2 = _mm512_dpbf16_ps(_sum2, (__m512bh)_pA1, (__m512bh)_pB0);
@@ -2447,7 +2446,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m512i _pA = _mm512_loadu_si512((const __m512i*)pA);
                 __m512i _pB0 = _mm512_castpd_si512(_mm512_set1_pd(((const double*)pB)[0]));
-                __m512i _pB1 = _mm512_alignr_epi8(_pB0, _pB0, 4);
+                __m512i _pB1 = _mm512_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm512_dpbf16_ps(_sum0, (__m512bh)_pA, (__m512bh)_pB0);
                 _sum1 = _mm512_dpbf16_ps(_sum1, (__m512bh)_pA, (__m512bh)_pB1);
                 pA += 32;
@@ -2549,10 +2548,10 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m512i _pB0 = _mm512_loadu_si512((const __m512i*)pB);
                 __m512i _pA00 = combine8x2_epi32(_pA0, _pA0);
-                __m512i _pA11 = _mm512_alignr_epi8(_pA00, _pA00, 8);
-                __m512i _pB1 = _mm512_alignr_epi8(_pB0, _pB0, 4);
+                __m512i _pA11 = _mm512_shuffle_epi32(_pA00, _MM_PERM_BADC);
+                __m512i _pB1 = _mm512_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 __m512i _pB2 = _mm512_permutex_epi64(_pB0, _MM_SHUFFLE(1, 0, 3, 2));
-                __m512i _pB3 = _mm512_alignr_epi8(_pB2, _pB2, 4);
+                __m512i _pB3 = _mm512_shuffle_epi32(_pB2, _MM_PERM_ADCB);
                 _sum0 = _mm512_dpbf16_ps(_sum0, (__m512bh)_pA00, (__m512bh)_pB0);
                 _sum1 = _mm512_dpbf16_ps(_sum1, (__m512bh)_pA00, (__m512bh)_pB1);
                 _sum2 = _mm512_dpbf16_ps(_sum2, (__m512bh)_pA11, (__m512bh)_pB0);
@@ -2631,10 +2630,10 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m256i _pB0 = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA1 = _mm256_alignr_epi8(_pA0, _pA0, 8);
-                __m256i _pB1 = _mm256_alignr_epi8(_pB0, _pB0, 4);
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_PERM_BADC);
+                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 __m256i _pB2 = _mm256_permute4x64_epi64(_pB0, _MM_SHUFFLE(1, 0, 3, 2));
-                __m256i _pB3 = _mm256_alignr_epi8(_pB2, _pB2, 4);
+                __m256i _pB3 = _mm256_shuffle_epi32(_pB2, _MM_PERM_ADCB);
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB0);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA0, (__m256bh)_pB1);
                 _sum2 = _mm256_dpbf16_ps(_sum2, (__m256bh)_pA1, (__m256bh)_pB0);
@@ -2705,8 +2704,8 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
                 __m256i _pA0 = _mm256_loadu_si256((const __m256i*)pA);
                 __m128i _pB = _mm_loadu_si128((const __m128i*)pB);
                 __m256i _pB0 = combine4x2_epi32(_pB, _pB);
-                __m256i _pA1 = _mm256_alignr_epi8(_pA0, _pA0, 8);
-                __m256i _pB1 = _mm256_alignr_epi8(_pB0, _pB0, 4);
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_PERM_BADC);
+                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB0);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA0, (__m256bh)_pB1);
                 _sum2 = _mm256_dpbf16_ps(_sum2, (__m256bh)_pA1, (__m256bh)_pB0);
@@ -2758,7 +2757,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m256i _pA = _mm256_loadu_si256((const __m256i*)pA);
                 __m256i _pB0 = _mm256_castpd_si256(_mm256_broadcast_sd((const double*)pB));
-                __m256i _pB1 = _mm256_alignr_epi8(_pB0, _pB0, 4);
+                __m256i _pB1 = _mm256_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA, (__m256bh)_pB0);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA, (__m256bh)_pB1);
                 pA += 16;
@@ -2851,8 +2850,8 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m512i _pA0 = _mm512_broadcast_i32x4(_mm_loadu_si128((const __m128i*)pA));
                 __m512i _pB0 = _mm512_loadu_si512((const __m512i*)pB);
-                __m512i _pA1 = _mm512_alignr_epi8(_pA0, _pA0, 8);
-                __m512i _pB1 = _mm512_alignr_epi8(_pB0, _pB0, 4);
+                __m512i _pA1 = _mm512_shuffle_epi32(_pA0, _MM_PERM_BADC);
+                __m512i _pB1 = _mm512_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm512_dpbf16_ps(_sum0, (__m512bh)_pA0, (__m512bh)_pB0);
                 _sum1 = _mm512_dpbf16_ps(_sum1, (__m512bh)_pA0, (__m512bh)_pB1);
                 _sum2 = _mm512_dpbf16_ps(_sum2, (__m512bh)_pA1, (__m512bh)_pB0);
@@ -2932,8 +2931,8 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
                 __m128i _pA0 = _mm_loadu_si128((const __m128i*)pA);
                 __m256i _pA00 = combine4x2_epi32(_pA0, _pA0);
                 __m256i _pB01 = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA11 = _mm256_alignr_epi8(_pA00, _pA00, 8);
-                __m256i _pB23 = _mm256_alignr_epi8(_pB01, _pB01, 4);
+                __m256i _pA11 = _mm256_shuffle_epi32(_pA00, _MM_PERM_BADC);
+                __m256i _pB23 = _mm256_shuffle_epi32(_pB01, _MM_PERM_ADCB);
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA00, (__m256bh)_pB01);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA11, (__m256bh)_pB01);
                 _sum2 = _mm256_dpbf16_ps(_sum2, (__m256bh)_pA00, (__m256bh)_pB23);
@@ -3020,8 +3019,8 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m128i _pA0 = _mm_loadu_si128((const __m128i*)pA);
                 __m128i _pB0 = _mm_loadu_si128((const __m128i*)pB);
-                __m128i _pA1 = _mm_alignr_epi8(_pA0, _pA0, 8);
-                __m128i _pB1 = _mm_alignr_epi8(_pB0, _pB0, 4);
+                __m128i _pA1 = _mm_shuffle_epi32(_pA0, _MM_PERM_BADC);
+                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm_dpbf16_ps(_sum0, (__m128bh)_pA0, (__m128bh)_pB0);
                 _sum1 = _mm_dpbf16_ps(_sum1, (__m128bh)_pA0, (__m128bh)_pB1);
                 _sum2 = _mm_dpbf16_ps(_sum2, (__m128bh)_pA1, (__m128bh)_pB0);
@@ -3072,7 +3071,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m128i _pA = _mm_loadu_si128((const __m128i*)pA);
                 __m128i _pB0 = _mm_castpd_si128(_mm_load1_pd((const double*)pB));
-                __m128i _pB1 = _mm_alignr_epi8(_pB0, _pB0, 4);
+                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm_dpbf16_ps(_sum0, (__m128bh)_pA, (__m128bh)_pB0);
                 _sum1 = _mm_dpbf16_ps(_sum1, (__m128bh)_pA, (__m128bh)_pB1);
                 pA += 8;
@@ -3161,7 +3160,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m512i _pA = _mm512_castpd_si512(_mm512_set1_pd(((const double*)pA)[0]));
                 __m512i _pB0 = _mm512_loadu_si512((const __m512i*)pB);
-                __m512i _pB1 = _mm512_alignr_epi8(_pB0, _pB0, 4);
+                __m512i _pB1 = _mm512_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm512_dpbf16_ps(_sum0, (__m512bh)_pA, (__m512bh)_pB0);
                 _sum1 = _mm512_dpbf16_ps(_sum1, (__m512bh)_pA, (__m512bh)_pB1);
                 pA += 4;
@@ -3218,7 +3217,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m256i _pA0 = _mm256_castpd_si256(_mm256_broadcast_sd((const double*)pA));
                 __m256i _pB = _mm256_loadu_si256((const __m256i*)pB);
-                __m256i _pA1 = _mm256_alignr_epi8(_pA0, _pA0, 4);
+                __m256i _pA1 = _mm256_shuffle_epi32(_pA0, _MM_PERM_ADCB);
                 _sum0 = _mm256_dpbf16_ps(_sum0, (__m256bh)_pA0, (__m256bh)_pB);
                 _sum1 = _mm256_dpbf16_ps(_sum1, (__m256bh)_pA1, (__m256bh)_pB);
                 pA += 4;
@@ -3282,7 +3281,7 @@ static void gemm_transB_packed_tile_bf16s(const Mat& AT_tile, const Mat& BT_tile
             {
                 __m128i _pA = _mm_castpd_si128(_mm_load1_pd((const double*)pA));
                 __m128i _pB0 = _mm_loadu_si128((const __m128i*)pB);
-                __m128i _pB1 = _mm_alignr_epi8(_pB0, _pB0, 4);
+                __m128i _pB1 = _mm_shuffle_epi32(_pB0, _MM_PERM_ADCB);
                 _sum0 = _mm_dpbf16_ps(_sum0, (__m128bh)_pA, (__m128bh)_pB0);
                 _sum1 = _mm_dpbf16_ps(_sum1, (__m128bh)_pA, (__m128bh)_pB1);
                 pA += 4;


### PR DESCRIPTION
On AMD Zen 5, the vpalignr instruction generated by GCC for _mm*_alignr_epi8(x,x,N) conflicts with vdpbf16ps for execution port resources, causing ~16% performance loss on the 16x16 micro kernel compared to Clang (which auto-replaces vpalignr with equivalent shuffles). Replace all _mm*_alignr_epi8(x,x,8) with _mm*_shuffle_epi32(x, _MM_PERM_BADC) and _mm*_alignr_epi8(x,x,4) with _mm*_shuffle_epi32(x, _MM_PERM_ADCB) in the AVX512BF16 kernel sections, which generate vpshufd instructions using different execution ports. Also apply interleaved instruction scheduling for the 16x16 kernel to further overlap shuffle and dpbf16ps computation latency.

```
  GCC 15.2.0 (libncnn.a built with GCC)

  ┌────────────────┬─────────────────┬────────────────┬────────┐
  │     MxNxK      │ Before (GFLOPS) │ After (GFLOPS) │ Delta  │
  ├────────────────┼─────────────────┼────────────────┼────────┤
  │ 128x128x128    │ 356             │ 400            │ +12.4% │
  ├────────────────┼─────────────────┼────────────────┼────────┤
  │ 256x256x256    │ 431             │ 494            │ +14.6% │
  ├────────────────┼─────────────────┼────────────────┼────────┤
  │ 512x512x512    │ 352             │ 400            │ +13.6% │
  ├────────────────┼─────────────────┼────────────────┼────────┤
  │ 1024x1024x1024 │ 454             │ 524            │ +15.4% │
  ├────────────────┼─────────────────┼────────────────┼────────┤
  │ 2048x2048x2048 │ 452             │ 524            │ +15.9% │
  ├────────────────┼─────────────────┼────────────────┼────────┤
  │ 256x256x512    │ 434             │ 501            │ +15.4% │
  ├────────────────┼─────────────────┼────────────────┼────────┤
  │ 512x512x1024   │ 450             │ 519            │ +15.3% │
  ├────────────────┼─────────────────┼────────────────┼────────┤
  │ 1024x1024x2048 │ 455             │ 526            │ +15.6% │
  ├────────────────┼─────────────────┼────────────────┼────────┤
  │ 128x128x1024   │ 433             │ 493            │ +13.9% │
  ├────────────────┼─────────────────┼────────────────┼────────┤
  │ 256x256x2048   │ 445             │ 512            │ +15.1% │
  └────────────────┴─────────────────┴────────────────┴────────┘

  Clang 21.1.8 (libncnn.a built with Clang)

  ┌────────────────┬─────────────────┬────────────────┬───────┐
  │     MxNxK      │ Before (GFLOPS) │ After (GFLOPS) │ Delta │
  ├────────────────┼─────────────────┼────────────────┼───────┤
  │ 128x128x128    │ 466             │ 462            │ -0.9% │
  ├────────────────┼─────────────────┼────────────────┼───────┤
  │ 256x256x256    │ 504             │ 493            │ -2.2% │
  ├────────────────┼─────────────────┼────────────────┼───────┤
  │ 512x512x512    │ 403             │ 396            │ -1.7% │
  ├────────────────┼─────────────────┼────────────────┼───────┤
  │ 1024x1024x1024 │ 527             │ 514            │ -2.5% │
  ├────────────────┼─────────────────┼────────────────┼───────┤
  │ 2048x2048x2048 │ 527             │ 515            │ -2.3% │
  ├────────────────┼─────────────────┼────────────────┼───────┤
  │ 256x256x512    │ 506             │ 495            │ -2.2% │
  ├────────────────┼─────────────────┼────────────────┼───────┤
  │ 512x512x1024   │ 521             │ 510            │ -2.1% │
  ├────────────────┼─────────────────┼────────────────┼───────┤
  │ 1024x1024x2048 │ 526             │ 517            │ -1.7% │
  ├────────────────┼─────────────────┼────────────────┼───────┤
  │ 128x128x1024   │ 498             │ 489            │ -1.8% │
  ├────────────────┼─────────────────┼────────────────┼───────┤
  │ 256x256x2048   │ 514             │ 504            │ -2.0% │
  └────────────────┴─────────────────┴────────────────┴───────┘

  总结

  - GCC: 平均提升约 14-16% —— 这是 vpalignr → vpshufd 替换带来的显著收益，因为 AMD Zen 5 上 vpalignr 和 vdpbf16ps 竞争相同的执行端口
  - Clang: 小幅下降约 2% —— Clang 之前就自动将 vpalignr 转换为 vshufps/vpshufd，但我们的 _mm_shuffle_epi32 + _MM_PERM_BADC 形式可能不如 Clang
  自己的代码选择优。这是使用显式 intrinsic 替代编译器自动变换的轻微代价
  - 优化后 GCC 性能接近 Clang 优化前的水平，说明核心问题（端口冲突）已被解决
  - Clang 2% 的回退在噪声范围内，且在实际微内核基准测试中该替换对 Clang 无影响——差异可能来自 ncnn 整体框架层面的编译差异

```

glm-5.1
36.9M input, 168.5k output, 36.3M cache read, 0 cache write