### PR TITLE
fix cm pipeline compilation failure on adreno

### DIFF
--- a/src/layer/vulkan/convolution1d_vulkan.cpp
+++ b/src/layer/vulkan/convolution1d_vulkan.cpp
@@ -96,6 +96,16 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
             UNROLL_WG_M = std::min((size + coopmat_M * UNROLL_SG_M - 1) / (coopmat_M * UNROLL_SG_M), 2);
             UNROLL_WG_N = std::min((num_output + coopmat_N * UNROLL_SG_N - 1) / (coopmat_N * UNROLL_SG_N), 2);
 
+            if (vkdev->info.vendor_id() == 0x5143)
+            {
+                // unrolling caused an error due to insufficient shared memory on adreno
+                UNROLL_SG_M = 1;
+                UNROLL_SG_N = 1;
+                UNROLL_SG_K = 1;
+                UNROLL_WG_M = 1;
+                UNROLL_WG_N = 1;
+            }
+
             Mat weight_data_r2;
 
             if (elempack == 4)
@@ -302,6 +312,16 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
 
             UNROLL_WG_M = std::min((size + coopmat_M * UNROLL_SG_M - 1) / (coopmat_M * UNROLL_SG_M), 2);
             UNROLL_WG_N = std::min((num_output + coopmat_N * UNROLL_SG_N - 1) / (coopmat_N * UNROLL_SG_N), 2);
+
+            if (vkdev->info.vendor_id() == 0x5143)
+            {
+                // unrolling caused an error due to insufficient shared memory on adreno
+                UNROLL_SG_M = 1;
+                UNROLL_SG_N = 1;
+                UNROLL_SG_K = 1;
+                UNROLL_WG_M = 1;
+                UNROLL_WG_N = 1;
+            }
 
             const int blocks_n = (num_output + coopmat_N * UNROLL_SG_N * UNROLL_WG_N - 1) / (coopmat_N * UNROLL_SG_N * UNROLL_WG_N);
             const int kk = (num_input + coopmat_K - 1) / coopmat_K;

--- a/src/layer/vulkan/convolution_vulkan.cpp
+++ b/src/layer/vulkan/convolution_vulkan.cpp
@@ -202,6 +202,16 @@ int Convolution_vulkan::create_pipeline(const Option& opt)
 
             UNROLL_WG_M = std::min((size + coopmat_M * UNROLL_SG_M - 1) / (coopmat_M * UNROLL_SG_M), 2);
             UNROLL_WG_N = std::min((num_output + coopmat_N * UNROLL_SG_N - 1) / (coopmat_N * UNROLL_SG_N), 2);
+
+            if (vkdev->info.vendor_id() == 0x5143)
+            {
+                // unrolling caused an error due to insufficient shared memory on adreno
+                UNROLL_SG_M = 1;
+                UNROLL_SG_N = 1;
+                UNROLL_SG_K = 1;
+                UNROLL_WG_M = 1;
+                UNROLL_WG_N = 1;
+            }
         }
 
         // winograd43 transform kernel
@@ -879,6 +889,16 @@ int Convolution_vulkan::create_pipeline(const Option& opt)
             UNROLL_WG_M = std::min((size + coopmat_M * UNROLL_SG_M - 1) / (coopmat_M * UNROLL_SG_M), 2);
             UNROLL_WG_N = std::min((num_output + coopmat_N * UNROLL_SG_N - 1) / (coopmat_N * UNROLL_SG_N), 2);
 
+            if (vkdev->info.vendor_id() == 0x5143)
+            {
+                // unrolling caused an error due to insufficient shared memory on adreno
+                UNROLL_SG_M = 1;
+                UNROLL_SG_N = 1;
+                UNROLL_SG_K = 1;
+                UNROLL_WG_M = 1;
+                UNROLL_WG_N = 1;
+            }
+
             Mat weight_data_r2;
 
             if (elempack == 4)
@@ -1066,6 +1086,16 @@ int Convolution_vulkan::create_pipeline(const Option& opt)
 
             UNROLL_WG_M = std::min((size + coopmat_M * UNROLL_SG_M - 1) / (coopmat_M * UNROLL_SG_M), 2);
             UNROLL_WG_N = std::min((num_output + coopmat_N * UNROLL_SG_N - 1) / (coopmat_N * UNROLL_SG_N), 2);
+
+            if (vkdev->info.vendor_id() == 0x5143)
+            {
+                // unrolling caused an error due to insufficient shared memory on adreno
+                UNROLL_SG_M = 1;
+                UNROLL_SG_N = 1;
+                UNROLL_SG_K = 1;
+                UNROLL_WG_M = 1;
+                UNROLL_WG_N = 1;
+            }
 
             //        +-N-+
             //        K   |

--- a/src/layer/vulkan/deconvolution_vulkan.cpp
+++ b/src/layer/vulkan/deconvolution_vulkan.cpp
@@ -134,6 +134,16 @@ int Deconvolution_vulkan::create_pipeline(const Option& opt)
             UNROLL_WG_M = std::min((size + coopmat_M * UNROLL_SG_M - 1) / (coopmat_M * UNROLL_SG_M), 2);
             UNROLL_WG_N = std::min((maxk * num_output + coopmat_N * UNROLL_SG_N - 1) / (coopmat_N * UNROLL_SG_N), 2);
 
+            if (vkdev->info.vendor_id() == 0x5143)
+            {
+                // unrolling caused an error due to insufficient shared memory on adreno
+                UNROLL_SG_M = 1;
+                UNROLL_SG_N = 1;
+                UNROLL_SG_K = 1;
+                UNROLL_WG_M = 1;
+                UNROLL_WG_N = 1;
+            }
+
             //        +-N-+
             //        K   |
             //        +SG_UN

--- a/src/layer/vulkan/gemm_vulkan.cpp
+++ b/src/layer/vulkan/gemm_vulkan.cpp
@@ -99,6 +99,16 @@ int Gemm_vulkan::create_pipeline(const Option& opt)
         UNROLL_WG_M = std::min((M + coopmat_M * UNROLL_SG_M - 1) / (coopmat_M * UNROLL_SG_M), 2);
         UNROLL_WG_N = std::min((N + coopmat_N * UNROLL_SG_N - 1) / (coopmat_N * UNROLL_SG_N), 2);
 
+        if (vkdev->info.vendor_id() == 0x5143)
+        {
+            // unrolling caused an error due to insufficient shared memory on adreno
+            UNROLL_SG_M = 1;
+            UNROLL_SG_N = 1;
+            UNROLL_SG_K = 1;
+            UNROLL_WG_M = 1;
+            UNROLL_WG_N = 1;
+        }
+
         if (constantA == 1)
         {
             //        +-K-+

--- a/src/layer/vulkan/sdpa_vulkan.cpp
+++ b/src/layer/vulkan/sdpa_vulkan.cpp
@@ -100,6 +100,13 @@ int SDPA_vulkan::create_pipeline(const Option& opt)
 
                 FA_UNROLL_WG_M = 2;
 
+                if (vkdev->info.vendor_id() == 0x5143)
+                {
+                    // unrolling caused an error due to insufficient shared memory on adreno
+                    FA_UNROLL_SG_M = 1;
+                    FA_UNROLL_WG_M = 1;
+                }
+
                 std::vector<vk_specialization_type> specializations(1 + 8);
                 specializations[0].i = attn_mask;
 
@@ -183,6 +190,16 @@ int SDPA_vulkan::create_pipeline(const Option& opt)
 
         UNROLL_WG_M = std::min((M + coopmat_M * UNROLL_SG_M - 1) / (coopmat_M * UNROLL_SG_M), 2);
         UNROLL_WG_N = std::min((N + coopmat_N * UNROLL_SG_N - 1) / (coopmat_N * UNROLL_SG_N), 2);
+
+        if (vkdev->info.vendor_id() == 0x5143)
+        {
+            // unrolling caused an error due to insufficient shared memory on adreno
+            UNROLL_SG_M = 1;
+            UNROLL_SG_N = 1;
+            UNROLL_SG_K = 1;
+            UNROLL_WG_M = 1;
+            UNROLL_WG_N = 1;
+        }
 
         // qk cross
         {


### PR DESCRIPTION
large tile sizes on adreno gpu cause excessive shared memory usage when loops are unrolled. disabling unroll specifically for the adreno to prevent compilation errors.