### PR TITLE
fix out-of-bounds blob index and unvalidated count in load_param_bin

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -24,6 +24,12 @@
 
 namespace ncnn {
 
+// maximum sizes accepted from an untrusted model file header;
+// larger values indicate a corrupt or malicious model and are rejected
+// before any allocation (resize with a huge count would otherwise OOM)
+static const int MAX_LAYER_COUNT = 1000000;
+static const int MAX_BLOB_COUNT = 1000000;
+
 class NetPrivate
 {
 public:
@@ -1699,9 +1705,9 @@ int Net::load_param_bin(const DataReader& dr)
     int blob_count = 0;
     READ_VALUE(layer_count)
     READ_VALUE(blob_count)
-    if (layer_count <= 0 || blob_count <= 0)
+    if (layer_count <= 0 || blob_count <= 0 || layer_count > MAX_LAYER_COUNT || blob_count > MAX_BLOB_COUNT)
     {
-        NCNN_LOGE("invalid layer_count or blob_count");
+        NCNN_LOGE("invalid layer_count or blob_count %d %d", layer_count, blob_count);
         return -1;
     }
 
@@ -1768,6 +1774,13 @@ int Net::load_param_bin(const DataReader& dr)
         READ_VALUE(bottom_count)
         READ_VALUE(top_count)
 
+        if (bottom_count < 0 || top_count < 0 || bottom_count > MAX_BLOB_COUNT || top_count > MAX_BLOB_COUNT)
+        {
+            NCNN_LOGE("invalid bottom_count or top_count %d %d", bottom_count, top_count);
+            clear();
+            return -1;
+        }
+
         Layer* layer = create_overwrite_builtin_layer(typeindex);
 #if NCNN_VULKAN
         if (!layer && opt.use_vulkan_compute && d->vkdev)
@@ -1806,6 +1819,14 @@ int Net::load_param_bin(const DataReader& dr)
             int bottom_blob_index;
             READ_VALUE(bottom_blob_index)
 
+            if (bottom_blob_index < 0 || bottom_blob_index >= blob_count)
+            {
+                NCNN_LOGE("invalid bottom_blob_index %d", bottom_blob_index);
+                d->layers[i] = layer;
+                clear();
+                return -1;
+            }
+
             Blob& blob = d->blobs[bottom_blob_index];
 
             blob.consumer = i;
@@ -1818,6 +1839,14 @@ int Net::load_param_bin(const DataReader& dr)
         {
             int top_blob_index;
             READ_VALUE(top_blob_index)
+
+            if (top_blob_index < 0 || top_blob_index >= blob_count)
+            {
+                NCNN_LOGE("invalid top_blob_index %d", top_blob_index);
+                d->layers[i] = layer;
+                clear();
+                return -1;
+            }
 
             Blob& blob = d->blobs[top_blob_index];
 


### PR DESCRIPTION
## Summary

`ncnn::Net::load_param_bin()` reads attacker-controlled integers from a `.parambin`
model file and uses them (a) to index into `d->blobs` with no bounds check, and
(b) to size `layer->bottoms` / `layer->tops` with no sign check. A crafted file can:

1. set `bottom_blob_index` / `top_blob_index` to any int32 → out-of-bounds read
   and write (`Blob& blob = d->blobs[idx]; blob.consumer = i;`) — CWE-125/787
2. set `bottom_count` / `top_count` to a negative value → `std::vector::resize(-1)`
   throws `std::length_error` → uncaught → `std::terminate()` — DoS

## Changes

- validate `bottom_count` / `top_count` are non-negative before use
- validate `bottom_blob_index` / `top_blob_index` are in `[0, blob_count)` before
  indexing `d->blobs`

## Why

ncnn parses untrusted model files in many embedding scenarios (mobile/desktop apps,
model hubs, WeChat/QQ). On master, a 149-byte crafted `.parambin` drives a
deterministic SIGSEGV (ASan: WRITE @ `src/net.cpp:1810`, `blob.consumer = i`);
a 28-byte file with `top_count = -1` aborts via uncaught `std::length_error`.
Both are fully reproducible and independent of the already-fixed CVE-2026-50144,
whose fix (`5a0288f2`) only guards parameter ids in `src/paramdict.cpp`.

## Test

| input | before (master a4d2ea1) | after |
|---|---|---|
| crafted `bottom_blob_index=0x09090909` (149B) | SIGSEGV (exit 139) | `ret=-1`, no crash |
| crafted `top_count=-1` (28B) | abort (exit 134, `std::length_error`) | `ret=-1`, no crash |
| valid header file | `ret=-1` (ParamDict err) | identical, no false positive |

The `clear(); return -1;` error path matches existing failure handling in this
function.
```