### PR TITLE
Fix Vulkan fallback crash with empty optional inputs

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -214,7 +214,7 @@ int NetPrivate::forward_layer(int layer_index, std::vector<Mat>& blob_mats, std:
 
         if (layer->support_vulkan)
         {
-            if (blob_mats_gpu[bottom_blob_index].dims == 0)
+            if (blob_mats_gpu[bottom_blob_index].dims == 0 && blob_mats[bottom_blob_index].dims != 0)
             {
                 // host to buffer
                 cmd.record_upload(blob_mats[bottom_blob_index], blob_mats_gpu[bottom_blob_index], opt);
@@ -228,7 +228,7 @@ int NetPrivate::forward_layer(int layer_index, std::vector<Mat>& blob_mats, std:
         }
         else
         {
-            if (blob_mats[bottom_blob_index].dims == 0)
+            if (blob_mats[bottom_blob_index].dims == 0 && blob_mats_gpu[bottom_blob_index].dims != 0)
             {
                 Option opt_download = opt;
                 opt_download.use_packing_layout = layer->support_packing;


### PR DESCRIPTION
## Summary

  Fix a crash in mixed Vulkan/CPU execution when a CPU fallback layer has an optional input that is empty on both the
  host and Vulkan sides.

  ## Problem

  When a layer does not support Vulkan, ncnn downloads its Vulkan inputs before executing the layer on CPU.

  For optional inputs, such as an empty K/V cache during the first decoder step of `MultiHeadAttention`, both the host
  `Mat` and GPU `VkMat` may be empty.

  The existing fallback code only checked whether the destination was empty and then attempted to transfer from an empty
  source:

  ```cpp
  if (blob_mats[bottom_blob_index].dims == 0)
  {
      cmd.record_download(blob_mats_gpu[bottom_blob_index], ...);
  }
  ```

  This caused an access violation on Windows (0xC0000005) when record_download() received an empty VkMat.

  The same issue could occur in the opposite host-to-Vulkan direction.

  ## Fix

  Only record a transfer when the destination is empty and the source actually exists:
```
  if (blob_mats_gpu[bottom_blob_index].dims == 0 &&
      blob_mats[bottom_blob_index].dims != 0)
  {
      cmd.record_upload(...);
  }

  if (blob_mats[bottom_blob_index].dims == 0 &&
      blob_mats_gpu[bottom_blob_index].dims != 0)
  {
      cmd.record_download(...);
  }
  ```
  If both sides are empty, the input remains empty and is passed to the layer as an optional input.

  ## Validation

  Tested with a translation encoder/decoder graph where int8 MultiHeadAttention falls back to CPU while other layers run
  on Vulkan.

  Verified:

  - First decoder step with empty K/V cache no longer crashes.
  - Subsequent decoder steps with non-empty K/V cache work correctly.
  - Full int8 mixed Vulkan/CPU inference completes successfully.
  - fp32 Vulkan zero-copy inference remains unchanged.
  - NVIDIA RTX 4060 and Intel Raptor Lake Vulkan devices both pass.
  - CPU-only inference remains functional.