### PR TITLE
Fix non-integer scale factor interpolation

### DIFF
--- a/src/layer/arm/interp_arm.cpp
+++ b/src/layer/arm/interp_arm.cpp
@@ -135,7 +135,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -161,7 +161,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -198,7 +198,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -238,7 +238,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -260,7 +260,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -290,7 +290,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -333,8 +333,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -371,8 +371,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -396,8 +396,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -417,8 +417,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -451,8 +451,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -476,8 +476,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -570,7 +570,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -596,7 +596,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -633,7 +633,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -673,7 +673,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -695,7 +695,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -725,7 +725,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -768,8 +768,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -806,8 +806,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -831,8 +831,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -852,8 +852,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -886,8 +886,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -911,8 +911,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/arm/interp_arm.cpp
+++ b/src/layer/arm/interp_arm.cpp
@@ -161,7 +161,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -198,7 +198,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -260,7 +260,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -290,7 +290,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -371,8 +371,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -396,8 +396,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -451,8 +451,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -476,8 +476,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -596,7 +596,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -633,7 +633,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -695,7 +695,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -725,7 +725,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -806,8 +806,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -831,8 +831,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -886,8 +886,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -911,8 +911,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/arm/interp_arm.cpp
+++ b/src/layer/arm/interp_arm.cpp
@@ -318,7 +318,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         return 0;
     }
 
-    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+    if (is_identity_resize(w, h, outw, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -753,7 +753,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         return 0;
     }
 
-    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+    if (is_identity_resize(w, h, outw, outh))
     {
         top_blob = bottom_blob;
         return 0;

--- a/src/layer/arm/interp_arm.cpp
+++ b/src/layer/arm/interp_arm.cpp
@@ -120,7 +120,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -135,7 +135,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = get_resize_scale_x(w, outw);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -161,7 +161,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -198,7 +198,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -238,7 +238,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -260,7 +260,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -290,7 +290,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -318,7 +318,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         return 0;
     }
 
-    if (outw == w && outh == h)
+    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -333,8 +333,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = get_resize_scale_y(h, outh);
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -371,8 +371,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -396,8 +396,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -417,8 +417,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = get_resize_scale_y(h, outh);
+        const float ws = get_resize_scale_x(w, outw);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -451,8 +451,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -476,8 +476,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -555,7 +555,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -570,7 +570,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = get_resize_scale_x(w, outw);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -596,7 +596,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -633,7 +633,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -673,7 +673,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -695,7 +695,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -725,7 +725,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -753,7 +753,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         return 0;
     }
 
-    if (outw == w && outh == h)
+    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -768,8 +768,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = get_resize_scale_y(h, outh);
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -806,8 +806,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -831,8 +831,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -852,8 +852,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = get_resize_scale_y(h, outh);
+        const float ws = get_resize_scale_x(w, outw);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -886,8 +886,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -911,8 +911,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/arm/interp_arm_asimdhp.cpp
+++ b/src/layer/arm/interp_arm_asimdhp.cpp
@@ -97,7 +97,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -123,7 +123,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -160,7 +160,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -199,7 +199,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -221,7 +221,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -251,7 +251,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -293,8 +293,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -331,8 +331,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -356,8 +356,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -376,8 +376,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -410,8 +410,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -435,8 +435,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -522,7 +522,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -548,7 +548,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -585,7 +585,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -631,7 +631,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -668,7 +668,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -712,7 +712,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -742,7 +742,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -784,8 +784,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -822,8 +822,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -847,8 +847,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -877,8 +877,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -902,8 +902,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -930,8 +930,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-        linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -955,8 +955,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-        cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/arm/interp_arm_asimdhp.cpp
+++ b/src/layer/arm/interp_arm_asimdhp.cpp
@@ -123,7 +123,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -160,7 +160,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -221,7 +221,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -251,7 +251,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -331,8 +331,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -356,8 +356,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -410,8 +410,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -435,8 +435,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -548,7 +548,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -585,7 +585,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -631,7 +631,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -668,7 +668,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -712,7 +712,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -742,7 +742,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -822,8 +822,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -847,8 +847,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -877,8 +877,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -902,8 +902,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -930,8 +930,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-        linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-        linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+        linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -955,8 +955,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-        cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/arm/interp_arm_asimdhp.cpp
+++ b/src/layer/arm/interp_arm_asimdhp.cpp
@@ -279,7 +279,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         return 0;
     }
 
-    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+    if (is_identity_resize(w, h, outw, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -770,7 +770,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         return 0;
     }
 
-    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+    if (is_identity_resize(w, h, outw, outh))
     {
         top_blob = bottom_blob;
         return 0;

--- a/src/layer/arm/interp_arm_asimdhp.cpp
+++ b/src/layer/arm/interp_arm_asimdhp.cpp
@@ -83,7 +83,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -97,7 +97,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = get_resize_scale_x(w, outw);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -123,7 +123,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -160,7 +160,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -199,7 +199,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -221,7 +221,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -251,7 +251,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -279,7 +279,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         return 0;
     }
 
-    if (outw == w && outh == h)
+    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -293,8 +293,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = get_resize_scale_y(h, outh);
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -331,8 +331,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -356,8 +356,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -376,8 +376,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = get_resize_scale_y(h, outh);
+        const float ws = get_resize_scale_x(w, outw);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -410,8 +410,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -435,8 +435,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -508,7 +508,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -522,7 +522,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = get_resize_scale_x(w, outw);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -548,7 +548,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -585,7 +585,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -631,7 +631,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -668,7 +668,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -712,7 +712,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -742,7 +742,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -770,7 +770,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         return 0;
     }
 
-    if (outw == w && outh == h)
+    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -784,8 +784,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = get_resize_scale_y(h, outh);
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -822,8 +822,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -847,8 +847,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -877,8 +877,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -902,8 +902,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -930,8 +930,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-        linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -955,8 +955,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-        cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/arm/interp_bicubic.h
+++ b/src/layer/arm/interp_bicubic.h
@@ -16,9 +16,9 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs_impl(int w, int outw, int* xofs, float* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/arm/interp_bicubic_fp16s.h
+++ b/src/layer/arm/interp_bicubic_fp16s.h
@@ -16,9 +16,9 @@ static inline void interpolate_cubic_fp16sa(float fx, __fp16* coeffs)
     coeffs[3] = (__fp16)((__fp16)1.f - coeffs[0] - coeffs[1] - coeffs[2]);
 }
 
-static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+static void cubic_coeffs_fp16sa_impl(int w, int outw, int* xofs, __fp16* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/arm/interp_bilinear.h
+++ b/src/layer/arm/interp_bilinear.h
@@ -1,9 +1,9 @@
 // Copyright 2020 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs_impl(int w, int outw, int* xofs, float* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/arm/interp_bilinear_fp16s.h
+++ b/src/layer/arm/interp_bilinear_fp16s.h
@@ -1,9 +1,9 @@
 // Copyright 2020 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+static void linear_coeffs_fp16sa_impl(int w, int outw, int* xofs, __fp16* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/interp.cpp
+++ b/src/layer/interp.cpp
@@ -593,7 +593,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         return 0;
     }
 
-    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+    if (is_identity_resize(w, h, outw, outh))
     {
         top_blob = bottom_blob;
         return 0;

--- a/src/layer/interp.cpp
+++ b/src/layer/interp.cpp
@@ -501,7 +501,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -513,7 +513,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -535,7 +535,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -565,7 +565,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -593,7 +593,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         return 0;
     }
 
-    if (outw == w && outh == h)
+    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -605,8 +605,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = get_resize_scale_y(h, outh);
+        const float ws = get_resize_scale_x(w, outw);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -635,8 +635,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; ++q)
@@ -660,8 +660,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/interp.cpp
+++ b/src/layer/interp.cpp
@@ -513,7 +513,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -535,7 +535,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -565,7 +565,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -605,8 +605,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -635,8 +635,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; ++q)
@@ -660,8 +660,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/interp.cpp
+++ b/src/layer/interp.cpp
@@ -53,9 +53,9 @@ int Interp::load_param(const ParamDict& pd)
 __attribute__((optimize("no-tree-vectorize")))
 #endif
 static void
-linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+linear_coeffs_impl(int w, int outw, int* xofs, float* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -191,9 +191,9 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs_impl(int w, int outw, int* xofs, float* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -535,7 +535,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -565,7 +565,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -635,8 +635,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; ++q)
@@ -660,8 +660,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/interp.h
+++ b/src/layer/interp.h
@@ -22,6 +22,26 @@ public:
 protected:
     int eval_size_expr(const std::vector<Mat>& bottom_blobs, int& outw, int& outh) const;
 
+    float get_resize_scale_x(int w, int outw) const
+    {
+        return (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+    }
+
+    float get_resize_scale_y(int h, int outh) const
+    {
+        return (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+    }
+
+    bool is_identity_resize_x(int w, int outw) const
+    {
+        return outw == w && (output_width || dynamic_target_size || !size_expr.empty() || width_scale == 1.f);
+    }
+
+    bool is_identity_resize_y(int h, int outh) const
+    {
+        return outh == h && (output_height || dynamic_target_size || !size_expr.empty() || height_scale == 1.f);
+    }
+
 public:
     // param
     int resize_type; //1=nearest  2=bilinear  3=bicubic

--- a/src/layer/interp.h
+++ b/src/layer/interp.h
@@ -34,12 +34,41 @@ protected:
 
     bool is_identity_resize_x(int w, int outw) const
     {
-        return outw == w && (output_width || dynamic_target_size || !size_expr.empty() || width_scale == 1.f);
+        if (outw != w)
+            return false;
+
+        if (resize_type == 2 && w <= 1)
+            return true;
+        if (resize_type == 3 && w <= 3)
+            return true;
+
+        return output_width || dynamic_target_size || !size_expr.empty() || width_scale == 1.f;
     }
 
     bool is_identity_resize_y(int h, int outh) const
     {
-        return outh == h && (output_height || dynamic_target_size || !size_expr.empty() || height_scale == 1.f);
+        if (outh != h)
+            return false;
+
+        if (resize_type == 2 && h <= 1)
+            return true;
+        if (resize_type == 3 && h <= 3)
+            return true;
+
+        return output_height || dynamic_target_size || !size_expr.empty() || height_scale == 1.f;
+    }
+
+    bool is_identity_resize(int w, int h, int outw, int outh) const
+    {
+        if (outw != w || outh != h)
+            return false;
+
+        if (resize_type == 2 && (w <= 1 || h <= 1))
+            return true;
+        if (resize_type == 3 && (w <= 3 || h <= 3))
+            return true;
+
+        return is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh);
     }
 
 public:

--- a/src/layer/loongarch/interp_bicubic.h
+++ b/src/layer/loongarch/interp_bicubic.h
@@ -16,9 +16,9 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs_impl(int w, int outw, int* xofs, float* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/loongarch/interp_bilinear.h
+++ b/src/layer/loongarch/interp_bilinear.h
@@ -1,9 +1,9 @@
 // Copyright 2022 yala <zhaojunchao@loongson.cn>;<junchao82@qq.com>
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs_impl(int w, int outw, int* xofs, float* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/loongarch/interp_loongarch.cpp
+++ b/src/layer/loongarch/interp_loongarch.cpp
@@ -115,7 +115,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -131,7 +131,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = get_resize_scale_x(w, outw);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -157,7 +157,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -195,7 +195,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -239,7 +239,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = get_resize_scale_x(w, outw);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -265,7 +265,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -303,7 +303,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -346,7 +346,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -368,7 +368,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -398,7 +398,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -426,7 +426,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         return 0;
     }
 
-    if (outw == w && outh == h)
+    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -442,8 +442,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = get_resize_scale_y(h, outh);
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -480,8 +480,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -505,8 +505,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -527,8 +527,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = get_resize_scale_y(h, outh);
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -565,8 +565,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -590,8 +590,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -611,8 +611,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = get_resize_scale_y(h, outh);
+        const float ws = get_resize_scale_x(w, outw);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -645,8 +645,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -670,8 +670,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -2249,7 +2249,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -2261,7 +2261,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -2286,7 +2286,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2427,7 +2427,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2589,7 +2589,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
 
     if (dims == 3)
     {
-        if (outw == w && outh == h)
+        if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
         {
             top_blob = bottom_blob;
             return 0;
@@ -2601,8 +2601,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
 
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = get_resize_scale_y(h, outh);
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -2638,8 +2638,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 2);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2756,8 +2756,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 4);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
 #if __loongarch_sx
 #if __loongarch_asx

--- a/src/layer/loongarch/interp_loongarch.cpp
+++ b/src/layer/loongarch/interp_loongarch.cpp
@@ -426,7 +426,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         return 0;
     }
 
-    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+    if (is_identity_resize(w, h, outw, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -2589,7 +2589,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
 
     if (dims == 3)
     {
-        if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+        if (is_identity_resize(w, h, outw, outh))
         {
             top_blob = bottom_blob;
             return 0;

--- a/src/layer/loongarch/interp_loongarch.cpp
+++ b/src/layer/loongarch/interp_loongarch.cpp
@@ -131,7 +131,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -157,7 +157,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -195,7 +195,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -239,7 +239,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -265,7 +265,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -303,7 +303,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -346,7 +346,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -368,7 +368,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -398,7 +398,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -442,8 +442,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -480,8 +480,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -505,8 +505,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -527,8 +527,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -565,8 +565,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -590,8 +590,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -611,8 +611,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -645,8 +645,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -670,8 +670,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -2261,7 +2261,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -2286,7 +2286,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2427,7 +2427,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2601,8 +2601,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
 
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -2638,8 +2638,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 2);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2756,8 +2756,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 4);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
 #if __loongarch_sx
 #if __loongarch_asx

--- a/src/layer/loongarch/interp_loongarch.cpp
+++ b/src/layer/loongarch/interp_loongarch.cpp
@@ -157,7 +157,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -195,7 +195,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -265,7 +265,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -303,7 +303,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -368,7 +368,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -398,7 +398,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -480,8 +480,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -505,8 +505,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -565,8 +565,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -590,8 +590,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -645,8 +645,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -670,8 +670,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -2286,7 +2286,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2427,7 +2427,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2638,8 +2638,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 2);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2756,8 +2756,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 4);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
 #if __loongarch_sx
 #if __loongarch_asx

--- a/src/layer/mips/interp_bicubic.h
+++ b/src/layer/mips/interp_bicubic.h
@@ -16,9 +16,9 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs_impl(int w, int outw, int* xofs, float* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/mips/interp_bilinear.h
+++ b/src/layer/mips/interp_bilinear.h
@@ -1,9 +1,9 @@
 // Copyright 2020 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs_impl(int w, int outw, int* xofs, float* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/mips/interp_mips.cpp
+++ b/src/layer/mips/interp_mips.cpp
@@ -94,7 +94,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -109,7 +109,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = get_resize_scale_x(w, outw);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -135,7 +135,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -173,7 +173,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -216,7 +216,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -238,7 +238,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -268,7 +268,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -296,7 +296,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         return 0;
     }
 
-    if (outw == w && outh == h)
+    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -311,8 +311,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = get_resize_scale_y(h, outh);
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -349,8 +349,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -374,8 +374,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -395,8 +395,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = get_resize_scale_y(h, outh);
+        const float ws = get_resize_scale_x(w, outw);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -429,8 +429,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -454,8 +454,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -1664,7 +1664,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -1676,7 +1676,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1701,7 +1701,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
 #if __mips_msa
             if (elempack == 8)
@@ -1809,7 +1809,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
 #if __mips_msa
             if (elempack == 8)
@@ -1932,7 +1932,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
 
     if (dims == 3)
     {
-        if (outw == w && outh == h)
+        if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
         {
             top_blob = bottom_blob;
             return 0;
@@ -1944,8 +1944,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
 
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = get_resize_scale_y(h, outh);
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -1981,8 +1981,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 2);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
 #if __mips_msa
             if (elempack == 8)
@@ -2080,8 +2080,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 4);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
 #if __mips_msa
             if (elempack == 8)

--- a/src/layer/mips/interp_mips.cpp
+++ b/src/layer/mips/interp_mips.cpp
@@ -296,7 +296,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         return 0;
     }
 
-    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+    if (is_identity_resize(w, h, outw, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -1932,7 +1932,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
 
     if (dims == 3)
     {
-        if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+        if (is_identity_resize(w, h, outw, outh))
         {
             top_blob = bottom_blob;
             return 0;

--- a/src/layer/mips/interp_mips.cpp
+++ b/src/layer/mips/interp_mips.cpp
@@ -109,7 +109,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -135,7 +135,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -173,7 +173,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -216,7 +216,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -238,7 +238,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -268,7 +268,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -311,8 +311,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -349,8 +349,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -374,8 +374,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -395,8 +395,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -429,8 +429,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -454,8 +454,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -1676,7 +1676,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1701,7 +1701,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
 #if __mips_msa
             if (elempack == 8)
@@ -1809,7 +1809,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
 #if __mips_msa
             if (elempack == 8)
@@ -1944,8 +1944,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
 
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -1981,8 +1981,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 2);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
 #if __mips_msa
             if (elempack == 8)
@@ -2080,8 +2080,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 4);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
 #if __mips_msa
             if (elempack == 8)

--- a/src/layer/mips/interp_mips.cpp
+++ b/src/layer/mips/interp_mips.cpp
@@ -135,7 +135,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -173,7 +173,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -238,7 +238,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -268,7 +268,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -349,8 +349,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -374,8 +374,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -429,8 +429,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -454,8 +454,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -1701,7 +1701,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
 #if __mips_msa
             if (elempack == 8)
@@ -1809,7 +1809,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
 #if __mips_msa
             if (elempack == 8)
@@ -1981,8 +1981,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 2);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
 #if __mips_msa
             if (elempack == 8)
@@ -2080,8 +2080,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 4);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
 #if __mips_msa
             if (elempack == 8)

--- a/src/layer/riscv/interp_bicubic.h
+++ b/src/layer/riscv/interp_bicubic.h
@@ -16,9 +16,9 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs_impl(int w, int outw, int* xofs, float* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/riscv/interp_bicubic_fp16s.h
+++ b/src/layer/riscv/interp_bicubic_fp16s.h
@@ -16,9 +16,9 @@ static inline void interpolate_cubic_fp16sa(float fx, __fp16* coeffs)
     coeffs[3] = (__fp16)(1.f - coeffs[0] - coeffs[1] - coeffs[2]);
 }
 
-static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+static void cubic_coeffs_fp16sa_impl(int w, int outw, int* xofs, __fp16* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/riscv/interp_bilinear.h
+++ b/src/layer/riscv/interp_bilinear.h
@@ -1,9 +1,9 @@
 // Copyright 2021 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs_impl(int w, int outw, int* xofs, float* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/riscv/interp_bilinear_fp16s.h
+++ b/src/layer/riscv/interp_bilinear_fp16s.h
@@ -1,9 +1,9 @@
 // Copyright 2020 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+static void linear_coeffs_fp16sa_impl(int w, int outw, int* xofs, __fp16* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/riscv/interp_riscv.cpp
+++ b/src/layer/riscv/interp_riscv.cpp
@@ -157,7 +157,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -194,7 +194,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -252,7 +252,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -282,7 +282,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -365,8 +365,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -390,8 +390,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -445,8 +445,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -470,8 +470,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/riscv/interp_riscv.cpp
+++ b/src/layer/riscv/interp_riscv.cpp
@@ -112,7 +112,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -129,7 +129,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             {
                 const size_t vl = __riscv_vsetvl_e32m1(packn);
 
-                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = get_resize_scale_x(w, outw);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -157,7 +157,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -194,7 +194,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -230,7 +230,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -252,7 +252,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -282,7 +282,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -310,7 +310,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         return 0;
     }
 
-    if (outw == w && outh == h)
+    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -327,8 +327,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         {
             const size_t vl = __riscv_vsetvl_e32m1(packn);
 
-            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = get_resize_scale_y(h, outh);
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -365,8 +365,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -390,8 +390,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -411,8 +411,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = get_resize_scale_y(h, outh);
+        const float ws = get_resize_scale_x(w, outw);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -445,8 +445,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -470,8 +470,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/riscv/interp_riscv.cpp
+++ b/src/layer/riscv/interp_riscv.cpp
@@ -310,7 +310,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         return 0;
     }
 
-    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+    if (is_identity_resize(w, h, outw, outh))
     {
         top_blob = bottom_blob;
         return 0;

--- a/src/layer/riscv/interp_riscv.cpp
+++ b/src/layer/riscv/interp_riscv.cpp
@@ -129,7 +129,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             {
                 const size_t vl = __riscv_vsetvl_e32m1(packn);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -157,7 +157,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -194,7 +194,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -230,7 +230,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -252,7 +252,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -282,7 +282,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -327,8 +327,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         {
             const size_t vl = __riscv_vsetvl_e32m1(packn);
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -365,8 +365,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -390,8 +390,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -411,8 +411,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -445,8 +445,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -470,8 +470,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/riscv/interp_riscv_zfh.cpp
+++ b/src/layer/riscv/interp_riscv_zfh.cpp
@@ -89,7 +89,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -106,7 +106,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             {
                 const size_t vl = __riscv_vsetvl_e16m1(packn);
 
-                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = get_resize_scale_x(w, outw);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -134,7 +134,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -171,7 +171,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -207,7 +207,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -229,7 +229,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -259,7 +259,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -287,7 +287,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         return 0;
     }
 
-    if (outw == w && outh == h)
+    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -304,8 +304,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         {
             const size_t vl = __riscv_vsetvl_e16m1(packn);
 
-            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = get_resize_scale_y(h, outh);
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -342,8 +342,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -367,8 +367,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -388,8 +388,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = get_resize_scale_y(h, outh);
+        const float ws = get_resize_scale_x(w, outw);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -422,8 +422,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -447,8 +447,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -502,7 +502,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -524,7 +524,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -561,7 +561,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -602,7 +602,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -632,7 +632,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -660,7 +660,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         return 0;
     }
 
-    if (outw == w && outh == h)
+    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -683,8 +683,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -708,8 +708,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -737,8 +737,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-        linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -762,8 +762,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-        cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/riscv/interp_riscv_zfh.cpp
+++ b/src/layer/riscv/interp_riscv_zfh.cpp
@@ -287,7 +287,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         return 0;
     }
 
-    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+    if (is_identity_resize(w, h, outw, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -660,7 +660,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         return 0;
     }
 
-    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+    if (is_identity_resize(w, h, outw, outh))
     {
         top_blob = bottom_blob;
         return 0;

--- a/src/layer/riscv/interp_riscv_zfh.cpp
+++ b/src/layer/riscv/interp_riscv_zfh.cpp
@@ -134,7 +134,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -171,7 +171,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -229,7 +229,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -259,7 +259,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -342,8 +342,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -367,8 +367,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -422,8 +422,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -447,8 +447,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -524,7 +524,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -561,7 +561,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -602,7 +602,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -632,7 +632,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -683,8 +683,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -708,8 +708,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -737,8 +737,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-        linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-        linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+        linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -762,8 +762,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-        cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/riscv/interp_riscv_zfh.cpp
+++ b/src/layer/riscv/interp_riscv_zfh.cpp
@@ -106,7 +106,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             {
                 const size_t vl = __riscv_vsetvl_e16m1(packn);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -134,7 +134,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -171,7 +171,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -207,7 +207,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -229,7 +229,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -259,7 +259,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -304,8 +304,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         {
             const size_t vl = __riscv_vsetvl_e16m1(packn);
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -342,8 +342,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -367,8 +367,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -388,8 +388,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -422,8 +422,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -447,8 +447,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -524,7 +524,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -561,7 +561,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+                cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -602,7 +602,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -632,7 +632,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -683,8 +683,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -708,8 +708,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+            cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -737,8 +737,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-        linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -762,8 +762,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-        cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_fp16sa_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_fp16sa_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/vulkan/interp_vulkan.cpp
+++ b/src/layer/vulkan/interp_vulkan.cpp
@@ -263,8 +263,8 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         constants[7].i = top_blob.h;
         constants[8].i = top_blob.c;
         constants[9].i = top_blob.cstep;
-        constants[10].f = output_width ? w / (float)outw : 1.f / width_scale;
-        constants[11].f = output_height ? h / (float)outh : 1.f / height_scale;
+        constants[10].f = (output_width || dynamic_target_size) ? w / (float)outw : 1.f / width_scale;
+        constants[11].f = (output_height || dynamic_target_size) ? h / (float)outh : 1.f / height_scale;
 
         const Pipeline* pipeline = elempack == 4 ? pipeline_interp_pack4 : pipeline_interp;
 
@@ -302,7 +302,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             constants[7].i = top_blob.h;
             constants[8].i = top_blob.c;
             constants[9].i = top_blob.cstep;
-            constants[10].f = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            constants[10].f = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             constants[11].f = 1.f;
 
             if (resize_type == 2 && align_corner)
@@ -333,7 +333,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
                 std::vector<vk_constant_type> constants(3);
                 constants[0].i = bottom_blob.w;
                 constants[1].i = outw;
-                constants[2].f = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                constants[2].f = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 if (align_corner)
                 {
@@ -399,8 +399,8 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         constants[7].i = top_blob.h;
         constants[8].i = top_blob.c;
         constants[9].i = top_blob.cstep;
-        constants[10].f = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
-        constants[11].f = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        constants[10].f = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        constants[11].f = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
 
         if (resize_type == 2 && align_corner)
         {
@@ -430,7 +430,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             std::vector<vk_constant_type> constants(3);
             constants[0].i = bottom_blob.w;
             constants[1].i = outw;
-            constants[2].f = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            constants[2].f = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             if (align_corner)
             {
@@ -457,7 +457,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             std::vector<vk_constant_type> constants(3);
             constants[0].i = bottom_blob.h;
             constants[1].i = outh;
-            constants[2].f = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            constants[2].f = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
 
             if (align_corner)
             {

--- a/src/layer/vulkan/interp_vulkan.cpp
+++ b/src/layer/vulkan/interp_vulkan.cpp
@@ -372,7 +372,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         return 0;
     }
 
-    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+    if (is_identity_resize(w, h, outw, outh))
     {
         top_blob = bottom_blob;
         return 0;

--- a/src/layer/vulkan/interp_vulkan.cpp
+++ b/src/layer/vulkan/interp_vulkan.cpp
@@ -263,8 +263,8 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         constants[7].i = top_blob.h;
         constants[8].i = top_blob.c;
         constants[9].i = top_blob.cstep;
-        constants[10].f = (output_width || dynamic_target_size) ? w / (float)outw : 1.f / width_scale;
-        constants[11].f = (output_height || dynamic_target_size) ? h / (float)outh : 1.f / height_scale;
+        constants[10].f = get_resize_scale_x(w, outw);
+        constants[11].f = get_resize_scale_y(h, outh);
 
         const Pipeline* pipeline = elempack == 4 ? pipeline_interp_pack4 : pipeline_interp;
 
@@ -275,7 +275,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -302,7 +302,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             constants[7].i = top_blob.h;
             constants[8].i = top_blob.c;
             constants[9].i = top_blob.cstep;
-            constants[10].f = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            constants[10].f = get_resize_scale_x(w, outw);
             constants[11].f = 1.f;
 
             if (resize_type == 2 && align_corner)
@@ -333,7 +333,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
                 std::vector<vk_constant_type> constants(3);
                 constants[0].i = bottom_blob.w;
                 constants[1].i = outw;
-                constants[2].f = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                constants[2].f = get_resize_scale_x(w, outw);
 
                 if (align_corner)
                 {
@@ -372,7 +372,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         return 0;
     }
 
-    if (outw == w && outh == h)
+    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -399,8 +399,8 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         constants[7].i = top_blob.h;
         constants[8].i = top_blob.c;
         constants[9].i = top_blob.cstep;
-        constants[10].f = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
-        constants[11].f = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        constants[10].f = get_resize_scale_x(w, outw);
+        constants[11].f = get_resize_scale_y(h, outh);
 
         if (resize_type == 2 && align_corner)
         {
@@ -430,7 +430,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             std::vector<vk_constant_type> constants(3);
             constants[0].i = bottom_blob.w;
             constants[1].i = outw;
-            constants[2].f = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            constants[2].f = get_resize_scale_x(w, outw);
 
             if (align_corner)
             {
@@ -457,7 +457,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             std::vector<vk_constant_type> constants(3);
             constants[0].i = bottom_blob.h;
             constants[1].i = outh;
-            constants[2].f = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            constants[2].f = get_resize_scale_y(h, outh);
 
             if (align_corner)
             {

--- a/src/layer/vulkan/interp_vulkan.cpp
+++ b/src/layer/vulkan/interp_vulkan.cpp
@@ -263,8 +263,8 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         constants[7].i = top_blob.h;
         constants[8].i = top_blob.c;
         constants[9].i = top_blob.cstep;
-        constants[10].f = (resize_type == 2 || output_width) ? w / (float)outw : 1.f / width_scale;
-        constants[11].f = (resize_type == 2 || output_height) ? h / (float)outh : 1.f / height_scale;
+        constants[10].f = output_width ? w / (float)outw : 1.f / width_scale;
+        constants[11].f = output_height ? h / (float)outh : 1.f / height_scale;
 
         const Pipeline* pipeline = elempack == 4 ? pipeline_interp_pack4 : pipeline_interp;
 
@@ -302,7 +302,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             constants[7].i = top_blob.h;
             constants[8].i = top_blob.c;
             constants[9].i = top_blob.cstep;
-            constants[10].f = (resize_type == 2 || output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            constants[10].f = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             constants[11].f = 1.f;
 
             if (resize_type == 2 && align_corner)
@@ -333,7 +333,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
                 std::vector<vk_constant_type> constants(3);
                 constants[0].i = bottom_blob.w;
                 constants[1].i = outw;
-                constants[2].f = (float)bottom_blob.w / outw;
+                constants[2].f = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 if (align_corner)
                 {
@@ -399,8 +399,8 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         constants[7].i = top_blob.h;
         constants[8].i = top_blob.c;
         constants[9].i = top_blob.cstep;
-        constants[10].f = (resize_type == 2 || output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
-        constants[11].f = (resize_type == 2 || output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        constants[10].f = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        constants[11].f = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
 
         if (resize_type == 2 && align_corner)
         {
@@ -430,7 +430,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             std::vector<vk_constant_type> constants(3);
             constants[0].i = bottom_blob.w;
             constants[1].i = outw;
-            constants[2].f = (float)bottom_blob.w / outw;
+            constants[2].f = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             if (align_corner)
             {
@@ -457,7 +457,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             std::vector<vk_constant_type> constants(3);
             constants[0].i = bottom_blob.h;
             constants[1].i = outh;
-            constants[2].f = (float)bottom_blob.h / outh;
+            constants[2].f = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
 
             if (align_corner)
             {

--- a/src/layer/x86/interp_bf16s.h
+++ b/src/layer/x86/interp_bf16s.h
@@ -1481,7 +1481,7 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1554,7 +1554,7 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1683,8 +1683,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || has_size_expr) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -1729,8 +1729,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || has_size_expr) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/x86/interp_bf16s.h
+++ b/src/layer/x86/interp_bf16s.h
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #if NCNN_RUNTIME_CPU && NCNN_AVX512BF16 && __AVX512F__ && !__AVX512BF16__
-void interp_forward_bf16s_sse_avx512bf16(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr);
+void interp_forward_bf16s_sse_avx512bf16(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_dynamic_output_size);
 #endif
 
-static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr);
+static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_dynamic_output_size);
 
 static void vresize_bilinear_bf16s(const float* rows0, const float* rows1, unsigned short* Dp, int n, float b0, float b1)
 {
@@ -1407,12 +1407,12 @@ static void resize_bicubic_image_bf16s(const Mat& src, Mat& dst, float* alpha, i
     }
 }
 
-static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr)
+static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_dynamic_output_size)
 {
 #if NCNN_RUNTIME_CPU && NCNN_AVX512BF16 && __AVX512F__ && !__AVX512BF16__
     if (ncnn::cpu_support_x86_avx512_bf16())
     {
-        interp_forward_bf16s_sse_avx512bf16(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, has_size_expr);
+        interp_forward_bf16s_sse_avx512bf16(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, has_dynamic_output_size);
         return;
     }
 #endif
@@ -1455,7 +1455,7 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
     {
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || has_dynamic_output_size) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1481,7 +1481,7 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || has_dynamic_output_size) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1554,7 +1554,7 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || has_dynamic_output_size) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1645,8 +1645,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || has_size_expr) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || has_dynamic_output_size) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || has_dynamic_output_size) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -1683,8 +1683,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || has_size_expr) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || has_dynamic_output_size) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || has_dynamic_output_size) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -1729,8 +1729,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || has_size_expr) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || has_dynamic_output_size) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || has_dynamic_output_size) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/x86/interp_bicubic.h
+++ b/src/layer/x86/interp_bicubic.h
@@ -20,9 +20,9 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs_impl(int w, int outw, int* xofs, float* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/x86/interp_bilinear.h
+++ b/src/layer/x86/interp_bilinear.h
@@ -5,9 +5,9 @@
 void resize_bilinear_image_avx2(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs);
 #endif
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs_impl(int w, int outw, int* xofs, float* alpha, int align_corner, float scale_factor)
 {
-    double scale = (double)w / outw;
+    double scale = scale_factor;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/x86/interp_x86.cpp
+++ b/src/layer/x86/interp_x86.cpp
@@ -142,7 +142,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
     if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -154,7 +154,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = get_resize_scale_x(w, outw);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -205,7 +205,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -284,7 +284,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -379,7 +379,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         return 0;
     }
 
-    if (outw == w && outh == h)
+    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -391,8 +391,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = get_resize_scale_y(h, outh);
+        const float ws = get_resize_scale_x(w, outw);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -429,8 +429,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -475,8 +475,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, get_resize_scale_x(w, outw));
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, get_resize_scale_y(h, outh));
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -552,7 +552,7 @@ int Interp_x86::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
     }
     else if (dims == 2)
     {
-        if (outw == w)
+        if (is_identity_resize_x(w, outw))
         {
             top_blob = bottom_blob;
             return 0;
@@ -564,7 +564,7 @@ int Interp_x86::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
     }
     else // dims == 3
     {
-        if (outw == w && outh == h)
+        if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
         {
             top_blob = bottom_blob;
             return 0;

--- a/src/layer/x86/interp_x86.cpp
+++ b/src/layer/x86/interp_x86.cpp
@@ -154,7 +154,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -205,7 +205,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -284,7 +284,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -391,8 +391,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -429,8 +429,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -475,8 +475,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
-        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -575,7 +575,7 @@ int Interp_x86::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             return -100;
     }
 
-    interp_forward_bf16s_sse(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, !size_expr.empty());
+    interp_forward_bf16s_sse(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, dynamic_target_size || !size_expr.empty());
 
     return 0;
 }

--- a/src/layer/x86/interp_x86.cpp
+++ b/src/layer/x86/interp_x86.cpp
@@ -379,7 +379,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         return 0;
     }
 
-    if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+    if (is_identity_resize(w, h, outw, outh))
     {
         top_blob = bottom_blob;
         return 0;
@@ -564,7 +564,7 @@ int Interp_x86::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
     }
     else // dims == 3
     {
-        if (is_identity_resize_x(w, outw) && is_identity_resize_y(h, outh))
+        if (is_identity_resize(w, h, outw, outh))
         {
             top_blob = bottom_blob;
             return 0;

--- a/src/layer/x86/interp_x86.cpp
+++ b/src/layer/x86/interp_x86.cpp
@@ -205,7 +205,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -284,7 +284,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -429,8 +429,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        linear_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -475,8 +475,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_impl(w, outw, xofs, alpha, align_corner, (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale);
+        cubic_coeffs_impl(h, outh, yofs, beta, align_corner, (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/x86/interp_x86_avx512bf16.cpp
+++ b/src/layer/x86/interp_x86_avx512bf16.cpp
@@ -11,9 +11,9 @@ namespace ncnn {
 #include "interp_bicubic.h"
 #include "interp_bf16s.h"
 
-void interp_forward_bf16s_sse_avx512bf16(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr)
+void interp_forward_bf16s_sse_avx512bf16(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_dynamic_output_size)
 {
-    interp_forward_bf16s_sse(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, has_size_expr);
+    interp_forward_bf16s_sse(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, has_dynamic_output_size);
 }
 
 } // namespace ncnn

--- a/tests/test_interp.cpp
+++ b/tests/test_interp.cpp
@@ -3,6 +3,8 @@
 
 #include "testutil.h"
 
+#include <math.h>
+
 static int test_interp(const ncnn::Mat& a, int resize_type, float height_scale, float width_scale, int output_height, int output_width)
 {
     ncnn::ParamDict pd;
@@ -125,6 +127,87 @@ static int test_interp_align_corner(const ncnn::Mat& a, int resize_type, float w
     }
 
     return ret;
+}
+
+static float cubic_weight(float x)
+{
+    const float A = -0.75f;
+    x = fabs(x);
+
+    if (x <= 1.f)
+        return (A + 2) * x * x * x - (A + 3) * x * x + 1;
+    if (x < 2.f)
+        return A * x * x * x - 5 * A * x * x + 8 * A * x - 4 * A;
+
+    return 0.f;
+}
+
+static int test_interp_noninteger_scale_factor(int resize_type)
+{
+    const int input_width = 7;
+    const int output_width = 10;
+    const float scale_factor = 1.5f;
+
+    ncnn::Mat a(input_width, 1);
+    for (int x = 0; x < input_width; x++)
+    {
+        a[x] = (float)x;
+    }
+
+    ncnn::ParamDict pd;
+    pd.set(0, resize_type);
+    pd.set(1, 1.f);
+    pd.set(2, scale_factor);
+    pd.set(3, 0);
+    pd.set(4, 0);
+
+    ncnn::Option opt;
+    opt.num_threads = 1;
+
+    ncnn::Layer* op = ncnn::create_layer_naive("Interp");
+    op->load_param(pd);
+    op->create_pipeline(opt);
+
+    ncnn::Mat b;
+    int ret = op->forward(a, b, opt);
+
+    op->destroy_pipeline(opt);
+    delete op;
+
+    if (ret != 0)
+        return ret;
+
+    for (int x = 0; x < output_width; x++)
+    {
+        const float sample_x = (x + 0.5f) / scale_factor - 0.5f;
+        float expected = 0.f;
+
+        if (resize_type == 2)
+        {
+            const int source_x = (int)floor(sample_x);
+            const int x0 = std::max(source_x, 0);
+            const int x1 = std::min(source_x + 1, input_width - 1);
+            const float weight = sample_x - source_x;
+            expected = a[x0] * (1.f - weight) + a[x1] * weight;
+        }
+        else
+        {
+            const int x0 = (int)floor(sample_x);
+            for (int k = -1; k <= 2; k++)
+            {
+                const int source_x = std::max(0, std::min(x0 + k, input_width - 1));
+                expected += a[source_x] * cubic_weight(sample_x - (x0 + k));
+            }
+        }
+
+        if (!NearlyEqual(expected, b[x], 0.0001f))
+        {
+            fprintf(stderr, "test_interp_noninteger_scale_factor failed resize_type=%d x=%d expected=%f actual=%f\n", resize_type, x, expected, b[x]);
+            return -1;
+        }
+    }
+
+    return 0;
 }
 
 static int test_interp_0()
@@ -707,5 +790,7 @@ int main()
            || test_interp_8()
            || test_interp_9()
            || test_interp_10()
-           || test_interp_11();
+           || test_interp_11()
+           || test_interp_noninteger_scale_factor(2)
+           || test_interp_noninteger_scale_factor(3);
 }

--- a/tests/test_interp.cpp
+++ b/tests/test_interp.cpp
@@ -142,11 +142,9 @@ static float cubic_weight(float x)
     return 0.f;
 }
 
-static int test_interp_noninteger_scale_factor(int resize_type)
+static int test_interp_scale_factor(int resize_type, float scale_factor, int output_width)
 {
     const int input_width = 7;
-    const int output_width = 10;
-    const float scale_factor = 1.5f;
 
     ncnn::Mat a(input_width, 1);
     for (int x = 0; x < input_width; x++)
@@ -202,7 +200,7 @@ static int test_interp_noninteger_scale_factor(int resize_type)
 
         if (!NearlyEqual(expected, b[x], 0.0001f))
         {
-            fprintf(stderr, "test_interp_noninteger_scale_factor failed resize_type=%d x=%d expected=%f actual=%f\n", resize_type, x, expected, b[x]);
+            fprintf(stderr, "test_interp_scale_factor failed resize_type=%d scale_factor=%f x=%d expected=%f actual=%f\n", resize_type, scale_factor, x, expected, b[x]);
             return -1;
         }
     }
@@ -241,6 +239,28 @@ static int test_interp_dynamic_target_size(int resize_type)
     if (ret != 0)
     {
         fprintf(stderr, "test_interp_dynamic_target_size failed resize_type=%d\n", resize_type);
+    }
+
+    return ret;
+}
+
+static int test_interp_inferred_fractional_scale(int resize_type)
+{
+    ncnn::Mat a = RandomMat(7, 7);
+
+    ncnn::ParamDict pd;
+    pd.set(0, resize_type);
+    pd.set(1, 1.1f);
+    pd.set(2, 1.1f);
+    pd.set(3, 0);
+    pd.set(4, 0);
+
+    std::vector<ncnn::Mat> weights(0);
+
+    int ret = test_layer("Interp", pd, weights, a);
+    if (ret != 0)
+    {
+        fprintf(stderr, "test_interp_inferred_fractional_scale failed resize_type=%d\n", resize_type);
     }
 
     return ret;
@@ -827,8 +847,12 @@ int main()
            || test_interp_9()
            || test_interp_10()
            || test_interp_11()
-           || test_interp_noninteger_scale_factor(2)
-           || test_interp_noninteger_scale_factor(3)
+           || test_interp_scale_factor(2, 1.5f, 10)
+           || test_interp_scale_factor(3, 1.5f, 10)
+           || test_interp_scale_factor(2, 1.1f, 7)
+           || test_interp_scale_factor(3, 1.1f, 7)
            || test_interp_dynamic_target_size(2)
-           || test_interp_dynamic_target_size(3);
+           || test_interp_dynamic_target_size(3)
+           || test_interp_inferred_fractional_scale(2)
+           || test_interp_inferred_fractional_scale(3);
 }

--- a/tests/test_interp.cpp
+++ b/tests/test_interp.cpp
@@ -266,6 +266,50 @@ static int test_interp_inferred_fractional_scale(int resize_type)
     return ret;
 }
 
+static int test_interp_small_axis(int resize_type, int input_width)
+{
+    ncnn::Mat a = RandomMat(input_width, 1);
+
+    ncnn::ParamDict pd;
+    pd.set(0, resize_type);
+    pd.set(1, 1.1f);
+    pd.set(2, 1.1f);
+    pd.set(3, 0);
+    pd.set(4, 0);
+
+    std::vector<ncnn::Mat> weights(0);
+
+    int ret = test_layer("Interp", pd, weights, a);
+    if (ret != 0)
+    {
+        fprintf(stderr, "test_interp_small_axis failed resize_type=%d input_width=%d\n", resize_type, input_width);
+    }
+
+    return ret;
+}
+
+static int test_interp_small_axis_3d(int resize_type, int input_width, int input_height)
+{
+    ncnn::Mat a = RandomMat(input_width, input_height, 1);
+
+    ncnn::ParamDict pd;
+    pd.set(0, resize_type);
+    pd.set(1, 1.1f);
+    pd.set(2, 1.1f);
+    pd.set(3, 0);
+    pd.set(4, 0);
+
+    std::vector<ncnn::Mat> weights(0);
+
+    int ret = test_layer("Interp", pd, weights, a);
+    if (ret != 0)
+    {
+        fprintf(stderr, "test_interp_small_axis_3d failed resize_type=%d input_width=%d input_height=%d\n", resize_type, input_width, input_height);
+    }
+
+    return ret;
+}
+
 static int test_interp_0()
 {
     ncnn::Mat a = RandomMat(15, 16, 7);
@@ -854,5 +898,10 @@ int main()
            || test_interp_dynamic_target_size(2)
            || test_interp_dynamic_target_size(3)
            || test_interp_inferred_fractional_scale(2)
-           || test_interp_inferred_fractional_scale(3);
+           || test_interp_inferred_fractional_scale(3)
+           || test_interp_small_axis(2, 1)
+           || test_interp_small_axis(3, 1)
+           || test_interp_small_axis(3, 3)
+           || test_interp_small_axis_3d(2, 3, 1)
+           || test_interp_small_axis_3d(3, 4, 3);
 }

--- a/tests/test_interp.cpp
+++ b/tests/test_interp.cpp
@@ -210,6 +210,42 @@ static int test_interp_noninteger_scale_factor(int resize_type)
     return 0;
 }
 
+static int test_interp_dynamic_target_size(int resize_type)
+{
+    const int input_width = 7;
+    const int input_height = 7;
+    const int output_width = 10;
+    const int output_height = 10;
+
+    ncnn::Mat a(input_width, input_height);
+    for (int y = 0; y < input_height; y++)
+    {
+        float* ptr = a.row(y);
+        for (int x = 0; x < input_width; x++)
+        {
+            ptr[x] = (float)(y * input_width + x);
+        }
+    }
+
+    ncnn::ParamDict pd;
+    pd.set(0, resize_type);
+    pd.set(5, 1);
+
+    std::vector<ncnn::Mat> as(2);
+    as[0] = a;
+    as[1] = ncnn::Mat(output_width, output_height);
+
+    std::vector<ncnn::Mat> weights(0);
+
+    int ret = test_layer("Interp", pd, weights, as);
+    if (ret != 0)
+    {
+        fprintf(stderr, "test_interp_dynamic_target_size failed resize_type=%d\n", resize_type);
+    }
+
+    return ret;
+}
+
 static int test_interp_0()
 {
     ncnn::Mat a = RandomMat(15, 16, 7);
@@ -792,5 +828,7 @@ int main()
            || test_interp_10()
            || test_interp_11()
            || test_interp_noninteger_scale_factor(2)
-           || test_interp_noninteger_scale_factor(3);
+           || test_interp_noninteger_scale_factor(3)
+           || test_interp_dynamic_target_size(2)
+           || test_interp_dynamic_target_size(3);
 }


### PR DESCRIPTION
## Summary
- Use the configured scale factor for bilinear and bicubic coordinate generation when output dimensions are inferred.
- Keep explicit output-size and size-expression behavior unchanged.
- Add regression coverage for 1.5x interpolation on a seven-pixel input.

## Verification
- Built and ran `test_interp` with the CPU-only CMake configuration.

## Notes
- Fixes #6836.