### PR TITLE
fix: replace NULL with nullptr in core C++ files

### DIFF
--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -266,12 +266,12 @@ void ncnn_option_set_num_threads(ncnn_option_t opt, int num_threads)
 
 void ncnn_option_set_blob_allocator(ncnn_option_t opt, ncnn_allocator_t allocator)
 {
-    ((Option*)opt)->blob_allocator = allocator ? (Allocator*)allocator->pthis : NULL;
+    ((Option*)opt)->blob_allocator = allocator ? (Allocator*)allocator->pthis : nullptr;
 }
 
 void ncnn_option_set_workspace_allocator(ncnn_option_t opt, ncnn_allocator_t allocator)
 {
-    ((Option*)opt)->workspace_allocator = allocator ? (Allocator*)allocator->pthis : NULL;
+    ((Option*)opt)->workspace_allocator = allocator ? (Allocator*)allocator->pthis : nullptr;
 }
 
 int ncnn_option_get_use_vulkan_compute(const ncnn_option_t opt)

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -698,7 +698,7 @@ int GpuInfoPrivate::query_extensions()
 {
     // get device extension
     uint32_t deviceExtensionPropertyCount = 0;
-    VkResult ret = vkEnumerateDeviceExtensionProperties(physicalDevice, NULL, &deviceExtensionPropertyCount, NULL);
+    VkResult ret = vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &deviceExtensionPropertyCount, nullptr);
     if (ret != VK_SUCCESS)
     {
         NCNN_LOGE("vkEnumerateDeviceExtensionProperties failed %d", ret);
@@ -706,7 +706,7 @@ int GpuInfoPrivate::query_extensions()
     }
 
     deviceExtensionProperties.resize(deviceExtensionPropertyCount);
-    ret = vkEnumerateDeviceExtensionProperties(physicalDevice, NULL, &deviceExtensionPropertyCount, deviceExtensionProperties.data());
+    ret = vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &deviceExtensionPropertyCount, deviceExtensionProperties.data());
     if (ret != VK_SUCCESS)
     {
         NCNN_LOGE("vkEnumerateDeviceExtensionProperties failed %d", ret);


### PR DESCRIPTION
## Motivation

The codebase uses \NULL\ (C-style macro) instead of \
ullptr\ (C++11 keyword) in several core files. Using \
ullptr\ provides better type safety and is the modern C++ standard.

## Changes

- \src/c_api.cpp\: Replace 2 occurrences of \NULL\ with \
ullptr\ in allocator setter functions
- \src/gpu.cpp\: Replace 2 occurrences of \NULL\ with \
ullptr\ in Vulkan API calls (\kEnumerateDeviceExtensionProperties\)

## Testing

- No functional changes - only modernization of null pointer syntax
- Existing tests should continue to pass
- Local environment limitations - relying on CI/CD automated testing

## Checklist

- [x] Code follows the project's coding standards
- [x] No new dependencies added
- [x] Commit messages follow conventional format