### PR TITLE
opt innerproduct and convolutiondepthwise x86 int8 sse4.1

### DIFF
--- a/src/layer/x86/convolutiondepthwise_x86.cpp
+++ b/src/layer/x86/convolutiondepthwise_x86.cpp
@@ -966,12 +966,16 @@ int ConvolutionDepthWise_x86::forward_int8_x86(const Mat& bottom_blob, Mat& top_
 
                             for (int k = 0; k < maxk; k++)
                             {
-                                // TODO use _mm_cvtepi8_epi16 on sse4.1
+#if __SSE4_1__
+                                __m128i _val = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)(sptr + space_ofs[k] * 8)));
+                                __m128i _w = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)(kptr + k * 8)));
+#else
                                 __m128i _val = _mm_loadl_epi64((const __m128i*)(sptr + space_ofs[k] * 8));
                                 _val = _mm_unpacklo_epi8(_val, _mm_cmpgt_epi8(_mm_setzero_si128(), _val));
 
                                 __m128i _w = _mm_loadl_epi64((const __m128i*)(kptr + k * 8));
                                 _w = _mm_unpacklo_epi8(_w, _mm_cmpgt_epi8(_mm_setzero_si128(), _w));
+#endif
 
                                 __m128i _sl = _mm_mullo_epi16(_val, _w);
                                 __m128i _sh = _mm_mulhi_epi16(_val, _w);

--- a/src/layer/x86/innerproduct_x86.cpp
+++ b/src/layer/x86/innerproduct_x86.cpp
@@ -464,9 +464,12 @@ int InnerProduct_x86::forward_int8_x86(const Mat& bottom_blob, Mat& top_blob, co
                     int i = 0;
                     for (; i < num_input; i++)
                     {
-                        // TODO use _mm_cvtepi8_epi16 on sse4.1
+#if __SSE4_1__
+                        __m128i _w = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)kptr));
+#else
                         __m128i _w = _mm_loadl_epi64((const __m128i*)kptr);
                         _w = _mm_unpacklo_epi8(_w, _mm_cmpgt_epi8(_mm_setzero_si128(), _w));
+#endif
 
                         __m128i _val0 = _mm_set1_epi16((short)m0[0]);
                         __m128i _val1 = _mm_set1_epi16((short)m1[0]);
@@ -643,9 +646,12 @@ int InnerProduct_x86::forward_int8_x86(const Mat& bottom_blob, Mat& top_blob, co
                     {
                         __m128i _val = _mm_set1_epi16((short)m[0]);
 
-                        // TODO use _mm_cvtepi8_epi16 on sse4.1
+#if __SSE4_1__
+                        __m128i _w = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)kptr));
+#else
                         __m128i _w = _mm_loadl_epi64((const __m128i*)kptr);
                         _w = _mm_unpacklo_epi8(_w, _mm_cmpgt_epi8(_mm_setzero_si128(), _w));
+#endif
 
                         __m128i _sl = _mm_mullo_epi16(_val, _w);
                         __m128i _sh = _mm_mulhi_epi16(_val, _w);
@@ -767,9 +773,12 @@ int InnerProduct_x86::forward_int8_x86(const Mat& bottom_blob, Mat& top_blob, co
             {
                 __m128i _val = _mm_set1_epi16((short)sptr[0]);
 
-                // TODO use _mm_cvtepi8_epi16 on sse4.1
+#if __SSE4_1__
+                __m128i _w = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)kptr));
+#else
                 __m128i _w = _mm_loadl_epi64((const __m128i*)kptr);
                 _w = _mm_unpacklo_epi8(_w, _mm_cmpgt_epi8(_mm_setzero_si128(), _w));
+#endif
 
                 __m128i _sl = _mm_mullo_epi16(_val, _w);
                 __m128i _sh = _mm_mulhi_epi16(_val, _w);


### PR DESCRIPTION
### Description

It's TODO in `src/layer/x86/convolutiondepthwise_x86.cpp` and `src/layer/x86/innerproduct_x86.cpp`

Add SSE4.1 `_mm_cvtepi8_epi16` (`pmovsxbw` instruction) for `int8` sign extension in x86, replacing the legacy SSE2 pseudo sign-extension sequence.

This avoids the overhead of unpacking and shifting masks, significantly unlocking the performance of int8 inference on x86 architectures, particularly for models with heavy fully connected or depthwise separable convolution layers. Added proper fallback and `-msse4.1` conditional `#ifndef __SSE4_1__` guard loops to preserve backward compatibility.

### Benchmark
* **Environment:** Debian 13 , 4 threads (Command: `./benchmark/benchncnn 8 4 0`)
* **CPU:** 12 × AMD Ryzen 5 PRO 4650U with Radeon Graphics
* **Base:** `master` (Clean build) vs **PR Branch:** `opt-innerproduct-x86-int8-sse41`

| Model | Master Avg (ms) | PR Avg (ms) | Speedup (%) |
|:---|---:|---:|---:|
| squeezenet_int8 | 6.83 | 6.56 | **+3.95%** |
| mobilenet_int8 | 7.01 | 5.44 | **+22.40%** |
| googlenet_int8 | 13.18 | 13.03 | **+1.14%** |
| resnet18_int8 | 9.68 | 9.74 | -0.62% |
| vgg16_int8 | 78.44 | 64.34 | **+17.98%** |
| resnet50_int8 | 32.63 | 27.72 | **+15.05%** |
| squeezenet_ssd_int8 | 17.06 | 15.57 | **+8.73%** |
| mobilenet_ssd_int8 | 11.35 | 11.09 | **+2.29%** |

*I noticed that there seems to be no benchmark testing for devices very similar to mine in `benchmark/README.md`. If needed, I can submit a new PR later to improve it.* :)