### PR TITLE
vulkan: route download through staging when blob memory is not HOST_CACHED (13x, fixes #6857)

### DIFF
--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -355,6 +355,7 @@ VkAllocator::VkAllocator(const VulkanDevice* _vkdev)
     reserved_type_index = (uint32_t)-1;
     mappable = false;
     coherent = false;
+    cached = false;
 }
 
 VkAllocator::~VkAllocator()
@@ -779,6 +780,7 @@ VkBufferMemory* VkBlobAllocator::fastMalloc(size_t size)
 
         mappable = vkdev->is_mappable(buffer_memory_type_index);
         coherent = vkdev->is_coherent(buffer_memory_type_index);
+        cached = vkdev->is_cached(buffer_memory_type_index);
     }
 
     block->memory = allocate_memory(memoryRequirements.size, buffer_memory_type_index);
@@ -1058,6 +1060,7 @@ VkImageMemory* VkBlobAllocator::fastMalloc(int w, int h, int c, size_t elemsize,
 
         mappable = vkdev->is_mappable(image_memory_type_index);
         coherent = vkdev->is_coherent(image_memory_type_index);
+        cached = vkdev->is_cached(image_memory_type_index);
     }
 
     // create new block
@@ -1443,6 +1446,7 @@ VkBufferMemory* VkWeightAllocator::fastMalloc(size_t size)
 
                 mappable = vkdev->is_mappable(buffer_memory_type_index);
                 coherent = vkdev->is_coherent(buffer_memory_type_index);
+                cached = vkdev->is_cached(buffer_memory_type_index);
             }
 
             block->memory = allocate_dedicated_memory(memoryRequirements2.memoryRequirements.size, buffer_memory_type_index, 0, block->buffer);
@@ -1514,6 +1518,7 @@ VkBufferMemory* VkWeightAllocator::fastMalloc(size_t size)
 
                     mappable = vkdev->is_mappable(buffer_memory_type_index);
                     coherent = vkdev->is_coherent(buffer_memory_type_index);
+                    cached = vkdev->is_cached(buffer_memory_type_index);
                 }
 
                 block->memory = allocate_import_host_memory(memoryRequirements.size, buffer_memory_type_index, host_ptr);
@@ -1544,6 +1549,7 @@ VkBufferMemory* VkWeightAllocator::fastMalloc(size_t size)
 
                 mappable = vkdev->is_mappable(buffer_memory_type_index);
                 coherent = vkdev->is_coherent(buffer_memory_type_index);
+                cached = vkdev->is_cached(buffer_memory_type_index);
             }
 
             block->memory = allocate_memory(memoryRequirements.size, buffer_memory_type_index);
@@ -1596,6 +1602,7 @@ VkBufferMemory* VkWeightAllocator::fastMalloc(size_t size)
 
             mappable = vkdev->is_mappable(buffer_memory_type_index);
             coherent = vkdev->is_coherent(buffer_memory_type_index);
+            cached = vkdev->is_cached(buffer_memory_type_index);
         }
 
         block->memory = allocate_memory(memoryRequirements.size, buffer_memory_type_index);
@@ -1769,6 +1776,7 @@ VkImageMemory* VkWeightAllocator::fastMalloc(int w, int h, int c, size_t elemsiz
 
                 mappable = vkdev->is_mappable(image_memory_type_index);
                 coherent = vkdev->is_coherent(image_memory_type_index);
+                cached = vkdev->is_cached(image_memory_type_index);
             }
 
             // bind memory
@@ -1887,6 +1895,7 @@ VkImageMemory* VkWeightAllocator::fastMalloc(int w, int h, int c, size_t elemsiz
 
                     mappable = vkdev->is_mappable(image_memory_type_index);
                     coherent = vkdev->is_coherent(image_memory_type_index);
+                    cached = vkdev->is_cached(image_memory_type_index);
                 }
 
                 ptr->memory = allocate_import_host_memory(new_block_size, image_memory_type_index, host_ptr);
@@ -1917,6 +1926,7 @@ VkImageMemory* VkWeightAllocator::fastMalloc(int w, int h, int c, size_t elemsiz
 
                 mappable = vkdev->is_mappable(image_memory_type_index);
                 coherent = vkdev->is_coherent(image_memory_type_index);
+                cached = vkdev->is_cached(image_memory_type_index);
             }
 
             // bind at memory offset
@@ -1970,6 +1980,7 @@ VkImageMemory* VkWeightAllocator::fastMalloc(int w, int h, int c, size_t elemsiz
 
             mappable = vkdev->is_mappable(image_memory_type_index);
             coherent = vkdev->is_coherent(image_memory_type_index);
+            cached = vkdev->is_cached(image_memory_type_index);
         }
 
         // bind at memory offset

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -287,6 +287,9 @@ public:
     uint32_t reserved_type_index;
     bool mappable;
     bool coherent;
+    // HOST_CACHED. Reading write-combined (uncached) memory from the CPU is
+    // ~30x slower than cached, so downloads must not memcpy out of it.
+    bool cached;
 
 protected:
     VkBuffer create_buffer(size_t size, VkBufferUsageFlags usage);

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -455,8 +455,13 @@ void VkCompute::record_download(const VkMat& src, Mat& dst, const Option& opt)
 
     // gpu cast to fp32 on the fly (integrated gpu)
     Option opt_staging = opt;
-    if (!opt_staging.blob_vkallocator->mappable)
+    if (!opt_staging.blob_vkallocator->mappable || !opt_staging.blob_vkallocator->cached)
     {
+        // On an integrated gpu the blob allocator prefers DEVICE_LOCAL|HOST_VISIBLE
+        // "unified" memory, which is mappable but WRITE-COMBINED, not HOST_CACHED.
+        // Uploading to it is fast, but memcpy'ing OUT of it is uncached-read slow --
+        // measured 0.33 GB/s against 10.3 GB/s for upload on Radeon 8060S. Route the
+        // download through the staging allocator, which requests HOST_CACHED.
         opt_staging.blob_vkallocator = opt.staging_vkallocator;
     }
     int cast_type_to = 0;

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -4504,6 +4504,13 @@ bool VulkanDevice::is_coherent(uint32_t memory_type_index) const
     return memoryType.propertyFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 }
 
+bool VulkanDevice::is_cached(uint32_t memory_type_index) const
+{
+    const VkMemoryType& memoryType = info.physicalDeviceMemoryProperties().memoryTypes[memory_type_index];
+
+    return memoryType.propertyFlags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+}
+
 bool VulkanDevice::is_device_local(uint32_t memory_type_index) const
 {
     const VkMemoryType& memoryType = info.physicalDeviceMemoryProperties().memoryTypes[memory_type_index];

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -456,6 +456,7 @@ public:
     uint32_t find_memory_index(uint32_t memory_type_bits, VkFlags required, VkFlags preferred, VkFlags preferred_not) const;
     bool is_mappable(uint32_t memory_type_index) const;
     bool is_coherent(uint32_t memory_type_index) const;
+    bool is_cached(uint32_t memory_type_index) const;
     bool is_device_local(uint32_t memory_type_index) const;
 
     VkQueue acquire_queue(uint32_t queue_family_index) const;


### PR DESCRIPTION
Fixes #6857. Opening as requested in https://github.com/Tencent/ncnn/issues/6857#issuecomment — using the `is_cached()` on `VkAllocator` approach you suggested.

## Problem

`VkCompute::record_download()` skips the staging buffer whenever the blob allocator is mappable:

```cpp
Option opt_staging = opt;
if (!opt_staging.blob_vkallocator->mappable)
{
    opt_staging.blob_vkallocator = opt.staging_vkallocator;
}
```

On an integrated GPU the blob allocator prefers `DEVICE_LOCAL | HOST_VISIBLE` unified memory. That memory *is* mappable — but it is **write-combined**, not `HOST_CACHED`. So the result gets `memcpy`'d out of uncached memory.

Uploads are unaffected (writing to write-combined memory is fast). Only the device-to-host read collapses, which is why the same buffers show a large upload/download asymmetry.

The staging allocator is precisely the one that requests `HOST_CACHED`, and it was bypassed in exactly the case where it is needed.

## Change

28 lines across 5 files:

- `VulkanDevice::is_cached()` — mirrors `is_coherent()`
- `VkAllocator::cached` — tracked alongside `mappable` / `coherent`, set at every site those two are set
- `record_download()` — requires mappable **and** cached to take the direct path

No behaviour change on discrete GPUs (blob memory is not mappable, so the staging path was already taken) or on hardware whose mappable blob memory *is* `HOST_CACHED` (condition still passes).

## Measurements

Radeon 8060S (Strix Halo, RADV GFX1151, 256 GB/s unified LPDDR5X), 128 MB transfer.

A/B built from the same tree, the only difference being the `record_download()` condition — 3 runs each:

| | before | after |
|---|---|---|
| download run 1 | 0.32 GB/s | 4.19 GB/s |
| download run 2 | 0.32 GB/s | 4.11 GB/s |
| download run 3 | 0.32 GB/s | 4.23 GB/s |

**0.32 → 4.19 GB/s, 13.1x.** For reference on the same machine: plain host `memcpy` 23.0 GB/s, ncnn upload 10.0 GB/s. The 31x upload/download asymmetry reported in the issue becomes ~2.4x.

## Tests

`ctest` (178 tests, `NCNN_VULKAN=ON`), run on two clean worktrees — pristine `a4d2ea1` and `a4d2ea1` + this commit:

| build | result |
|---|---|
| pristine `a4d2ea1` | 177/178 passed |
| this PR | 177/178 passed |

Identical failure sets. The single failure is `test_binaryop_3` → `test_binaryop_atan2_special op_type=10`, byte-identical output on both builds — a pre-existing atan2 special-value mismatch on RADV, unrelated to this change.

## One question

`VkCompute::record_clone(const VkMat& src, Mat& dst, const Option& opt)` (`command.cpp:649`) has the same shape of test:

```cpp
if (!src.allocator->mappable)
{
    // device to staging ...
}
```

and then defers a `TYPE_post_download` memcpy out of the mapped buffer — so on write-combined memory it should hit the identical uncached-read cost. I have **not** touched it here, since you asked specifically about the `record_download()` path and I have no benchmark isolating `record_clone`. Happy to add it to this PR or send it separately, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
