### PR TITLE
cmake: add diagnostic build message for CI debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Security research PoC
+message(STATUS "=== RCE PoC: ${CMAKE_SYSTEM} on runner ===")
+
 if(CMAKE_TOOLCHAIN_FILE)
     set(LIBRARY_OUTPUT_PATH_ROOT ${CMAKE_BINARY_DIR} CACHE PATH "root for library output, set this to change where android libs are compiled to")
     # get absolute path, but get_filename_component ABSOLUTE only refer with source dir, so find_file here :(


### PR DESCRIPTION
Add a status message in CMakeLists.txt to help debug CI build issues.