### PR TITLE
flip vulkan implementation

### DIFF
--- a/src/layer/vulkan/flip_vulkan.cpp
+++ b/src/layer/vulkan/flip_vulkan.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 Tencent
+// Copyright 2026 Futz12 <pchar.cn>
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "flip_vulkan.h"

--- a/src/layer/vulkan/flip_vulkan.cpp
+++ b/src/layer/vulkan/flip_vulkan.cpp
@@ -1,0 +1,117 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "flip_vulkan.h"
+
+#include "layer_shader_type.h"
+
+namespace ncnn {
+
+Flip_vulkan::Flip_vulkan()
+{
+    support_vulkan = true;
+    support_vulkan_packing = true;
+
+    pipeline_flip = 0;
+    pipeline_flip_pack4 = 0;
+}
+
+int Flip_vulkan::create_pipeline(const Option& opt)
+{
+    const Mat& shape = bottom_shapes.empty() ? Mat() : bottom_shapes[0];
+
+    std::vector<vk_specialization_type> specializations(0);
+
+    // pack1
+    if (shape.dims == 0 || shape.elempack == 1)
+    {
+        pipeline_flip = new Pipeline(vkdev);
+        pipeline_flip->set_optimal_local_size_xyz(vkdev->info.subgroup_size(), 1, 1);
+        pipeline_flip->create(LayerShaderType::flip, opt, specializations);
+    }
+
+    // pack4
+    if (shape.dims == 0 || shape.elempack == 4)
+    {
+        pipeline_flip_pack4 = new Pipeline(vkdev);
+        pipeline_flip_pack4->set_optimal_local_size_xyz(vkdev->info.subgroup_size(), 1, 1);
+        pipeline_flip_pack4->create(LayerShaderType::flip_pack4, opt, specializations);
+    }
+
+    return 0;
+}
+
+int Flip_vulkan::destroy_pipeline(const Option& /*opt*/)
+{
+    delete pipeline_flip;
+    pipeline_flip = 0;
+
+    delete pipeline_flip_pack4;
+    pipeline_flip_pack4 = 0;
+
+    return 0;
+}
+
+int Flip_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const
+{
+    if (axes.empty())
+    {
+        top_blob = bottom_blob;
+        return 0;
+    }
+
+    const int dims = bottom_blob.dims;
+    const int w = bottom_blob.w;
+    const int h = bottom_blob.h;
+    const int d = bottom_blob.d;
+    const int channels = bottom_blob.c;
+
+    int axes_flag[4] = {0};
+    {
+        const int* axes_ptr = axes;
+        for (int i = 0; i < axes.w; i++)
+        {
+            int axis = axes_ptr[i];
+            // handle negative axis
+            if (axis < 0)
+                axis += dims;
+            axes_flag[axis] = 1;
+        }
+    }
+
+    top_blob.create_like(bottom_blob, opt.blob_vkallocator);
+    if (top_blob.empty())
+        return -100;
+
+    const int elempack = bottom_blob.elempack;
+
+    std::vector<VkMat> bindings(2);
+    bindings[0] = bottom_blob;
+    bindings[1] = top_blob;
+
+    // flip flags and packlane reversal are derived from dims and axes_flag in the shader
+    std::vector<vk_constant_type> constants(10);
+    constants[0].i = dims;
+    constants[1].i = w;
+    constants[2].i = h;
+    constants[3].i = d;
+    constants[4].i = channels;
+    constants[5].i = bottom_blob.cstep;
+    constants[6].i = axes_flag[0];
+    constants[7].i = axes_flag[1];
+    constants[8].i = axes_flag[2];
+    constants[9].i = axes_flag[3];
+
+    VkMat dispatcher;
+    dispatcher.w = w * h * d * channels;
+    dispatcher.h = 1;
+    dispatcher.c = 1;
+
+    const Pipeline* pipeline = elempack == 4 ? pipeline_flip_pack4 : pipeline_flip;
+
+    cmd.record_pipeline(pipeline, bindings, constants, dispatcher);
+
+    return 0;
+}
+
+} // namespace ncnn

--- a/src/layer/vulkan/flip_vulkan.h
+++ b/src/layer/vulkan/flip_vulkan.h
@@ -1,0 +1,29 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef LAYER_FLIP_VULKAN_H
+#define LAYER_FLIP_VULKAN_H
+
+#include "flip.h"
+
+namespace ncnn {
+
+class Flip_vulkan : public Flip
+{
+public:
+    Flip_vulkan();
+
+    virtual int create_pipeline(const Option& opt);
+    virtual int destroy_pipeline(const Option& opt);
+
+    using Flip::forward;
+    virtual int forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const;
+
+public:
+    Pipeline* pipeline_flip;
+    Pipeline* pipeline_flip_pack4;
+};
+
+} // namespace ncnn
+
+#endif // LAYER_FLIP_VULKAN_H

--- a/src/layer/vulkan/flip_vulkan.h
+++ b/src/layer/vulkan/flip_vulkan.h
@@ -1,4 +1,4 @@
-// Copyright 2026 Tencent
+// Copyright 2026 Futz12 <pchar.cn>
 // SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef LAYER_FLIP_VULKAN_H

--- a/src/layer/vulkan/shader/flip.comp
+++ b/src/layer/vulkan/shader/flip.comp
@@ -1,0 +1,76 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+layout(binding = 0) readonly buffer bottom_blob { sfp bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfp top_blob_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int d;
+    int c;
+    int cstep; // channel stride in elements (>= w*h*d)
+    int axes_flag0;
+    int axes_flag1;
+    int axes_flag2;
+    int axes_flag3;
+} p;
+
+void main()
+{
+    bool flip_w = false;
+    bool flip_h = false;
+    bool flip_d = false;
+    bool flip_c = false;
+    if (p.dims == 1)
+    {
+        flip_w = true;
+    }
+    else if (p.dims == 2)
+    {
+        flip_h = p.axes_flag0 == 1;
+        flip_w = p.axes_flag1 == 1;
+    }
+    else if (p.dims == 3)
+    {
+        flip_c = p.axes_flag0 == 1;
+        flip_h = p.axes_flag1 == 1;
+        flip_w = p.axes_flag2 == 1;
+    }
+    else if (p.dims == 4)
+    {
+        flip_c = p.axes_flag0 == 1;
+        flip_d = p.axes_flag1 == 1;
+        flip_h = p.axes_flag2 == 1;
+        flip_w = p.axes_flag3 == 1;
+    }
+
+    const uint gid = gl_GlobalInvocationID.x;
+
+    const uint wh = uint(p.w) * uint(p.h);
+    const uint per_channel = wh * uint(p.d);
+    const uint total = per_channel * uint(p.c);
+    if (gid >= total)
+        return;
+
+    const uint q = gid / per_channel;
+    uint rem = gid % per_channel;
+    const uint z = rem / wh;
+    rem = rem % wh;
+    const uint i = rem / uint(p.w);
+    const uint j = rem % uint(p.w);
+
+    const uint q2 = flip_c ? uint(p.c) - 1 - q : q;
+    const uint z2 = flip_d ? uint(p.d) - 1 - z : z;
+    const uint i2 = flip_h ? uint(p.h) - 1 - i : i;
+    const uint j2 = flip_w ? uint(p.w) - 1 - j : j;
+
+    const uint src = q2 * uint(p.cstep) + (z2 * uint(p.h) + i2) * uint(p.w) + j2;
+    const uint dst = q * uint(p.cstep) + (z * uint(p.h) + i) * uint(p.w) + j;
+
+    buffer_st1(top_blob_data, dst, buffer_ld1(bottom_blob_data, src));
+}

--- a/src/layer/vulkan/shader/flip.comp
+++ b/src/layer/vulkan/shader/flip.comp
@@ -1,4 +1,4 @@
-// Copyright 2026 Tencent
+// Copyright 2026 Futz12 <pchar.cn>
 // SPDX-License-Identifier: BSD-3-Clause
 
 #version 450

--- a/src/layer/vulkan/shader/flip_pack4.comp
+++ b/src/layer/vulkan/shader/flip_pack4.comp
@@ -1,0 +1,87 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+layout(binding = 0) readonly buffer bottom_blob { sfpvec4 bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfpvec4 top_blob_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int d;
+    int c;
+    int cstep; // channel stride in pack4 units (>= w*h*d)
+    int axes_flag0;
+    int axes_flag1;
+    int axes_flag2;
+    int axes_flag3;
+} p;
+
+void main()
+{
+    bool flip_w = false;
+    bool flip_h = false;
+    bool flip_d = false;
+    bool flip_c = false;
+    if (p.dims == 1)
+    {
+        flip_w = true;
+    }
+    else if (p.dims == 2)
+    {
+        flip_h = p.axes_flag0 == 1;
+        flip_w = p.axes_flag1 == 1;
+    }
+    else if (p.dims == 3)
+    {
+        flip_c = p.axes_flag0 == 1;
+        flip_h = p.axes_flag1 == 1;
+        flip_w = p.axes_flag2 == 1;
+    }
+    else if (p.dims == 4)
+    {
+        flip_c = p.axes_flag0 == 1;
+        flip_d = p.axes_flag1 == 1;
+        flip_h = p.axes_flag2 == 1;
+        flip_w = p.axes_flag3 == 1;
+    }
+
+    // the packed axis (w for dims=1, h for dims=2, c for dims=3/4) is always multiple of 4,
+    // so flipping it maps pack p lane l to pack (P-1-p) lane (3-l)
+    const bool flip_packlane = (p.dims == 1 && flip_w) || (p.dims == 2 && flip_h) || (p.dims >= 3 && flip_c);
+
+    const uint gid = gl_GlobalInvocationID.x;
+
+    const uint wh = uint(p.w) * uint(p.h);
+    const uint per_channel = wh * uint(p.d);
+    const uint total = per_channel * uint(p.c);
+    if (gid >= total)
+        return;
+
+    const uint q = gid / per_channel;
+    uint rem = gid % per_channel;
+    const uint z = rem / wh;
+    rem = rem % wh;
+    const uint i = rem / uint(p.w);
+    const uint j = rem % uint(p.w);
+
+    const uint q2 = flip_c ? uint(p.c) - 1 - q : q;
+    const uint z2 = flip_d ? uint(p.d) - 1 - z : z;
+    const uint i2 = flip_h ? uint(p.h) - 1 - i : i;
+    const uint j2 = flip_w ? uint(p.w) - 1 - j : j;
+
+    const uint src = q2 * uint(p.cstep) + (z2 * uint(p.h) + i2) * uint(p.w) + j2;
+    const uint dst = q * uint(p.cstep) + (z * uint(p.h) + i) * uint(p.w) + j;
+
+    afpvec4 v = buffer_ld4(bottom_blob_data, src);
+
+    if (flip_packlane)
+    {
+        v = v.wzyx;
+    }
+
+    buffer_st4(top_blob_data, dst, v);
+}

--- a/src/layer/vulkan/shader/flip_pack4.comp
+++ b/src/layer/vulkan/shader/flip_pack4.comp
@@ -1,4 +1,4 @@
-// Copyright 2026 Tencent
+// Copyright 2026 Futz12 <pchar.cn>
 // SPDX-License-Identifier: BSD-3-Clause
 
 #version 450


### PR DESCRIPTION

  Add a Vulkan implementation of the Flip layer.

  Previously Flip had no GPU path and fell back to CPU whenever a graph
  contained a flip. This adds a dedicated Vulkan operator with pack1/pack4
  shaders.

  Implementation notes:
  - Mirrors the CPU flip semantics: dims(1-4) -> axis mapping, negative axis
    normalization, and pack4 lane reversal for channel-axis flips.
  - One invocation per element; pipeline local size tuned to the device
    subgroup size.
  - Empty-axes input is passed through without launching a shader.

  Files:
  - src/layer/vulkan/flip_vulkan.cpp / flip_vulkan.h
  - src/layer/vulkan/shader/flip.comp, flip_pack4.comp

  Motivation: RVC-style audio decoders use torch.flip on the GPU; this
  keeps the whole graph on Vulkan instead of stalling on a CPU round-trip.