### PR TITLE
refactor bf16 logic to work around ohos clang crash on aarch64

### DIFF
--- a/.github/workflows/harmonyos.yml
+++ b/.github/workflows/harmonyos.yml
@@ -41,7 +41,6 @@ jobs:
         -DCMAKE_TOOLCHAIN_FILE=/data/action/osd/ohos-sdk/linux/native/build/cmake/ohos.toolchain.cmake \
         -DCMAKE_INSTALL_PREFIX=install \
         -DCMAKE_BUILD_TYPE=Release \
-        -DNCNN_SIMPLEOMP=ON \
         -DNCNN_VULKAN=ON \
 
     steps:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ https://github.com/Tencent/ncnn/releases/latest
 
 <tr>
 <td rowspan=3>
-  <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/HMOS_Logo_Icon.svg/240px-HMOS_Logo_Icon.svg.png" width="120" height="auto">
+  <img src="https://upload.wikimedia.org/wikipedia/commons/3/37/HMOS_Logo_Icon.svg" width="120" height="auto">
 </td>
 <td colspan=3>
 

--- a/docs/how-to-build/how-to-build.md
+++ b/docs/how-to-build/how-to-build.md
@@ -948,10 +948,8 @@ cd build
 export HM_SDK=/opt/ohos-sdk/linux
 
 # Choose HarmonyOS sdk cmake toolchain file.
-# If you want to enable vulkan, set -DNCNN_VULKAN=ON
-# The HarmonyOS sdk does not support openmp, use ncnn simpleomp instead.
 # Cross-compiling with CMake must use the one provided by the HarmonyOS SDK; otherwise, it won't recognize parameters like OHOS_PLATFORM, leading to compilation errors.
-${HM_SDK}/native/build-tools/cmake/bin/cmake -DOHOS_STL=c++_static -DOHOS_ARCH=arm64-v8a -DOHOS_PLATFORM=OHOS -DCMAKE_TOOLCHAIN_FILE=${HM_SDK}/native/build/cmake/ohos.toolchain.cmake -DNCNN_VULKAN=ON -DNCNN_SIMPLEOMP=ON ..
+${HM_SDK}/native/build-tools/cmake/bin/cmake -DOHOS_ARCH=arm64-v8a -DCMAKE_TOOLCHAIN_FILE=${HM_SDK}/native/build/cmake/ohos.toolchain.cmake -DNCNN_VULKAN=ON ..
 
 make -j$(nproc)
 make install

--- a/src/layer/arm/gemm_bf16s.h
+++ b/src/layer/arm/gemm_bf16s.h
@@ -2495,10 +2495,10 @@ static void transpose_pack_A_tile_fp32_to_bf16(const Mat& A, Mat& AT, int i, int
         }
         for (; kk + 1 < max_kk; kk += 2)
         {
-            uint16x4_t _k0 = float2bfloat(vcombine_f32(vld1_f32(p0), vdup_n_f32(0.f)));
-            uint16x4_t _k1 = float2bfloat(vcombine_f32(vld1_f32(p0 + A_hstep), vdup_n_f32(0.f)));
-            uint16x4x2_t _r01 = vzip_u16(_k0, _k1);
-            vst1_u16(pp, _r01.val[0]);
+            pp[0] = float32_to_bfloat16(p0[0]);
+            pp[1] = float32_to_bfloat16(p0[A_hstep]);
+            pp[2] = float32_to_bfloat16(p0[1]);
+            pp[3] = float32_to_bfloat16(p0[A_hstep + 1]);
             pp += 4;
             p0 += A_hstep * 2;
         }
@@ -3277,10 +3277,10 @@ static void transpose_pack_B_tile_fp32_to_bf16(const Mat& B, Mat& BT, int j, int
         }
         for (; kk + 1 < max_kk; kk += 2)
         {
-            uint16x4_t _k0 = float2bfloat(vcombine_f32(vld1_f32(p0), vdup_n_f32(0.f)));
-            uint16x4_t _k1 = float2bfloat(vcombine_f32(vld1_f32(p0 + B_hstep), vdup_n_f32(0.f)));
-            uint16x4x2_t _r01 = vzip_u16(_k0, _k1);
-            vst1_u16(pp, _r01.val[0]);
+            pp[0] = float32_to_bfloat16(p0[0]);
+            pp[1] = float32_to_bfloat16(p0[B_hstep]);
+            pp[2] = float32_to_bfloat16(p0[1]);
+            pp[3] = float32_to_bfloat16(p0[B_hstep + 1]);
             pp += 4;
             p0 += B_hstep * 2;
         }


### PR DESCRIPTION
```
fatal error: error in backend: Cannot select: 0x557ae9c40320: v4bf16 = AArch64ISD::ZIP1 0x557ae7e0e548, 0x557aea109a60
  0x557ae7e0e548: v4bf16 = extract_subvector 0x557ae9c40730, Constant:i64<0>
    0x557ae9c40730: v8bf16 = llvm.aarch64.neon.bfcvtn nnan ninf nsz arcp contract afn reassoc TargetConstant:i64<461>, 0x557ae7e0eaf8
      0x557ae9c3ffe0: i64 = TargetConstant<461>
      0x557ae7e0eaf8: v4f32 = concat_vectors 0x557ae7e0e4e0, 0x557ae9a26fe8
        0x557ae7e0e4e0: v2f32 = bitcast 0x557aea109990
          0x557aea109990: v2i32,ch = load<(load (s64) from %ir.93, align 4)> 0x557ae9b89408, 0x557ae9c40b40, undef:i64
            0x557ae9c40b40: i64,ch = CopyFromReg 0x557ae9b89408, Register:i64 %34
              0x557ae9a26488: i64 = Register %34
            0x557ae7e0e2d8: i64 = undef
        0x557ae9a26fe8: v2f32 = AArch64ISD::NVCAST 0x557ae7e0e750
          0x557ae7e0e750: f64 = AArch64ISD::MOVIedit Constant:i32<0>
            0x557aea109ed8: i32 = Constant<0>
    0x557ae9c40ad8: i64 = Constant<0>
  0x557aea109a60: v4bf16 = extract_subvector 0x557ae9a26de0, Constant:i64<0>
    0x557ae9a26de0: v8bf16 = llvm.aarch64.neon.bfcvtn nnan ninf nsz arcp contract afn reassoc TargetConstant:i64<461>, 0x557ae9c40c10
      0x557ae9c3ffe0: i64 = TargetConstant<461>
      0x557ae9c40c10: v4f32 = concat_vectors 0x557ae7e0e888, 0x557ae9a26fe8
        0x557ae7e0e888: v2f32 = bitcast 0x557ae9a269d0
          0x557ae9a269d0: v2i32,ch = load<(load (s64) from %ir.99, align 4)> 0x557ae9b89408, 0x557aea10a488, undef:i64
            0x557aea10a488: i64 = add 0x557ae9c40b40, 0x557ae9c409a0
              0x557ae9c40b40: i64,ch = CopyFromReg 0x557ae9b89408, Register:i64 %34
                0x557ae9a26488: i64 = Register %34
              0x557ae9c409a0: i64,ch = CopyFromReg 0x557ae9b89408, Register:i64 %4
                0x557ae9a26b08: i64 = Register %4
            0x557ae7e0e2d8: i64 = undef
        0x557ae9a26fe8: v2f32 = AArch64ISD::NVCAST 0x557ae7e0e750
          0x557ae7e0e750: f64 = AArch64ISD::MOVIedit Constant:i32<0>
            0x557aea109ed8: i32 = Constant<0>
    0x557ae9c40ad8: i64 = Constant<0>
In function: _ZN4ncnn39transpose_pack_A_tile_fp32_to_bf16_bf16ERKNS_3MatERS0_iiii
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.      Program arguments: /data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang++ --target=aarch64-linux-ohos --gcc-toolchain=/data/action/osd/tmp/ohos-sdk/linux/native/llvm --sysroot=/data/action/osd/tmp/ohos-sdk/linux/native/sysroot -I/data/action/osd/ncnn/src/layer/arm -I/data/action/osd/ncnn/src -I/data/action/osd/ncnn/build-arm64-v8a/src -I/data/action/osd/ncnn/src/layer -I/data/action/osd/ncnn/src/.. -I/data/action/osd/ncnn/glslang/glslang/.. -I/data/action/osd/ncnn/build-arm64-v8a/include -I/data/action/osd/ncnn/glslang/SPIRV/.. -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -fno-addrsig -Wa,--noexecstack -Wformat -Werror=format-security -D__MUSL__ -O2 -DNDEBUG -std=gnu++11 -fPIC -DNCNN_STATIC_DEFINE -Wall -Wextra -Wno-unused-function -ffast-math -fvisibility=hidden -fvisibility-inlines-hidden -fopenmp=libomp -pthread -march=armv8.4-a+fp16+dotprod+bf16 -MD -MT src/CMakeFiles/ncnn.dir/layer/arm/gemm_arm_bf16.cpp.o -MF CMakeFiles/ncnn.dir/layer/arm/gemm_arm_bf16.cpp.o.d -o CMakeFiles/ncnn.dir/layer/arm/gemm_arm_bf16.cpp.o -c /data/action/osd/ncnn/src/layer/arm/gemm_arm_bf16.cpp
1.      <eof> parser at end of file
2.      Code generation
3.      Running pass 'Function Pass Manager' on module '/data/action/osd/ncnn/src/layer/arm/gemm_arm_bf16.cpp'.
4.      Running pass 'AArch64 Instruction Selection' on function '@_ZN4ncnn39transpose_pack_A_tile_fp32_to_bf16_bf16ERKNS_3MatERS0_iiii'
 #0 0x0000557ab1fa9d31 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x44edd31)
 #1 0x0000557ab1fa74de llvm::sys::RunSignalHandlers() (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x44eb4de)
 #2 0x0000557ab1fa8ef6 llvm::sys::CleanupOnSignal(unsigned long) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x44ecef6)
 #3 0x0000557ab1ef56ba (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x44396ba)
 #4 0x0000557ab1ef55cb (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x44395cb)
 #5 0x0000557ab1fa3d47 llvm::sys::Process::Exit(int, bool) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x44e7d47)
 #6 0x0000557ab041a662 (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x295e662)
 #7 0x0000557ab1efa2c0 llvm::report_fatal_error(llvm::Twine const&, bool) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x443e2c0)
 #8 0x0000557ab32f12de llvm::SelectionDAGISel::CannotYetSelect(llvm::SDNode*) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x58352de)
 #9 0x0000557ab32f08a8 llvm::SelectionDAGISel::SelectCodeCommon(llvm::SDNode*, unsigned char const*, unsigned int) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x58348a8)
#10 0x0000557ab05eb6c9 (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x2b2f6c9)
#11 0x0000557ab32e78bf llvm::SelectionDAGISel::DoInstructionSelection() (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x582b8bf)
#12 0x0000557ab32e6d09 llvm::SelectionDAGISel::CodeGenAndEmitDAG() (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x582ad09)
#13 0x0000557ab32e5bf4 llvm::SelectionDAGISel::SelectAllBasicBlocks(llvm::Function const&) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x5829bf4)
#14 0x0000557ab32e28c3 llvm::SelectionDAGISel::runOnMachineFunction(llvm::MachineFunction&) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x58268c3)
#15 0x0000557ab1271b6c llvm::MachineFunctionPass::runOnFunction(llvm::Function&) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x37b5b6c)
#16 0x0000557ab1755022 llvm::FPPassManager::runOnFunction(llvm::Function&) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x3c99022)
#17 0x0000557ab175eec3 llvm::FPPassManager::runOnModule(llvm::Module&) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x3ca2ec3)
#18 0x0000557ab1755f66 llvm::legacy::PassManagerImpl::run(llvm::Module&) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x3c99f66)
#19 0x0000557ab28d1633 clang::EmitBackendOutput(clang::DiagnosticsEngine&, clang::HeaderSearchOptions const&, clang::CodeGenOptions const&, clang::TargetOptions const&, clang::LangOptions const&, llvm::StringRef, llvm::Module*, clang::BackendAction, std::__1::unique_ptr<llvm::raw_pwrite_stream, std::__1::default_delete<llvm::raw_pwrite_stream>>) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x4e15633)
#20 0x0000557ab2dd7909 (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x531b909)
#21 0x0000557ab42ee795 clang::ParseAST(clang::Sema&, bool, bool) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x6832795)
#22 0x0000557ab2dd501c clang::CodeGenAction::ExecuteAction() (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x531901c)
#23 0x0000557ab2ce5100 clang::FrontendAction::Execute() (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x5229100)
#24 0x0000557ab2c48ff2 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x518cff2)
#25 0x0000557ab2dcfef3 clang::ExecuteCompilerInvocation(clang::CompilerInstance*) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x5313ef3)
#26 0x0000557ab0419b3c cc1_main(llvm::ArrayRef<char const*>, char const*, void*) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x295db3c)
#27 0x0000557ab04177c8 (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x295b7c8)
#28 0x0000557ab2a56202 (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x4f9a202)
#29 0x0000557ab1ef551a llvm::CrashRecoveryContext::RunSafely(llvm::function_ref<void ()>) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x443951a)
#30 0x0000557ab2a55e12 clang::driver::CC1Command::Execute(llvm::ArrayRef<llvm::Optional<llvm::StringRef>>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*, bool*) const (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x4f99e12)
#31 0x0000557ab2a0df5a clang::driver::Compilation::ExecuteCommand(clang::driver::Command const&, clang::driver::Command const*&, bool) const (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x4f51f5a)
#32 0x0000557ab2a30bfe clang::driver::Driver::ExecuteCompilation(clang::driver::Compilation&, llvm::SmallVectorImpl<std::__1::pair<int, clang::driver::Command const*>>&) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x4f74bfe)
#33 0x0000557ab0416bc9 clang_main(int, char**) (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x295abc9)
#34 0x00007f487a0342a0 __libc_start_call_main (/lib64/libc.so.6+0x282a0)
#35 0x00007f487a034359 __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x28359)
#36 0x0000557ab038da8a _start (/data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin/clang+++0x28d1a8a)
clang++: error: clang frontend command failed with exit code 70 (use -v to see invocation)
OHOS (dev) clang version 15.0.4 (llvm-project bb5cdf0f93bfb5316dd3cc2a80d12ab829e49b43)
Target: aarch64-unknown-linux-ohos
Thread model: posix
InstalledDir: /data/action/osd/tmp/ohos-sdk/linux/native/llvm/bin
clang++: note: diagnostic msg: 
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang++: note: diagnostic msg: /tmp/gemm_arm_bf16-2a22f7.cpp
clang++: note: diagnostic msg: /tmp/gemm_arm_bf16-2a22f7.sh
clang++: note: diagnostic msg: 

********************
```