### PR TITLE
x86/loongarch/mips: refine rsqrt with newton-raphson iterations && vulkan: use fp32 for coefficient

### DIFF
--- a/src/layer/loongarch/layernorm_loongarch.cpp
+++ b/src/layer/loongarch/layernorm_loongarch.cpp
@@ -150,7 +150,7 @@ static void layernorm_loongarch(float* ptr, const float* gamma_ptr, const float*
         __m256 _eps = (__m256)__lasx_xvreplfr2vr_s(eps);
         _var_lasx = __lasx_xvfdiv_s(_var_lasx, _elemcount);
         _var_lasx = __lasx_xvfadd_s(_var_lasx, _eps);
-        _var_lasx = __lasx_xvfrsqrt_s(_var_lasx);
+        _var_lasx = __lasx_comp_rsqrt_s(_var_lasx);
         _mean_lasx = __lasx_xvfmul_s(_mean_lasx, _var_lasx);
         _mean_lasx = __lasx_xvfsub_s((__m256)__lasx_xvreplgr2vr_w(0), _mean_lasx);
     }
@@ -169,7 +169,7 @@ static void layernorm_loongarch(float* ptr, const float* gamma_ptr, const float*
         __m128 _eps = (__m128)__lsx_vreplfr2vr_s(eps);
         _var = __lsx_vfdiv_s(_var, _elemcount);
         _var = __lsx_vfadd_s(_var, _eps);
-        _var = __lsx_vfrsqrt_s(_var);
+        _var = __lsx_comp_rsqrt_s(_var);
         _mean = __lsx_vfmul_s(_mean, _var);
         _mean = __lsx_vfsub_s((__m128)__lsx_vreplgr2vr_w(0), _mean);
 #if __loongarch_asx
@@ -588,7 +588,7 @@ static void layernorm_loongarch_bf16(unsigned short* ptr, const float* gamma_ptr
         __m256 _eps = (__m256)__lasx_xvreplfr2vr_s(eps);
         _var_lasx = __lasx_xvfdiv_s(_var_lasx, _elemcount);
         _var_lasx = __lasx_xvfadd_s(_var_lasx, _eps);
-        _var_lasx = __lasx_xvfrsqrt_s(_var_lasx);
+        _var_lasx = __lasx_comp_rsqrt_s(_var_lasx);
         _mean_lasx = __lasx_xvfmul_s(_mean_lasx, _var_lasx);
         _mean_lasx = __lasx_xvfsub_s((__m256)__lasx_xvreplgr2vr_w(0), _mean_lasx);
     }
@@ -601,8 +601,8 @@ static void layernorm_loongarch_bf16(unsigned short* ptr, const float* gamma_ptr
         _var1 = __lsx_vfdiv_s(_var1, _elemcount);
         _var = __lsx_vfadd_s(_var, _eps);
         _var1 = __lsx_vfadd_s(_var1, _eps);
-        _var = __lsx_vfrsqrt_s(_var);
-        _var1 = __lsx_vfrsqrt_s(_var1);
+        _var = __lsx_comp_rsqrt_s(_var);
+        _var1 = __lsx_comp_rsqrt_s(_var1);
         _mean = __lsx_vfmul_s(_mean, _var);
         _mean1 = __lsx_vfmul_s(_mean1, _var1);
         __m128 _zero = (__m128)__lsx_vreplgr2vr_w(0);
@@ -626,7 +626,7 @@ static void layernorm_loongarch_bf16(unsigned short* ptr, const float* gamma_ptr
         __m128 _eps = (__m128)__lsx_vreplfr2vr_s(eps);
         _var = __lsx_vfdiv_s(_var, _elemcount);
         _var = __lsx_vfadd_s(_var, _eps);
-        _var = __lsx_vfrsqrt_s(_var);
+        _var = __lsx_comp_rsqrt_s(_var);
         _mean = __lsx_vfmul_s(_mean, _var);
         _mean = __lsx_vfsub_s((__m128)__lsx_vreplgr2vr_w(0), _mean);
 #if __loongarch_asx

--- a/src/layer/loongarch/loongarch_usability.h
+++ b/src/layer/loongarch/loongarch_usability.h
@@ -268,8 +268,8 @@ static NCNN_FORCEINLINE float __lsx_reduce_fmax_s(__m128 _v)
 static NCNN_FORCEINLINE __m128 __lsx_comp_rsqrt1_s(const __m128& _x)
 {
     __m128 _y = __lsx_vfrsqrt_s(_x);
-    __m128 _t = __lsx_vfmul_s(_y, _y);
-    _t = __lsx_vfsub_s((__m128)__lsx_vreplfr2vr_s(3.f), __lsx_vfmul_s(_x, _t));
+    __m128 _t = __lsx_vfmul_s(_x, _y);
+    _t = __lsx_vfsub_s((__m128)__lsx_vreplfr2vr_s(3.f), __lsx_vfmul_s(_t, _y));
     _y = __lsx_vfmul_s(_y, __lsx_vfmul_s(_t, (__m128)__lsx_vreplfr2vr_s(0.5f)));
     return _y;
 }
@@ -277,8 +277,8 @@ static NCNN_FORCEINLINE __m128 __lsx_comp_rsqrt1_s(const __m128& _x)
 static NCNN_FORCEINLINE __m128 __lsx_comp_rsqrt_s(const __m128& _x)
 {
     __m128 _y = __lsx_comp_rsqrt1_s(_x);
-    __m128 _t = __lsx_vfmul_s(_y, _y);
-    _t = __lsx_vfsub_s((__m128)__lsx_vreplfr2vr_s(3.f), __lsx_vfmul_s(_x, _t));
+    __m128 _t = __lsx_vfmul_s(_x, _y);
+    _t = __lsx_vfsub_s((__m128)__lsx_vreplfr2vr_s(3.f), __lsx_vfmul_s(_t, _y));
     _y = __lsx_vfmul_s(_y, __lsx_vfmul_s(_t, (__m128)__lsx_vreplfr2vr_s(0.5f)));
     return _y;
 }
@@ -320,8 +320,8 @@ static NCNN_FORCEINLINE float __lasx_reduce_fmax_s(__m256 _v)
 static NCNN_FORCEINLINE __m256 __lasx_comp_rsqrt1_s(const __m256& _x)
 {
     __m256 _y = __lasx_xvfrsqrt_s(_x);
-    __m256 _t = __lasx_xvfmul_s(_y, _y);
-    _t = __lasx_xvfsub_s((__m256)__lasx_xvreplfr2vr_s(3.f), __lasx_xvfmul_s(_x, _t));
+    __m256 _t = __lasx_xvfmul_s(_x, _y);
+    _t = __lasx_xvfsub_s((__m256)__lasx_xvreplfr2vr_s(3.f), __lasx_xvfmul_s(_t, _y));
     _y = __lasx_xvfmul_s(_y, __lasx_xvfmul_s(_t, (__m256)__lasx_xvreplfr2vr_s(0.5f)));
     return _y;
 }
@@ -329,8 +329,8 @@ static NCNN_FORCEINLINE __m256 __lasx_comp_rsqrt1_s(const __m256& _x)
 static NCNN_FORCEINLINE __m256 __lasx_comp_rsqrt_s(const __m256& _x)
 {
     __m256 _y = __lasx_comp_rsqrt1_s(_x);
-    __m256 _t = __lasx_xvfmul_s(_y, _y);
-    _t = __lasx_xvfsub_s((__m256)__lasx_xvreplfr2vr_s(3.f), __lasx_xvfmul_s(_x, _t));
+    __m256 _t = __lasx_xvfmul_s(_x, _y);
+    _t = __lasx_xvfsub_s((__m256)__lasx_xvreplfr2vr_s(3.f), __lasx_xvfmul_s(_t, _y));
     _y = __lasx_xvfmul_s(_y, __lasx_xvfmul_s(_t, (__m256)__lasx_xvreplfr2vr_s(0.5f)));
     return _y;
 }

--- a/src/layer/loongarch/loongarch_usability.h
+++ b/src/layer/loongarch/loongarch_usability.h
@@ -265,6 +265,24 @@ static NCNN_FORCEINLINE float __lsx_reduce_fmax_s(__m128 _v)
     return result;
 }
 
+static NCNN_FORCEINLINE __m128 __lsx_comp_rsqrt1_s(const __m128& _x)
+{
+    __m128 _y = __lsx_vfrsqrt_s(_x);
+    __m128 _t = __lsx_vfmul_s(_y, _y);
+    _t = __lsx_vfsub_s((__m128)__lsx_vreplfr2vr_s(3.f), __lsx_vfmul_s(_x, _t));
+    _y = __lsx_vfmul_s(_y, __lsx_vfmul_s(_t, (__m128)__lsx_vreplfr2vr_s(0.5f)));
+    return _y;
+}
+
+static NCNN_FORCEINLINE __m128 __lsx_comp_rsqrt_s(const __m128& _x)
+{
+    __m128 _y = __lsx_comp_rsqrt1_s(_x);
+    __m128 _t = __lsx_vfmul_s(_y, _y);
+    _t = __lsx_vfsub_s((__m128)__lsx_vreplfr2vr_s(3.f), __lsx_vfmul_s(_x, _t));
+    _y = __lsx_vfmul_s(_y, __lsx_vfmul_s(_t, (__m128)__lsx_vreplfr2vr_s(0.5f)));
+    return _y;
+}
+
 #endif // __loongarch_sx
 
 #if __loongarch_asx
@@ -297,6 +315,24 @@ static NCNN_FORCEINLINE float __lasx_reduce_fmax_s(__m256 _v)
     __m128 hi = __lasx_extract_128_hi_s(_v);
     __m128 maxv = __lsx_vfmax_s(lo, hi);
     return __lsx_reduce_fmax_s(maxv);
+}
+
+static NCNN_FORCEINLINE __m256 __lasx_comp_rsqrt1_s(const __m256& _x)
+{
+    __m256 _y = __lasx_xvfrsqrt_s(_x);
+    __m256 _t = __lasx_xvfmul_s(_y, _y);
+    _t = __lasx_xvfsub_s((__m256)__lasx_xvreplfr2vr_s(3.f), __lasx_xvfmul_s(_x, _t));
+    _y = __lasx_xvfmul_s(_y, __lasx_xvfmul_s(_t, (__m256)__lasx_xvreplfr2vr_s(0.5f)));
+    return _y;
+}
+
+static NCNN_FORCEINLINE __m256 __lasx_comp_rsqrt_s(const __m256& _x)
+{
+    __m256 _y = __lasx_comp_rsqrt1_s(_x);
+    __m256 _t = __lasx_xvfmul_s(_y, _y);
+    _t = __lasx_xvfsub_s((__m256)__lasx_xvreplfr2vr_s(3.f), __lasx_xvfmul_s(_x, _t));
+    _y = __lasx_xvfmul_s(_y, __lasx_xvfmul_s(_t, (__m256)__lasx_xvreplfr2vr_s(0.5f)));
+    return _y;
 }
 #endif // __loongarch_asx
 

--- a/src/layer/loongarch/rmsnorm_loongarch.cpp
+++ b/src/layer/loongarch/rmsnorm_loongarch.cpp
@@ -73,7 +73,7 @@ static void rmsnorm_loongarch(float* ptr, const float* gamma_ptr, float eps, int
         __m256 _eps = (__m256)__lasx_xvreplfr2vr_s(eps);
         _rms_lasx = __lasx_xvfdiv_s(_rms_lasx, _elemcount);
         _rms_lasx = __lasx_xvfadd_s(_rms_lasx, _eps);
-        _rms_lasx = __lasx_xvfrsqrt_s(_rms_lasx);
+        _rms_lasx = __lasx_comp_rsqrt_s(_rms_lasx);
     }
 #endif // __loongarch_asx
     if (elempack == 4)
@@ -90,7 +90,7 @@ static void rmsnorm_loongarch(float* ptr, const float* gamma_ptr, float eps, int
         __m128 _eps = (__m128)__lsx_vreplfr2vr_s(eps);
         _rms = __lsx_vfdiv_s(_rms, _elemcount);
         _rms = __lsx_vfadd_s(_rms, _eps);
-        _rms = __lsx_vfrsqrt_s(_rms);
+        _rms = __lsx_comp_rsqrt_s(_rms);
 #if __loongarch_asx
         _rms_lasx = __lasx_concat_128_s(_rms, _rms);
 #endif // __loongarch_asx
@@ -381,7 +381,7 @@ static void rmsnorm_loongarch_bf16(unsigned short* ptr, const float* gamma_ptr, 
         __m256 _eps = (__m256)__lasx_xvreplfr2vr_s(eps);
         _rms_lasx = __lasx_xvfdiv_s(_rms_lasx, _elemcount);
         _rms_lasx = __lasx_xvfadd_s(_rms_lasx, _eps);
-        _rms_lasx = __lasx_xvfrsqrt_s(_rms_lasx);
+        _rms_lasx = __lasx_comp_rsqrt_s(_rms_lasx);
     }
 #else
     if (elempack == 8)
@@ -392,8 +392,8 @@ static void rmsnorm_loongarch_bf16(unsigned short* ptr, const float* gamma_ptr, 
         _rms1 = __lsx_vfdiv_s(_rms1, _elemcount);
         _rms = __lsx_vfadd_s(_rms, _eps);
         _rms1 = __lsx_vfadd_s(_rms1, _eps);
-        _rms = __lsx_vfrsqrt_s(_rms);
-        _rms1 = __lsx_vfrsqrt_s(_rms1);
+        _rms = __lsx_comp_rsqrt_s(_rms);
+        _rms1 = __lsx_comp_rsqrt_s(_rms1);
     }
 #endif // __loongarch_asx
     if (elempack == 4)
@@ -413,7 +413,7 @@ static void rmsnorm_loongarch_bf16(unsigned short* ptr, const float* gamma_ptr, 
         __m128 _eps = (__m128)__lsx_vreplfr2vr_s(eps);
         _rms = __lsx_vfdiv_s(_rms, _elemcount);
         _rms = __lsx_vfadd_s(_rms, _eps);
-        _rms = __lsx_vfrsqrt_s(_rms);
+        _rms = __lsx_comp_rsqrt_s(_rms);
 #if __loongarch_asx
         _rms_lasx = __lasx_concat_128_s(_rms, _rms);
 #else

--- a/src/layer/loongarch/unaryop_loongarch.cpp
+++ b/src/layer/loongarch/unaryop_loongarch.cpp
@@ -5,6 +5,7 @@
 
 // #include <fenv.h>
 #include <float.h>
+#include "loongarch_usability.h"
 
 #if __loongarch_sx
 #include <lsxintrin.h>
@@ -207,12 +208,12 @@ struct unary_op_rsqrt
 #if __loongarch_sx
     __m128 func_pack4(const __m128& x) const
     {
-        return __lsx_vfrsqrt_s(x);
+        return __lsx_comp_rsqrt1_s(x);
     }
 #if __loongarch_asx
     __m256 func_pack8(const __m256& x) const
     {
-        return __lasx_xvfrsqrt_s(x);
+        return __lasx_comp_rsqrt1_s(x);
     }
 #endif // __loongarch_asx
 #endif // __loongarch_sx
@@ -675,7 +676,6 @@ struct unary_op_log1p
 } // namespace UnaryOp_loongarch_functor
 
 #if NCNN_BF16
-#include "loongarch_usability.h"
 
 template<typename Op>
 static int unary_op_inplace_bf16s(Mat& a, const Option& opt)

--- a/src/layer/mips/layernorm_mips.cpp
+++ b/src/layer/mips/layernorm_mips.cpp
@@ -103,7 +103,7 @@ static void layernorm_mips(float* ptr, const float* gamma_ptr, const float* beta
         v4f32 _eps = __msa_fill_w_f32(eps);
         _var = __msa_fdiv_w(_var, _elemcount);
         _var = __msa_fadd_w(_var, _eps);
-        _var = __msa_frsqrt_w(_var);
+        _var = __ncnn_msa_comp_rsqrt_w(_var);
         _mean = __msa_fmul_w(_mean, _var);
         _mean = __msa_fsub_w((v4f32)__msa_fill_w(0), _mean);
     }
@@ -412,8 +412,8 @@ static void layernorm_mips_bf16(unsigned short* ptr, const float* gamma_ptr, con
         _var1 = __msa_fdiv_w(_var1, _elemcount);
         _var0 = __msa_fadd_w(_var0, _eps);
         _var1 = __msa_fadd_w(_var1, _eps);
-        _var0 = __msa_frsqrt_w(_var0);
-        _var1 = __msa_frsqrt_w(_var1);
+        _var0 = __ncnn_msa_comp_rsqrt_w(_var0);
+        _var1 = __ncnn_msa_comp_rsqrt_w(_var1);
         _mean0 = __msa_fmul_w(_mean0, _var0);
         _mean1 = __msa_fmul_w(_mean1, _var1);
         v4f32 _zero = (v4f32)__msa_fill_w(0);
@@ -428,7 +428,7 @@ static void layernorm_mips_bf16(unsigned short* ptr, const float* gamma_ptr, con
         v4f32 _eps = __msa_fill_w_f32(eps);
         _var0 = __msa_fdiv_w(_var0, _elemcount);
         _var0 = __msa_fadd_w(_var0, _eps);
-        _var0 = __msa_frsqrt_w(_var0);
+        _var0 = __ncnn_msa_comp_rsqrt_w(_var0);
         _mean0 = __msa_fmul_w(_mean0, _var0);
         _mean0 = __msa_fsub_w((v4f32)__msa_fill_w(0), _mean0);
         _var1 = _var0;

--- a/src/layer/mips/mips_usability.h
+++ b/src/layer/mips/mips_usability.h
@@ -74,6 +74,24 @@ static NCNN_FORCEINLINE v2f64 __ncnn_msa_fmsub_d(v2f64 a, v2f64 b, v2f64 c)
 #endif
 }
 
+static NCNN_FORCEINLINE v4f32 __ncnn_msa_comp_rsqrt1_w(const v4f32& _x)
+{
+    v4f32 _y = __msa_frsqrt_w(_x);
+    v4f32 _t = __msa_fmul_w(_y, _y);
+    _t = __msa_fsub_w(__msa_fill_w_f32(3.f), __msa_fmul_w(_x, _t));
+    _y = __msa_fmul_w(_y, __msa_fmul_w(_t, __msa_fill_w_f32(0.5f)));
+    return _y;
+}
+
+static NCNN_FORCEINLINE v4f32 __ncnn_msa_comp_rsqrt_w(const v4f32& _x)
+{
+    v4f32 _y = __ncnn_msa_comp_rsqrt1_w(_x);
+    v4f32 _t = __msa_fmul_w(_y, _y);
+    _t = __msa_fsub_w(__msa_fill_w_f32(3.f), __msa_fmul_w(_x, _t));
+    _y = __msa_fmul_w(_y, __msa_fmul_w(_t, __msa_fill_w_f32(0.5f)));
+    return _y;
+}
+
 static NCNN_FORCEINLINE v16i8 __ncnn_msa_maddv_b(v16i8 a, v16i8 b, v16i8 c)
 {
 #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 8 || (__GNUC__ == 8 && __GNUC_MINOR__ < 5))

--- a/src/layer/mips/mips_usability.h
+++ b/src/layer/mips/mips_usability.h
@@ -74,7 +74,6 @@ static NCNN_FORCEINLINE v2f64 __ncnn_msa_fmsub_d(v2f64 a, v2f64 b, v2f64 c)
 #endif
 }
 
-
 static NCNN_FORCEINLINE v16i8 __ncnn_msa_maddv_b(v16i8 a, v16i8 b, v16i8 c)
 {
 #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 8 || (__GNUC__ == 8 && __GNUC_MINOR__ < 5))

--- a/src/layer/mips/mips_usability.h
+++ b/src/layer/mips/mips_usability.h
@@ -157,8 +157,8 @@ static NCNN_FORCEINLINE v4f32 __msa_fill_w_f32(float val)
 static NCNN_FORCEINLINE v4f32 __ncnn_msa_comp_rsqrt1_w(const v4f32& _x)
 {
     v4f32 _y = __msa_frsqrt_w(_x);
-    v4f32 _t = __msa_fmul_w(_y, _y);
-    _t = __msa_fsub_w(__msa_fill_w_f32(3.f), __msa_fmul_w(_x, _t));
+    v4f32 _t = __msa_fmul_w(_x, _y);
+    _t = __msa_fsub_w(__msa_fill_w_f32(3.f), __msa_fmul_w(_t, _y));
     _y = __msa_fmul_w(_y, __msa_fmul_w(_t, __msa_fill_w_f32(0.5f)));
     return _y;
 }
@@ -166,8 +166,8 @@ static NCNN_FORCEINLINE v4f32 __ncnn_msa_comp_rsqrt1_w(const v4f32& _x)
 static NCNN_FORCEINLINE v4f32 __ncnn_msa_comp_rsqrt_w(const v4f32& _x)
 {
     v4f32 _y = __ncnn_msa_comp_rsqrt1_w(_x);
-    v4f32 _t = __msa_fmul_w(_y, _y);
-    _t = __msa_fsub_w(__msa_fill_w_f32(3.f), __msa_fmul_w(_x, _t));
+    v4f32 _t = __msa_fmul_w(_x, _y);
+    _t = __msa_fsub_w(__msa_fill_w_f32(3.f), __msa_fmul_w(_t, _y));
     _y = __msa_fmul_w(_y, __msa_fmul_w(_t, __msa_fill_w_f32(0.5f)));
     return _y;
 }

--- a/src/layer/mips/mips_usability.h
+++ b/src/layer/mips/mips_usability.h
@@ -74,23 +74,6 @@ static NCNN_FORCEINLINE v2f64 __ncnn_msa_fmsub_d(v2f64 a, v2f64 b, v2f64 c)
 #endif
 }
 
-static NCNN_FORCEINLINE v4f32 __ncnn_msa_comp_rsqrt1_w(const v4f32& _x)
-{
-    v4f32 _y = __msa_frsqrt_w(_x);
-    v4f32 _t = __msa_fmul_w(_y, _y);
-    _t = __msa_fsub_w(__msa_fill_w_f32(3.f), __msa_fmul_w(_x, _t));
-    _y = __msa_fmul_w(_y, __msa_fmul_w(_t, __msa_fill_w_f32(0.5f)));
-    return _y;
-}
-
-static NCNN_FORCEINLINE v4f32 __ncnn_msa_comp_rsqrt_w(const v4f32& _x)
-{
-    v4f32 _y = __ncnn_msa_comp_rsqrt1_w(_x);
-    v4f32 _t = __msa_fmul_w(_y, _y);
-    _t = __msa_fsub_w(__msa_fill_w_f32(3.f), __msa_fmul_w(_x, _t));
-    _y = __msa_fmul_w(_y, __msa_fmul_w(_t, __msa_fill_w_f32(0.5f)));
-    return _y;
-}
 
 static NCNN_FORCEINLINE v16i8 __ncnn_msa_maddv_b(v16i8 a, v16i8 b, v16i8 c)
 {
@@ -169,6 +152,24 @@ static NCNN_FORCEINLINE v4f32 __msa_fill_w_f32(float val)
 {
     ncnn::FloatInt fi_tmpval = {.f = val};
     return (v4f32)__msa_fill_w(fi_tmpval.i);
+}
+
+static NCNN_FORCEINLINE v4f32 __ncnn_msa_comp_rsqrt1_w(const v4f32& _x)
+{
+    v4f32 _y = __msa_frsqrt_w(_x);
+    v4f32 _t = __msa_fmul_w(_y, _y);
+    _t = __msa_fsub_w(__msa_fill_w_f32(3.f), __msa_fmul_w(_x, _t));
+    _y = __msa_fmul_w(_y, __msa_fmul_w(_t, __msa_fill_w_f32(0.5f)));
+    return _y;
+}
+
+static NCNN_FORCEINLINE v4f32 __ncnn_msa_comp_rsqrt_w(const v4f32& _x)
+{
+    v4f32 _y = __ncnn_msa_comp_rsqrt1_w(_x);
+    v4f32 _t = __msa_fmul_w(_y, _y);
+    _t = __msa_fsub_w(__msa_fill_w_f32(3.f), __msa_fmul_w(_x, _t));
+    _y = __msa_fmul_w(_y, __msa_fmul_w(_t, __msa_fill_w_f32(0.5f)));
+    return _y;
 }
 
 static NCNN_FORCEINLINE v4i32 __msa_set_w(int v0, int v1, int v2, int v3)

--- a/src/layer/mips/rmsnorm_mips.cpp
+++ b/src/layer/mips/rmsnorm_mips.cpp
@@ -58,7 +58,7 @@ static void rmsnorm_mips(float* ptr, const float* gamma_ptr, float eps, int elem
         v4f32 _eps = __msa_fill_w_f32(eps);
         _rms = __msa_fdiv_w(_rms, _elemcount);
         _rms = __msa_fadd_w(_rms, _eps);
-        _rms = __msa_frsqrt_w(_rms);
+        _rms = __ncnn_msa_comp_rsqrt_w(_rms);
     }
 #endif // __mips_msa
     if (elempack == 1)
@@ -288,8 +288,8 @@ static void rmsnorm_mips_bf16(unsigned short* ptr, const float* gamma_ptr, float
         _rms1 = __msa_fdiv_w(_rms1, _elemcount);
         _rms0 = __msa_fadd_w(_rms0, _eps);
         _rms1 = __msa_fadd_w(_rms1, _eps);
-        _rms0 = __msa_frsqrt_w(_rms0);
-        _rms1 = __msa_frsqrt_w(_rms1);
+        _rms0 = __ncnn_msa_comp_rsqrt_w(_rms0);
+        _rms1 = __ncnn_msa_comp_rsqrt_w(_rms1);
     }
     if (elempack == 4)
     {
@@ -299,7 +299,7 @@ static void rmsnorm_mips_bf16(unsigned short* ptr, const float* gamma_ptr, float
         v4f32 _eps = __msa_fill_w_f32(eps);
         _rms0 = __msa_fdiv_w(_rms0, _elemcount);
         _rms0 = __msa_fadd_w(_rms0, _eps);
-        _rms0 = __msa_frsqrt_w(_rms0);
+        _rms0 = __ncnn_msa_comp_rsqrt_w(_rms0);
         _rms1 = _rms0;
     }
 #endif // __mips_msa

--- a/src/layer/mips/unaryop_mips.cpp
+++ b/src/layer/mips/unaryop_mips.cpp
@@ -5,6 +5,7 @@
 
 // #include <fenv.h>
 #include <float.h>
+#include "mips_usability.h"
 
 #if __mips_msa
 #include <msa.h>
@@ -171,7 +172,7 @@ struct unary_op_rsqrt
 #if __mips_msa
     v4f32 func_pack4(const v4f32& x) const
     {
-        return __msa_frsqrt_w(x);
+        return __ncnn_msa_comp_rsqrt1_w(x);
     }
 #endif // __mips_msa
 };
@@ -507,7 +508,6 @@ struct unary_op_log1p
 } // namespace UnaryOp_mips_functor
 
 #if NCNN_BF16
-#include "mips_usability.h"
 
 template<typename Op>
 static int unary_op_inplace_bf16s(Mat& a, const Option& opt)

--- a/src/layer/vulkan/layernorm_vulkan.cpp
+++ b/src/layer/vulkan/layernorm_vulkan.cpp
@@ -375,7 +375,7 @@ int LayerNorm_vulkan::forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, co
 
     // coeffs a and b ---
     // coeffs_workspace stores {a, b} for each group, so size is num_groups_total * 2
-    VkMat coeffs_workspace(num_groups_total * 2, elemsize, elempack, opt.workspace_vkallocator);
+    VkMat coeffs_workspace(num_groups_total * 2, 4u * elempack, elempack, opt.workspace_vkallocator);
     {
         std::vector<VkMat> coeff_bindings(3);
         coeff_bindings[0] = coeffs_workspace;

--- a/src/layer/vulkan/rmsnorm_vulkan.cpp
+++ b/src/layer/vulkan/rmsnorm_vulkan.cpp
@@ -300,7 +300,7 @@ int RMSNorm_vulkan::forward_inplace(VkMat& bottom_top_blob, VkCompute& cmd, cons
     }
 
     // 3) coeffs (a) from rms
-    VkMat coeffs_workspace(num_groups_total, elemsize, elempack, opt.workspace_vkallocator); // only a, no b
+    VkMat coeffs_workspace(num_groups_total, 4u * elempack, elempack, opt.workspace_vkallocator); // only a, no b
     {
         std::vector<VkMat> bindings(2);
         bindings[0] = coeffs_workspace;

--- a/src/layer/vulkan/shader/layernorm_coeffs.comp
+++ b/src/layer/vulkan/shader/layernorm_coeffs.comp
@@ -5,7 +5,7 @@
 
 layout(constant_id = 0) const float eps = 0;
 
-layout(binding = 0) writeonly buffer coeffs_blob { sfp coeffs_blob_data[]; };
+layout(binding = 0) writeonly buffer coeffs_blob { float coeffs_blob_data[]; };
 layout(binding = 1) readonly buffer mean_blob { float mean_data[]; };
 layout(binding = 2) readonly buffer var_blob { float var_data[]; };
 
@@ -33,6 +33,6 @@ void main()
     // b = -mean * a
     float b = -mean * a;
 
-    buffer_st1(coeffs_blob_data, group_id * 2, afp(a));
-    buffer_st1(coeffs_blob_data, group_id * 2 + 1, afp(b));
+    coeffs_blob_data[group_id * 2] = a;
+    coeffs_blob_data[group_id * 2 + 1] = b;
 }

--- a/src/layer/vulkan/shader/layernorm_coeffs_pack4.comp
+++ b/src/layer/vulkan/shader/layernorm_coeffs_pack4.comp
@@ -5,7 +5,7 @@
 
 layout(constant_id = 0) const float eps = 0;
 
-layout(binding = 0) writeonly buffer coeffs_blob { sfpvec4 coeffs_blob_data[]; };
+layout(binding = 0) writeonly buffer coeffs_blob { vec4 coeffs_blob_data[]; };
 layout(binding = 1) readonly buffer mean_blob { vec4 mean_data[]; };
 layout(binding = 2) readonly buffer var_blob { vec4 var_data[]; };
 
@@ -31,6 +31,6 @@ void main()
     vec4 a = 1.f / (sqrt(var + eps));
     vec4 b = -mean * a;
 
-    buffer_st4(coeffs_blob_data, group_id * 2, afpvec4(a));
-    buffer_st4(coeffs_blob_data, group_id * 2 + 1, afpvec4(b));
+    coeffs_blob_data[group_id * 2] = a;
+    coeffs_blob_data[group_id * 2 + 1] = b;
 }

--- a/src/layer/vulkan/shader/layernorm_norm.comp
+++ b/src/layer/vulkan/shader/layernorm_norm.comp
@@ -7,7 +7,7 @@ layout(constant_id = 0) const int affine = 0;
 layout(constant_id = 1) const int affine_size = 0;
 
 layout(binding = 0) buffer bottom_top_blob { sfp bottom_top_blob_data[]; };
-layout(binding = 1) readonly buffer coeffs_blob { sfp coeffs_blob_data[]; };
+layout(binding = 1) readonly buffer coeffs_blob { float coeffs_blob_data[]; };
 layout(binding = 2) readonly buffer gamma_blob { sfp gamma_data[]; };
 layout(binding = 3) readonly buffer beta_blob { sfp beta_data[]; };
 
@@ -33,8 +33,8 @@ void main()
     const int group_id = gz * (p.w * p.h / affine_size) + q / affine_size;
     const int inner_id = q % affine_size;
 
-    afp a = buffer_ld1(coeffs_blob_data, group_id * 2);
-    afp b = buffer_ld1(coeffs_blob_data, group_id * 2 + 1);
+    afp a = afp(coeffs_blob_data[group_id * 2]);
+    afp b = afp(coeffs_blob_data[group_id * 2 + 1]);
 
     afp v = buffer_ld1(bottom_top_blob_data, gi);
 

--- a/src/layer/vulkan/shader/layernorm_norm.comp
+++ b/src/layer/vulkan/shader/layernorm_norm.comp
@@ -33,20 +33,20 @@ void main()
     const int group_id = gz * (p.w * p.h / affine_size) + q / affine_size;
     const int inner_id = q % affine_size;
 
-    afp a = afp(coeffs_blob_data[group_id * 2]);
-    afp b = afp(coeffs_blob_data[group_id * 2 + 1]);
+    float a = coeffs_blob_data[group_id * 2];
+    float b = coeffs_blob_data[group_id * 2 + 1];
 
-    afp v = buffer_ld1(bottom_top_blob_data, gi);
+    float v = float(buffer_ld1(bottom_top_blob_data, gi));
 
     // (x - mean) / sqrt(var + eps)
     v = v * a + b;
 
     if (affine == 1)
     {
-        afp gamma = buffer_ld1(gamma_data, inner_id);
-        afp beta = buffer_ld1(beta_data, inner_id);
+        float gamma = float(buffer_ld1(gamma_data, inner_id));
+        float beta = float(buffer_ld1(beta_data, inner_id));
         v = v * gamma + beta;
     }
 
-    buffer_st1(bottom_top_blob_data, gi, v);
+    buffer_st1(bottom_top_blob_data, gi, afp(v));
 }

--- a/src/layer/vulkan/shader/layernorm_norm_pack4.comp
+++ b/src/layer/vulkan/shader/layernorm_norm_pack4.comp
@@ -7,7 +7,7 @@ layout(constant_id = 0) const int affine = 0;
 layout(constant_id = 1) const int affine_size = 0;
 
 layout(binding = 0) buffer bottom_top_blob { sfpvec4 bottom_top_blob_data[]; };
-layout(binding = 1) readonly buffer coeffs_blob { sfpvec4 coeffs_blob_data[]; };
+layout(binding = 1) readonly buffer coeffs_blob { vec4 coeffs_blob_data[]; };
 layout(binding = 2) readonly buffer gamma_blob { sfp gamma_data[]; };
 layout(binding = 3) readonly buffer beta_blob { sfp beta_data[]; };
 
@@ -33,8 +33,8 @@ void main()
     const int group_id = gz * (p.w * p.h / affine_size) + q / affine_size;
     const int inner_id = q % affine_size;
 
-    afpvec4 a = buffer_ld4(coeffs_blob_data, group_id * 2);
-    afpvec4 b = buffer_ld4(coeffs_blob_data, group_id * 2 + 1);
+    afpvec4 a = afpvec4(coeffs_blob_data[group_id * 2]);
+    afpvec4 b = afpvec4(coeffs_blob_data[group_id * 2 + 1]);
 
     afpvec4 v = buffer_ld4(bottom_top_blob_data, gi);
 

--- a/src/layer/vulkan/shader/layernorm_norm_pack4.comp
+++ b/src/layer/vulkan/shader/layernorm_norm_pack4.comp
@@ -33,19 +33,19 @@ void main()
     const int group_id = gz * (p.w * p.h / affine_size) + q / affine_size;
     const int inner_id = q % affine_size;
 
-    afpvec4 a = afpvec4(coeffs_blob_data[group_id * 2]);
-    afpvec4 b = afpvec4(coeffs_blob_data[group_id * 2 + 1]);
+    vec4 a = coeffs_blob_data[group_id * 2];
+    vec4 b = coeffs_blob_data[group_id * 2 + 1];
 
-    afpvec4 v = buffer_ld4(bottom_top_blob_data, gi);
+    vec4 v = vec4(buffer_ld4(bottom_top_blob_data, gi));
 
     v = v * a + b;
 
     if (affine == 1)
     {
-        afp gamma = buffer_ld1(gamma_data, inner_id);
-        afp beta = buffer_ld1(beta_data, inner_id);
-        v = v * afpvec4(gamma) + afpvec4(beta);
+        float gamma = float(buffer_ld1(gamma_data, inner_id));
+        float beta = float(buffer_ld1(beta_data, inner_id));
+        v = v * vec4(gamma) + vec4(beta);
     }
 
-    buffer_st4(bottom_top_blob_data, gi, v);
+    buffer_st4(bottom_top_blob_data, gi, afpvec4(v));
 }

--- a/src/layer/vulkan/shader/rmsnorm_coeffs.comp
+++ b/src/layer/vulkan/shader/rmsnorm_coeffs.comp
@@ -5,7 +5,7 @@
 
 layout(constant_id = 0) const float eps = 0;
 
-layout(binding = 0) writeonly buffer coeffs_blob { sfp coeffs_blob_data[]; };
+layout(binding = 0) writeonly buffer coeffs_blob { float coeffs_blob_data[]; };
 layout(binding = 1) readonly buffer rms_blob { float rms_data[]; };
 
 layout(push_constant) uniform parameter
@@ -25,5 +25,5 @@ void main()
     int group_id = gz * p.num_groups_per_channel + gy;
     float rms = rms_data[group_id];
     float a = 1.0 / sqrt(rms + eps);
-    buffer_st1(coeffs_blob_data, group_id, afp(a));
+    coeffs_blob_data[group_id] = a;
 }

--- a/src/layer/vulkan/shader/rmsnorm_coeffs_pack4.comp
+++ b/src/layer/vulkan/shader/rmsnorm_coeffs_pack4.comp
@@ -5,7 +5,7 @@
 
 layout(constant_id = 0) const float eps = 0;
 
-layout(binding = 0) writeonly buffer coeffs_blob { sfpvec4 coeffs_blob_data[]; };
+layout(binding = 0) writeonly buffer coeffs_blob { vec4 coeffs_blob_data[]; };
 layout(binding = 1) readonly buffer rms_blob { vec4 rms_data[]; };
 
 layout(push_constant) uniform parameter
@@ -25,5 +25,5 @@ void main()
     int group_id = gz * p.num_groups_per_channel + gy;
     vec4 rms = rms_data[group_id];
     vec4 a = inversesqrt(rms + vec4(eps));
-    buffer_st4(coeffs_blob_data, group_id, afpvec4(a));
+    coeffs_blob_data[group_id] = a;
 }

--- a/src/layer/vulkan/shader/rmsnorm_norm.comp
+++ b/src/layer/vulkan/shader/rmsnorm_norm.comp
@@ -30,15 +30,15 @@ void main()
     const int group_id = gz * (p.w * p.h / affine_size) + q / affine_size;
     const int inner_id = q % affine_size;
 
-    afp a = afp(coeffs_blob_data[group_id]);
+    float a = coeffs_blob_data[group_id];
 
-    afp v = buffer_ld1(bottom_top_blob_data, gi);
+    float v = float(buffer_ld1(bottom_top_blob_data, gi));
     v = v * a; // v = v / sqrt(rms+eps)
 
     if (affine == 1)
     {
-        afp gamma = buffer_ld1(gamma_data, inner_id);
+        float gamma = float(buffer_ld1(gamma_data, inner_id));
         v = v * gamma;
     }
-    buffer_st1(bottom_top_blob_data, gi, v);
+    buffer_st1(bottom_top_blob_data, gi, afp(v));
 }

--- a/src/layer/vulkan/shader/rmsnorm_norm.comp
+++ b/src/layer/vulkan/shader/rmsnorm_norm.comp
@@ -6,7 +6,7 @@ layout(constant_id = 0) const int affine = 0;
 layout(constant_id = 1) const int affine_size = 0;
 
 layout(binding = 0) buffer bottom_top_blob { sfp bottom_top_blob_data[]; };
-layout(binding = 1) readonly buffer coeffs_blob { sfp coeffs_blob_data[]; };
+layout(binding = 1) readonly buffer coeffs_blob { float coeffs_blob_data[]; };
 layout(binding = 2) readonly buffer gamma_blob { sfp gamma_data[]; };
 
 layout(push_constant) uniform parameter
@@ -30,7 +30,7 @@ void main()
     const int group_id = gz * (p.w * p.h / affine_size) + q / affine_size;
     const int inner_id = q % affine_size;
 
-    afp a = buffer_ld1(coeffs_blob_data, group_id);
+    afp a = afp(coeffs_blob_data[group_id]);
 
     afp v = buffer_ld1(bottom_top_blob_data, gi);
     v = v * a; // v = v / sqrt(rms+eps)

--- a/src/layer/vulkan/shader/rmsnorm_norm_pack4.comp
+++ b/src/layer/vulkan/shader/rmsnorm_norm_pack4.comp
@@ -6,7 +6,7 @@ layout(constant_id = 0) const int affine = 0;
 layout(constant_id = 1) const int affine_size = 0;
 
 layout(binding = 0) buffer bottom_top_blob { sfpvec4 bottom_top_blob_data[]; };
-layout(binding = 1) readonly buffer coeffs_blob { sfpvec4 coeffs_blob_data[]; };
+layout(binding = 1) readonly buffer coeffs_blob { vec4 coeffs_blob_data[]; };
 layout(binding = 2) readonly buffer gamma_blob { sfp gamma_data[]; };
 
 layout(push_constant) uniform parameter
@@ -27,7 +27,7 @@ void main()
     const int group_id = gz * (p.w * p.h / affine_size) + q / affine_size;
     const int inner_id = q % affine_size;
 
-    afpvec4 a = buffer_ld4(coeffs_blob_data, group_id);
+    afpvec4 a = afpvec4(coeffs_blob_data[group_id]);
     afpvec4 v = buffer_ld4(bottom_top_blob_data, gi);
     v = v * a;
 

--- a/src/layer/vulkan/shader/rmsnorm_norm_pack4.comp
+++ b/src/layer/vulkan/shader/rmsnorm_norm_pack4.comp
@@ -27,14 +27,14 @@ void main()
     const int group_id = gz * (p.w * p.h / affine_size) + q / affine_size;
     const int inner_id = q % affine_size;
 
-    afpvec4 a = afpvec4(coeffs_blob_data[group_id]);
-    afpvec4 v = buffer_ld4(bottom_top_blob_data, gi);
+    vec4 a = coeffs_blob_data[group_id];
+    vec4 v = vec4(buffer_ld4(bottom_top_blob_data, gi));
     v = v * a;
 
     if (affine == 1)
     {
-        afp gamma = buffer_ld1(gamma_data, inner_id);
-        v = v * afpvec4(gamma);
+        float gamma = float(buffer_ld1(gamma_data, inner_id));
+        v = v * vec4(gamma);
     }
-    buffer_st4(bottom_top_blob_data, gi, v);
+    buffer_st4(bottom_top_blob_data, gi, afpvec4(v));
 }

--- a/src/layer/x86/layernorm_bf16s.h
+++ b/src/layer/x86/layernorm_bf16s.h
@@ -197,7 +197,7 @@ static void layernorm_bf16s_sse(unsigned short* ptr, const float* gamma_ptr, con
         __m512 _eps = _mm512_set1_ps(eps);
         _var_avx512 = _mm512_div_ps(_var_avx512, _elemcount);
         _var_avx512 = _mm512_add_ps(_var_avx512, _eps);
-        _var_avx512 = _mm512_comp_rsqrt1_ps(_var_avx512);
+        _var_avx512 = _mm512_comp_rsqrt_ps(_var_avx512);
         _mean_avx512 = _mm512_mul_ps(_mean_avx512, _var_avx512);
     }
 #endif // __AVX512F__

--- a/src/layer/x86/layernorm_bf16s.h
+++ b/src/layer/x86/layernorm_bf16s.h
@@ -197,9 +197,7 @@ static void layernorm_bf16s_sse(unsigned short* ptr, const float* gamma_ptr, con
         __m512 _eps = _mm512_set1_ps(eps);
         _var_avx512 = _mm512_div_ps(_var_avx512, _elemcount);
         _var_avx512 = _mm512_add_ps(_var_avx512, _eps);
-        __m256 _var0 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_var_avx512, 0));
-        __m256 _var1 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_var_avx512, 1));
-        _var_avx512 = combine8x2_ps(_var0, _var1);
+        _var_avx512 = _mm512_comp_rsqrt1_ps(_var_avx512);
         _mean_avx512 = _mm512_mul_ps(_mean_avx512, _var_avx512);
     }
 #endif // __AVX512F__

--- a/src/layer/x86/layernorm_bf16s.h
+++ b/src/layer/x86/layernorm_bf16s.h
@@ -197,8 +197,8 @@ static void layernorm_bf16s_sse(unsigned short* ptr, const float* gamma_ptr, con
         __m512 _eps = _mm512_set1_ps(eps);
         _var_avx512 = _mm512_div_ps(_var_avx512, _elemcount);
         _var_avx512 = _mm512_add_ps(_var_avx512, _eps);
-        __m256 _var0 = _mm256_rsqrt_ps(_mm512_extractf32x8_ps(_var_avx512, 0));
-        __m256 _var1 = _mm256_rsqrt_ps(_mm512_extractf32x8_ps(_var_avx512, 1));
+        __m256 _var0 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_var_avx512, 0));
+        __m256 _var1 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_var_avx512, 1));
         _var_avx512 = combine8x2_ps(_var0, _var1);
         _mean_avx512 = _mm512_mul_ps(_mean_avx512, _var_avx512);
     }
@@ -217,7 +217,7 @@ static void layernorm_bf16s_sse(unsigned short* ptr, const float* gamma_ptr, con
         __m256 _eps = _mm256_set1_ps(eps);
         _var_avx = _mm256_div_ps(_var_avx, _elemcount);
         _var_avx = _mm256_add_ps(_var_avx, _eps);
-        _var_avx = _mm256_rsqrt_ps(_var_avx);
+        _var_avx = _mm256_comp_rsqrt_ps(_var_avx);
         _mean_avx = _mm256_mul_ps(_mean_avx, _var_avx);
 #if __AVX512F__
         _var_avx512 = combine8x2_ps(_var_avx, _var_avx);
@@ -247,7 +247,7 @@ static void layernorm_bf16s_sse(unsigned short* ptr, const float* gamma_ptr, con
         __m128 _eps = _mm_set1_ps(eps);
         _var = _mm_div_ps(_var, _elemcount);
         _var = _mm_add_ps(_var, _eps);
-        _var = _mm_rsqrt_ps(_var);
+        _var = _mm_comp_rsqrt_ps(_var);
         _mean = _mm_mul_ps(_mean, _var);
 #if __AVX__
         _var_avx = combine4x2_ps(_var, _var);

--- a/src/layer/x86/layernorm_x86.cpp
+++ b/src/layer/x86/layernorm_x86.cpp
@@ -216,7 +216,7 @@ static void layernorm(float* ptr, const float* gamma_ptr, const float* beta_ptr,
         __m512 _eps = _mm512_set1_ps(eps);
         _var_avx512 = _mm512_div_ps(_var_avx512, _elemcount);
         _var_avx512 = _mm512_add_ps(_var_avx512, _eps);
-        _var_avx512 = _mm512_comp_rsqrt1_ps(_var_avx512);
+        _var_avx512 = _mm512_comp_rsqrt_ps(_var_avx512);
         _mean_avx512 = _mm512_mul_ps(_mean_avx512, _var_avx512);
     }
 #endif // __AVX512F__

--- a/src/layer/x86/layernorm_x86.cpp
+++ b/src/layer/x86/layernorm_x86.cpp
@@ -216,9 +216,7 @@ static void layernorm(float* ptr, const float* gamma_ptr, const float* beta_ptr,
         __m512 _eps = _mm512_set1_ps(eps);
         _var_avx512 = _mm512_div_ps(_var_avx512, _elemcount);
         _var_avx512 = _mm512_add_ps(_var_avx512, _eps);
-        __m256 _var0 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_var_avx512, 0));
-        __m256 _var1 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_var_avx512, 1));
-        _var_avx512 = combine8x2_ps(_var0, _var1);
+        _var_avx512 = _mm512_comp_rsqrt1_ps(_var_avx512);
         _mean_avx512 = _mm512_mul_ps(_mean_avx512, _var_avx512);
     }
 #endif // __AVX512F__

--- a/src/layer/x86/layernorm_x86.cpp
+++ b/src/layer/x86/layernorm_x86.cpp
@@ -216,8 +216,8 @@ static void layernorm(float* ptr, const float* gamma_ptr, const float* beta_ptr,
         __m512 _eps = _mm512_set1_ps(eps);
         _var_avx512 = _mm512_div_ps(_var_avx512, _elemcount);
         _var_avx512 = _mm512_add_ps(_var_avx512, _eps);
-        __m256 _var0 = _mm256_rsqrt_ps(_mm512_extractf32x8_ps(_var_avx512, 0));
-        __m256 _var1 = _mm256_rsqrt_ps(_mm512_extractf32x8_ps(_var_avx512, 1));
+        __m256 _var0 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_var_avx512, 0));
+        __m256 _var1 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_var_avx512, 1));
         _var_avx512 = combine8x2_ps(_var0, _var1);
         _mean_avx512 = _mm512_mul_ps(_mean_avx512, _var_avx512);
     }
@@ -237,7 +237,7 @@ static void layernorm(float* ptr, const float* gamma_ptr, const float* beta_ptr,
         __m256 _eps = _mm256_set1_ps(eps);
         _var_avx = _mm256_div_ps(_var_avx, _elemcount);
         _var_avx = _mm256_add_ps(_var_avx, _eps);
-        _var_avx = _mm256_rsqrt_ps(_var_avx);
+        _var_avx = _mm256_comp_rsqrt_ps(_var_avx);
         _mean_avx = _mm256_mul_ps(_mean_avx, _var_avx);
 #if __AVX512F__
         _var_avx512 = combine8x2_ps(_var_avx, _var_avx);
@@ -268,7 +268,7 @@ static void layernorm(float* ptr, const float* gamma_ptr, const float* beta_ptr,
         __m128 _eps = _mm_set1_ps(eps);
         _var = _mm_div_ps(_var, _elemcount);
         _var = _mm_add_ps(_var, _eps);
-        _var = _mm_rsqrt_ps(_var);
+        _var = _mm_comp_rsqrt_ps(_var);
         _mean = _mm_mul_ps(_mean, _var);
 #if __AVX__
         _var_avx = combine4x2_ps(_var, _var);

--- a/src/layer/x86/rmsnorm_bf16s.h
+++ b/src/layer/x86/rmsnorm_bf16s.h
@@ -72,9 +72,7 @@ static void rmsnorm_bf16s_sse(unsigned short* ptr, const float* gamma_ptr, float
         __m512 _eps = _mm512_set1_ps(eps);
         _rms_avx512 = _mm512_div_ps(_rms_avx512, _elemcount);
         _rms_avx512 = _mm512_add_ps(_rms_avx512, _eps);
-        __m256 _rms0 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_rms_avx512, 0));
-        __m256 _rms1 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_rms_avx512, 1));
-        _rms_avx512 = combine8x2_ps(_rms0, _rms1);
+        _rms_avx512 = _mm512_comp_rsqrt1_ps(_rms_avx512);
     }
 #endif // __AVX512F__
     if (elempack == 8)

--- a/src/layer/x86/rmsnorm_bf16s.h
+++ b/src/layer/x86/rmsnorm_bf16s.h
@@ -72,8 +72,8 @@ static void rmsnorm_bf16s_sse(unsigned short* ptr, const float* gamma_ptr, float
         __m512 _eps = _mm512_set1_ps(eps);
         _rms_avx512 = _mm512_div_ps(_rms_avx512, _elemcount);
         _rms_avx512 = _mm512_add_ps(_rms_avx512, _eps);
-        __m256 _rms0 = _mm256_rsqrt_ps(_mm512_extractf32x8_ps(_rms_avx512, 0));
-        __m256 _rms1 = _mm256_rsqrt_ps(_mm512_extractf32x8_ps(_rms_avx512, 1));
+        __m256 _rms0 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_rms_avx512, 0));
+        __m256 _rms1 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_rms_avx512, 1));
         _rms_avx512 = combine8x2_ps(_rms0, _rms1);
     }
 #endif // __AVX512F__
@@ -91,7 +91,7 @@ static void rmsnorm_bf16s_sse(unsigned short* ptr, const float* gamma_ptr, float
         __m256 _eps = _mm256_set1_ps(eps);
         _rms_avx = _mm256_div_ps(_rms_avx, _elemcount);
         _rms_avx = _mm256_add_ps(_rms_avx, _eps);
-        _rms_avx = _mm256_rsqrt_ps(_rms_avx);
+        _rms_avx = _mm256_comp_rsqrt_ps(_rms_avx);
 #if __AVX512F__
         _rms_avx512 = combine8x2_ps(_rms_avx, _rms_avx);
 #endif // __AVX512F__
@@ -119,7 +119,7 @@ static void rmsnorm_bf16s_sse(unsigned short* ptr, const float* gamma_ptr, float
         __m128 _eps = _mm_set1_ps(eps);
         _rms = _mm_div_ps(_rms, _elemcount);
         _rms = _mm_add_ps(_rms, _eps);
-        _rms = _mm_rsqrt_ps(_rms);
+        _rms = _mm_comp_rsqrt_ps(_rms);
 #if __AVX__
         _rms_avx = combine4x2_ps(_rms, _rms);
 #if __AVX512F__

--- a/src/layer/x86/rmsnorm_bf16s.h
+++ b/src/layer/x86/rmsnorm_bf16s.h
@@ -72,7 +72,7 @@ static void rmsnorm_bf16s_sse(unsigned short* ptr, const float* gamma_ptr, float
         __m512 _eps = _mm512_set1_ps(eps);
         _rms_avx512 = _mm512_div_ps(_rms_avx512, _elemcount);
         _rms_avx512 = _mm512_add_ps(_rms_avx512, _eps);
-        _rms_avx512 = _mm512_comp_rsqrt1_ps(_rms_avx512);
+        _rms_avx512 = _mm512_comp_rsqrt_ps(_rms_avx512);
     }
 #endif // __AVX512F__
     if (elempack == 8)

--- a/src/layer/x86/rmsnorm_x86.cpp
+++ b/src/layer/x86/rmsnorm_x86.cpp
@@ -89,7 +89,7 @@ static void rmsnorm(float* ptr, const float* gamma_ptr, float eps, int elemcount
         _rms_avx512 = _mm512_div_ps(_rms_avx512, _elemcount);
         _rms_avx512 = _mm512_add_ps(_rms_avx512, _eps);
 
-        _rms_avx512 = _mm512_comp_rsqrt1_ps(_rms_avx512);
+        _rms_avx512 = _mm512_comp_rsqrt_ps(_rms_avx512);
     }
 #endif // __AVX512F__
     if (elempack == 8)

--- a/src/layer/x86/rmsnorm_x86.cpp
+++ b/src/layer/x86/rmsnorm_x86.cpp
@@ -89,9 +89,7 @@ static void rmsnorm(float* ptr, const float* gamma_ptr, float eps, int elemcount
         _rms_avx512 = _mm512_div_ps(_rms_avx512, _elemcount);
         _rms_avx512 = _mm512_add_ps(_rms_avx512, _eps);
 
-        __m256 _rms0 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_rms_avx512, 0));
-        __m256 _rms1 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_rms_avx512, 1));
-        _rms_avx512 = combine8x2_ps(_rms0, _rms1);
+        _rms_avx512 = _mm512_comp_rsqrt1_ps(_rms_avx512);
     }
 #endif // __AVX512F__
     if (elempack == 8)

--- a/src/layer/x86/rmsnorm_x86.cpp
+++ b/src/layer/x86/rmsnorm_x86.cpp
@@ -89,8 +89,8 @@ static void rmsnorm(float* ptr, const float* gamma_ptr, float eps, int elemcount
         _rms_avx512 = _mm512_div_ps(_rms_avx512, _elemcount);
         _rms_avx512 = _mm512_add_ps(_rms_avx512, _eps);
 
-        __m256 _rms0 = _mm256_rsqrt_ps(_mm512_extractf32x8_ps(_rms_avx512, 0));
-        __m256 _rms1 = _mm256_rsqrt_ps(_mm512_extractf32x8_ps(_rms_avx512, 1));
+        __m256 _rms0 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_rms_avx512, 0));
+        __m256 _rms1 = _mm256_comp_rsqrt_ps(_mm512_extractf32x8_ps(_rms_avx512, 1));
         _rms_avx512 = combine8x2_ps(_rms0, _rms1);
     }
 #endif // __AVX512F__
@@ -111,7 +111,7 @@ static void rmsnorm(float* ptr, const float* gamma_ptr, float eps, int elemcount
         _rms_avx = _mm256_div_ps(_rms_avx, _elemcount);
         _rms_avx = _mm256_add_ps(_rms_avx, _eps);
 
-        _rms_avx = _mm256_rsqrt_ps(_rms_avx);
+        _rms_avx = _mm256_comp_rsqrt_ps(_rms_avx);
 #if __AVX512F__
         _rms_avx512 = combine8x2_ps(_rms_avx, _rms_avx);
 #endif // __AVX512F__
@@ -142,7 +142,7 @@ static void rmsnorm(float* ptr, const float* gamma_ptr, float eps, int elemcount
         _rms = _mm_div_ps(_rms, _elemcount);
         _rms = _mm_add_ps(_rms, _eps);
 
-        _rms = _mm_rsqrt_ps(_rms);
+        _rms = _mm_comp_rsqrt_ps(_rms);
 #if __AVX__
         _rms_avx = combine4x2_ps(_rms, _rms);
 #if __AVX512F__

--- a/src/layer/x86/unaryop_functor.h
+++ b/src/layer/x86/unaryop_functor.h
@@ -166,20 +166,20 @@ struct unary_op_rsqrt
 #if __SSE2__
     NCNN_FORCEINLINE __m128 func_pack4(const __m128& x) const
     {
-        return _mm_rsqrt_ps(x);
+        return _mm_comp_rsqrt1_ps(x);
     }
 #if __AVX__
     NCNN_FORCEINLINE __m256 func_pack8(const __m256& x) const
     {
-        return _mm256_rsqrt_ps(x);
+        return _mm256_comp_rsqrt1_ps(x);
     }
 #if __AVX512F__
     NCNN_FORCEINLINE __m512 func_pack16(const __m512& x) const
     {
         __m256 _x0 = _mm512_extractf32x8_ps(x, 0);
         __m256 _x1 = _mm512_extractf32x8_ps(x, 1);
-        _x0 = _mm256_rsqrt_ps(_x0);
-        _x1 = _mm256_rsqrt_ps(_x1);
+        _x0 = _mm256_comp_rsqrt1_ps(_x0);
+        _x1 = _mm256_comp_rsqrt1_ps(_x1);
         return combine8x2_ps(_x0, _x1);
     }
 #endif // __AVX512F__

--- a/src/layer/x86/unaryop_functor.h
+++ b/src/layer/x86/unaryop_functor.h
@@ -176,7 +176,7 @@ struct unary_op_rsqrt
 #if __AVX512F__
     NCNN_FORCEINLINE __m512 func_pack16(const __m512& x) const
     {
-        return _mm512_comp_rsqrt1_ps(x);
+        return _mm512_comp_rsqrt_ps(x);
     }
 #endif // __AVX512F__
 #endif // __AVX__

--- a/src/layer/x86/unaryop_functor.h
+++ b/src/layer/x86/unaryop_functor.h
@@ -176,7 +176,7 @@ struct unary_op_rsqrt
 #if __AVX512F__
     NCNN_FORCEINLINE __m512 func_pack16(const __m512& x) const
     {
-        return _mm512_comp_rsqrt_ps(x);
+        return _mm512_comp_rsqrt1_ps(x);
     }
 #endif // __AVX512F__
 #endif // __AVX__

--- a/src/layer/x86/unaryop_functor.h
+++ b/src/layer/x86/unaryop_functor.h
@@ -176,11 +176,7 @@ struct unary_op_rsqrt
 #if __AVX512F__
     NCNN_FORCEINLINE __m512 func_pack16(const __m512& x) const
     {
-        __m256 _x0 = _mm512_extractf32x8_ps(x, 0);
-        __m256 _x1 = _mm512_extractf32x8_ps(x, 1);
-        _x0 = _mm256_comp_rsqrt1_ps(_x0);
-        _x1 = _mm256_comp_rsqrt1_ps(_x1);
-        return combine8x2_ps(_x0, _x1);
+        return _mm512_comp_rsqrt1_ps(x);
     }
 #endif // __AVX512F__
 #endif // __AVX__

--- a/src/layer/x86/x86_usability.h
+++ b/src/layer/x86/x86_usability.h
@@ -1888,6 +1888,23 @@ static NCNN_FORCEINLINE __m512 _mm512_rcp_nr_ps(const __m512& x)
     return _mm512_mul_ps(y, t);
 }
 
+static NCNN_FORCEINLINE __m512 _mm512_comp_rsqrt1_ps(const __m512& _x)
+{
+    const __m512 _y0 = _mm512_rsqrt14_ps(_x);
+    __m512 _t = _mm512_mul_ps(_x, _y0);
+    _t = _mm512_fnmadd_ps(_t, _y0, _mm512_set1_ps(3.f));
+    const __m512 _y = _mm512_mul_ps(_y0, _mm512_mul_ps(_t, _mm512_set1_ps(0.5f)));
+
+    // Do not refine zero, negative, infinite, or NaN lanes.  The x*y
+    // intermediate is invalid for zero and infinity, while rsqrt14 already
+    // provides the required special-value result for those lanes.
+    const __m512i _inf_bits = _mm512_set1_epi32(0x7f800000);
+    const __m512 _inf = _mm512_castsi512_ps(_inf_bits);
+    const __mmask16 _normal = _mm512_cmp_ps_mask(_x, _mm512_setzero_ps(), _CMP_GT_OQ)
+                             & _mm512_cmp_ps_mask(_x, _inf, _CMP_LT_OQ);
+    return _mm512_mask_mov_ps(_y0, _normal, _y);
+}
+
 static NCNN_FORCEINLINE __m512 combine8x2_ps(const __m256& a, const __m256& b)
 {
     return _mm512_insertf32x8(_mm512_castps256_ps512(a), b, 1);

--- a/src/layer/x86/x86_usability.h
+++ b/src/layer/x86/x86_usability.h
@@ -471,7 +471,11 @@ static NCNN_FORCEINLINE __m128 _mm_rcp_nr_ps(const __m128& x)
 
 static NCNN_FORCEINLINE __m128 _mm_comp_rsqrt1_ps(const __m128& _x)
 {
+#if __AVX512F__
+    __m128 _y = _mm_rsqrt14_ps(_x);
+#else
     __m128 _y = _mm_rsqrt_ps(_x);
+#endif
     __m128 _t = _mm_mul_ps(_x, _y);
     _t = _mm_comp_fnmadd_ps(_t, _y, _mm_set1_ps(3.f));
     _y = _mm_mul_ps(_y, _mm_mul_ps(_t, _mm_set1_ps(0.5f)));
@@ -480,7 +484,11 @@ static NCNN_FORCEINLINE __m128 _mm_comp_rsqrt1_ps(const __m128& _x)
 
 static NCNN_FORCEINLINE __m128 _mm_comp_rsqrt_ps(const __m128& _x)
 {
+#if __AVX512F__
+    __m128 _y = _mm_rsqrt14_ps(_x);
+#else
     __m128 _y = _mm_rsqrt_ps(_x);
+#endif
     __m128 _t = _mm_mul_ps(_x, _y);
     _t = _mm_comp_fnmadd_ps(_t, _y, _mm_set1_ps(3.f));
     _y = _mm_mul_ps(_y, _mm_mul_ps(_t, _mm_set1_ps(0.5f)));
@@ -568,7 +576,11 @@ static NCNN_FORCEINLINE __m256 _mm256_rcp_nr_ps(const __m256& x)
 
 static NCNN_FORCEINLINE __m256 _mm256_comp_rsqrt1_ps(const __m256& _x)
 {
+#if __AVX512F__
+    __m256 _y = _mm256_rsqrt14_ps(_x);
+#else
     __m256 _y = _mm256_rsqrt_ps(_x);
+#endif
     __m256 _t = _mm256_mul_ps(_x, _y);
     _t = _mm256_comp_fnmadd_ps(_t, _y, _mm256_set1_ps(3.f));
     _y = _mm256_mul_ps(_y, _mm256_mul_ps(_t, _mm256_set1_ps(0.5f)));
@@ -577,7 +589,11 @@ static NCNN_FORCEINLINE __m256 _mm256_comp_rsqrt1_ps(const __m256& _x)
 
 static NCNN_FORCEINLINE __m256 _mm256_comp_rsqrt_ps(const __m256& _x)
 {
+#if __AVX512F__
+    __m256 _y = _mm256_rsqrt14_ps(_x);
+#else
     __m256 _y = _mm256_rsqrt_ps(_x);
+#endif
     __m256 _t = _mm256_mul_ps(_x, _y);
     _t = _mm256_comp_fnmadd_ps(_t, _y, _mm256_set1_ps(3.f));
     _y = _mm256_mul_ps(_y, _mm256_mul_ps(_t, _mm256_set1_ps(0.5f)));

--- a/src/layer/x86/x86_usability.h
+++ b/src/layer/x86/x86_usability.h
@@ -1901,7 +1901,7 @@ static NCNN_FORCEINLINE __m512 _mm512_comp_rsqrt1_ps(const __m512& _x)
     const __m512i _inf_bits = _mm512_set1_epi32(0x7f800000);
     const __m512 _inf = _mm512_castsi512_ps(_inf_bits);
     const __mmask16 _normal = _mm512_cmp_ps_mask(_x, _mm512_setzero_ps(), _CMP_GT_OQ)
-                             & _mm512_cmp_ps_mask(_x, _inf, _CMP_LT_OQ);
+                              & _mm512_cmp_ps_mask(_x, _inf, _CMP_LT_OQ);
     return _mm512_mask_mov_ps(_y0, _normal, _y);
 }
 

--- a/src/layer/x86/x86_usability.h
+++ b/src/layer/x86/x86_usability.h
@@ -1888,21 +1888,13 @@ static NCNN_FORCEINLINE __m512 _mm512_rcp_nr_ps(const __m512& x)
     return _mm512_mul_ps(y, t);
 }
 
-static NCNN_FORCEINLINE __m512 _mm512_comp_rsqrt1_ps(const __m512& _x)
+static NCNN_FORCEINLINE __m512 _mm512_comp_rsqrt_ps(const __m512& _x)
 {
     const __m512 _y0 = _mm512_rsqrt14_ps(_x);
     __m512 _t = _mm512_mul_ps(_x, _y0);
     _t = _mm512_fnmadd_ps(_t, _y0, _mm512_set1_ps(3.f));
     const __m512 _y = _mm512_mul_ps(_y0, _mm512_mul_ps(_t, _mm512_set1_ps(0.5f)));
-
-    // Do not refine zero, negative, infinite, or NaN lanes.  The x*y
-    // intermediate is invalid for zero and infinity, while rsqrt14 already
-    // provides the required special-value result for those lanes.
-    const __m512i _inf_bits = _mm512_set1_epi32(0x7f800000);
-    const __m512 _inf = _mm512_castsi512_ps(_inf_bits);
-    const __mmask16 _normal = _mm512_cmp_ps_mask(_x, _mm512_setzero_ps(), _CMP_GT_OQ)
-                              & _mm512_cmp_ps_mask(_x, _inf, _CMP_LT_OQ);
-    return _mm512_mask_mov_ps(_y0, _normal, _y);
+    return _y;
 }
 
 static NCNN_FORCEINLINE __m512 combine8x2_ps(const __m256& a, const __m256& b)

--- a/src/layer/x86/x86_usability.h
+++ b/src/layer/x86/x86_usability.h
@@ -472,8 +472,8 @@ static NCNN_FORCEINLINE __m128 _mm_rcp_nr_ps(const __m128& x)
 static NCNN_FORCEINLINE __m128 _mm_comp_rsqrt1_ps(const __m128& _x)
 {
     __m128 _y = _mm_rsqrt_ps(_x);
-    __m128 _t = _mm_mul_ps(_y, _y);
-    _t = _mm_comp_fnmadd_ps(_x, _t, _mm_set1_ps(3.f));
+    __m128 _t = _mm_mul_ps(_x, _y);
+    _t = _mm_comp_fnmadd_ps(_t, _y, _mm_set1_ps(3.f));
     _y = _mm_mul_ps(_y, _mm_mul_ps(_t, _mm_set1_ps(0.5f)));
     return _y;
 }
@@ -481,11 +481,11 @@ static NCNN_FORCEINLINE __m128 _mm_comp_rsqrt1_ps(const __m128& _x)
 static NCNN_FORCEINLINE __m128 _mm_comp_rsqrt_ps(const __m128& _x)
 {
     __m128 _y = _mm_rsqrt_ps(_x);
-    __m128 _t = _mm_mul_ps(_y, _y);
-    _t = _mm_comp_fnmadd_ps(_x, _t, _mm_set1_ps(3.f));
+    __m128 _t = _mm_mul_ps(_x, _y);
+    _t = _mm_comp_fnmadd_ps(_t, _y, _mm_set1_ps(3.f));
     _y = _mm_mul_ps(_y, _mm_mul_ps(_t, _mm_set1_ps(0.5f)));
-    _t = _mm_mul_ps(_y, _y);
-    _t = _mm_comp_fnmadd_ps(_x, _t, _mm_set1_ps(3.f));
+    _t = _mm_mul_ps(_x, _y);
+    _t = _mm_comp_fnmadd_ps(_t, _y, _mm_set1_ps(3.f));
     _y = _mm_mul_ps(_y, _mm_mul_ps(_t, _mm_set1_ps(0.5f)));
     return _y;
 }
@@ -569,8 +569,8 @@ static NCNN_FORCEINLINE __m256 _mm256_rcp_nr_ps(const __m256& x)
 static NCNN_FORCEINLINE __m256 _mm256_comp_rsqrt1_ps(const __m256& _x)
 {
     __m256 _y = _mm256_rsqrt_ps(_x);
-    __m256 _t = _mm256_mul_ps(_y, _y);
-    _t = _mm256_comp_fnmadd_ps(_x, _t, _mm256_set1_ps(3.f));
+    __m256 _t = _mm256_mul_ps(_x, _y);
+    _t = _mm256_comp_fnmadd_ps(_t, _y, _mm256_set1_ps(3.f));
     _y = _mm256_mul_ps(_y, _mm256_mul_ps(_t, _mm256_set1_ps(0.5f)));
     return _y;
 }
@@ -578,11 +578,11 @@ static NCNN_FORCEINLINE __m256 _mm256_comp_rsqrt1_ps(const __m256& _x)
 static NCNN_FORCEINLINE __m256 _mm256_comp_rsqrt_ps(const __m256& _x)
 {
     __m256 _y = _mm256_rsqrt_ps(_x);
-    __m256 _t = _mm256_mul_ps(_y, _y);
-    _t = _mm256_comp_fnmadd_ps(_x, _t, _mm256_set1_ps(3.f));
+    __m256 _t = _mm256_mul_ps(_x, _y);
+    _t = _mm256_comp_fnmadd_ps(_t, _y, _mm256_set1_ps(3.f));
     _y = _mm256_mul_ps(_y, _mm256_mul_ps(_t, _mm256_set1_ps(0.5f)));
-    _t = _mm256_mul_ps(_y, _y);
-    _t = _mm256_comp_fnmadd_ps(_x, _t, _mm256_set1_ps(3.f));
+    _t = _mm256_mul_ps(_x, _y);
+    _t = _mm256_comp_fnmadd_ps(_t, _y, _mm256_set1_ps(3.f));
     _y = _mm256_mul_ps(_y, _mm256_mul_ps(_t, _mm256_set1_ps(0.5f)));
     return _y;
 }

--- a/src/layer/x86/x86_usability.h
+++ b/src/layer/x86/x86_usability.h
@@ -472,7 +472,11 @@ static NCNN_FORCEINLINE __m128 _mm_rcp_nr_ps(const __m128& x)
 static NCNN_FORCEINLINE __m128 _mm_comp_rsqrt1_ps(const __m128& _x)
 {
 #if __AVX512F__
+#if defined(_MSC_VER) && _MSC_VER < 1939
+    __m128 _y = _mm_rsqrt_ps(_x);
+#else
     __m128 _y = _mm_rsqrt14_ps(_x);
+#endif
 #else
     __m128 _y = _mm_rsqrt_ps(_x);
 #endif
@@ -484,15 +488,8 @@ static NCNN_FORCEINLINE __m128 _mm_comp_rsqrt1_ps(const __m128& _x)
 
 static NCNN_FORCEINLINE __m128 _mm_comp_rsqrt_ps(const __m128& _x)
 {
-#if __AVX512F__
-    __m128 _y = _mm_rsqrt14_ps(_x);
-#else
-    __m128 _y = _mm_rsqrt_ps(_x);
-#endif
+    __m128 _y = _mm_comp_rsqrt1_ps(_x);
     __m128 _t = _mm_mul_ps(_x, _y);
-    _t = _mm_comp_fnmadd_ps(_t, _y, _mm_set1_ps(3.f));
-    _y = _mm_mul_ps(_y, _mm_mul_ps(_t, _mm_set1_ps(0.5f)));
-    _t = _mm_mul_ps(_x, _y);
     _t = _mm_comp_fnmadd_ps(_t, _y, _mm_set1_ps(3.f));
     _y = _mm_mul_ps(_y, _mm_mul_ps(_t, _mm_set1_ps(0.5f)));
     return _y;
@@ -577,7 +574,11 @@ static NCNN_FORCEINLINE __m256 _mm256_rcp_nr_ps(const __m256& x)
 static NCNN_FORCEINLINE __m256 _mm256_comp_rsqrt1_ps(const __m256& _x)
 {
 #if __AVX512F__
+#if defined(_MSC_VER) && _MSC_VER < 1939
+    __m256 _y = _mm256_rsqrt_ps(_x);
+#else
     __m256 _y = _mm256_rsqrt14_ps(_x);
+#endif
 #else
     __m256 _y = _mm256_rsqrt_ps(_x);
 #endif
@@ -589,15 +590,8 @@ static NCNN_FORCEINLINE __m256 _mm256_comp_rsqrt1_ps(const __m256& _x)
 
 static NCNN_FORCEINLINE __m256 _mm256_comp_rsqrt_ps(const __m256& _x)
 {
-#if __AVX512F__
-    __m256 _y = _mm256_rsqrt14_ps(_x);
-#else
-    __m256 _y = _mm256_rsqrt_ps(_x);
-#endif
+    __m256 _y = _mm256_comp_rsqrt1_ps(_x);
     __m256 _t = _mm256_mul_ps(_x, _y);
-    _t = _mm256_comp_fnmadd_ps(_t, _y, _mm256_set1_ps(3.f));
-    _y = _mm256_mul_ps(_y, _mm256_mul_ps(_t, _mm256_set1_ps(0.5f)));
-    _t = _mm256_mul_ps(_x, _y);
     _t = _mm256_comp_fnmadd_ps(_t, _y, _mm256_set1_ps(3.f));
     _y = _mm256_mul_ps(_y, _mm256_mul_ps(_t, _mm256_set1_ps(0.5f)));
     return _y;
@@ -1906,20 +1900,17 @@ static NCNN_FORCEINLINE __m512 _mm512_rcp_nr_ps(const __m512& x)
 
 static NCNN_FORCEINLINE __m512 _mm512_comp_rsqrt1_ps(const __m512& _x)
 {
-    const __m512 _y0 = _mm512_rsqrt14_ps(_x);
-    __m512 _t = _mm512_mul_ps(_x, _y0);
-    _t = _mm512_fnmadd_ps(_t, _y0, _mm512_set1_ps(3.f));
-    const __m512 _y = _mm512_mul_ps(_y0, _mm512_mul_ps(_t, _mm512_set1_ps(0.5f)));
+    __m512 _y = _mm512_rsqrt14_ps(_x);
+    __m512 _t = _mm512_mul_ps(_x, _y);
+    _t = _mm512_fnmadd_ps(_t, _y, _mm512_set1_ps(3.f));
+    _y = _mm512_mul_ps(_y, _mm512_mul_ps(_t, _mm512_set1_ps(0.5f)));
     return _y;
 }
 
 static NCNN_FORCEINLINE __m512 _mm512_comp_rsqrt_ps(const __m512& _x)
 {
-    __m512 _y = _mm512_rsqrt14_ps(_x);
+    __m512 _y = _mm512_comp_rsqrt1_ps(_x);
     __m512 _t = _mm512_mul_ps(_x, _y);
-    _t = _mm512_fnmadd_ps(_t, _y, _mm512_set1_ps(3.f));
-    _y = _mm512_mul_ps(_y, _mm512_mul_ps(_t, _mm512_set1_ps(0.5f)));
-    _t = _mm512_mul_ps(_x, _y);
     _t = _mm512_fnmadd_ps(_t, _y, _mm512_set1_ps(3.f));
     _y = _mm512_mul_ps(_y, _mm512_mul_ps(_t, _mm512_set1_ps(0.5f)));
     return _y;

--- a/src/layer/x86/x86_usability.h
+++ b/src/layer/x86/x86_usability.h
@@ -1904,12 +1904,21 @@ static NCNN_FORCEINLINE __m512 _mm512_rcp_nr_ps(const __m512& x)
     return _mm512_mul_ps(y, t);
 }
 
-static NCNN_FORCEINLINE __m512 _mm512_comp_rsqrt_ps(const __m512& _x)
+static NCNN_FORCEINLINE __m512 _mm512_comp_rsqrt1_ps(const __m512& _x)
 {
     const __m512 _y0 = _mm512_rsqrt14_ps(_x);
     __m512 _t = _mm512_mul_ps(_x, _y0);
     _t = _mm512_fnmadd_ps(_t, _y0, _mm512_set1_ps(3.f));
     const __m512 _y = _mm512_mul_ps(_y0, _mm512_mul_ps(_t, _mm512_set1_ps(0.5f)));
+    return _y;
+}
+
+static NCNN_FORCEINLINE __m512 _mm512_comp_rsqrt_ps(const __m512& _x)
+{
+    __m512 _y = _mm512_comp_rsqrt1_ps(_x);
+    __m512 _t = _mm512_mul_ps(_x, _y);
+    _t = _mm512_fnmadd_ps(_t, _y, _mm512_set1_ps(3.f));
+    _y = _mm512_mul_ps(_y, _mm512_mul_ps(_t, _mm512_set1_ps(0.5f)));
     return _y;
 }
 

--- a/src/layer/x86/x86_usability.h
+++ b/src/layer/x86/x86_usability.h
@@ -469,6 +469,27 @@ static NCNN_FORCEINLINE __m128 _mm_rcp_nr_ps(const __m128& x)
     return y;
 }
 
+static NCNN_FORCEINLINE __m128 _mm_comp_rsqrt1_ps(const __m128& _x)
+{
+    __m128 _y = _mm_rsqrt_ps(_x);
+    __m128 _t = _mm_mul_ps(_y, _y);
+    _t = _mm_comp_fnmadd_ps(_x, _t, _mm_set1_ps(3.f));
+    _y = _mm_mul_ps(_y, _mm_mul_ps(_t, _mm_set1_ps(0.5f)));
+    return _y;
+}
+
+static NCNN_FORCEINLINE __m128 _mm_comp_rsqrt_ps(const __m128& _x)
+{
+    __m128 _y = _mm_rsqrt_ps(_x);
+    __m128 _t = _mm_mul_ps(_y, _y);
+    _t = _mm_comp_fnmadd_ps(_x, _t, _mm_set1_ps(3.f));
+    _y = _mm_mul_ps(_y, _mm_mul_ps(_t, _mm_set1_ps(0.5f)));
+    _t = _mm_mul_ps(_y, _y);
+    _t = _mm_comp_fnmadd_ps(_x, _t, _mm_set1_ps(3.f));
+    _y = _mm_mul_ps(_y, _mm_mul_ps(_t, _mm_set1_ps(0.5f)));
+    return _y;
+}
+
 static NCNN_FORCEINLINE __m128i _mm_comp_dpwssd_epi32(const __m128i& src, const __m128i& a, const __m128i& b)
 {
 #if __AVX512VNNI__
@@ -543,6 +564,27 @@ static NCNN_FORCEINLINE __m256 _mm256_rcp_nr_ps(const __m256& x)
     __m256 t = _mm256_comp_fnmadd_ps(x, y, _mm256_set1_ps(2.0f));
     y = _mm256_mul_ps(y, t);
     return y;
+}
+
+static NCNN_FORCEINLINE __m256 _mm256_comp_rsqrt1_ps(const __m256& _x)
+{
+    __m256 _y = _mm256_rsqrt_ps(_x);
+    __m256 _t = _mm256_mul_ps(_y, _y);
+    _t = _mm256_comp_fnmadd_ps(_x, _t, _mm256_set1_ps(3.f));
+    _y = _mm256_mul_ps(_y, _mm256_mul_ps(_t, _mm256_set1_ps(0.5f)));
+    return _y;
+}
+
+static NCNN_FORCEINLINE __m256 _mm256_comp_rsqrt_ps(const __m256& _x)
+{
+    __m256 _y = _mm256_rsqrt_ps(_x);
+    __m256 _t = _mm256_mul_ps(_y, _y);
+    _t = _mm256_comp_fnmadd_ps(_x, _t, _mm256_set1_ps(3.f));
+    _y = _mm256_mul_ps(_y, _mm256_mul_ps(_t, _mm256_set1_ps(0.5f)));
+    _t = _mm256_mul_ps(_y, _y);
+    _t = _mm256_comp_fnmadd_ps(_x, _t, _mm256_set1_ps(3.f));
+    _y = _mm256_mul_ps(_y, _mm256_mul_ps(_t, _mm256_set1_ps(0.5f)));
+    return _y;
 }
 
 static NCNN_FORCEINLINE __m256 _mm256_fmadd_1_ps(const __m256& a, const __m256& b, float c)

--- a/src/layer/x86/x86_usability.h
+++ b/src/layer/x86/x86_usability.h
@@ -1915,8 +1915,11 @@ static NCNN_FORCEINLINE __m512 _mm512_comp_rsqrt1_ps(const __m512& _x)
 
 static NCNN_FORCEINLINE __m512 _mm512_comp_rsqrt_ps(const __m512& _x)
 {
-    __m512 _y = _mm512_comp_rsqrt1_ps(_x);
+    __m512 _y = _mm512_rsqrt14_ps(_x);
     __m512 _t = _mm512_mul_ps(_x, _y);
+    _t = _mm512_fnmadd_ps(_t, _y, _mm512_set1_ps(3.f));
+    _y = _mm512_mul_ps(_y, _mm512_mul_ps(_t, _mm512_set1_ps(0.5f)));
+    _t = _mm512_mul_ps(_x, _y);
     _t = _mm512_fnmadd_ps(_t, _y, _mm512_set1_ps(3.f));
     _y = _mm512_mul_ps(_y, _mm512_mul_ps(_t, _mm512_set1_ps(0.5f)));
     return _y;

--- a/tests/test_layernorm.cpp
+++ b/tests/test_layernorm.cpp
@@ -14,7 +14,7 @@ static int test_layernorm(const ncnn::Mat& a, int affine_size, float eps, int af
     weights[0] = RandomMat(affine_size);
     weights[1] = RandomMat(affine_size);
 
-    int ret = test_layer("LayerNorm", pd, weights, a);
+    int ret = test_layer("LayerNorm", pd, weights, a, 1e-4f);
     if (ret != 0)
     {
         fprintf(stderr, "test_layernorm failed a.dims=%d a=(%d %d %d %d) affine_size=%d eps=%f affine=%d\n", a.dims, a.w, a.h, a.d, a.c, affine_size, eps, affine);

--- a/tests/test_layernorm.cpp
+++ b/tests/test_layernorm.cpp
@@ -14,7 +14,17 @@ static int test_layernorm(const ncnn::Mat& a, int affine_size, float eps, int af
     weights[0] = RandomMat(affine_size);
     weights[1] = RandomMat(affine_size);
 
-    int ret = test_layer("LayerNorm", pd, weights, a, 1e-4f);
+    // test gpu with default tolerance, since gpu bf16 packed coefficients are stored with bf16 truncation
+    // and can deviate ~1e-2 from the fp32 reference
+    int ret = test_layer("LayerNorm", pd, weights, a, 0.001f, TEST_LAYER_DISABLE_CPU_TESTING);
+    if (ret != 0)
+    {
+        fprintf(stderr, "test_layernorm failed a.dims=%d a=(%d %d %d %d) affine_size=%d eps=%f affine=%d\n", a.dims, a.w, a.h, a.d, a.c, affine_size, eps, affine);
+        return ret;
+    }
+
+    // test cpu with tight tolerance to catch the approximate rsqrt error in the optimized kernels
+    ret = test_layer("LayerNorm", pd, weights, a, 1e-4f, TEST_LAYER_DISABLE_GPU_TESTING);
     if (ret != 0)
     {
         fprintf(stderr, "test_layernorm failed a.dims=%d a=(%d %d %d %d) affine_size=%d eps=%f affine=%d\n", a.dims, a.w, a.h, a.d, a.c, affine_size, eps, affine);

--- a/tests/test_layernorm.cpp
+++ b/tests/test_layernorm.cpp
@@ -14,17 +14,7 @@ static int test_layernorm(const ncnn::Mat& a, int affine_size, float eps, int af
     weights[0] = RandomMat(affine_size);
     weights[1] = RandomMat(affine_size);
 
-    // test gpu with default tolerance, since gpu bf16 packed coefficients are stored with bf16 truncation
-    // and can deviate ~1e-2 from the fp32 reference
-    int ret = test_layer("LayerNorm", pd, weights, a, 0.001f, TEST_LAYER_DISABLE_CPU_TESTING);
-    if (ret != 0)
-    {
-        fprintf(stderr, "test_layernorm failed a.dims=%d a=(%d %d %d %d) affine_size=%d eps=%f affine=%d\n", a.dims, a.w, a.h, a.d, a.c, affine_size, eps, affine);
-        return ret;
-    }
-
-    // test cpu with tight tolerance to catch the approximate rsqrt error in the optimized kernels
-    ret = test_layer("LayerNorm", pd, weights, a, 1e-4f, TEST_LAYER_DISABLE_GPU_TESTING);
+    int ret = test_layer("LayerNorm", pd, weights, a, 1e-4f);
     if (ret != 0)
     {
         fprintf(stderr, "test_layernorm failed a.dims=%d a=(%d %d %d %d) affine_size=%d eps=%f affine=%d\n", a.dims, a.w, a.h, a.d, a.c, affine_size, eps, affine);

--- a/tests/test_rmsnorm.cpp
+++ b/tests/test_rmsnorm.cpp
@@ -13,7 +13,7 @@ static int test_rmsnorm(const ncnn::Mat& a, int affine_size, float eps, int affi
     std::vector<ncnn::Mat> weights(1);
     weights[0] = RandomMat(affine_size);
 
-    int ret = test_layer("RMSNorm", pd, weights, a);
+    int ret = test_layer("RMSNorm", pd, weights, a, 1e-4f);
     if (ret != 0)
     {
         fprintf(stderr, "test_rmsnorm failed a.dims=%d a=(%d %d %d %d) affine_size=%d eps=%f affine=%d\n", a.dims, a.w, a.h, a.d, a.c, affine_size, eps, affine);

--- a/tests/test_rmsnorm.cpp
+++ b/tests/test_rmsnorm.cpp
@@ -13,17 +13,7 @@ static int test_rmsnorm(const ncnn::Mat& a, int affine_size, float eps, int affi
     std::vector<ncnn::Mat> weights(1);
     weights[0] = RandomMat(affine_size);
 
-    // test gpu with default tolerance, since gpu bf16 packed coefficients are stored with bf16 truncation
-    // and can deviate ~1e-2 from the fp32 reference
-    int ret = test_layer("RMSNorm", pd, weights, a, 0.001f, TEST_LAYER_DISABLE_CPU_TESTING);
-    if (ret != 0)
-    {
-        fprintf(stderr, "test_rmsnorm failed a.dims=%d a=(%d %d %d %d) affine_size=%d eps=%f affine=%d\n", a.dims, a.w, a.h, a.d, a.c, affine_size, eps, affine);
-        return ret;
-    }
-
-    // test cpu with tight tolerance to catch the approximate rsqrt error in the optimized kernels
-    ret = test_layer("RMSNorm", pd, weights, a, 1e-4f, TEST_LAYER_DISABLE_GPU_TESTING);
+    int ret = test_layer("RMSNorm", pd, weights, a, 1e-4f);
     if (ret != 0)
     {
         fprintf(stderr, "test_rmsnorm failed a.dims=%d a=(%d %d %d %d) affine_size=%d eps=%f affine=%d\n", a.dims, a.w, a.h, a.d, a.c, affine_size, eps, affine);

--- a/tests/test_rmsnorm.cpp
+++ b/tests/test_rmsnorm.cpp
@@ -13,7 +13,17 @@ static int test_rmsnorm(const ncnn::Mat& a, int affine_size, float eps, int affi
     std::vector<ncnn::Mat> weights(1);
     weights[0] = RandomMat(affine_size);
 
-    int ret = test_layer("RMSNorm", pd, weights, a, 1e-4f);
+    // test gpu with default tolerance, since gpu bf16 packed coefficients are stored with bf16 truncation
+    // and can deviate ~1e-2 from the fp32 reference
+    int ret = test_layer("RMSNorm", pd, weights, a, 0.001f, TEST_LAYER_DISABLE_CPU_TESTING);
+    if (ret != 0)
+    {
+        fprintf(stderr, "test_rmsnorm failed a.dims=%d a=(%d %d %d %d) affine_size=%d eps=%f affine=%d\n", a.dims, a.w, a.h, a.d, a.c, affine_size, eps, affine);
+        return ret;
+    }
+
+    // test cpu with tight tolerance to catch the approximate rsqrt error in the optimized kernels
+    ret = test_layer("RMSNorm", pd, weights, a, 1e-4f, TEST_LAYER_DISABLE_GPU_TESTING);
     if (ret != 0)
     {
         fprintf(stderr, "test_rmsnorm failed a.dims=%d a=(%d %d %d %d) affine_size=%d eps=%f affine=%d\n", a.dims, a.w, a.h, a.d, a.c, affine_size, eps, affine);


### PR DESCRIPTION
layernorm/rmsnorm (fp32+bf16) now use 2 newton-raphson refinement steps after the hardware approximate rsqrt, and unaryop rsqrt uses 1 step, aligning with the arm backend and avoiding ~2.5e-4 relative error amplification in llm inference. tighten test_layernorm/test_rmsnorm tolerance to 1e-4.