### PR TITLE
docs: fix minor grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![codecov](https://img.shields.io/codecov/c/github/Tencent/ncnn/master?style=for-the-badge)](https://codecov.io/gh/Tencent/ncnn)
 
 ncnn is a high-performance neural network inference computing framework optimized for mobile platforms.
-ncnn is deeply considerate about deployment and uses on mobile phones from the beginning of design.
+ncnn is deeply considerate of deployment and uses on mobile phones from the beginning of design.
 ncnn does not have third-party dependencies.
 It is cross-platform and runs faster than all known open-source frameworks on mobile phone cpu.
 Developers can easily deploy deep learning algorithm models to the mobile platform by using efficient ncnn implementation, creating intelligent APPs, and bringing artificial intelligence to your fingertips.


### PR DESCRIPTION
## Summary
Fix a minor grammar issue in the README: change "considerate about" to "considerate of" for correct English usage.

## Test Plan
- Visual inspection of README.md