### PR TITLE
vulkan: implement MatMul (fixes #6858)

### DIFF
--- a/src/layer/vulkan/matmul_vulkan.cpp
+++ b/src/layer/vulkan/matmul_vulkan.cpp
@@ -1,0 +1,247 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "matmul_vulkan.h"
+
+#include "layer_shader_type.h"
+
+namespace ncnn {
+
+MatMul_vulkan::MatMul_vulkan()
+{
+    support_vulkan = true;
+
+    // The shader indexes elements one at a time, so it needs the plain
+    // (unpacked) layout. support_vulkan_packing already defaults to false,
+    // which keeps batch slicing a simple stride and avoids re-deriving
+    // pack4/pack8 addressing for every rank.
+
+    pipeline_matmul = 0;
+}
+
+int MatMul_vulkan::create_pipeline(const Option& opt)
+{
+    std::vector<vk_specialization_type> specializations(1 + 3);
+    specializations[0].i = transB;
+    // Shapes are resolved per call, so leave the shape constants unspecialised.
+    specializations[1 + 0].i = 0;
+    specializations[1 + 1].i = 0;
+    specializations[1 + 2].i = 0;
+
+    pipeline_matmul = new Pipeline(vkdev);
+    pipeline_matmul->set_optimal_local_size_xyz(8, 8, 1);
+    pipeline_matmul->create(LayerShaderType::matmul, opt, specializations);
+
+    return 0;
+}
+
+int MatMul_vulkan::destroy_pipeline(const Option& /*opt*/)
+{
+    delete pipeline_matmul;
+    pipeline_matmul = 0;
+
+    return 0;
+}
+
+int MatMul_vulkan::forward(const std::vector<VkMat>& bottom_blobs, std::vector<VkMat>& top_blobs, VkCompute& cmd, const Option& opt) const
+{
+    const VkMat& A = bottom_blobs[0];
+    const VkMat& B = bottom_blobs[1];
+
+    const int Adims = A.dims;
+    const int Bdims = B.dims;
+
+    // Normalise both operands to (batch, rows, cols), mirroring MatMul::forward:
+    //   1-D A is a row vector (1, K); 1-D B is a column vector (K, 1).
+    const int M = Adims == 1 ? 1 : A.h;
+    const int K = A.w;
+    const int N = Bdims == 1 ? 1 : (transB == 0 ? B.w : B.h);
+
+    // c and d broadcast independently, exactly as MatMul::forward does.
+    //
+    // Mind the promotion: when the ranks are mixed, MatMul::forward lifts a 3-D
+    // operand with A.reshape(w, h, c, 1), which turns its CHANNEL axis into the
+    // DEPTH axis. Depth then strides by the original cstep rather than by w*h.
+    // Reading A.c as channels in that case rejects valid broadcasts.
+    const int max_ABdims = std::max(Adims, Bdims);
+
+    int a_c = 1, a_d = 1, a_cstep = 0, a_dstep = 0;
+    int b_c = 1, b_d = 1, b_cstep = 0, b_dstep = 0;
+
+    if (max_ABdims == 4 && Adims > 2)
+    {
+        if (Adims == 4)
+        {
+            a_c = A.c;
+            a_d = std::max(A.d, 1);
+            a_cstep = (int)A.cstep;
+            a_dstep = A.w * A.h;
+        }
+        else // Adims == 3, promoted to (w, h, c, 1)
+        {
+            a_d = A.c;
+            a_dstep = (int)A.cstep;
+        }
+    }
+    else if (Adims > 2)
+    {
+        a_c = A.c;
+        a_d = Adims <= 3 ? 1 : std::max(A.d, 1);
+        a_cstep = (int)A.cstep;
+        a_dstep = A.w * A.h;
+    }
+
+    if (max_ABdims == 4 && Bdims > 2)
+    {
+        if (Bdims == 4)
+        {
+            b_c = B.c;
+            b_d = std::max(B.d, 1);
+            b_cstep = (int)B.cstep;
+            b_dstep = B.w * B.h;
+        }
+        else // Bdims == 3, promoted to (w, h, c, 1)
+        {
+            b_d = B.c;
+            b_dstep = (int)B.cstep;
+        }
+    }
+    else if (Bdims > 2)
+    {
+        b_c = B.c;
+        b_d = Bdims <= 3 ? 1 : std::max(B.d, 1);
+        b_cstep = (int)B.cstep;
+        b_dstep = B.w * B.h;
+    }
+
+    // A 1-D operand pairs with a batched one without promotion: the output keeps
+    // the batched operand's own d and c, so leave those descriptors as read.
+    if (Adims == 1 || Bdims == 1)
+    {
+        if (Bdims > 2)
+        {
+            b_c = B.c;
+            b_d = Bdims <= 3 ? 1 : std::max(B.d, 1);
+            b_cstep = (int)B.cstep;
+            b_dstep = B.w * B.h;
+        }
+        if (Adims > 2)
+        {
+            a_c = A.c;
+            a_d = Adims <= 3 ? 1 : std::max(A.d, 1);
+            a_cstep = (int)A.cstep;
+            a_dstep = A.w * A.h;
+        }
+    }
+
+    const int outc = std::max(a_c, b_c);
+    const int outd = std::max(a_d, b_d);
+
+    if ((a_c != b_c && a_c != 1 && b_c != 1) || (a_d != b_d && a_d != 1 && b_d != 1))
+        return -1;
+
+    const size_t elemsize = A.elemsize;
+
+    VkMat& top_blob = top_blobs[0];
+
+    // Output shape follows MatMul::forward exactly. A 1-D operand contributes no
+    // dimension of its own, so the CPU path computes into a degenerate (N,1) or
+    // (1,M) blob and reshapes the extra axis away. Create the final shape here
+    // and describe it to the shader with explicit strides, because a reshaped
+    // blob does not have the strides the general case would imply.
+    int c_cstep = 0;
+    int c_dstep = 0;
+
+    if (Adims == 1 && Bdims == 1)
+    {
+        // dot product
+        top_blob.create(1, elemsize, opt.blob_vkallocator);
+    }
+    else if (Adims == 1 && Bdims == 2)
+    {
+        top_blob.create(N, elemsize, opt.blob_vkallocator);
+    }
+    else if (Adims == 2 && Bdims == 1)
+    {
+        top_blob.create(M, elemsize, opt.blob_vkallocator);
+    }
+    else if (Adims == 1 && Bdims == 3)
+    {
+        top_blob.create(N, outc, elemsize, opt.blob_vkallocator);
+        c_cstep = N;
+    }
+    else if (Adims == 1 && Bdims == 4)
+    {
+        top_blob.create(N, outd, outc, elemsize, opt.blob_vkallocator);
+        c_cstep = (int)top_blob.cstep;
+        c_dstep = N;
+    }
+    else if (Adims == 3 && Bdims == 1)
+    {
+        top_blob.create(M, outc, elemsize, opt.blob_vkallocator);
+        c_cstep = M;
+    }
+    else if (Adims == 4 && Bdims == 1)
+    {
+        top_blob.create(M, outd, outc, elemsize, opt.blob_vkallocator);
+        c_cstep = (int)top_blob.cstep;
+        c_dstep = M;
+    }
+    else if (outc == 1 && outd == 1)
+    {
+        top_blob.create(N, M, elemsize, opt.blob_vkallocator);
+    }
+    else if (outd == 1)
+    {
+        top_blob.create(N, M, outc, elemsize, opt.blob_vkallocator);
+        c_cstep = (int)top_blob.cstep;
+        c_dstep = N * M;
+    }
+    else
+    {
+        top_blob.create(N, M, outd, outc, elemsize, opt.blob_vkallocator);
+        c_cstep = (int)top_blob.cstep;
+        c_dstep = N * M;
+    }
+
+    if (top_blob.empty())
+        return -100;
+
+    std::vector<VkMat> bindings(3);
+    bindings[0] = A;
+    bindings[1] = B;
+    bindings[2] = top_blob;
+
+    std::vector<vk_constant_type> constants(15);
+    constants[0].i = M;
+    constants[1].i = N;
+    constants[2].i = K;
+    constants[3].i = outc;
+    constants[4].i = outd;
+    constants[5].i = a_cstep;
+    constants[6].i = a_dstep;
+    constants[7].i = a_c;
+    constants[8].i = a_d;
+    constants[9].i = b_cstep;
+    constants[10].i = b_dstep;
+    constants[11].i = b_c;
+    constants[12].i = b_d;
+    constants[13].i = c_cstep;
+    constants[14].i = c_dstep;
+
+    // Dispatch over the LOGICAL (N, M, outd, outc) grid rather than over
+    // top_blob: when a degenerate axis has been reshaped away the blob no
+    // longer carries M and outd separately, and the shader decodes depth
+    // out of y as gy / M. A shape-only Mat supplies the group counts.
+    Mat dispatcher;
+    dispatcher.w = N;
+    dispatcher.h = M;
+    dispatcher.d = outd;
+    dispatcher.c = outc;
+
+    cmd.record_pipeline(pipeline_matmul, bindings, std::vector<VkImageMat>(), constants, dispatcher);
+
+    return 0;
+}
+
+} // namespace ncnn

--- a/src/layer/vulkan/matmul_vulkan.h
+++ b/src/layer/vulkan/matmul_vulkan.h
@@ -1,0 +1,28 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef LAYER_MATMUL_VULKAN_H
+#define LAYER_MATMUL_VULKAN_H
+
+#include "matmul.h"
+
+namespace ncnn {
+
+class MatMul_vulkan : public MatMul
+{
+public:
+    MatMul_vulkan();
+
+    virtual int create_pipeline(const Option& opt);
+    virtual int destroy_pipeline(const Option& opt);
+
+    using MatMul::forward;
+    virtual int forward(const std::vector<VkMat>& bottom_blobs, std::vector<VkMat>& top_blobs, VkCompute& cmd, const Option& opt) const;
+
+public:
+    Pipeline* pipeline_matmul;
+};
+
+} // namespace ncnn
+
+#endif // LAYER_MATMUL_VULKAN_H

--- a/src/layer/vulkan/shader/matmul.comp
+++ b/src/layer/vulkan/shader/matmul.comp
@@ -1,0 +1,85 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+layout(constant_id = 0) const int transB = 0;
+
+#define shape_constant_id_offset 1
+layout(constant_id = shape_constant_id_offset + 0) const int M = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int N = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int K = 0;
+
+layout(binding = 0) readonly buffer a_blob { sfp a_blob_data[]; };
+layout(binding = 1) readonly buffer b_blob { sfp b_blob_data[]; };
+layout(binding = 2) writeonly buffer top_blob { sfp top_blob_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int M;
+    int N;
+    int K;
+
+    // Output batch extents. ncnn dispatches y over h*d and z over c
+    // (see VkCompute::record_pipeline), so depth is decoded out of y.
+    int outc;
+    int outd;
+
+    // An ncnn Mat strides channels by cstep and depth by w*h.
+    // c and d broadcast INDEPENDENTLY, matching MatMul::forward.
+    int a_cstep;
+    int a_dstep;
+    int a_c;
+    int a_d;
+    int b_cstep;
+    int b_dstep;
+    int b_c;
+    int b_d;
+    int c_cstep;
+    int c_dstep;
+} p;
+
+void main()
+{
+    const int n = int(gl_GlobalInvocationID.x);
+    const int gy = int(gl_GlobalInvocationID.y);
+    const int cz = int(gl_GlobalInvocationID.z);
+
+    const int dz = gy / psc(M);
+    const int m = gy % psc(M);
+
+    if (n >= psc(N) || dz >= p.outd || cz >= p.outc)
+        return;
+
+    const int ac = p.a_c == 1 ? 0 : cz;
+    const int ad = p.a_d == 1 ? 0 : dz;
+    const int bc = p.b_c == 1 ? 0 : cz;
+    const int bd = p.b_d == 1 ? 0 : dz;
+
+    const int a_base = ac * p.a_cstep + ad * p.a_dstep + m * psc(K);
+    const int b_base = bc * p.b_cstep + bd * p.b_dstep;
+
+    afp sum = afp(0.f);
+
+    if (transB == 0)
+    {
+        // B is (K, N) row-major within its slice
+        for (int k = 0; k < psc(K); k++)
+        {
+            sum += buffer_ld1(a_blob_data, a_base + k)
+                 * buffer_ld1(b_blob_data, b_base + k * psc(N) + n);
+        }
+    }
+    else
+    {
+        // B is (N, K) row-major within its slice
+        const int b_row = b_base + n * psc(K);
+        for (int k = 0; k < psc(K); k++)
+        {
+            sum += buffer_ld1(a_blob_data, a_base + k)
+                 * buffer_ld1(b_blob_data, b_row + k);
+        }
+    }
+
+    buffer_st1(top_blob_data, cz * p.c_cstep + dz * p.c_dstep + m * psc(N) + n, sum);
+}


### PR DESCRIPTION
Implements the Vulkan `MatMul` requested in #6858.

`MatMul` had no Vulkan implementation — there is no `src/layer/vulkan/matmul_vulkan.cpp` — so every `MatMul` in a Vulkan graph ran on the CPU, forcing a download of both operands and a re-upload of the result mid-graph. On a 22-model YOLO zoo, `yolo12n` (16 `MatMul` layers) was the only model where **Vulkan was slower than the CPU**.

## Results

Raw forward pass, Radeon 8060S (Strix Halo, RADV GFX1151), 640×640, 4 threads, median of 3 alternating sessions, **same build on both sides**:

| model | MatMuls | Vulkan before | Vulkan after | |
|---|---|---|---|---|
| yolo12n | 16 | 62.64 ms | **8.93 ms** | **7.0x** |
| yolo11n | 2 | 9.77 ms | 6.02 ms | 1.6x |
| yolov8n | **0** | 5.99 ms | 5.93 ms | 1.01x |

`yolov8n` contains no `MatMul` and is included as a **control** — it does not move, which is what attributes the other two gains to this layer rather than to build or machine differences.

Two notes on honesty of measurement:
- These were taken **without** the #6857 download fix, so they isolate `MatMul` alone. With both applied the numbers improve further, but that would confound the two changes.
- The absolute figures are lower than the `1.81x -> 4.19x` I quoted in #6858; that earlier run was on a differently-loaded machine and a build that also carried the download fix. The before/after ratio here is measured in one sitting with alternating sessions.

## Correctness

`tests/test_matmul` passes. It runs the GPU path through `test_layer`, covering 1-D through 4-D operands, `transB`, and broadcasting.

Full `ctest`: **177/178 both with and without this commit**, identical failure sets. The single failure is `test_binaryop_3` → `test_binaryop_atan2_special op_type=10`, a pre-existing atan2 special-value mismatch on RADV, byte-identical on pristine `a4d2ea1`.

Worth flagging: my first draft **failed `test_matmul`**, and the failures were instructive enough to be worth recording here.

1. **Degenerate axes.** A 1-D operand contributes no dimension of its own. `MatMul::forward` computes into a `(N,1)` / `(1,M)` blob and reshapes the extra axis away. Creating `(N, M, …)` unconditionally gave `dims=2` where the CPU gives `dims=1`. The final shape is now created directly and described to the shader with explicit strides, because a reshaped blob does not carry the strides the general case implies.

2. **Rank promotion.** With mixed ranks, `MatMul::forward` lifts a 3-D operand with `reshape(w, h, c, 1)` — its **channel** axis becomes the **depth** axis, and depth then strides by the original `cstep`, not `w*h`. Reading `A.c` as channels rejected valid broadcasts: `test_matmul_13` (A `(14,23,10)` × B `(5,14,1,16)`) hit the broadcast guard, returned −1, and the never-created blob then segfaulted in `record_download`.

3. **Dispatch grid.** Dispatch is over the logical `(N, M, outd, outc)` grid rather than over the output blob, since a reshaped blob no longer carries `M` and `outd` separately while the shader decodes depth out of y as `gy / M`. The `Mat` dispatcher overload supplies the group counts without allocating.

## Implementation notes

- `support_vulkan_packing` stays at its default `false`: the shader indexes elements one at a time, which keeps batch slicing a simple stride instead of re-deriving pack4/pack8 addressing for every rank.
- Shape specialisation constants are left unspecialised, so shapes are resolved per call via push constants and one pipeline serves every shape.
- `ncnn_add_layer(MatMul)` already picks the Vulkan source up; no CMake change needed.

This is a straightforward scalar implementation — correct and a large improvement over the CPU round trip, but not a tuned GEMM. Tiling and cooperative matrix would go considerably further on the batched attention shapes from #6858. Happy to iterate if you would rather land something closer to that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
