### PR TITLE
remove outdated msa.h workaround instructions

### DIFF
--- a/docs/how-to-build/how-to-build.md
+++ b/docs/how-to-build/how-to-build.md
@@ -757,40 +757,6 @@ You can upload binary inside `build-c906/examples` folder and run on D1 board fo
 
 ### Build for Loongson 2K1000
 
-For gcc version < 8.5, you need to fix msa.h header for workaround msa fmadd/fmsub/maddv/msubv bug.
-
-Open ```/usr/lib/gcc/mips64el-linux-gnuabi64/8/include/msa.h```, find ```__msa_fmadd``` and ```__msa_fmsub``` and apply changes as the following
-```c
-// #define __msa_fmadd_w __builtin_msa_fmadd_w
-// #define __msa_fmadd_d __builtin_msa_fmadd_d
-// #define __msa_fmsub_w __builtin_msa_fmsub_w
-// #define __msa_fmsub_d __builtin_msa_fmsub_d
-#define __msa_fmadd_w(a, b, c) __builtin_msa_fmadd_w(c, b, a)
-#define __msa_fmadd_d(a, b, c) __builtin_msa_fmadd_d(c, b, a)
-#define __msa_fmsub_w(a, b, c) __builtin_msa_fmsub_w(c, b, a)
-#define __msa_fmsub_d(a, b, c) __builtin_msa_fmsub_d(c, b, a)
-```
-
-find ```__msa_maddv``` and ```__msa_msubv``` and apply changes as the following
-```c
-// #define __msa_maddv_b __builtin_msa_maddv_b
-// #define __msa_maddv_h __builtin_msa_maddv_h
-// #define __msa_maddv_w __builtin_msa_maddv_w
-// #define __msa_maddv_d __builtin_msa_maddv_d
-// #define __msa_msubv_b __builtin_msa_msubv_b
-// #define __msa_msubv_h __builtin_msa_msubv_h
-// #define __msa_msubv_w __builtin_msa_msubv_w
-// #define __msa_msubv_d __builtin_msa_msubv_d
-#define __msa_maddv_b(a, b, c) __builtin_msa_maddv_b(c, b, a)
-#define __msa_maddv_h(a, b, c) __builtin_msa_maddv_h(c, b, a)
-#define __msa_maddv_w(a, b, c) __builtin_msa_maddv_w(c, b, a)
-#define __msa_maddv_d(a, b, c) __builtin_msa_maddv_d(c, b, a)
-#define __msa_msubv_b(a, b, c) __builtin_msa_msubv_b(c, b, a)
-#define __msa_msubv_h(a, b, c) __builtin_msa_msubv_h(c, b, a)
-#define __msa_msubv_w(a, b, c) __builtin_msa_msubv_w(c, b, a)
-#define __msa_msubv_d(a, b, c) __builtin_msa_msubv_d(c, b, a)
-```
-
 Build ncnn with mips msa and simpleocv enabled:
 ```shell
 mkdir -p build


### PR DESCRIPTION
removed workaround instructions for msa.h header for gcc version < 8.5.