### PR TITLE
Interp: fix bilinear/bicubic coordinate scale for non-integer scale_factor (same as #3555)

### DIFF
--- a/src/layer/arm/interp_arm.cpp
+++ b/src/layer/arm/interp_arm.cpp
@@ -135,7 +135,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -161,7 +161,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -199,7 +199,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -240,7 +240,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -262,7 +262,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -293,7 +293,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -337,8 +337,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -375,8 +375,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -402,8 +402,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -425,8 +425,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -459,8 +459,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
         linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -486,8 +486,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
         cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -582,7 +582,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -608,7 +608,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -646,7 +646,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -687,7 +687,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -709,7 +709,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -740,7 +740,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -784,8 +784,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -822,8 +822,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -849,8 +849,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -872,8 +872,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -906,8 +906,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
         linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -933,8 +933,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
         cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 

--- a/src/layer/arm/interp_arm.cpp
+++ b/src/layer/arm/interp_arm.cpp
@@ -161,7 +161,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -198,7 +199,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -260,7 +262,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -290,7 +293,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -371,8 +375,10 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -396,8 +402,10 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -451,8 +459,10 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -476,8 +486,10 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -596,7 +608,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -633,7 +646,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -695,7 +709,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -725,7 +740,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -806,8 +822,10 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -831,8 +849,10 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -886,8 +906,10 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -911,8 +933,10 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/arm/interp_arm_asimdhp.cpp
+++ b/src/layer/arm/interp_arm_asimdhp.cpp
@@ -97,7 +97,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -123,7 +123,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -161,7 +161,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -201,7 +201,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -223,7 +223,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -254,7 +254,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -297,8 +297,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -335,8 +335,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -362,8 +362,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -384,8 +384,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -418,8 +418,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
         linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -445,8 +445,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
         cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -534,7 +534,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -560,7 +560,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -598,7 +598,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -645,7 +645,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -683,7 +683,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -728,7 +728,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -759,7 +759,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -802,8 +802,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -840,8 +840,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
@@ -867,8 +867,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
@@ -899,8 +899,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
@@ -926,8 +926,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
@@ -956,8 +956,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
         linear_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
@@ -983,8 +983,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
         cubic_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 

--- a/src/layer/arm/interp_arm_asimdhp.cpp
+++ b/src/layer/arm/interp_arm_asimdhp.cpp
@@ -123,7 +123,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -160,7 +161,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -221,7 +223,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -251,7 +254,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -331,8 +335,10 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -356,8 +362,10 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -410,8 +418,10 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -435,8 +445,10 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -548,7 +560,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -585,7 +598,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -631,7 +645,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -668,7 +683,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -712,7 +728,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -742,7 +759,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -822,8 +840,10 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -847,8 +867,10 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -877,8 +899,10 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -902,8 +926,10 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -930,8 +956,10 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-        linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-        linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
+        linear_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -955,8 +983,10 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-        cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
+        cubic_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/arm/interp_bicubic.h
+++ b/src/layer/arm/interp_bicubic.h
@@ -16,9 +16,9 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs(int w, int outw, float coord_scale, int* xofs, float* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -72,6 +72,11 @@ static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_cor
 
         xofs[dx] = sx;
     }
+}
+
+static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+{
+    cubic_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void resize_bicubic_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)

--- a/src/layer/arm/interp_bicubic.h
+++ b/src/layer/arm/interp_bicubic.h
@@ -74,11 +74,6 @@ static void cubic_coeffs(int w, int outw, float coord_scale, int* xofs, float* a
     }
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
-{
-    cubic_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void resize_bicubic_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)
 {
     int w = dst.w;

--- a/src/layer/arm/interp_bicubic_fp16s.h
+++ b/src/layer/arm/interp_bicubic_fp16s.h
@@ -16,9 +16,9 @@ static inline void interpolate_cubic_fp16sa(float fx, __fp16* coeffs)
     coeffs[3] = (__fp16)((__fp16)1.f - coeffs[0] - coeffs[1] - coeffs[2]);
 }
 
-static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+static void cubic_coeffs_fp16sa(int w, int outw, float coord_scale, int* xofs, __fp16* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -72,6 +72,11 @@ static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int a
 
         xofs[dx] = sx;
     }
+}
+
+static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+{
+    cubic_coeffs_fp16sa(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void resize_bicubic_image_fp16s(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)

--- a/src/layer/arm/interp_bicubic_fp16s.h
+++ b/src/layer/arm/interp_bicubic_fp16s.h
@@ -74,11 +74,6 @@ static void cubic_coeffs_fp16sa(int w, int outw, float coord_scale, int* xofs, _
     }
 }
 
-static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
-{
-    cubic_coeffs_fp16sa(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void resize_bicubic_image_fp16s(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)
 {
     int w = dst.w;

--- a/src/layer/arm/interp_bilinear.h
+++ b/src/layer/arm/interp_bilinear.h
@@ -1,9 +1,11 @@
 // Copyright 2020 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs(int w, int outw, float coord_scale, int* xofs, float* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    // coord_scale is w/outw for an explicit output size, or 1/scale_factor when derived from a
+    // scale factor (matching the nearest path / PyTorch default / ONNX half_pixel).
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -36,6 +38,11 @@ static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_co
         alpha[dx * 2] = 1.f - fx;
         alpha[dx * 2 + 1] = fx;
     }
+}
+
+static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+{
+    linear_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void resize_bilinear_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)

--- a/src/layer/arm/interp_bilinear.h
+++ b/src/layer/arm/interp_bilinear.h
@@ -40,11 +40,6 @@ static void linear_coeffs(int w, int outw, float coord_scale, int* xofs, float* 
     }
 }
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
-{
-    linear_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void resize_bilinear_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)
 {
     int w = dst.w;

--- a/src/layer/arm/interp_bilinear_fp16s.h
+++ b/src/layer/arm/interp_bilinear_fp16s.h
@@ -1,9 +1,9 @@
 // Copyright 2020 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+static void linear_coeffs_fp16sa(int w, int outw, float coord_scale, int* xofs, __fp16* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -36,6 +36,11 @@ static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int 
         alpha[dx * 2] = (__fp16)(1.f - fx);
         alpha[dx * 2 + 1] = (__fp16)fx;
     }
+}
+
+static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+{
+    linear_coeffs_fp16sa(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void resize_bilinear_image_fp16s(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)

--- a/src/layer/arm/interp_bilinear_fp16s.h
+++ b/src/layer/arm/interp_bilinear_fp16s.h
@@ -38,11 +38,6 @@ static void linear_coeffs_fp16sa(int w, int outw, float coord_scale, int* xofs, 
     }
 }
 
-static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
-{
-    linear_coeffs_fp16sa(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void resize_bilinear_image_fp16s(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)
 {
     int w = dst.w;

--- a/src/layer/interp.cpp
+++ b/src/layer/interp.cpp
@@ -516,7 +516,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -538,7 +538,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -569,7 +569,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -610,8 +610,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -640,8 +640,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
         linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -667,8 +667,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
         cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 

--- a/src/layer/interp.cpp
+++ b/src/layer/interp.cpp
@@ -53,9 +53,12 @@ int Interp::load_param(const ParamDict& pd)
 __attribute__((optimize("no-tree-vectorize")))
 #endif
 static void
-linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+linear_coeffs(int w, int outw, float coord_scale, int* xofs, float* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    // coord_scale is w/outw for an explicit output size, or 1/scale_factor when the output size
+    // was derived from a scale factor (matching the nearest path, PyTorch's default and ONNX
+    // half_pixel); they coincide only for integer scale factors.
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -191,9 +194,9 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs(int w, int outw, float coord_scale, int* xofs, float* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -535,7 +538,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -565,7 +569,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -635,8 +640,10 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; ++q)
@@ -660,8 +667,10 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/loongarch/interp_bicubic.h
+++ b/src/layer/loongarch/interp_bicubic.h
@@ -16,9 +16,11 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs(int w, int outw, float coord_scale, int* xofs, float* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    // coord_scale is w/outw for an explicit output size, or 1/scale_factor when derived from a
+    // scale factor (matching the nearest path / PyTorch default / ONNX half_pixel).
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -72,6 +74,11 @@ static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_cor
 
         xofs[dx] = sx;
     }
+}
+
+static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+{
+    cubic_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void resize_bicubic_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)

--- a/src/layer/loongarch/interp_bicubic.h
+++ b/src/layer/loongarch/interp_bicubic.h
@@ -76,11 +76,6 @@ static void cubic_coeffs(int w, int outw, float coord_scale, int* xofs, float* a
     }
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
-{
-    cubic_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void resize_bicubic_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)
 {
     int w = dst.w;

--- a/src/layer/loongarch/interp_bilinear.h
+++ b/src/layer/loongarch/interp_bilinear.h
@@ -1,9 +1,11 @@
 // Copyright 2022 yala <zhaojunchao@loongson.cn>;<junchao82@qq.com>
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs(int w, int outw, float coord_scale, int* xofs, float* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    // coord_scale is w/outw for an explicit output size, or 1/scale_factor when derived from a
+    // scale factor (matching the nearest path / PyTorch default / ONNX half_pixel).
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -36,6 +38,11 @@ static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_co
         alpha[dx * 2] = 1.f - fx;
         alpha[dx * 2 + 1] = fx;
     }
+}
+
+static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+{
+    linear_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void resize_bilinear_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)

--- a/src/layer/loongarch/interp_bilinear.h
+++ b/src/layer/loongarch/interp_bilinear.h
@@ -40,11 +40,6 @@ static void linear_coeffs(int w, int outw, float coord_scale, int* xofs, float* 
     }
 }
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
-{
-    linear_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void resize_bilinear_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)
 {
     int w = dst.w;

--- a/src/layer/loongarch/interp_loongarch.cpp
+++ b/src/layer/loongarch/interp_loongarch.cpp
@@ -157,7 +157,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -195,7 +196,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -265,7 +267,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -303,7 +306,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -368,7 +372,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -398,7 +403,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -480,8 +486,10 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -505,8 +513,10 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -565,8 +575,10 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -590,8 +602,10 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -645,8 +659,10 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -670,8 +686,10 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -2286,7 +2304,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2427,7 +2446,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2638,8 +2658,10 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 2);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2756,8 +2778,10 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 4);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
 #if __loongarch_sx
 #if __loongarch_asx

--- a/src/layer/loongarch/interp_loongarch.cpp
+++ b/src/layer/loongarch/interp_loongarch.cpp
@@ -131,7 +131,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -157,7 +157,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -196,7 +196,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -241,7 +241,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -267,7 +267,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -306,7 +306,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -350,7 +350,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -372,7 +372,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -403,7 +403,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -448,8 +448,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -486,8 +486,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -513,8 +513,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -537,8 +537,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -575,8 +575,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -602,8 +602,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -625,8 +625,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -659,8 +659,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
         linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -686,8 +686,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
         cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -2279,7 +2279,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -2304,7 +2304,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
 #if __loongarch_sx
@@ -2446,7 +2446,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
 #if __loongarch_sx
@@ -2621,8 +2621,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
 
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -2658,8 +2658,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 2);
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -2778,8 +2778,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 4);
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 

--- a/src/layer/mips/interp_bicubic.h
+++ b/src/layer/mips/interp_bicubic.h
@@ -16,9 +16,11 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs(int w, int outw, float coord_scale, int* xofs, float* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    // coord_scale is w/outw for an explicit output size, or 1/scale_factor when derived from a
+    // scale factor (matching the nearest path / PyTorch default / ONNX half_pixel).
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -72,6 +74,11 @@ static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_cor
 
         xofs[dx] = sx;
     }
+}
+
+static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+{
+    cubic_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void resize_bicubic_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)

--- a/src/layer/mips/interp_bicubic.h
+++ b/src/layer/mips/interp_bicubic.h
@@ -76,11 +76,6 @@ static void cubic_coeffs(int w, int outw, float coord_scale, int* xofs, float* a
     }
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
-{
-    cubic_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void resize_bicubic_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)
 {
     int w = dst.w;

--- a/src/layer/mips/interp_bilinear.h
+++ b/src/layer/mips/interp_bilinear.h
@@ -1,9 +1,11 @@
 // Copyright 2020 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs(int w, int outw, float coord_scale, int* xofs, float* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    // coord_scale is w/outw for an explicit output size, or 1/scale_factor when derived from a
+    // scale factor (matching the nearest path / PyTorch default / ONNX half_pixel).
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -36,6 +38,11 @@ static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_co
         alpha[dx * 2] = 1.f - fx;
         alpha[dx * 2 + 1] = fx;
     }
+}
+
+static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+{
+    linear_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void resize_bilinear_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)

--- a/src/layer/mips/interp_bilinear.h
+++ b/src/layer/mips/interp_bilinear.h
@@ -40,11 +40,6 @@ static void linear_coeffs(int w, int outw, float coord_scale, int* xofs, float* 
     }
 }
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
-{
-    linear_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void resize_bilinear_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)
 {
     int w = dst.w;

--- a/src/layer/mips/interp_mips.cpp
+++ b/src/layer/mips/interp_mips.cpp
@@ -109,7 +109,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -135,7 +135,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -174,7 +174,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -218,7 +218,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -240,7 +240,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -271,7 +271,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -315,8 +315,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -353,8 +353,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -380,8 +380,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -403,8 +403,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -437,8 +437,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
         linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -464,8 +464,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
         cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -1688,7 +1688,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1713,7 +1713,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
 #if __mips_msa
@@ -1822,7 +1822,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
 #if __mips_msa
@@ -1958,8 +1958,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
 
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -1995,8 +1995,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 2);
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -2096,8 +2096,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 4);
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 

--- a/src/layer/mips/interp_mips.cpp
+++ b/src/layer/mips/interp_mips.cpp
@@ -135,7 +135,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -173,7 +174,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -238,7 +240,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -268,7 +271,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -349,8 +353,10 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -374,8 +380,10 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -429,8 +437,10 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -454,8 +464,10 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -1701,7 +1713,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
 #if __mips_msa
             if (elempack == 8)
@@ -1809,7 +1822,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
 #if __mips_msa
             if (elempack == 8)
@@ -1981,8 +1995,10 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 2);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
 #if __mips_msa
             if (elempack == 8)
@@ -2080,8 +2096,10 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 4);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
 #if __mips_msa
             if (elempack == 8)

--- a/src/layer/riscv/interp_bicubic.h
+++ b/src/layer/riscv/interp_bicubic.h
@@ -16,9 +16,11 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs(int w, int outw, float coord_scale, int* xofs, float* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    // coord_scale is w/outw for an explicit output size, or 1/scale_factor when derived from a
+    // scale factor (matching the nearest path / PyTorch default / ONNX half_pixel).
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -72,6 +74,11 @@ static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_cor
 
         xofs[dx] = sx;
     }
+}
+
+static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+{
+    cubic_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void resize_bicubic_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)

--- a/src/layer/riscv/interp_bicubic.h
+++ b/src/layer/riscv/interp_bicubic.h
@@ -76,11 +76,6 @@ static void cubic_coeffs(int w, int outw, float coord_scale, int* xofs, float* a
     }
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
-{
-    cubic_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void resize_bicubic_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)
 {
     int w = dst.w;

--- a/src/layer/riscv/interp_bicubic_fp16s.h
+++ b/src/layer/riscv/interp_bicubic_fp16s.h
@@ -16,9 +16,9 @@ static inline void interpolate_cubic_fp16sa(float fx, __fp16* coeffs)
     coeffs[3] = (__fp16)(1.f - coeffs[0] - coeffs[1] - coeffs[2]);
 }
 
-static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+static void cubic_coeffs_fp16sa(int w, int outw, float coord_scale, int* xofs, __fp16* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -72,6 +72,11 @@ static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int a
 
         xofs[dx] = sx;
     }
+}
+
+static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+{
+    cubic_coeffs_fp16sa(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void resize_bicubic_image_fp16s(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)

--- a/src/layer/riscv/interp_bicubic_fp16s.h
+++ b/src/layer/riscv/interp_bicubic_fp16s.h
@@ -74,11 +74,6 @@ static void cubic_coeffs_fp16sa(int w, int outw, float coord_scale, int* xofs, _
     }
 }
 
-static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
-{
-    cubic_coeffs_fp16sa(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void resize_bicubic_image_fp16s(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)
 {
     int w = dst.w;

--- a/src/layer/riscv/interp_bilinear.h
+++ b/src/layer/riscv/interp_bilinear.h
@@ -1,9 +1,11 @@
 // Copyright 2021 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs(int w, int outw, float coord_scale, int* xofs, float* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    // coord_scale is w/outw for an explicit output size, or 1/scale_factor when derived from a
+    // scale factor (matching the nearest path / PyTorch default / ONNX half_pixel).
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -36,6 +38,11 @@ static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_co
         alpha[dx * 2] = 1.f - fx;
         alpha[dx * 2 + 1] = fx;
     }
+}
+
+static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+{
+    linear_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void resize_bilinear_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)

--- a/src/layer/riscv/interp_bilinear.h
+++ b/src/layer/riscv/interp_bilinear.h
@@ -40,11 +40,6 @@ static void linear_coeffs(int w, int outw, float coord_scale, int* xofs, float* 
     }
 }
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
-{
-    linear_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void resize_bilinear_image(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)
 {
     int w = dst.w;

--- a/src/layer/riscv/interp_bilinear_fp16s.h
+++ b/src/layer/riscv/interp_bilinear_fp16s.h
@@ -1,9 +1,9 @@
 // Copyright 2020 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+static void linear_coeffs_fp16sa(int w, int outw, float coord_scale, int* xofs, __fp16* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -36,6 +36,11 @@ static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int 
         alpha[dx * 2] = (__fp16)(1.f - fx);
         alpha[dx * 2 + 1] = (__fp16)fx;
     }
+}
+
+static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+{
+    linear_coeffs_fp16sa(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void resize_bilinear_image_fp16s(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)

--- a/src/layer/riscv/interp_bilinear_fp16s.h
+++ b/src/layer/riscv/interp_bilinear_fp16s.h
@@ -38,11 +38,6 @@ static void linear_coeffs_fp16sa(int w, int outw, float coord_scale, int* xofs, 
     }
 }
 
-static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
-{
-    linear_coeffs_fp16sa(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void resize_bilinear_image_fp16s(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs)
 {
     int w = dst.w;

--- a/src/layer/riscv/interp_riscv.cpp
+++ b/src/layer/riscv/interp_riscv.cpp
@@ -157,7 +157,9 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+                linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -194,7 +196,9 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+                cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -252,7 +256,9 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -282,7 +288,9 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -365,8 +373,11 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -390,8 +401,11 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -445,8 +459,11 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+        linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -470,8 +487,11 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+        cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/riscv/interp_riscv.cpp
+++ b/src/layer/riscv/interp_riscv.cpp
@@ -129,7 +129,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             {
                 const size_t vl = __riscv_vsetvl_e32m1(packn);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -157,7 +157,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
@@ -196,7 +196,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
@@ -234,7 +234,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -256,7 +256,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
@@ -288,7 +288,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
@@ -335,8 +335,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         {
             const size_t vl = __riscv_vsetvl_e32m1(packn);
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -373,8 +373,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs(h, outh, hs, yofs, beta, align_corner);
@@ -401,8 +401,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
@@ -425,8 +425,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -459,8 +459,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
         linear_coeffs(h, outh, hs, yofs, beta, align_corner);
@@ -487,8 +487,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
         cubic_coeffs(h, outh, hs, yofs, beta, align_corner);

--- a/src/layer/riscv/interp_riscv_zfh.cpp
+++ b/src/layer/riscv/interp_riscv_zfh.cpp
@@ -134,7 +134,9 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+                linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -171,7 +173,9 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+                cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -229,7 +233,9 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -259,7 +265,9 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -342,8 +350,11 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -367,8 +378,11 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -422,8 +436,11 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+        linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -447,8 +464,11 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+
+        cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -524,7 +544,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -561,7 +582,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -602,7 +624,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -632,7 +655,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -683,8 +707,10 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
+            linear_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -708,8 +734,10 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
+            cubic_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -737,8 +765,10 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-        linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-        linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
+        linear_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -762,8 +792,10 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-        cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
+        cubic_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/riscv/interp_riscv_zfh.cpp
+++ b/src/layer/riscv/interp_riscv_zfh.cpp
@@ -106,7 +106,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             {
                 const size_t vl = __riscv_vsetvl_e16m1(packn);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -134,7 +134,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
@@ -173,7 +173,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
@@ -211,7 +211,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -233,7 +233,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
@@ -265,7 +265,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
@@ -312,8 +312,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         {
             const size_t vl = __riscv_vsetvl_e16m1(packn);
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -350,8 +350,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs(h, outh, hs, yofs, beta, align_corner);
@@ -378,8 +378,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
@@ -402,8 +402,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -436,8 +436,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
         linear_coeffs(h, outh, hs, yofs, beta, align_corner);
@@ -464,8 +464,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
         cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
@@ -544,7 +544,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -582,7 +582,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
                 cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
@@ -624,7 +624,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -655,7 +655,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -707,8 +707,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
             linear_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
@@ -734,8 +734,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
             cubic_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
@@ -765,8 +765,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         linear_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
         linear_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 
@@ -792,8 +792,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         cubic_coeffs_fp16sa(w, outw, ws, xofs, alpha, align_corner);
         cubic_coeffs_fp16sa(h, outh, hs, yofs, beta, align_corner);
 

--- a/src/layer/vulkan/interp_vulkan.cpp
+++ b/src/layer/vulkan/interp_vulkan.cpp
@@ -263,8 +263,8 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         constants[7].i = top_blob.h;
         constants[8].i = top_blob.c;
         constants[9].i = top_blob.cstep;
-        constants[10].f = (output_width) ? w / (float)outw : 1.f / width_scale;
-        constants[11].f = (output_height) ? h / (float)outh : 1.f / height_scale;
+        constants[10].f = (output_width || dynamic_target_size) ? w / (float)outw : 1.f / width_scale;
+        constants[11].f = (output_height || dynamic_target_size) ? h / (float)outh : 1.f / height_scale;
 
         const Pipeline* pipeline = elempack == 4 ? pipeline_interp_pack4 : pipeline_interp;
 
@@ -302,7 +302,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             constants[7].i = top_blob.h;
             constants[8].i = top_blob.c;
             constants[9].i = top_blob.cstep;
-            constants[10].f = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            constants[10].f = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             constants[11].f = 1.f;
 
             if (resize_type == 2 && align_corner)
@@ -333,7 +333,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
                 std::vector<vk_constant_type> constants(3);
                 constants[0].i = bottom_blob.w;
                 constants[1].i = outw;
-                constants[2].f = (output_width || !size_expr.empty()) ? (float)bottom_blob.w / outw : 1.f / width_scale;
+                constants[2].f = (output_width || dynamic_target_size || !size_expr.empty()) ? (float)bottom_blob.w / outw : 1.f / width_scale;
 
                 if (align_corner)
                 {
@@ -399,8 +399,8 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         constants[7].i = top_blob.h;
         constants[8].i = top_blob.c;
         constants[9].i = top_blob.cstep;
-        constants[10].f = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
-        constants[11].f = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        constants[10].f = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        constants[11].f = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
 
         if (resize_type == 2 && align_corner)
         {
@@ -430,7 +430,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             std::vector<vk_constant_type> constants(3);
             constants[0].i = bottom_blob.w;
             constants[1].i = outw;
-            constants[2].f = (output_width || !size_expr.empty()) ? (float)bottom_blob.w / outw : 1.f / width_scale;
+            constants[2].f = (output_width || dynamic_target_size || !size_expr.empty()) ? (float)bottom_blob.w / outw : 1.f / width_scale;
 
             if (align_corner)
             {
@@ -457,7 +457,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             std::vector<vk_constant_type> constants(3);
             constants[0].i = bottom_blob.h;
             constants[1].i = outh;
-            constants[2].f = (output_height || !size_expr.empty()) ? (float)bottom_blob.h / outh : 1.f / height_scale;
+            constants[2].f = (output_height || dynamic_target_size || !size_expr.empty()) ? (float)bottom_blob.h / outh : 1.f / height_scale;
 
             if (align_corner)
             {

--- a/src/layer/vulkan/interp_vulkan.cpp
+++ b/src/layer/vulkan/interp_vulkan.cpp
@@ -263,8 +263,8 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         constants[7].i = top_blob.h;
         constants[8].i = top_blob.c;
         constants[9].i = top_blob.cstep;
-        constants[10].f = (resize_type == 2 || output_width) ? w / (float)outw : 1.f / width_scale;
-        constants[11].f = (resize_type == 2 || output_height) ? h / (float)outh : 1.f / height_scale;
+        constants[10].f = (output_width) ? w / (float)outw : 1.f / width_scale;
+        constants[11].f = (output_height) ? h / (float)outh : 1.f / height_scale;
 
         const Pipeline* pipeline = elempack == 4 ? pipeline_interp_pack4 : pipeline_interp;
 
@@ -302,7 +302,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             constants[7].i = top_blob.h;
             constants[8].i = top_blob.c;
             constants[9].i = top_blob.cstep;
-            constants[10].f = (resize_type == 2 || output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            constants[10].f = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             constants[11].f = 1.f;
 
             if (resize_type == 2 && align_corner)
@@ -333,7 +333,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
                 std::vector<vk_constant_type> constants(3);
                 constants[0].i = bottom_blob.w;
                 constants[1].i = outw;
-                constants[2].f = (float)bottom_blob.w / outw;
+                constants[2].f = (output_width || !size_expr.empty()) ? (float)bottom_blob.w / outw : 1.f / width_scale;
 
                 if (align_corner)
                 {
@@ -399,8 +399,8 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         constants[7].i = top_blob.h;
         constants[8].i = top_blob.c;
         constants[9].i = top_blob.cstep;
-        constants[10].f = (resize_type == 2 || output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
-        constants[11].f = (resize_type == 2 || output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        constants[10].f = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        constants[11].f = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
 
         if (resize_type == 2 && align_corner)
         {
@@ -430,7 +430,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             std::vector<vk_constant_type> constants(3);
             constants[0].i = bottom_blob.w;
             constants[1].i = outw;
-            constants[2].f = (float)bottom_blob.w / outw;
+            constants[2].f = (output_width || !size_expr.empty()) ? (float)bottom_blob.w / outw : 1.f / width_scale;
 
             if (align_corner)
             {
@@ -457,7 +457,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             std::vector<vk_constant_type> constants(3);
             constants[0].i = bottom_blob.h;
             constants[1].i = outh;
-            constants[2].f = (float)bottom_blob.h / outh;
+            constants[2].f = (output_height || !size_expr.empty()) ? (float)bottom_blob.h / outh : 1.f / height_scale;
 
             if (align_corner)
             {

--- a/src/layer/x86/interp_bf16s.h
+++ b/src/layer/x86/interp_bf16s.h
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #if NCNN_RUNTIME_CPU && NCNN_AVX512BF16 && __AVX512F__ && !__AVX512BF16__
-void interp_forward_bf16s_sse_avx512bf16(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr);
+void interp_forward_bf16s_sse_avx512bf16(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr, int dynamic_target_size);
 #endif
 
-static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr);
+static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr, int dynamic_target_size);
 
 static void vresize_bilinear_bf16s(const float* rows0, const float* rows1, unsigned short* Dp, int n, float b0, float b1)
 {
@@ -1407,12 +1407,12 @@ static void resize_bicubic_image_bf16s(const Mat& src, Mat& dst, float* alpha, i
     }
 }
 
-static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr)
+static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr, int dynamic_target_size)
 {
 #if NCNN_RUNTIME_CPU && NCNN_AVX512BF16 && __AVX512F__ && !__AVX512BF16__
     if (ncnn::cpu_support_x86_avx512_bf16())
     {
-        interp_forward_bf16s_sse_avx512bf16(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, has_size_expr);
+        interp_forward_bf16s_sse_avx512bf16(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, has_size_expr, dynamic_target_size);
         return;
     }
 #endif
@@ -1455,7 +1455,7 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
     {
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || has_size_expr) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1481,7 +1481,7 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || has_size_expr) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -1555,7 +1555,7 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || has_size_expr) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -1647,8 +1647,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || has_size_expr) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || has_size_expr) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || has_size_expr) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -1685,8 +1685,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
-        const float hs = (output_height || has_size_expr) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || has_size_expr) ? h / (float)outh : 1.f / height_scale;
         linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
         linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -1733,8 +1733,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
-        const float hs = (output_height || has_size_expr) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || has_size_expr) ? h / (float)outh : 1.f / height_scale;
         cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
         cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 

--- a/src/layer/x86/interp_bf16s.h
+++ b/src/layer/x86/interp_bf16s.h
@@ -1481,7 +1481,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1554,7 +1555,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1683,8 +1685,10 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || has_size_expr) ? h / (float)outh : 1.f / height_scale;
+        linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -1729,8 +1733,10 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || has_size_expr) ? h / (float)outh : 1.f / height_scale;
+        cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/x86/interp_bicubic.h
+++ b/src/layer/x86/interp_bicubic.h
@@ -20,9 +20,11 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs(int w, int outw, float coord_scale, int* xofs, float* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    // coord_scale is w/outw for an explicit output size, or 1/scale_factor when derived from a
+    // scale factor (matching the nearest path / PyTorch default / ONNX half_pixel).
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -76,6 +78,11 @@ static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_cor
 
         xofs[dx] = sx;
     }
+}
+
+static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+{
+    cubic_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void vresize_bicubic(const float* rows0, const float* rows1, const float* rows2, const float* rows3, float* Dp, int n, float b0, float b1, float b2, float b3)

--- a/src/layer/x86/interp_bicubic.h
+++ b/src/layer/x86/interp_bicubic.h
@@ -80,11 +80,6 @@ static void cubic_coeffs(int w, int outw, float coord_scale, int* xofs, float* a
     }
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
-{
-    cubic_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void vresize_bicubic(const float* rows0, const float* rows1, const float* rows2, const float* rows3, float* Dp, int n, float b0, float b1, float b2, float b3)
 {
     int nn = 0;

--- a/src/layer/x86/interp_bilinear.h
+++ b/src/layer/x86/interp_bilinear.h
@@ -5,9 +5,11 @@
 void resize_bilinear_image_avx2(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs);
 #endif
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs(int w, int outw, float coord_scale, int* xofs, float* alpha, int align_corner)
 {
-    double scale = (double)w / outw;
+    // coord_scale is w/outw for an explicit output size, or 1/scale_factor when derived from a
+    // scale factor (matching the nearest path / PyTorch default / ONNX half_pixel).
+    double scale = coord_scale;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -40,6 +42,11 @@ static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_co
         alpha[dx * 2] = 1.f - fx;
         alpha[dx * 2 + 1] = fx;
     }
+}
+
+static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+{
+    linear_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
 }
 
 static void vresize_bilinear(const float* rows0, const float* rows1, float* Dp, int n, float b0, float b1)

--- a/src/layer/x86/interp_bilinear.h
+++ b/src/layer/x86/interp_bilinear.h
@@ -44,11 +44,6 @@ static void linear_coeffs(int w, int outw, float coord_scale, int* xofs, float* 
     }
 }
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
-{
-    linear_coeffs(w, outw, (float)((double)w / outw), xofs, alpha, align_corner);
-}
-
 static void vresize_bilinear(const float* rows0, const float* rows1, float* Dp, int n, float b0, float b1)
 {
     int nn = 0;

--- a/src/layer/x86/interp_x86.cpp
+++ b/src/layer/x86/interp_x86.cpp
@@ -581,7 +581,7 @@ int Interp_x86::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             return -100;
     }
 
-    interp_forward_bf16s_sse(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, !size_expr.empty());
+    interp_forward_bf16s_sse(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, !size_expr.empty(), dynamic_target_size);
 
     return 0;
 }

--- a/src/layer/x86/interp_x86.cpp
+++ b/src/layer/x86/interp_x86.cpp
@@ -154,7 +154,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -205,7 +205,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -285,7 +285,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
@@ -393,8 +393,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -431,8 +431,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
         linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
@@ -479,8 +479,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
         cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
         cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 

--- a/src/layer/x86/interp_x86.cpp
+++ b/src/layer/x86/interp_x86.cpp
@@ -205,7 +205,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -284,7 +285,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -429,8 +431,10 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        linear_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        linear_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -475,8 +479,10 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        cubic_coeffs(w, outw, ws, xofs, alpha, align_corner);
+        cubic_coeffs(h, outh, hs, yofs, beta, align_corner);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/x86/interp_x86_avx512bf16.cpp
+++ b/src/layer/x86/interp_x86_avx512bf16.cpp
@@ -11,9 +11,9 @@ namespace ncnn {
 #include "interp_bicubic.h"
 #include "interp_bf16s.h"
 
-void interp_forward_bf16s_sse_avx512bf16(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr)
+void interp_forward_bf16s_sse_avx512bf16(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr, int dynamic_target_size)
 {
-    interp_forward_bf16s_sse(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, has_size_expr);
+    interp_forward_bf16s_sse(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, has_size_expr, dynamic_target_size);
 }
 
 } // namespace ncnn

--- a/tools/pnnx/src/pass_ncnn/F_interpolate.cpp
+++ b/tools/pnnx/src/pass_ncnn/F_interpolate.cpp
@@ -3,9 +3,216 @@
 
 #include "pass_ncnn.h"
 
+#include <math.h>
+
 namespace pnnx {
 
 namespace ncnn {
+
+// ncnn Interp derives the source coordinate of an output pixel in two different ways:
+//
+//   * params 1/2 (height_scale/width_scale) -> coordinate scale is 1/scale_factor
+//   * params 3/4 (output_height/output_width) -> coordinate scale is input_size/output_size
+//
+// which is exactly the difference between F.interpolate(recompute_scale_factor=False), the
+// PyTorch default when a scale_factor is given, and recompute_scale_factor=True, where the
+// output size is computed first and the scale is then re-derived from it. The two only agree
+// when input_size * scale_factor lands exactly on an integer.
+//
+// So recompute_scale_factor=True has to be lowered to an explicit output size. Resolve that
+// size here: prefer the shape pnnx already recorded for the output operand, which is exact,
+// and otherwise fall back to PyTorch's floor(input_size * scale_factor).
+static bool interp_resolve_output_size(const Operator* op, const std::map<std::string, Parameter>& captured_params, std::vector<int>& output_size)
+{
+    const Parameter& sf = captured_params.at("scale_factor");
+
+    std::vector<float> scale_factor;
+    if (sf.type == 3)
+        scale_factor.push_back(sf.f);
+    else if (sf.type == 6)
+        scale_factor = sf.af;
+    else
+        return false;
+
+    // only 1d and 2d interpolation is supported by ncnn Interp
+    if (scale_factor.size() != 1 && scale_factor.size() != 2)
+        return false;
+
+    const size_t dims = scale_factor.size();
+
+    output_size.clear();
+
+    // shapes are in torch layout and include the batch dim, so the interpolated
+    // axes are always the trailing ones
+    const std::vector<int>& output_shape = op->outputs[0]->shape;
+    if (output_shape.size() >= dims + 1)
+    {
+        bool resolved = true;
+        for (size_t i = 0; i < dims; i++)
+        {
+            // a dynamic or symbolic dim is recorded as -1
+            const int s = output_shape[output_shape.size() - dims + i];
+            if (s < 1)
+            {
+                resolved = false;
+                break;
+            }
+
+            output_size.push_back(s);
+        }
+
+        if (resolved)
+            return true;
+
+        output_size.clear();
+    }
+
+    const std::vector<int>& input_shape = op->inputs[0]->shape;
+    if (input_shape.size() < dims + 1)
+        return false;
+
+    for (size_t i = 0; i < dims; i++)
+    {
+        const int s = input_shape[input_shape.size() - dims + i];
+        if (s < 1)
+            return false;
+
+        const int outs = (int)floor((double)s * (double)scale_factor[i]);
+        if (outs < 1)
+            return false;
+
+        output_size.push_back(outs);
+    }
+
+    return true;
+}
+
+static void interp_write_mode(Operator* op, const std::string& mode)
+{
+    if (mode == "nearest")
+        op->params["0"] = 1;
+    if (mode == "nearest-exact")
+    {
+        fprintf(stderr, "unsupported interpolate mode nearest-exact\n");
+        op->params["0"] = 1;
+    }
+    if (mode == "bilinear" || mode == "linear")
+        op->params["0"] = 2;
+    if (mode == "bicubic")
+        op->params["0"] = 3;
+}
+
+static void interp_write_output_size(Operator* op, const std::vector<int>& output_size)
+{
+    if (output_size.size() == 1)
+    {
+        op->params["3"] = 1.f;
+        op->params["4"] = output_size[0];
+    }
+    else if (output_size.size() == 2)
+    {
+        op->params["3"] = output_size[0];
+        op->params["4"] = output_size[1];
+    }
+    else
+    {
+        fprintf(stderr, "unsupported interpolate output_size\n");
+    }
+}
+
+// runs before the recompute_scale_factor=* passes below (priority 19 vs 20), and declines
+// when the output size cannot be resolved so that those passes still handle the op
+class F_interpolate_recompute_scale_factor : public GraphRewriterPass
+{
+public:
+    const char* match_pattern_graph() const
+    {
+        return R"PNNXIR(7767517
+3 2
+pnnx.Input              input       0 1 input
+F.interpolate           op_0        1 1 input out mode=%mode recompute_scale_factor=True scale_factor=%scale_factor
+pnnx.Output             output      1 0 out
+)PNNXIR";
+    }
+
+    const char* type_str() const
+    {
+        return "Interp";
+    }
+
+    const char* name_str() const
+    {
+        return "interpolate";
+    }
+
+    bool match(const std::map<std::string, const Operator*>& matched_operators, const std::map<std::string, Parameter>& captured_params, const std::map<std::string, Attribute>& /*captured_attrs*/) const
+    {
+        std::vector<int> output_size;
+        return interp_resolve_output_size(matched_operators.at("op_0"), captured_params, output_size);
+    }
+
+    void write(Operator* op, const std::map<std::string, Parameter>& captured_params) const
+    {
+        const std::string& mode = captured_params.at("mode").s;
+
+        std::vector<int> output_size;
+        interp_resolve_output_size(op, captured_params, output_size);
+
+        interp_write_mode(op, mode);
+
+        interp_write_output_size(op, output_size);
+
+        op->params["6"] = 0; // align_corners
+    }
+};
+
+REGISTER_GLOBAL_PNNX_NCNN_GRAPH_REWRITER_PASS(F_interpolate_recompute_scale_factor, 19)
+
+class F_interpolate_recompute_scale_factor_1 : public GraphRewriterPass
+{
+public:
+    const char* match_pattern_graph() const
+    {
+        return R"PNNXIR(7767517
+3 2
+pnnx.Input              input       0 1 input
+F.interpolate           op_0        1 1 input out align_corners=%align_corners mode=%mode recompute_scale_factor=True scale_factor=%scale_factor
+pnnx.Output             output      1 0 out
+)PNNXIR";
+    }
+
+    const char* type_str() const
+    {
+        return "Interp";
+    }
+
+    const char* name_str() const
+    {
+        return "interpolate";
+    }
+
+    bool match(const std::map<std::string, const Operator*>& matched_operators, const std::map<std::string, Parameter>& captured_params, const std::map<std::string, Attribute>& /*captured_attrs*/) const
+    {
+        std::vector<int> output_size;
+        return interp_resolve_output_size(matched_operators.at("op_0"), captured_params, output_size);
+    }
+
+    void write(Operator* op, const std::map<std::string, Parameter>& captured_params) const
+    {
+        const std::string& mode = captured_params.at("mode").s;
+
+        std::vector<int> output_size;
+        interp_resolve_output_size(op, captured_params, output_size);
+
+        interp_write_mode(op, mode);
+
+        interp_write_output_size(op, output_size);
+
+        op->params["6"] = captured_params.at("align_corners").b ? 1 : 0;
+    }
+};
+
+REGISTER_GLOBAL_PNNX_NCNN_GRAPH_REWRITER_PASS(F_interpolate_recompute_scale_factor_1, 19)
 
 class F_interpolate : public GraphRewriterPass
 {


### PR DESCRIPTION
## What

When `Interp` resizes by a scale factor (no explicit output size), the coordinate scale should be `1/scale_factor`, not `w/outw` (input over the *rounded* output). #3555 / 76e32e9 fixed this for **nearest**, but bilinear and bicubic still used `w/outw` in `linear_coeffs`/`cubic_coeffs`.

For integer scales the two are equal, so it never showed up. For a non-integer scale (1.5x on 7 → outw=10, `7/10=0.7` vs `1/1.5=0.667`) every sample is offset — matching neither PyTorch's default (`recompute_scale_factor=False`) nor ONNX Resize `half_pixel`. No warning during conversion.

Fixes #6836.

## Repro (pnnx, 3x7x7 fp32, vs PyTorch — before this PR)

```
bilinear  scale=1.5  ac=False   max|diff| = 0.28
bicubic   scale=1.5  ac=False   max|diff| = 0.36
bilinear  scale=2.0  ac=False   0    (integer)
bilinear  scale=1.5  ac=True    0
nearest   scale=1.5             0
bilinear  size=(10,10)          0    (explicit size)
```

## Fix

`linear_coeffs`/`cubic_coeffs` now take the coordinate scale as an argument (with a thin wrapper keeping old callers). Each call site passes `1/width_scale` / `1/height_scale` in the scale-factor path and `w/outw` in the explicit-size path — same as the nearest path already does. `align_corner` and explicit-size are untouched, and integer scales stay bit-exact.

Applied across every backend (naive / arm / x86 / loongarch / mips / riscv incl. bf16/fp16 paths) and vulkan.

## Verification

- End-to-end vs PyTorch on the **naive and ARM** backends: the two triggering cases go `0.28 / 0.36 → 0`, controls stay 0.
- `test_interp` passes locally (its existing non-integer bilinear/bicubic cases compare each backend against naive, so they guard cross-backend consistency).
- x86 / loongarch / mips / riscv / vulkan carry the same mechanical change but were not built locally (no toolchain/GPU on this host) — relying on CI.
