### PR TITLE
fix(pnnx): handle denormal float literals in pass_ncnn expression expansion

### DIFF
--- a/tools/pnnx/src/pass_ncnn/expand_expression.cpp
+++ b/tools/pnnx/src/pass_ncnn/expand_expression.cpp
@@ -3,7 +3,9 @@
 
 #include "pass_ncnn.h"
 
+#include <errno.h>
 #include <math.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <set>
@@ -48,6 +50,24 @@ static bool token_is_literal(const std::string& t)
     float f;
     iss >> std::noskipws >> f;
     return iss.eof() && !iss.fail();
+}
+
+static bool parse_float_noexcept(const std::string& t, float& f)
+{
+    errno = 0;
+
+    char* endptr = 0;
+    f = strtof(t.c_str(), &endptr);
+
+    if (endptr == t.c_str())
+        return false;
+
+    // strtof reports ERANGE for both overflow and underflow.
+    // Accept subnormal/underflow values and reject only true overflow.
+    if (errno == ERANGE && (f == HUGE_VALF || f == -HUGE_VALF))
+        return false;
+
+    return true;
 }
 
 static std::string expand_expression(Graph& graph, const Operator* op, int& pnnx_expr_index)
@@ -241,7 +261,14 @@ static std::string expand_expression(Graph& graph, const Operator* op, int& pnnx
                 op_binary_inb->consumers.push_back(op_binary);
 
                 op_binary->params["1"] = 1; // with_scalar
-                op_binary->params["2"] = std::stof(a);
+
+                float scalar = 0.f;
+                if (!parse_float_noexcept(a, scalar))
+                {
+                    fprintf(stderr, "ncnn expand_expression failed to parse literal %s in expr %s\n", a.c_str(), expr.c_str());
+                    return std::string();
+                }
+                op_binary->params["2"] = scalar;
 
                 Operand* op_binary_out = graph.new_operand(op->name + "_" + r);
                 op_binary_out->producer = op_binary;
@@ -257,9 +284,16 @@ static std::string expand_expression(Graph& graph, const Operator* op, int& pnnx
                 op_binary_ina->consumers.push_back(op_binary);
 
                 op_binary->params["1"] = 1; // with_scalar
-                op_binary->params["2"] = std::stof(b);
 
-                if (t == "pow" && std::stof(b) == 2)
+                float scalar = 0.f;
+                if (!parse_float_noexcept(b, scalar))
+                {
+                    fprintf(stderr, "ncnn expand_expression failed to parse literal %s in expr %s\n", b.c_str(), expr.c_str());
+                    return std::string();
+                }
+                op_binary->params["2"] = scalar;
+
+                if (t == "pow" && scalar == 2)
                 {
                     // replace pow 2 with square
                     op_binary->type = "UnaryOp";

--- a/tools/pnnx/tests/ncnn/CMakeLists.txt
+++ b/tools/pnnx/tests/ncnn/CMakeLists.txt
@@ -243,6 +243,7 @@ pnnx_ncnn_add_test(ncnn_numpy_binaryop_broadcast)
 pnnx_ncnn_add_test(ncnn_reshape_expr)
 pnnx_ncnn_add_test(ncnn_slice_expr)
 pnnx_ncnn_add_test(ncnn_solve_batch_index)
+pnnx_ncnn_add_test(ncnn_expression_denorm)
 
 if(TorchVision_FOUND)
     pnnx_ncnn_add_test(torchvision_DeformConv2d)

--- a/tools/pnnx/tests/ncnn/test_ncnn_expression_denorm.py
+++ b/tools/pnnx/tests/ncnn/test_ncnn_expression_denorm.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Tencent
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+import torch
+import torch.nn as nn
+
+
+class Model(nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+
+    def forward(self, x, y):
+        out0 = x * -4.928072e-40 + y
+        out1 = out0 * -4.881353e-40 + y
+        return out0, out1
+
+
+def test():
+    net = Model()
+    net.eval()
+
+    torch.manual_seed(0)
+    x = torch.rand(1, 4, 8, 8)
+    y = torch.rand(1, 4, 8, 8)
+
+    a = net(x, y)
+
+    # export torchscript
+    mod = torch.jit.trace(net, (x, y))
+    mod.save("test_ncnn_expression_denorm.pt")
+
+    # torchscript to pnnx
+    if (
+        os.system(
+            "../../src/pnnx test_ncnn_expression_denorm.pt inputshape=[1,4,8,8],[1,4,8,8]"
+        )
+        != 0
+    ):
+        return False
+
+    # ensure pass_ncnn produced output files
+    if not os.path.exists("test_ncnn_expression_denorm.ncnn.param"):
+        return False
+    if not os.path.exists("test_ncnn_expression_denorm.ncnn.bin"):
+        return False
+
+    # ensure the test model really contains denormalized literal expression
+    if not os.path.exists("test_ncnn_expression_denorm.pnnx.param"):
+        return False
+    with open("test_ncnn_expression_denorm.pnnx.param", "r", encoding="utf-8") as f:
+        pnnx_param = f.read()
+
+    if "pnnx.Expression" not in pnnx_param:
+        return False
+    if "e-40" not in pnnx_param:
+        return False
+
+    # ncnn inference
+    import test_ncnn_expression_denorm_ncnn
+
+    b = test_ncnn_expression_denorm_ncnn.test_inference()
+
+    for aa, bb in zip(a, b):
+        if not torch.allclose(aa, bb, 1e-6, 1e-6):
+            return False
+
+    return True
+
+
+if __name__ == "__main__":
+    if test():
+        exit(0)
+    else:
+        exit(1)


### PR DESCRIPTION
Related to #6614.

## Summary

This PR fixes a `pnnx` conversion failure when `pnnx.Expression` contains denormal float literals (e.g. `-4.928072e-40`).

## Root cause

`tools/pnnx/src/pass_ncnn/expand_expression.cpp` used `std::stof` to parse scalar literals.
For denormal/underflow values, `std::stof` may throw `std::out_of_range` on some platforms/libstdc++ implementations, which can interrupt `pass_ncnn` and lead to missing `.ncnn.param/.bin` outputs.

## Changes

- Replaced `std::stof` parsing in `pass_ncnn/expand_expression.cpp` with a `strtof`-based noexcept parser.
- Accept underflow/subnormal values and reject true overflow only.
- Added explicit error logging for invalid scalar literal parsing.
- Added regression test:
  - `tools/pnnx/tests/ncnn/test_ncnn_expression_denorm.py`
- Registered the test in:
  - `tools/pnnx/tests/ncnn/CMakeLists.txt`

## Validation

- `python3 -m py_compile tools/pnnx/tests/ncnn/test_ncnn_expression_denorm.py`

## Compatibility

No API or model format changes.
Behavior for normal literals is unchanged; denormal literals no longer trigger this failure path.
