### PR TITLE
paramdict: reject negative array and string lengths

### DIFF
--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -294,7 +294,19 @@ int ParamDict::load_param(const DataReader& dr)
                 return -1;
             }
 
+            if (len < 0)
+            {
+                NCNN_LOGE("ParamDict invalid array length %d (id=%d)", len, id);
+                return -1;
+            }
+
             d->params[id].v.create(len);
+
+            if (len > 0 && d->params[id].v.empty())
+            {
+                NCNN_LOGE("ParamDict array allocation failed (id=%d, len=%d)", id, len);
+                return -1;
+            }
 
             for (int j = 0; j < len; j++)
             {
@@ -551,9 +563,9 @@ int ParamDict::load_param_bin(const DataReader& dr)
             swap_endianness_32(&len);
 #endif
 
-            if (len > 255)
+            if (len < 0 || len > 255)
             {
-                NCNN_LOGE("string too long (id=%d)", id);
+                NCNN_LOGE("invalid string length %d (id=%d)", len, id);
                 return -1;
             }
 
@@ -588,7 +600,19 @@ int ParamDict::load_param_bin(const DataReader& dr)
             swap_endianness_32(&len);
 #endif
 
+            if (len < 0)
+            {
+                NCNN_LOGE("ParamDict invalid array length %d (id=%d)", len, id);
+                return -1;
+            }
+
             d->params[id].v.create(len);
+
+            if (len > 0 && d->params[id].v.empty())
+            {
+                NCNN_LOGE("ParamDict array allocation failed (id=%d, len=%d)", id, len);
+                return -1;
+            }
 
             float* ptr = d->params[id].v;
             nread = dr.read(ptr, sizeof(float) * len);

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -695,9 +695,17 @@ static int test_paramdict_7()
 
     // binary array, negative length
     {
-        const int mem[] = {-23304, -4, 1, 2, 3, 4, -233};
+        static const unsigned char mem[] = {
+            0xf8, 0xa4, 0xff, 0xff, // -23304, array id 4
+            0xfc, 0xff, 0xff, 0xff, // length -4
+            0x01, 0x00, 0x00, 0x00,
+            0x02, 0x00, 0x00, 0x00,
+            0x03, 0x00, 0x00, 0x00,
+            0x04, 0x00, 0x00, 0x00,
+            0x17, 0xff, 0xff, 0xff  // -233, end of params
+        };
         ParamDictTest pdt;
-        if (pdt.load_param_bin((const unsigned char*)mem) == 0)
+        if (pdt.load_param_bin(mem) == 0)
         {
             fprintf(stderr, "test_paramdict negative bin array length not rejected\n");
             return -1;
@@ -706,9 +714,16 @@ static int test_paramdict_7()
 
     // binary string, negative length
     {
-        const int mem[] = {-23404, -8, 0, 0, 0, -233};
+        static const unsigned char mem[] = {
+            0x94, 0xa4, 0xff, 0xff, // -23404, string id 4
+            0xf8, 0xff, 0xff, 0xff, // length -8
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x17, 0xff, 0xff, 0xff  // -233, end of params
+        };
         ParamDictTest pdt;
-        if (pdt.load_param_bin((const unsigned char*)mem) == 0)
+        if (pdt.load_param_bin(mem) == 0)
         {
             fprintf(stderr, "test_paramdict negative bin string length not rejected\n");
             return -1;

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -678,6 +678,46 @@ static int test_paramdict_6()
     return 0;
 }
 
+static int test_paramdict_7()
+{
+    // malformed length fields must be rejected rather than reaching Mat::create
+    // with a negative width
+
+    // text array, negative length
+    {
+        ParamDictTest pdt;
+        if (pdt.load_param("-23304=-4") == 0)
+        {
+            fprintf(stderr, "test_paramdict negative text array length not rejected\n");
+            return -1;
+        }
+    }
+
+    // binary array, negative length
+    {
+        const int mem[] = {-23304, -4, 1, 2, 3, 4, -233};
+        ParamDictTest pdt;
+        if (pdt.load_param_bin((const unsigned char*)mem) == 0)
+        {
+            fprintf(stderr, "test_paramdict negative bin array length not rejected\n");
+            return -1;
+        }
+    }
+
+    // binary string, negative length
+    {
+        const int mem[] = {-23404, -8, 0, 0, 0, -233};
+        ParamDictTest pdt;
+        if (pdt.load_param_bin((const unsigned char*)mem) == 0)
+        {
+            fprintf(stderr, "test_paramdict negative bin string length not rejected\n");
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
 int main()
 {
     return 0
@@ -687,5 +727,6 @@ int main()
            || test_paramdict_3()
            || test_paramdict_4()
            || test_paramdict_5()
-           || test_paramdict_6();
+           || test_paramdict_6()
+           || test_paramdict_7();
 }


### PR DESCRIPTION
The array and string length fields in ParamDict are read from the model file as signed ints and used without a lower bound.

In load_param_bin the array branch does:

    d->params[id].v.create(len);
    float* ptr = d->params[id].v;
    nread = dr.read(ptr, sizeof(float) * len);

With a negative len, Mat::create computes w * elemsize as a size_t, which wraps, so the aligned total also wraps and the allocation request comes out small enough to succeed. The result is a small block whose refcount pointer lands before the allocation, followed by a read of sizeof(float) * len bytes into it. Against a build with AddressSanitizer this shows up as a heap-buffer-overflow write of 4060 bytes into a 76 byte region, from an ordinary ncnn::Net::load_param_bin() call on a crafted .param.bin.

Three places need it:

- load_param, text array at line 297, len comes from dr.scan("%d") with no check
- load_param_bin, string at line 554, checks len > 255 but not len < 0. A negative length makes (len + 3) / 4 * 4 negative, which converts to a huge size_t and throws an uncaught length_error out of the loader
- load_param_bin, array at line 591, no check at all

This is the same shape as the id fix in 5a0288f255, which changed `id >= NCNN_MAX_PARAM_COUNT` to `id < 0 || id >= NCNN_MAX_PARAM_COUNT` in both functions. The length fields in those same two functions kept an upper bound or no bound.

The patch rejects negative lengths at all three sites, and also checks that the allocation actually succeeded before reading into it, since a large positive length can fail to allocate and leave a null data pointer.

Added test_paramdict_7 covering the three cases. It fails on current main and passes with the fix. Full test suite is 176/176 either way.
