### PR TITLE
fix(interp): use 1/scale_factor coordinate scale for bilinear/bicubic resize

### DIFF
--- a/src/layer/arm/interp_arm.cpp
+++ b/src/layer/arm/interp_arm.cpp
@@ -135,7 +135,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -161,7 +161,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -198,7 +198,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -238,7 +238,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -260,7 +260,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -290,7 +290,7 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -333,8 +333,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -371,8 +371,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -396,8 +396,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -417,8 +417,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -451,8 +451,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -476,8 +476,8 @@ int Interp_arm::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -570,7 +570,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -596,7 +596,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -633,7 +633,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -673,7 +673,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -695,7 +695,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -725,7 +725,7 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -768,8 +768,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -806,8 +806,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -831,8 +831,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -852,8 +852,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -886,8 +886,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -911,8 +911,8 @@ int Interp_arm::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/arm/interp_arm_asimdhp.cpp
+++ b/src/layer/arm/interp_arm_asimdhp.cpp
@@ -97,7 +97,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -123,7 +123,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -160,7 +160,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -199,7 +199,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -221,7 +221,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -251,7 +251,7 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -293,8 +293,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -331,8 +331,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -356,8 +356,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -376,8 +376,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -410,8 +410,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -435,8 +435,8 @@ int Interp_arm::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -522,7 +522,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -548,7 +548,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -585,7 +585,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -631,7 +631,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -668,7 +668,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -712,7 +712,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -742,7 +742,7 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -784,8 +784,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -822,8 +822,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -847,8 +847,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -877,8 +877,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -902,8 +902,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -930,8 +930,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-        linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-        linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+        linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -955,8 +955,8 @@ int Interp_arm::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vector
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-        cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/arm/interp_bicubic.h
+++ b/src/layer/arm/interp_bicubic.h
@@ -16,9 +16,8 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/arm/interp_bicubic_fp16s.h
+++ b/src/layer/arm/interp_bicubic_fp16s.h
@@ -16,9 +16,8 @@ static inline void interpolate_cubic_fp16sa(float fx, __fp16* coeffs)
     coeffs[3] = (__fp16)((__fp16)1.f - coeffs[0] - coeffs[1] - coeffs[2]);
 }
 
-static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/arm/interp_bilinear.h
+++ b/src/layer/arm/interp_bilinear.h
@@ -1,9 +1,8 @@
 // Copyright 2020 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/arm/interp_bilinear_fp16s.h
+++ b/src/layer/arm/interp_bilinear_fp16s.h
@@ -1,9 +1,8 @@
 // Copyright 2020 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/interp.cpp
+++ b/src/layer/interp.cpp
@@ -53,9 +53,8 @@ int Interp::load_param(const ParamDict& pd)
 __attribute__((optimize("no-tree-vectorize")))
 #endif
 static void
-linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -191,9 +190,8 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);
@@ -513,7 +511,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -535,7 +533,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -565,7 +563,7 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -605,8 +603,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -635,8 +633,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; ++q)
@@ -660,8 +658,8 @@ int Interp::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/loongarch/interp_bicubic.h
+++ b/src/layer/loongarch/interp_bicubic.h
@@ -16,9 +16,8 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/loongarch/interp_bilinear.h
+++ b/src/layer/loongarch/interp_bilinear.h
@@ -1,9 +1,8 @@
 // Copyright 2022 yala <zhaojunchao@loongson.cn>;<junchao82@qq.com>
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/loongarch/interp_loongarch.cpp
+++ b/src/layer/loongarch/interp_loongarch.cpp
@@ -131,7 +131,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -157,7 +157,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -195,7 +195,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -239,7 +239,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -265,7 +265,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -303,7 +303,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -346,7 +346,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -368,7 +368,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -398,7 +398,7 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -442,8 +442,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -480,8 +480,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -505,8 +505,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -527,8 +527,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -565,8 +565,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -590,8 +590,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -611,8 +611,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -645,8 +645,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -670,8 +670,8 @@ int Interp_loongarch::forward(const std::vector<Mat>& bottom_blobs, std::vector<
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -2261,7 +2261,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -2286,7 +2286,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2427,7 +2427,7 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2601,8 +2601,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
 
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -2638,8 +2638,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 2);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
 #if __loongarch_sx
 #if __loongarch_asx
@@ -2756,8 +2756,8 @@ int Interp_loongarch::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::v
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 4);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
 #if __loongarch_sx
 #if __loongarch_asx

--- a/src/layer/mips/interp_bicubic.h
+++ b/src/layer/mips/interp_bicubic.h
@@ -16,9 +16,8 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/mips/interp_bilinear.h
+++ b/src/layer/mips/interp_bilinear.h
@@ -1,9 +1,8 @@
 // Copyright 2020 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/mips/interp_mips.cpp
+++ b/src/layer/mips/interp_mips.cpp
@@ -109,7 +109,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         {
             if (resize_type == 1) // nearest
             {
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -135,7 +135,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -173,7 +173,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -216,7 +216,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -238,7 +238,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -268,7 +268,7 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -311,8 +311,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
     {
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -349,8 +349,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -374,8 +374,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -395,8 +395,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -429,8 +429,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -454,8 +454,8 @@ int Interp_mips::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>&
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -1676,7 +1676,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1701,7 +1701,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
 #if __mips_msa
             if (elempack == 8)
@@ -1809,7 +1809,7 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
 #if __mips_msa
             if (elempack == 8)
@@ -1944,8 +1944,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
 
         if (resize_type == 1) // nearest
         {
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -1981,8 +1981,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 2);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
 #if __mips_msa
             if (elempack == 8)
@@ -2080,8 +2080,8 @@ int Interp_mips::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector
             float* alpha = (float*)(buf + outw + outh);
             float* beta = (float*)(buf + outw + outh + outw * 4);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
 #if __mips_msa
             if (elempack == 8)

--- a/src/layer/riscv/interp_bicubic.h
+++ b/src/layer/riscv/interp_bicubic.h
@@ -16,9 +16,8 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/riscv/interp_bicubic_fp16s.h
+++ b/src/layer/riscv/interp_bicubic_fp16s.h
@@ -16,9 +16,8 @@ static inline void interpolate_cubic_fp16sa(float fx, __fp16* coeffs)
     coeffs[3] = (__fp16)(1.f - coeffs[0] - coeffs[1] - coeffs[2]);
 }
 
-static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+static void cubic_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/riscv/interp_bilinear.h
+++ b/src/layer/riscv/interp_bilinear.h
@@ -1,9 +1,8 @@
 // Copyright 2021 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/riscv/interp_bilinear_fp16s.h
+++ b/src/layer/riscv/interp_bilinear_fp16s.h
@@ -1,9 +1,8 @@
 // Copyright 2020 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner)
+static void linear_coeffs_fp16sa(int w, int outw, int* xofs, __fp16* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/riscv/interp_riscv.cpp
+++ b/src/layer/riscv/interp_riscv.cpp
@@ -129,7 +129,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             {
                 const size_t vl = __riscv_vsetvl_e32m1(packn);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -157,7 +157,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -194,7 +194,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -230,7 +230,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -252,7 +252,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -282,7 +282,7 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -327,8 +327,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         {
             const size_t vl = __riscv_vsetvl_e32m1(packn);
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -365,8 +365,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -390,8 +390,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -411,8 +411,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -445,8 +445,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -470,8 +470,8 @@ int Interp_riscv::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/riscv/interp_riscv_zfh.cpp
+++ b/src/layer/riscv/interp_riscv_zfh.cpp
@@ -106,7 +106,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             {
                 const size_t vl = __riscv_vsetvl_e16m1(packn);
 
-                const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+                const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -134,7 +134,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                linear_coeffs(w, outw, xofs, alpha, align_corner);
+                linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -171,7 +171,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
                 int* xofs = buf;
                 float* alpha = (float*)(buf + outw);
 
-                cubic_coeffs(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -207,7 +207,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -229,7 +229,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -259,7 +259,7 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -304,8 +304,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         {
             const size_t vl = __riscv_vsetvl_e16m1(packn);
 
-            const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -342,8 +342,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
             float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
-            linear_coeffs(h, outh, yofs, beta, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -367,8 +367,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
             float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
             float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs(h, outh, yofs, beta, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -388,8 +388,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -422,8 +422,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -447,8 +447,8 @@ int Interp_riscv::forward_fp16s(const std::vector<Mat>& bottom_blobs, std::vecto
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -524,7 +524,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -561,7 +561,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
                 int* xofs = buf;
                 __fp16* alpha = (__fp16*)(buf + outw);
 
-                cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+                cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
                 #pragma omp parallel for num_threads(opt.num_threads)
                 for (int y = 0; y < h; y++)
@@ -602,7 +602,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -632,7 +632,7 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             int* xofs = buf;
             __fp16* alpha = (__fp16*)(buf + outw);
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -683,8 +683,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -708,8 +708,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
             __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
             __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-            cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+            cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+            cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int q = 0; q < channels; q++)
@@ -737,8 +737,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 2];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 2); //new __fp16[outh * 2];
 
-        linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-        linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+        linear_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        linear_coeffs_fp16sa(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -762,8 +762,8 @@ int Interp_riscv::forward_fp16sa(const std::vector<Mat>& bottom_blobs, std::vect
         __fp16* alpha = (__fp16*)(buf + outw + outh);           //new __fp16[outw * 4];
         __fp16* beta = (__fp16*)(buf + outw + outh + outw * 4); //new __fp16[outh * 4];
 
-        cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner);
+        cubic_coeffs_fp16sa(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        cubic_coeffs_fp16sa(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/vulkan/interp_vulkan.cpp
+++ b/src/layer/vulkan/interp_vulkan.cpp
@@ -263,8 +263,8 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         constants[7].i = top_blob.h;
         constants[8].i = top_blob.c;
         constants[9].i = top_blob.cstep;
-        constants[10].f = (resize_type == 2 || output_width) ? w / (float)outw : 1.f / width_scale;
-        constants[11].f = (resize_type == 2 || output_height) ? h / (float)outh : 1.f / height_scale;
+        constants[10].f = (output_width) ? w / (float)outw : 1.f / width_scale;
+        constants[11].f = (output_height) ? h / (float)outh : 1.f / height_scale;
 
         const Pipeline* pipeline = elempack == 4 ? pipeline_interp_pack4 : pipeline_interp;
 
@@ -302,7 +302,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             constants[7].i = top_blob.h;
             constants[8].i = top_blob.c;
             constants[9].i = top_blob.cstep;
-            constants[10].f = (resize_type == 2 || output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            constants[10].f = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
             constants[11].f = 1.f;
 
             if (resize_type == 2 && align_corner)
@@ -333,7 +333,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
                 std::vector<vk_constant_type> constants(3);
                 constants[0].i = bottom_blob.w;
                 constants[1].i = outw;
-                constants[2].f = (float)bottom_blob.w / outw;
+                constants[2].f = (output_width || dynamic_target_size || !size_expr.empty()) ? (float)bottom_blob.w / outw : 1.f / width_scale;
 
                 if (align_corner)
                 {
@@ -399,8 +399,8 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
         constants[7].i = top_blob.h;
         constants[8].i = top_blob.c;
         constants[9].i = top_blob.cstep;
-        constants[10].f = (resize_type == 2 || output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
-        constants[11].f = (resize_type == 2 || output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        constants[10].f = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        constants[11].f = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
 
         if (resize_type == 2 && align_corner)
         {
@@ -430,7 +430,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             std::vector<vk_constant_type> constants(3);
             constants[0].i = bottom_blob.w;
             constants[1].i = outw;
-            constants[2].f = (float)bottom_blob.w / outw;
+            constants[2].f = (output_width || dynamic_target_size || !size_expr.empty()) ? (float)bottom_blob.w / outw : 1.f / width_scale;
 
             if (align_corner)
             {
@@ -457,7 +457,7 @@ int Interp_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<V
             std::vector<vk_constant_type> constants(3);
             constants[0].i = bottom_blob.h;
             constants[1].i = outh;
-            constants[2].f = (float)bottom_blob.h / outh;
+            constants[2].f = (output_height || dynamic_target_size || !size_expr.empty()) ? (float)bottom_blob.h / outh : 1.f / height_scale;
 
             if (align_corner)
             {

--- a/src/layer/x86/interp_bf16s.h
+++ b/src/layer/x86/interp_bf16s.h
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #if NCNN_RUNTIME_CPU && NCNN_AVX512BF16 && __AVX512F__ && !__AVX512BF16__
-void interp_forward_bf16s_sse_avx512bf16(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr);
+void interp_forward_bf16s_sse_avx512bf16(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int dynamic_target_size, int has_size_expr);
 #endif
 
-static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr);
+static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int dynamic_target_size, int has_size_expr);
 
 static void vresize_bilinear_bf16s(const float* rows0, const float* rows1, unsigned short* Dp, int n, float b0, float b1)
 {
@@ -1407,12 +1407,12 @@ static void resize_bicubic_image_bf16s(const Mat& src, Mat& dst, float* alpha, i
     }
 }
 
-static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr)
+static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int dynamic_target_size, int has_size_expr)
 {
 #if NCNN_RUNTIME_CPU && NCNN_AVX512BF16 && __AVX512F__ && !__AVX512BF16__
     if (ncnn::cpu_support_x86_avx512_bf16())
     {
-        interp_forward_bf16s_sse_avx512bf16(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, has_size_expr);
+        interp_forward_bf16s_sse_avx512bf16(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, dynamic_target_size, has_size_expr);
         return;
     }
 #endif
@@ -1455,7 +1455,7 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
     {
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || has_size_expr) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1481,7 +1481,7 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || has_size_expr) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1554,7 +1554,7 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || has_size_expr) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -1645,8 +1645,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || has_size_expr) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || has_size_expr) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || has_size_expr) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || has_size_expr) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -1683,8 +1683,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || has_size_expr) ? (double)w / outw : 1.0 / width_scale);
+        linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || has_size_expr) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -1729,8 +1729,8 @@ static void interp_forward_bf16s_sse(const std::vector<Mat>& bottom_blobs, std::
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || has_size_expr) ? (double)w / outw : 1.0 / width_scale);
+        cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || has_size_expr) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)

--- a/src/layer/x86/interp_bicubic.h
+++ b/src/layer/x86/interp_bicubic.h
@@ -20,9 +20,8 @@ static inline void interpolate_cubic(float fx, float* coeffs)
     coeffs[3] = 1.f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 
-static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void cubic_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/x86/interp_bilinear.h
+++ b/src/layer/x86/interp_bilinear.h
@@ -5,9 +5,8 @@
 void resize_bilinear_image_avx2(const Mat& src, Mat& dst, float* alpha, int* xofs, float* beta, int* yofs);
 #endif
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
+static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner, double scale)
 {
-    double scale = (double)w / outw;
     if (align_corner)
     {
         scale = (double)(w - 1) / (outw - 1);

--- a/src/layer/x86/interp_x86.cpp
+++ b/src/layer/x86/interp_x86.cpp
@@ -154,7 +154,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
         if (resize_type == 1) // nearest
         {
-            const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+            const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -205,7 +205,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            linear_coeffs(w, outw, xofs, alpha, align_corner);
+            linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -284,7 +284,7 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
             int* xofs = buf;
             float* alpha = (float*)(buf + outw);
 
-            cubic_coeffs(w, outw, xofs, alpha, align_corner);
+            cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
 
             #pragma omp parallel for num_threads(opt.num_threads)
             for (int y = 0; y < h; y++)
@@ -391,8 +391,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
 
     if (resize_type == 1) // nearest
     {
-        const float hs = (output_height || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
-        const float ws = (output_width || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
+        const float hs = (output_height || dynamic_target_size || !size_expr.empty()) ? h / (float)outh : 1.f / height_scale;
+        const float ws = (output_width || dynamic_target_size || !size_expr.empty()) ? w / (float)outw : 1.f / width_scale;
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -429,8 +429,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 2];
         float* beta = (float*)(buf + outw + outh + outw * 2); //new float[outh * 2];
 
-        linear_coeffs(w, outw, xofs, alpha, align_corner);
-        linear_coeffs(h, outh, yofs, beta, align_corner);
+        linear_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        linear_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -475,8 +475,8 @@ int Interp_x86::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& 
         float* alpha = (float*)(buf + outw + outh);           //new float[outw * 4];
         float* beta = (float*)(buf + outw + outh + outw * 4); //new float[outh * 4];
 
-        cubic_coeffs(w, outw, xofs, alpha, align_corner);
-        cubic_coeffs(h, outh, yofs, beta, align_corner);
+        cubic_coeffs(w, outw, xofs, alpha, align_corner, (output_width || dynamic_target_size || !size_expr.empty()) ? (double)w / outw : 1.0 / width_scale);
+        cubic_coeffs(h, outh, yofs, beta, align_corner, (output_height || dynamic_target_size || !size_expr.empty()) ? (double)h / outh : 1.0 / height_scale);
 
         #pragma omp parallel for num_threads(opt.num_threads)
         for (int q = 0; q < channels; q++)
@@ -575,7 +575,7 @@ int Interp_x86::forward_bf16s(const std::vector<Mat>& bottom_blobs, std::vector<
             return -100;
     }
 
-    interp_forward_bf16s_sse(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, !size_expr.empty());
+    interp_forward_bf16s_sse(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, dynamic_target_size, !size_expr.empty());
 
     return 0;
 }

--- a/src/layer/x86/interp_x86_avx512bf16.cpp
+++ b/src/layer/x86/interp_x86_avx512bf16.cpp
@@ -11,9 +11,9 @@ namespace ncnn {
 #include "interp_bicubic.h"
 #include "interp_bf16s.h"
 
-void interp_forward_bf16s_sse_avx512bf16(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int has_size_expr)
+void interp_forward_bf16s_sse_avx512bf16(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_blobs, const Option& opt, int resize_type, int align_corner, float height_scale, float width_scale, int output_height, int output_width, int dynamic_target_size, int has_size_expr)
 {
-    interp_forward_bf16s_sse(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, has_size_expr);
+    interp_forward_bf16s_sse(bottom_blobs, top_blobs, opt, resize_type, align_corner, height_scale, width_scale, output_height, output_width, dynamic_target_size, has_size_expr);
 }
 
 } // namespace ncnn


### PR DESCRIPTION
`Interp`'s `linear_coeffs`/`cubic_coeffs` always derive the sampling scale from `w / outw`, but when resizing by a scale factor (no explicit output size) the coordinate scale should be `1 / scale_factor`, matching PyTorch. #3555 fixed this for nearest; bilinear/bicubic were missed.

For integer scale factors the two are equal, so this only affects non-integer factors, e.g. `F.interpolate(x, scale_factor=1.5, mode='bilinear')`.

**Fix**: thread the scale-factor-aware scale (the same expression already used on the nearest path) into `linear_coeffs`/`cubic_coeffs` across all backends. The vulkan path drops the `resize_type == 2` special-case so bilinear uses the same scale as nearest - the shader already applies the scale generically.

**Verification**: for a 5-wide input at `scale_factor=1.5` (outw=7), bilinear output changes from `0, 0.5714, 1.2857, ...` to `0, 0.5, 1.1667, 1.8333, 2.5, 3.1667, 3.8333`, matching PyTorch's `(dx+0.5)/1.5 - 0.5` mapping exactly. Verified locally on x86 (native) and aarch64 (cross-compiled + qemu) that each backend's output matches the corrected naive reference via `test_interp`.

Closes #6836
