### PR TITLE
tools:Move Embed/MHA/RNN/LSTM/GRU weight scale generation to ncnn2table

### DIFF
--- a/tools/quantize/ncnn2int8.cpp
+++ b/tools/quantize/ncnn2int8.cpp
@@ -563,6 +563,15 @@ int NetQuantize::quantize_embed()
         if (layers[i]->type != "Embed")
             continue;
 
+        char key[256];
+        snprintf(key, 256, "%s_param_0", layers[i]->name.c_str());
+        std::map<std::string, ncnn::Mat>::iterator iter = weight_int8scale_table.find(key);
+        if (iter == weight_int8scale_table.end())
+        {
+            fprintf(stderr, "this layer need to be quantized, but no scale param!\n");
+            return -1;
+        }
+
         // Embed - quantize weight from fp32 to int8
         ncnn::Embed* embed = (ncnn::Embed*)layers[i];
 
@@ -573,17 +582,7 @@ int NetQuantize::quantize_embed()
         const int num_output = embed->num_output;
         const int input_dim = embed->input_dim;
 
-        ncnn::Mat weight_data_int8_scales(1);
-        {
-            const float* ptr = embed->weight_data;
-            float absmax = 0.f;
-            for (int i = 0; i < embed->weight_data.w; i++)
-            {
-                absmax = std::max(absmax, (float)fabs(ptr[i]));
-            }
-
-            weight_data_int8_scales[0] = absmax == 0.f ? 1.f : 127 / absmax;
-        }
+        ncnn::Mat weight_data_int8_scales = iter->second;
 
         {
             ncnn::Mat weight_data_int8;

--- a/tools/quantize/ncnn2int8.cpp
+++ b/tools/quantize/ncnn2int8.cpp
@@ -1119,4 +1119,4 @@ int main(int argc, char** argv)
     quantizer.save(outparam, outbin);
 
     return 0;
-} 
+}

--- a/tools/quantize/ncnn2int8.cpp
+++ b/tools/quantize/ncnn2int8.cpp
@@ -1119,4 +1119,4 @@ int main(int argc, char** argv)
     quantizer.save(outparam, outbin);
 
     return 0;
-}
+} 

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -129,7 +129,7 @@ int QuantNet::init()
             conv_bottom_blobs.push_back(layer->bottoms[0]);
             conv_top_blobs.push_back(layer->tops[0]);
         }
-        
+
         // find embed layers
         else if (layer->type == "Embed")
         {
@@ -187,7 +187,7 @@ int QuantNet::save_table(const char* tablepath)
         }
         fprintf(fp, "\n");
     }
-    
+
     fprintf(stdout, "param:%d\n", embed_layer_count);
     for (int i = 0; i < embed_layer_count; i++)
     {
@@ -442,7 +442,6 @@ int QuantNet::quantize_KL()
             absmax = std::max(absmax, (float)fabs(ptr[j]));
         }
         embed_weight_scales[i] = absmax == 0.f ? 1.f : 127 / absmax;
-               
     }
 
     // count the absmax
@@ -940,7 +939,6 @@ int QuantNet::quantize_ACIQ()
             absmax = std::max(absmax, (float)fabs(ptr[j]));
         }
         embed_weight_scales[i] = absmax == 0.f ? 1.f : 127 / absmax;
-               
     }
 
     // count the absmax

--- a/tools/quantize/ncnn2table.cpp
+++ b/tools/quantize/ncnn2table.cpp
@@ -38,6 +38,7 @@
 #include "layer/convolution.h"
 #include "layer/convolutiondepthwise.h"
 #include "layer/innerproduct.h"
+#include "layer/embed.h"
 
 class QuantBlobStat
 {
@@ -91,11 +92,13 @@ public:
     std::vector<int> conv_layers;
     std::vector<int> conv_bottom_blobs;
     std::vector<int> conv_top_blobs;
+    std::vector<int> embed_layers;
 
     // result
     std::vector<QuantBlobStat> quant_blob_stats;
     std::vector<ncnn::Mat> weight_scales;
     std::vector<ncnn::Mat> bottom_blob_scales;
+    std::vector<float> embed_weight_scales;
 };
 
 QuantNet::QuantNet()
@@ -126,14 +129,22 @@ int QuantNet::init()
             conv_bottom_blobs.push_back(layer->bottoms[0]);
             conv_top_blobs.push_back(layer->tops[0]);
         }
+        
+        // find embed layers
+        else if (layer->type == "Embed")
+        {
+            embed_layers.push_back(i);
+        }
     }
 
     const int conv_layer_count = (int)conv_layers.size();
     const int conv_bottom_blob_count = (int)conv_bottom_blobs.size();
+    const int embed_layer_count = (int)embed_layers.size();
 
     quant_blob_stats.resize(conv_bottom_blob_count);
     weight_scales.resize(conv_layer_count);
     bottom_blob_scales.resize(conv_bottom_blob_count);
+    embed_weight_scales.resize(embed_layer_count);
 
     return 0;
 }
@@ -149,6 +160,7 @@ int QuantNet::save_table(const char* tablepath)
 
     const int conv_layer_count = (int)conv_layers.size();
     const int conv_bottom_blob_count = (int)conv_bottom_blobs.size();
+    const int embed_layer_count = (int)embed_layers.size();
 
     fprintf(stdout, "param:%d\n", conv_layer_count);
 
@@ -173,6 +185,14 @@ int QuantNet::save_table(const char* tablepath)
         {
             fprintf(fp, "%f ", bottom_blob_scale[j]);
         }
+        fprintf(fp, "\n");
+    }
+    
+    fprintf(stdout, "param:%d\n", embed_layer_count);
+    for (int i = 0; i < embed_layer_count; i++)
+    {
+        fprintf(fp, "%s_param_0 ", layers[embed_layers[i]]->name.c_str());
+        fprintf(fp, "%f ", embed_weight_scales[i]);
         fprintf(fp, "\n");
     }
 
@@ -302,6 +322,8 @@ int QuantNet::quantize_KL()
     const int input_blob_count = (int)input_blobs.size();
     const int conv_layer_count = (int)conv_layers.size();
     const int conv_bottom_blob_count = (int)conv_bottom_blobs.size();
+    const int embed_layer_count = (int)embed_layers.size();
+
     const int file_count = (int)listspaths[0].size();
 
     const int num_histogram_bins = 2048;
@@ -405,6 +427,22 @@ int QuantNet::quantize_KL()
                 weight_scales[i][n] = 127 / absmax;
             }
         }
+    }
+
+    // initialize embed weight scales
+    for (int i = 0; i < embed_layer_count; i++)
+    {
+        const ncnn::Layer* layer = layers[embed_layers[i]];
+        const ncnn::Embed* embed = (const ncnn::Embed*)layer;
+        const float* ptr = embed->weight_data;
+
+        float absmax = 0.f;
+        for (int j = 0; j < embed->weight_data.w; j++)
+        {
+            absmax = std::max(absmax, (float)fabs(ptr[j]));
+        }
+        embed_weight_scales[i] = absmax == 0.f ? 1.f : 127 / absmax;
+               
     }
 
     // count the absmax
@@ -780,6 +818,8 @@ int QuantNet::quantize_ACIQ()
     const int input_blob_count = (int)input_blobs.size();
     const int conv_layer_count = (int)conv_layers.size();
     const int conv_bottom_blob_count = (int)conv_bottom_blobs.size();
+    const int embed_layer_count = (int)embed_layers.size();
+
     const int file_count = (int)listspaths[0].size();
 
     std::vector<ncnn::UnlockedPoolAllocator> blob_allocators(quantize_num_threads);
@@ -885,6 +925,22 @@ int QuantNet::quantize_ACIQ()
                 weight_scales[i][n] = 127 / threshold;
             }
         }
+    }
+
+    // initialize embed weight scales
+    for (int i = 0; i < embed_layer_count; i++)
+    {
+        const ncnn::Layer* layer = layers[embed_layers[i]];
+        const ncnn::Embed* embed = (const ncnn::Embed*)layer;
+        const float* ptr = embed->weight_data;
+
+        float absmax = 0.f;
+        for (int j = 0; j < embed->weight_data.w; j++)
+        {
+            absmax = std::max(absmax, (float)fabs(ptr[j]));
+        }
+        embed_weight_scales[i] = absmax == 0.f ? 1.f : 127 / absmax;
+               
     }
 
     // count the absmax


### PR DESCRIPTION
# Description
This PR moves static weight scale generation for several non-convolution layers from ncnn2int8 to ncnn2table, following the same table-driven workflow already used by other quantized layers.

# Changes

- Add  Embed and MultiHeadAttention weight scale generation to ncnn2table
- Add RNN, LSTM, and GRU weight scale generation to ncnn2table
- Update ncnn2int8 to read these scales from the calibration table instead of recomputing them locally
- Make calibration dataset optional for models that only need static weight scales and do not require activation calibration
- Keep SDPA unchanged, since it uses dynamic activation quantization in forward_int8

# Test
 using minimal RNN,LSTM,GRU,Eembed-Attn network to test:

## Eembed-Attn

quantized param files:

```
7767517
3 3
Input                    in0                      0 1 in0
Embed                    embed_0                  1 1 in0 1 0=8 1=16 3=128 18=2
MultiHeadAttention       attention_1              1 1 1 out0 0=8 1=2 2=64 3=8 4=8 6=5.000000e-01 18=2
```

precision analysis:

```
fp32 model : tiny_embed_attn.ncnn.param/.bin
int8 model : tiny_embed_attn_int8.ncnn.param/.bin
samples    : 100
seq_len    : 4
input_size : 8
seed       : 0

overall metrics
  max_abs  = 0.00712827
  mean_abs = 0.00212720
  rmse     = 0.00247913
```

## RNN

quantized param files:

```
7767517
3 3
Input                    in0                      0 1 in0
RNN                      rnn_1                    1 1 in0 1 0=8 1=64 8=2
Gemm                     gemm_0                   1 1 1 out0 3=1 5=1 6=1 7=4 8=4 9=8 10=4 18=2
```

precision analysis:

```
fp32 model : tiny_rnn.ncnn.param/.bin
int8 model : tiny_rnn_int8.ncnn.param/.bin
samples    : 100
seq_len    : 4
input_size : 8
seed       : 0

overall metrics
  max_abs  = 0.04329279
  mean_abs = 0.00797669
  rmse     = 0.01239488
```

## GRU

quantized param files:

```
7767517
3 3
Input                    in0                      0 1 in0
GRU                      gru_1                    1 1 in0 1 0=8 1=192 8=2
Gemm                     gemm_0                   1 1 1 out0 3=1 5=1 6=1 7=4 8=4 9=8 10=4 18=2
```

precision analysis:

```
fp32 model : tiny_gru.ncnn.param/.bin
int8 model : tiny_gru_int8.ncnn.param/.bin
samples    : 100
seq_len    : 4
input_size : 8
seed       : 0

overall metrics
  max_abs  = 0.00559735
  mean_abs = 0.00107971
  rmse     = 0.00136703
```

## LSTM

quantized param files:

```
7767517
3 3
Input                    in0                      0 1 in0
LSTM                     lstm_1                   1 1 in0 1 0=8 1=256 3=8 8=2
Gemm                     gemm_0                   1 1 1 out0 3=1 5=1 6=1 7=4 8=4 9=8 10=4 18=2
```

precision analysis:

```
fp32 model : tiny_lstm.ncnn.param/.bin
int8 model : tiny_lstm_int8.ncnn.param/.bin
samples    : 100
seq_len    : 4
input_size : 8
seed       : 0

overall metrics
  max_abs  = 0.00386286
  mean_abs = 0.00055465
  rmse     = 0.00072828
```
