### PR TITLE
fix(allocator): drop _POSIX_C_SOURCE from posix_memalign branch

### DIFF
--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -1329,7 +1329,7 @@ static void* fastMalloc_with_alignment(size_t size, size_t alignment)
 {
 #if _MSC_VER
     return _aligned_malloc(size, alignment);
-#elif (defined(__unix__) || defined(__APPLE__)) && _POSIX_C_SOURCE >= 200112L || (__ANDROID__ && __ANDROID_API__ >= 17)
+#elif ((defined(__unix__) || defined(__APPLE__)) && !defined(__ANDROID__)) || (__ANDROID__ && __ANDROID_API__ >= 17)
     void* ptr = 0;
     if (posix_memalign(&ptr, alignment, size))
         ptr = 0;

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -57,7 +57,7 @@ static NCNN_FORCEINLINE void* fastMalloc(size_t size)
 {
 #if _MSC_VER
     return _aligned_malloc(size + NCNN_MALLOC_OVERREAD, NCNN_MALLOC_ALIGN);
-#elif (defined(__unix__) || defined(__APPLE__)) || (__ANDROID__ && __ANDROID_API__ >= 17)
+#elif ((defined(__unix__) || defined(__APPLE__)) && !defined(__ANDROID__)) || (__ANDROID__ && __ANDROID_API__ >= 17)
     void* ptr = 0;
     if (posix_memalign(&ptr, NCNN_MALLOC_ALIGN, size + NCNN_MALLOC_OVERREAD))
         ptr = 0;
@@ -80,7 +80,7 @@ static NCNN_FORCEINLINE void fastFree(void* ptr)
     {
 #if _MSC_VER
         _aligned_free(ptr);
-#elif (defined(__unix__) || defined(__APPLE__)) || (__ANDROID__ && __ANDROID_API__ >= 17)
+#elif ((defined(__unix__) || defined(__APPLE__)) && !defined(__ANDROID__)) || (__ANDROID__ && __ANDROID_API__ >= 17)
         free(ptr);
 #elif __ANDROID__ && __ANDROID_API__ < 17
         free(ptr);

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -57,7 +57,7 @@ static NCNN_FORCEINLINE void* fastMalloc(size_t size)
 {
 #if _MSC_VER
     return _aligned_malloc(size + NCNN_MALLOC_OVERREAD, NCNN_MALLOC_ALIGN);
-#elif (defined(__unix__) || defined(__APPLE__)) && _POSIX_C_SOURCE >= 200112L || (__ANDROID__ && __ANDROID_API__ >= 17)
+#elif (defined(__unix__) || defined(__APPLE__)) || (__ANDROID__ && __ANDROID_API__ >= 17)
     void* ptr = 0;
     if (posix_memalign(&ptr, NCNN_MALLOC_ALIGN, size + NCNN_MALLOC_OVERREAD))
         ptr = 0;
@@ -80,7 +80,7 @@ static NCNN_FORCEINLINE void fastFree(void* ptr)
     {
 #if _MSC_VER
         _aligned_free(ptr);
-#elif (defined(__unix__) || defined(__APPLE__)) && _POSIX_C_SOURCE >= 200112L || (__ANDROID__ && __ANDROID_API__ >= 17)
+#elif (defined(__unix__) || defined(__APPLE__)) || (__ANDROID__ && __ANDROID_API__ >= 17)
         free(ptr);
 #elif __ANDROID__ && __ANDROID_API__ < 17
         free(ptr);


### PR DESCRIPTION
Makes `fastMalloc`/`fastFree` use a consistent posix_memalign/free scheme regardless of whether `_POSIX_C_SOURCE` was defined by an earlier include (e.g. Python.h).

Fixes #6888