### PR TITLE
spectrogram and inversespectrogram x86 conv1d and vulkan implementation

### DIFF
--- a/src/layer/vulkan/inversespectrogram_vulkan.cpp
+++ b/src/layer/vulkan/inversespectrogram_vulkan.cpp
@@ -1,0 +1,148 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "inversespectrogram_vulkan.h"
+
+#include "layer_shader_type.h"
+
+#include <math.h>
+
+namespace ncnn {
+
+InverseSpectrogram_vulkan::InverseSpectrogram_vulkan()
+{
+    support_vulkan = true;
+    support_vulkan_packing = false;
+    support_vulkan_any_packing = false;
+
+    pipeline_inversespectrogram = 0;
+}
+
+int InverseSpectrogram_vulkan::load_param(const ParamDict& pd)
+{
+    int ret = InverseSpectrogram::load_param(pd);
+    if (ret != 0)
+        return ret;
+
+    // idft basis as conv weight, 4 planes of [bin k][tap m]
+    // re[m] += (sp_re[k] * cos(2*pi*k*m/n_fft) - sp_im[k] * sin(2*pi*k*m/n_fft)) / n_fft * window[m] * norm
+    // im[m] += (sp_re[k] * sin(2*pi*k*m/n_fft) + sp_im[k] * cos(2*pi*k*m/n_fft)) / n_fft * window[m] * norm
+    float norm = 1.f;
+    if (normalized == 1)
+        norm = sqrt((float)n_fft);
+    if (normalized == 2)
+        norm = window_data[n_fft];
+
+    idft_weight.create(4 * n_fft * n_fft);
+    {
+        float* w_re_re = idft_weight;
+        float* w_re_im = w_re_re + n_fft * n_fft;
+        float* w_im_re = w_re_im + n_fft * n_fft;
+        float* w_im_im = w_im_re + n_fft * n_fft;
+        for (int k = 0; k < n_fft; k++)
+        {
+            for (int m = 0; m < n_fft; m++)
+            {
+                double angle = 2 * 3.14159265358979323846 * k * m / n_fft;
+                const float wcos = (float)(window_data[m] * cos(angle) / n_fft * norm);
+                const float wsin = (float)(window_data[m] * sin(angle) / n_fft * norm);
+                w_re_re[k * n_fft + m] = wcos;
+                w_re_im[k * n_fft + m] = -wsin;
+                w_im_re[k * n_fft + m] = wsin;
+                w_im_im[k * n_fft + m] = wcos;
+            }
+        }
+    }
+
+    window_sq.create(n_fft);
+    {
+        float* p = window_sq;
+        for (int i = 0; i < n_fft; i++)
+        {
+            p[i] = window_data[i] * window_data[i];
+        }
+    }
+
+    return 0;
+}
+
+int InverseSpectrogram_vulkan::create_pipeline(const Option& opt)
+{
+    const int pad = center == 1 ? n_fft / 2 : 0;
+
+    std::vector<vk_specialization_type> specializations(4);
+    specializations[0].i = n_fft;
+    specializations[1].i = hoplen;
+    specializations[2].i = returns;
+    specializations[3].i = pad;
+
+    pipeline_inversespectrogram = new Pipeline(vkdev);
+    pipeline_inversespectrogram->set_optimal_local_size_xyz(64, 1, 1);
+    pipeline_inversespectrogram->create(LayerShaderType::inversespectrogram_conv, opt, specializations);
+
+    return 0;
+}
+
+int InverseSpectrogram_vulkan::destroy_pipeline(const Option& /*opt*/)
+{
+    delete pipeline_inversespectrogram;
+    pipeline_inversespectrogram = 0;
+
+    return 0;
+}
+
+int InverseSpectrogram_vulkan::upload_model(VkTransfer& cmd, const Option& opt)
+{
+    cmd.record_upload(idft_weight, weight_data_gpu, opt);
+    cmd.record_upload(window_sq, window_sq_gpu, opt);
+
+    idft_weight.release();
+    window_sq.release();
+
+    return 0;
+}
+
+int InverseSpectrogram_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const
+{
+    // input is complex spectrogram [c=freqs, h=frames, w=2]
+    const int frames = bottom_blob.h;
+
+    const int pad = center == 1 ? n_fft / 2 : 0;
+    const int outsize = (frames - 1) * hoplen + n_fft - pad * 2;
+
+    const size_t elemsize = bottom_blob.elemsize;
+
+    if (returns == 0)
+    {
+        top_blob.create(2, outsize, elemsize, 1u, opt.blob_vkallocator);
+    }
+    else
+    {
+        top_blob.create(outsize, elemsize, 1u, opt.blob_vkallocator);
+    }
+    if (top_blob.empty())
+        return -100;
+
+    std::vector<VkMat> bindings(4);
+    bindings[0] = bottom_blob;
+    bindings[1] = top_blob;
+    bindings[2] = weight_data_gpu;
+    bindings[3] = window_sq_gpu;
+
+    std::vector<vk_constant_type> constants(4);
+    constants[0].i = frames;
+    constants[1].i = outsize;
+    constants[2].i = bottom_blob.c;
+    constants[3].i = bottom_blob.cstep;
+
+    VkMat dispatcher;
+    dispatcher.w = outsize;
+    dispatcher.h = 1;
+    dispatcher.c = 1;
+
+    cmd.record_pipeline(pipeline_inversespectrogram, bindings, constants, dispatcher);
+
+    return 0;
+}
+
+} // namespace ncnn

--- a/src/layer/vulkan/inversespectrogram_vulkan.cpp
+++ b/src/layer/vulkan/inversespectrogram_vulkan.cpp
@@ -93,8 +93,16 @@ int InverseSpectrogram_vulkan::destroy_pipeline(const Option& /*opt*/)
 
 int InverseSpectrogram_vulkan::upload_model(VkTransfer& cmd, const Option& opt)
 {
-    cmd.record_upload(idft_weight, weight_data_gpu, opt);
-    cmd.record_upload(window_sq, window_sq_gpu, opt);
+    // generated idft coefficients must stay fp32:
+    // window/n_fft and window^2 underflow fp16 at large n_fft
+    Option opt_fp32 = opt;
+    opt_fp32.use_fp16_storage = false;
+    opt_fp32.use_fp16_packed = false;
+    opt_fp32.use_bf16_storage = false;
+    opt_fp32.use_bf16_packed = false;
+
+    cmd.record_upload(idft_weight, weight_data_gpu, opt_fp32);
+    cmd.record_upload(window_sq, window_sq_gpu, opt_fp32);
 
     idft_weight.release();
     window_sq.release();

--- a/src/layer/vulkan/inversespectrogram_vulkan.cpp
+++ b/src/layer/vulkan/inversespectrogram_vulkan.cpp
@@ -33,23 +33,20 @@ int InverseSpectrogram_vulkan::load_param(const ParamDict& pd)
     if (normalized == 2)
         norm = window_data[n_fft];
 
-    idft_weight.create(4 * n_fft * n_fft);
+    // idft basis as wcos/wsin planes (halves storage, keeps each buffer bindable):
+    //   w_re_re = wcos, w_re_im = -wsin, w_im_re = wsin, w_im_im = wcos
+    idft_weight.create(n_fft * n_fft);
+    idft_weight_sin.create(n_fft * n_fft);
     {
-        float* w_re_re = idft_weight;
-        float* w_re_im = w_re_re + n_fft * n_fft;
-        float* w_im_re = w_re_im + n_fft * n_fft;
-        float* w_im_im = w_im_re + n_fft * n_fft;
+        float* w_cos = idft_weight;
+        float* w_sin = idft_weight_sin;
         for (int k = 0; k < n_fft; k++)
         {
             for (int m = 0; m < n_fft; m++)
             {
                 double angle = 2 * 3.14159265358979323846 * k * m / n_fft;
-                const float wcos = (float)(window_data[m] * cos(angle) / n_fft * norm);
-                const float wsin = (float)(window_data[m] * sin(angle) / n_fft * norm);
-                w_re_re[k * n_fft + m] = wcos;
-                w_re_im[k * n_fft + m] = -wsin;
-                w_im_re[k * n_fft + m] = wsin;
-                w_im_im[k * n_fft + m] = wcos;
+                w_cos[k * n_fft + m] = (float)(window_data[m] * cos(angle) / n_fft * norm);
+                w_sin[k * n_fft + m] = (float)(window_data[m] * sin(angle) / n_fft * norm);
             }
         }
     }
@@ -102,9 +99,11 @@ int InverseSpectrogram_vulkan::upload_model(VkTransfer& cmd, const Option& opt)
     opt_fp32.use_bf16_packed = false;
 
     cmd.record_upload(idft_weight, weight_data_gpu, opt_fp32);
+    cmd.record_upload(idft_weight_sin, weight_sin_data_gpu, opt_fp32);
     cmd.record_upload(window_sq, window_sq_gpu, opt_fp32);
 
     idft_weight.release();
+    idft_weight_sin.release();
     window_sq.release();
 
     return 0;
@@ -131,11 +130,12 @@ int InverseSpectrogram_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob
     if (top_blob.empty())
         return -100;
 
-    std::vector<VkMat> bindings(4);
+    std::vector<VkMat> bindings(5);
     bindings[0] = bottom_blob;
     bindings[1] = top_blob;
     bindings[2] = weight_data_gpu;
-    bindings[3] = window_sq_gpu;
+    bindings[3] = weight_sin_data_gpu;
+    bindings[4] = window_sq_gpu;
 
     std::vector<vk_constant_type> constants(4);
     constants[0].i = frames;

--- a/src/layer/vulkan/inversespectrogram_vulkan.h
+++ b/src/layer/vulkan/inversespectrogram_vulkan.h
@@ -24,14 +24,16 @@ public:
     virtual int forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const;
 
 public:
-    // idft basis, 4 planes of [bin k][tap m]:
-    //   plane 0: re from sp_re, plane 1: re from sp_im
-    //   plane 2: im from sp_re, plane 3: im from sp_im
+    // idft basis, 2 planes of [bin k][tap m]:
+    //   idft_weight = wcos, idft_weight_sin = wsin
+    //   (w_re_re = wcos, w_re_im = -wsin, w_im_re = wsin, w_im_im = wcos)
     Mat idft_weight;
+    Mat idft_weight_sin;
     // window_data[k]^2 for overlap-add normalization
     Mat window_sq;
 
     VkMat weight_data_gpu;
+    VkMat weight_sin_data_gpu;
     VkMat window_sq_gpu;
 
     Pipeline* pipeline_inversespectrogram;

--- a/src/layer/vulkan/inversespectrogram_vulkan.h
+++ b/src/layer/vulkan/inversespectrogram_vulkan.h
@@ -1,0 +1,42 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef LAYER_INVERSESPECTROGRAM_VULKAN_H
+#define LAYER_INVERSESPECTROGRAM_VULKAN_H
+
+#include "inversespectrogram.h"
+
+namespace ncnn {
+
+class InverseSpectrogram_vulkan : public InverseSpectrogram
+{
+public:
+    InverseSpectrogram_vulkan();
+
+    virtual int load_param(const ParamDict& pd);
+
+    virtual int create_pipeline(const Option& opt);
+    virtual int destroy_pipeline(const Option& opt);
+
+    virtual int upload_model(VkTransfer& cmd, const Option& opt);
+
+    using InverseSpectrogram::forward;
+    virtual int forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const;
+
+public:
+    // idft basis, 4 planes of [bin k][tap m]:
+    //   plane 0: re from sp_re, plane 1: re from sp_im
+    //   plane 2: im from sp_re, plane 3: im from sp_im
+    Mat idft_weight;
+    // window_data[k]^2 for overlap-add normalization
+    Mat window_sq;
+
+    VkMat weight_data_gpu;
+    VkMat window_sq_gpu;
+
+    Pipeline* pipeline_inversespectrogram;
+};
+
+} // namespace ncnn
+
+#endif // LAYER_INVERSESPECTROGRAM_VULKAN_H

--- a/src/layer/vulkan/shader/inversespectrogram_conv.comp
+++ b/src/layer/vulkan/shader/inversespectrogram_conv.comp
@@ -1,0 +1,108 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+// istft as conv (gather form, no atomics):
+// each thread computes one output sample n
+//   re[n] = sum_j sum_k sp_re[j][k] * w_re_re[k][m] + sp_im[j][k] * w_re_im[k][m]
+//   im[n] = sum_j sum_k sp_re[j][k] * w_im_re[k][m] + sp_im[j][k] * w_im_im[k][m]
+// where m = n + pad - j * hoplen covers all frames overlapping n
+// input is complex spectrogram [c=freqs, h=frames, w=2]
+// dispatch: x = output sample n
+
+layout(constant_id = 0) const int n_fft = 0;
+layout(constant_id = 1) const int hoplen = 0;
+layout(constant_id = 2) const int returns = 0;
+layout(constant_id = 3) const int pad = 0;
+
+layout(binding = 0) readonly buffer sp_blob { sfp sp_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfp top_data[]; };
+layout(binding = 2) readonly buffer weight_blob { sfp weight_data[]; };
+layout(binding = 3) readonly buffer win2_blob { sfp win2_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int frames;
+    int outsize;
+    int sp_c;      // input channels (freqs)
+    int sp_cstep;  // input channel stride
+} p;
+
+void main()
+{
+    int n = int(gl_GlobalInvocationID.x);
+
+    if (n >= p.outsize)
+        return;
+
+    // uncropped position: output n comes from deconv position x
+    int x = n + pad;
+
+    // frames j with tap m = x - j*hoplen in [0, n_fft)
+    int j0 = x - n_fft + 1;
+    j0 = j0 > 0 ? (j0 + hoplen - 1) / hoplen : 0;
+    int j1 = x / hoplen;
+    if (j1 > p.frames - 1)
+        j1 = p.frames - 1;
+
+    const int onesided = (p.sp_c == n_fft / 2 + 1) ? 1 : 0;
+
+    float re = 0.f;
+    float im = 0.f;
+    float ws = 0.f;
+
+    for (int j = j0; j <= j1; j++)
+    {
+        int m = x - j * hoplen;
+
+        ws += float(buffer_ld1(win2_data, m));
+
+        float r0 = 0.f;
+        float i0 = 0.f;
+
+        const int sp_off = j * 2;
+
+        for (int k = 0; k < n_fft; k++)
+        {
+            // conjugate mirror for onesided input
+            int srcbin = k;
+            float imsign = 1.f;
+            if (onesided == 1 && k >= p.sp_c)
+            {
+                srcbin = n_fft - k;
+                imsign = -1.f;
+            }
+
+            float sre = float(buffer_ld1(sp_data, srcbin * p.sp_cstep + sp_off));
+            float sim = float(buffer_ld1(sp_data, srcbin * p.sp_cstep + sp_off + 1)) * imsign;
+
+            const int wk = k * n_fft + m;
+            r0 += sre * float(buffer_ld1(weight_data, wk))
+                + sim * float(buffer_ld1(weight_data, n_fft * n_fft + wk));
+            i0 += sre * float(buffer_ld1(weight_data, 2 * n_fft * n_fft + wk))
+                + sim * float(buffer_ld1(weight_data, 3 * n_fft * n_fft + wk));
+        }
+
+        re += r0;
+        im += i0;
+    }
+
+    // square window overlap-add norm (skip division where zero, as reference)
+    if (ws == 0.f)
+        ws = 1.f;
+
+    if (returns == 0)
+    {
+        buffer_st1(top_data, n * 2 + 0, afp(re / ws));
+        buffer_st1(top_data, n * 2 + 1, afp(im / ws));
+    }
+    else if (returns == 1)
+    {
+        buffer_st1(top_data, n, afp(re / ws));
+    }
+    else
+    {
+        buffer_st1(top_data, n, afp(im / ws));
+    }
+}

--- a/src/layer/vulkan/shader/inversespectrogram_conv.comp
+++ b/src/layer/vulkan/shader/inversespectrogram_conv.comp
@@ -19,7 +19,8 @@ layout(constant_id = 3) const int pad = 0;
 layout(binding = 0) readonly buffer sp_blob { sfp sp_data[]; };
 layout(binding = 1) writeonly buffer top_blob { sfp top_data[]; };
 layout(binding = 2) readonly buffer weight_blob { float weight_data[]; };
-layout(binding = 3) readonly buffer win2_blob { float win2_data[]; };
+layout(binding = 3) readonly buffer weight_sin_blob { float weight_sin_data[]; };
+layout(binding = 4) readonly buffer win2_blob { float win2_data[]; };
 
 layout(push_constant) uniform parameter
 {
@@ -78,10 +79,10 @@ void main()
             float sim = float(buffer_ld1(sp_data, srcbin * p.sp_cstep + sp_off + 1)) * imsign;
 
             const int wk = k * n_fft + m;
-            r0 += sre * float(buffer_ld1(weight_data, wk))
-                  + sim * float(buffer_ld1(weight_data, n_fft * n_fft + wk));
-            i0 += sre * float(buffer_ld1(weight_data, 2 * n_fft * n_fft + wk))
-                  + sim * float(buffer_ld1(weight_data, 3 * n_fft * n_fft + wk));
+            const float wc = float(buffer_ld1(weight_data, wk));
+            const float ws = float(buffer_ld1(weight_sin_data, wk));
+            r0 += sre * wc - sim * ws;
+            i0 += sre * ws + sim * wc;
         }
 
         re += r0;

--- a/src/layer/vulkan/shader/inversespectrogram_conv.comp
+++ b/src/layer/vulkan/shader/inversespectrogram_conv.comp
@@ -25,8 +25,8 @@ layout(push_constant) uniform parameter
 {
     int frames;
     int outsize;
-    int sp_c;      // input channels (freqs)
-    int sp_cstep;  // input channel stride
+    int sp_c;     // input channels (freqs)
+    int sp_cstep; // input channel stride
 } p;
 
 void main()
@@ -79,9 +79,9 @@ void main()
 
             const int wk = k * n_fft + m;
             r0 += sre * float(buffer_ld1(weight_data, wk))
-                + sim * float(buffer_ld1(weight_data, n_fft * n_fft + wk));
+                  + sim * float(buffer_ld1(weight_data, n_fft * n_fft + wk));
             i0 += sre * float(buffer_ld1(weight_data, 2 * n_fft * n_fft + wk))
-                + sim * float(buffer_ld1(weight_data, 3 * n_fft * n_fft + wk));
+                  + sim * float(buffer_ld1(weight_data, 3 * n_fft * n_fft + wk));
         }
 
         re += r0;

--- a/src/layer/vulkan/shader/inversespectrogram_conv.comp
+++ b/src/layer/vulkan/shader/inversespectrogram_conv.comp
@@ -18,8 +18,8 @@ layout(constant_id = 3) const int pad = 0;
 
 layout(binding = 0) readonly buffer sp_blob { sfp sp_data[]; };
 layout(binding = 1) writeonly buffer top_blob { sfp top_data[]; };
-layout(binding = 2) readonly buffer weight_blob { sfp weight_data[]; };
-layout(binding = 3) readonly buffer win2_blob { sfp win2_data[]; };
+layout(binding = 2) readonly buffer weight_blob { float weight_data[]; };
+layout(binding = 3) readonly buffer win2_blob { float win2_data[]; };
 
 layout(push_constant) uniform parameter
 {

--- a/src/layer/vulkan/shader/spectrogram_conv.comp
+++ b/src/layer/vulkan/shader/spectrogram_conv.comp
@@ -1,0 +1,73 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+// stft as conv: kernel=n_fft stride=hoplen, dft basis as weight
+// weight row i = real basis of bin i, row freqs_onesided + i = imag basis
+// input is the (optionally center-padded) 1D signal
+// dispatch: x = frame j, y = freq bin i
+
+layout(constant_id = 0) const int n_fft = 0;
+layout(constant_id = 1) const int hoplen = 0;
+layout(constant_id = 2) const int freqs_onesided = 0;
+layout(constant_id = 3) const int power = 0;
+layout(constant_id = 4) const int onesided = 1;
+layout(constant_id = 5) const int freqs = 0;
+
+layout(binding = 0) readonly buffer bottom_blob { sfp bottom_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfp top_data[]; };
+layout(binding = 2) readonly buffer weight_blob { sfp weight_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int frames;
+    int cstep;  // top channel stride (power == 0 only)
+} p;
+
+void main()
+{
+    int j = int(gl_GlobalInvocationID.x);
+    int i = int(gl_GlobalInvocationID.y);
+
+    if (j >= p.frames || i >= freqs)
+        return;
+
+    // mirrored high bins reuse low bin weights with negated imag
+    int bin = i;
+    float im_sign = 1.f;
+    if (bin >= freqs_onesided)
+    {
+        bin = n_fft - bin;
+        im_sign = -1.f;
+    }
+
+    float re = 0.f;
+    float im = 0.f;
+
+    const int base = j * hoplen;
+    const int wbase = bin * n_fft;
+    const int wbase_im = (freqs_onesided + bin) * n_fft;
+
+    for (int k = 0; k < n_fft; k++)
+    {
+        float v = float(buffer_ld1(bottom_data, base + k));
+        re += v * float(buffer_ld1(weight_data, wbase + k));
+        im += v * float(buffer_ld1(weight_data, wbase_im + k));
+    }
+
+    im *= im_sign;
+
+    if (power == 0)
+    {
+        // complex as real: [c=freqs, h=frames, w=2]
+        int offset = i * p.cstep + j * 2;
+        buffer_st1(top_data, offset + 0, afp(re));
+        buffer_st1(top_data, offset + 1, afp(im));
+    }
+    else
+    {
+        float v = power == 1 ? sqrt(re * re + im * im) : (re * re + im * im);
+        buffer_st1(top_data, i * p.frames + j, afp(v));
+    }
+}

--- a/src/layer/vulkan/shader/spectrogram_conv.comp
+++ b/src/layer/vulkan/shader/spectrogram_conv.comp
@@ -22,7 +22,7 @@ layout(binding = 2) readonly buffer weight_blob { sfp weight_data[]; };
 layout(push_constant) uniform parameter
 {
     int frames;
-    int cstep;  // top channel stride (power == 0 only)
+    int cstep; // top channel stride (power == 0 only)
 } p;
 
 void main()

--- a/src/layer/vulkan/spectrogram_vulkan.cpp
+++ b/src/layer/vulkan/spectrogram_vulkan.cpp
@@ -60,6 +60,9 @@ int Spectrogram_vulkan::create_pipeline(const Option& opt)
     if (center == 1)
     {
         padding = create_layer_vulkan(LayerType::Padding);
+        if (!padding)
+            return -100;
+
         padding->vkdev = vkdev;
 
         ParamDict pd;

--- a/src/layer/vulkan/spectrogram_vulkan.cpp
+++ b/src/layer/vulkan/spectrogram_vulkan.cpp
@@ -124,6 +124,18 @@ int Spectrogram_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCom
     if (center == 1)
     {
         padding->forward(bottom_blob, bottom_blob_bordered, cmd, opt);
+
+        // the stft shader indexes samples as scalars; unpack pack4 padding output
+        if (bottom_blob_bordered.elempack != 1)
+        {
+            Option opt_unpack = opt;
+            opt_unpack.blob_vkallocator = opt.workspace_vkallocator;
+
+            VkMat bottom_blob_bordered_p1;
+            vkdev->convert_packing(bottom_blob_bordered, bottom_blob_bordered_p1, 1, cmd, opt_unpack);
+            bottom_blob_bordered = bottom_blob_bordered_p1;
+        }
+
         input = &bottom_blob_bordered;
     }
 

--- a/src/layer/vulkan/spectrogram_vulkan.cpp
+++ b/src/layer/vulkan/spectrogram_vulkan.cpp
@@ -1,0 +1,167 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "spectrogram_vulkan.h"
+
+#include "layer_shader_type.h"
+#include "layer_type.h"
+
+#include <math.h>
+
+namespace ncnn {
+
+Spectrogram_vulkan::Spectrogram_vulkan()
+{
+    support_vulkan = true;
+    support_vulkan_packing = false;
+    support_vulkan_any_packing = false;
+
+    padding = 0;
+    pipeline_spectrogram = 0;
+}
+
+int Spectrogram_vulkan::load_param(const ParamDict& pd)
+{
+    int ret = Spectrogram::load_param(pd);
+    if (ret != 0)
+        return ret;
+
+    // stft as conv: kernel=n_fft stride=hoplen, dft basis as weight
+    // row i = real basis of bin i, row freqs_onesided + i = imag basis
+    const int freqs_onesided = n_fft / 2 + 1;
+
+    float norm = 1.f;
+    if (normalized == 1)
+        norm = 1.f / sqrt((float)n_fft);
+    if (normalized == 2)
+        norm = window_data[n_fft];
+
+    dft_weight.create(freqs_onesided * 2 * n_fft);
+    {
+        float* weight = dft_weight;
+        for (int i = 0; i < freqs_onesided; i++)
+        {
+            float* re_row = weight + i * n_fft;
+            float* im_row = weight + (freqs_onesided + i) * n_fft;
+            for (int k = 0; k < n_fft; k++)
+            {
+                double angle = 2 * 3.14159265358979323846 * i * k / n_fft;
+                re_row[k] = (float)(window_data[k] * cos(angle) * norm);
+                im_row[k] = (float)(-window_data[k] * sin(angle) * norm);
+            }
+        }
+    }
+
+    return 0;
+}
+
+int Spectrogram_vulkan::create_pipeline(const Option& opt)
+{
+    if (center == 1)
+    {
+        padding = create_layer_vulkan(LayerType::Padding);
+        padding->vkdev = vkdev;
+
+        ParamDict pd;
+        pd.set(0, 0);
+        pd.set(1, 0);
+        pd.set(2, n_fft / 2);
+        pd.set(3, n_fft / 2);
+        pd.set(4, pad_type);
+        pd.set(5, 0.f);
+
+        padding->load_param(pd);
+        padding->create_pipeline(opt);
+    }
+
+    const int freqs_onesided = n_fft / 2 + 1;
+    const int freqs = onesided ? freqs_onesided : n_fft;
+
+    std::vector<vk_specialization_type> specializations(6);
+    specializations[0].i = n_fft;
+    specializations[1].i = hoplen;
+    specializations[2].i = freqs_onesided;
+    specializations[3].i = power;
+    specializations[4].i = onesided;
+    specializations[5].i = freqs;
+
+    pipeline_spectrogram = new Pipeline(vkdev);
+    pipeline_spectrogram->set_optimal_local_size_xyz(8, 8, 1);
+    pipeline_spectrogram->create(LayerShaderType::spectrogram_conv, opt, specializations);
+
+    return 0;
+}
+
+int Spectrogram_vulkan::destroy_pipeline(const Option& opt)
+{
+    if (padding)
+    {
+        padding->destroy_pipeline(opt);
+        delete padding;
+        padding = 0;
+    }
+
+    delete pipeline_spectrogram;
+    pipeline_spectrogram = 0;
+
+    return 0;
+}
+
+int Spectrogram_vulkan::upload_model(VkTransfer& cmd, const Option& opt)
+{
+    cmd.record_upload(dft_weight, weight_data_gpu, opt);
+
+    dft_weight.release();
+
+    return 0;
+}
+
+int Spectrogram_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const
+{
+    // center border via Padding layer (same semantics as cpu copy_make_border)
+    const VkMat* input = &bottom_blob;
+    VkMat bottom_blob_bordered;
+    if (center == 1)
+    {
+        padding->forward(bottom_blob, bottom_blob_bordered, cmd, opt);
+        input = &bottom_blob_bordered;
+    }
+
+    const int size = input->w;
+    const int frames = (size - n_fft) / hoplen + 1;
+    const int freqs_onesided = n_fft / 2 + 1;
+    const int freqs = onesided ? freqs_onesided : n_fft;
+
+    const size_t elemsize = bottom_blob.elemsize;
+
+    if (power == 0)
+    {
+        top_blob.create(2, frames, freqs, elemsize, 1u, opt.blob_vkallocator);
+    }
+    else
+    {
+        top_blob.create(frames, freqs, elemsize, 1u, opt.blob_vkallocator);
+    }
+    if (top_blob.empty())
+        return -100;
+
+    std::vector<VkMat> bindings(3);
+    bindings[0] = *input;
+    bindings[1] = top_blob;
+    bindings[2] = weight_data_gpu;
+
+    std::vector<vk_constant_type> constants(2);
+    constants[0].i = frames;
+    constants[1].i = top_blob.cstep; // channel stride (power == 0 only)
+
+    VkMat dispatcher;
+    dispatcher.w = frames;
+    dispatcher.h = freqs;
+    dispatcher.c = 1;
+
+    cmd.record_pipeline(pipeline_spectrogram, bindings, constants, dispatcher);
+
+    return 0;
+}
+
+} // namespace ncnn

--- a/src/layer/vulkan/spectrogram_vulkan.h
+++ b/src/layer/vulkan/spectrogram_vulkan.h
@@ -1,0 +1,40 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef LAYER_SPECTROGRAM_VULKAN_H
+#define LAYER_SPECTROGRAM_VULKAN_H
+
+#include "spectrogram.h"
+
+namespace ncnn {
+
+class Spectrogram_vulkan : public Spectrogram
+{
+public:
+    Spectrogram_vulkan();
+
+    virtual int load_param(const ParamDict& pd);
+
+    virtual int create_pipeline(const Option& opt);
+    virtual int destroy_pipeline(const Option& opt);
+
+    virtual int upload_model(VkTransfer& cmd, const Option& opt);
+
+    using Spectrogram::forward;
+    virtual int forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const;
+
+public:
+    // stft as conv: kernel=n_fft stride=hoplen, dft basis as weight
+    // row i = real basis of bin i, row freqs_onesided + i = imag basis
+    Mat dft_weight;
+    VkMat weight_data_gpu;
+
+    // center border (constant / replicate / reflect)
+    Layer* padding;
+
+    Pipeline* pipeline_spectrogram;
+};
+
+} // namespace ncnn
+
+#endif // LAYER_SPECTROGRAM_VULKAN_H

--- a/src/layer/x86/inversespectrogram_x86.cpp
+++ b/src/layer/x86/inversespectrogram_x86.cpp
@@ -81,7 +81,14 @@ int InverseSpectrogram_x86::load_param(const ParamDict& pd)
 int InverseSpectrogram_x86::create_pipeline(const Option& opt)
 {
     if (conv1d)
-        conv1d->create_pipeline(opt);
+    {
+        int ret = conv1d->create_pipeline(opt);
+        if (ret != 0)
+            return ret;
+
+        if (opt.lightmode)
+            idft_weight.release();
+    }
 
     return 0;
 }

--- a/src/layer/x86/inversespectrogram_x86.cpp
+++ b/src/layer/x86/inversespectrogram_x86.cpp
@@ -82,7 +82,12 @@ int InverseSpectrogram_x86::create_pipeline(const Option& opt)
 {
     if (conv1d)
     {
-        int ret = conv1d->create_pipeline(opt);
+        // the nested conv must not build bf16 weights while this layer runs in fp32
+        Option opt_bf16 = opt;
+        opt_bf16.use_bf16_storage = false;
+        opt_bf16.use_bf16_packed = false;
+
+        int ret = conv1d->create_pipeline(opt_bf16);
         if (ret != 0)
             return ret;
 
@@ -155,7 +160,11 @@ int InverseSpectrogram_x86::forward(const Mat& bottom_blob, Mat& top_blob, const
     Mat conv_out;
     {
         Mat conv_out_packed;
-        int ret = conv1d->forward(sp, conv_out_packed, opt);
+        Option opt_bf16 = opt;
+        opt_bf16.use_bf16_storage = false;
+        opt_bf16.use_bf16_packed = false;
+
+        int ret = conv1d->forward(sp, conv_out_packed, opt_bf16);
         if (ret != 0)
             return ret;
 

--- a/src/layer/x86/inversespectrogram_x86.cpp
+++ b/src/layer/x86/inversespectrogram_x86.cpp
@@ -56,6 +56,8 @@ int InverseSpectrogram_x86::load_param(const ParamDict& pd)
     }
 
     conv1d = create_layer_cpu(LayerType::Convolution1D);
+    if (!conv1d)
+        return -100;
     {
         ParamDict pd_conv;
         pd_conv.set(0, num_output);             // num_output

--- a/src/layer/x86/inversespectrogram_x86.cpp
+++ b/src/layer/x86/inversespectrogram_x86.cpp
@@ -1,0 +1,240 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "inversespectrogram_x86.h"
+
+#include "cpu.h"
+#include "layer_type.h"
+
+#include <math.h>
+
+namespace ncnn {
+
+InverseSpectrogram_x86::InverseSpectrogram_x86()
+{
+    conv1d = 0;
+}
+
+int InverseSpectrogram_x86::load_param(const ParamDict& pd)
+{
+    int ret = InverseSpectrogram::load_param(pd);
+    if (ret != 0)
+        return ret;
+
+    // istft per-frame idft: tap m of frame j gets
+    // re += (sp_re[k] * cos(2*pi*k*m/n_fft) - sp_im[k] * sin(2*pi*k*m/n_fft)) / n_fft * window[m] * norm
+    // im += (sp_re[k] * sin(2*pi*k*m/n_fft) + sp_im[k] * cos(2*pi*k*m/n_fft)) / n_fft * window[m] * norm
+    // as conv1d 1x1: num_input = 2*n_fft (sp_re then sp_im), num_output = 2*n_fft (re taps then im taps)
+    const int num_input = n_fft * 2;
+    const int num_output = n_fft * 2;
+
+    float norm = 1.f;
+    if (normalized == 1)
+        norm = sqrt((float)n_fft);
+    if (normalized == 2)
+        norm = window_data[n_fft];
+
+    // conv1d weight layout: [out_ch][in_ch q], kernel=1
+    // out_ch [0, n_fft) = re taps, out_ch [n_fft, 2*n_fft) = im taps
+    // in_ch [0, n_fft) = sp_re, in_ch [n_fft, 2*n_fft) = sp_im
+    idft_weight.create(num_output * num_input);
+    {
+        float* weight = idft_weight;
+        for (int m = 0; m < n_fft; m++)
+        {
+            float* re_row = weight + m * num_input;
+            float* im_row = weight + (n_fft + m) * num_input;
+            for (int k = 0; k < n_fft; k++)
+            {
+                double angle = 2 * 3.14159265358979323846 * k * m / n_fft;
+                re_row[k] = (float)(window_data[m] * cos(angle) / n_fft * norm);
+                re_row[n_fft + k] = (float)(-window_data[m] * sin(angle) / n_fft * norm);
+                im_row[k] = (float)(window_data[m] * sin(angle) / n_fft * norm);
+                im_row[n_fft + k] = (float)(window_data[m] * cos(angle) / n_fft * norm);
+            }
+        }
+    }
+
+    conv1d = create_layer_cpu(LayerType::Convolution1D);
+    {
+        ParamDict pd_conv;
+        pd_conv.set(0, num_output);             // num_output
+        pd_conv.set(1, 1);                      // kernel_w
+        pd_conv.set(2, 1);                      // dilation_w
+        pd_conv.set(3, 1);                      // stride_w
+        pd_conv.set(4, 0);                      // pad_left
+        pd_conv.set(15, 0);                     // pad_right
+        pd_conv.set(5, 0);                      // bias_term
+        pd_conv.set(6, num_output * num_input); // weight_data_size
+        pd_conv.set(9, 0);                      // activation_type
+        conv1d->load_param(pd_conv);
+
+        Mat weights[1] = {idft_weight};
+        conv1d->load_model(ModelBinFromMatArray(weights));
+    }
+
+    return 0;
+}
+
+int InverseSpectrogram_x86::create_pipeline(const Option& opt)
+{
+    if (conv1d)
+        conv1d->create_pipeline(opt);
+
+    return 0;
+}
+
+int InverseSpectrogram_x86::destroy_pipeline(const Option& opt)
+{
+    if (conv1d)
+    {
+        conv1d->destroy_pipeline(opt);
+        delete conv1d;
+        conv1d = 0;
+    }
+
+    return 0;
+}
+
+int InverseSpectrogram_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const
+{
+    // https://github.com/librosa/librosa/blob/main/librosa/core/spectrum.py#L630
+
+    const int frames = bottom_blob.h;
+    const int freqs = bottom_blob.c;
+    // assert freqs == n_fft or freqs == n_fft / 2 + 1
+
+    const int onesided = freqs == n_fft / 2 + 1 ? 1 : 0;
+
+    const size_t elemsize = bottom_blob.elemsize;
+
+    // collect full complex spectrum as conv input [w=frames, h=2*n_fft]
+    // row k = re of bin k, row n_fft + k = im of bin k
+    Mat sp(frames, n_fft * 2, elemsize, opt.workspace_allocator);
+    if (sp.empty())
+        return -100;
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int k = 0; k < n_fft; k++)
+    {
+        float* re_row = sp.row(k);
+        float* im_row = sp.row(n_fft + k);
+        if (k < freqs)
+        {
+            const float* ptr = bottom_blob.channel(k);
+            for (int j = 0; j < frames; j++)
+            {
+                re_row[j] = ptr[0];
+                im_row[j] = ptr[1];
+                ptr += 2;
+            }
+        }
+        else // if (onesided)
+        {
+            // conjugate mirror of bin n_fft - k
+            const float* ptr = bottom_blob.channel(n_fft - k);
+            for (int j = 0; j < frames; j++)
+            {
+                re_row[j] = ptr[0];
+                im_row[j] = -ptr[1];
+                ptr += 2;
+            }
+        }
+    }
+
+    // conv1d 1x1: [w=frames, h=n_fft], row m = idft tap m over frames
+    Mat conv_out;
+    {
+        Mat conv_out_packed;
+        int ret = conv1d->forward(sp, conv_out_packed, opt);
+        if (ret != 0)
+            return ret;
+
+        // x86 conv1d may produce pack4/8/16 output, unpack to pack1
+        if (conv_out_packed.elempack != 1)
+        {
+            convert_packing(conv_out_packed, conv_out, 1, opt);
+        }
+        else
+        {
+            conv_out = conv_out_packed;
+        }
+    }
+
+    const int pad = center == 1 ? n_fft / 2 : 0;
+    const int outsize = (frames - 1) * hoplen + n_fft - pad * 2;
+
+    if (returns == 0)
+    {
+        top_blob.create(2, outsize, elemsize, opt.blob_allocator);
+    }
+    else
+    {
+        top_blob.create(outsize, elemsize, opt.blob_allocator);
+    }
+    if (top_blob.empty())
+        return -100;
+
+    // overlap-add shifted taps into uncropped buffers, with square window norm
+    // (same accumulation as reference)
+    const int full_size = outsize + pad * 2;
+    Mat yfull_re(full_size, elemsize, opt.workspace_allocator);
+    Mat yfull_im(full_size, elemsize, opt.workspace_allocator);
+    Mat window_sumsquare(full_size, elemsize, opt.workspace_allocator);
+    if (yfull_re.empty() || yfull_im.empty() || window_sumsquare.empty())
+        return -100;
+    yfull_re.fill(0.f);
+    yfull_im.fill(0.f);
+    window_sumsquare.fill(0.f);
+
+    for (int m = 0; m < n_fft; m++)
+    {
+        const float* re_row = conv_out.row(m);
+        const float* im_row = conv_out.row(n_fft + m);
+        const float w2 = window_data[m] * window_data[m];
+        for (int j = 0; j < frames; j++)
+        {
+            const int idx = j * hoplen + m;
+            yfull_re[idx] += re_row[j];
+            yfull_im[idx] += im_row[j];
+            window_sumsquare[idx] += w2;
+        }
+    }
+
+    // crop center pad and normalize
+    if (returns == 0)
+    {
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int i = 0; i < outsize; i++)
+        {
+            float* outptr = top_blob.row(i);
+            const float ws = window_sumsquare[i + pad];
+            const float re = yfull_re[i + pad];
+            const float im = yfull_im[i + pad];
+            if (ws != 0.f)
+            {
+                outptr[0] = re / ws;
+                outptr[1] = im / ws;
+            }
+            else
+            {
+                outptr[0] = re;
+                outptr[1] = im;
+            }
+        }
+    }
+    else
+    {
+        const Mat& yfull = returns == 2 ? yfull_im : yfull_re;
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int i = 0; i < outsize; i++)
+        {
+            const float ws = window_sumsquare[i + pad];
+            top_blob[i] = ws != 0.f ? yfull[i + pad] / ws : yfull[i + pad];
+        }
+    }
+
+    return 0;
+}
+
+} // namespace ncnn

--- a/src/layer/x86/inversespectrogram_x86.h
+++ b/src/layer/x86/inversespectrogram_x86.h
@@ -1,0 +1,33 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef LAYER_INVERSESPECTROGRAM_X86_H
+#define LAYER_INVERSESPECTROGRAM_X86_H
+
+#include "inversespectrogram.h"
+
+namespace ncnn {
+
+class InverseSpectrogram_x86 : virtual public InverseSpectrogram
+{
+public:
+    InverseSpectrogram_x86();
+
+    virtual int load_param(const ParamDict& pd);
+
+    virtual int create_pipeline(const Option& opt);
+    virtual int destroy_pipeline(const Option& opt);
+
+    virtual int forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const;
+
+public:
+    // istft per-frame idft as conv1d 1x1 (sgemm): out[t][m] = sum_q sp[q][t] * W[q][m]
+    // num_input = 2*n_fft (re bins then im bins), num_output = 2*n_fft (re taps then im taps)
+    // overlap-add over the hoplen-shifted taps gives the waveform
+    Layer* conv1d;
+    Mat idft_weight;
+};
+
+} // namespace ncnn
+
+#endif // LAYER_INVERSESPECTROGRAM_X86_H

--- a/src/layer/x86/spectrogram_x86.cpp
+++ b/src/layer/x86/spectrogram_x86.cpp
@@ -76,7 +76,14 @@ int Spectrogram_x86::load_param(const ParamDict& pd)
 int Spectrogram_x86::create_pipeline(const Option& opt)
 {
     if (conv1d)
-        conv1d->create_pipeline(opt);
+    {
+        int ret = conv1d->create_pipeline(opt);
+        if (ret != 0)
+            return ret;
+
+        if (opt.lightmode)
+            dft_weight.release();
+    }
 
     return 0;
 }

--- a/src/layer/x86/spectrogram_x86.cpp
+++ b/src/layer/x86/spectrogram_x86.cpp
@@ -53,15 +53,15 @@ int Spectrogram_x86::load_param(const ParamDict& pd)
     conv1d = create_layer_cpu(LayerType::Convolution1D);
     {
         ParamDict pd_conv;
-        pd_conv.set(0, num_output);             // num_output
-        pd_conv.set(1, n_fft);                  // kernel_w
-        pd_conv.set(2, 1);                      // dilation_w
-        pd_conv.set(3, hoplen);                 // stride_w
-        pd_conv.set(4, 0);                      // pad_left
-        pd_conv.set(15, 0);                     // pad_right
-        pd_conv.set(5, 0);                      // bias_term
-        pd_conv.set(6, num_output * n_fft);     // weight_data_size
-        pd_conv.set(9, 0);                      // activation_type
+        pd_conv.set(0, num_output);         // num_output
+        pd_conv.set(1, n_fft);              // kernel_w
+        pd_conv.set(2, 1);                  // dilation_w
+        pd_conv.set(3, hoplen);             // stride_w
+        pd_conv.set(4, 0);                  // pad_left
+        pd_conv.set(15, 0);                 // pad_right
+        pd_conv.set(5, 0);                  // bias_term
+        pd_conv.set(6, num_output * n_fft); // weight_data_size
+        pd_conv.set(9, 0);                  // activation_type
         conv1d->load_param(pd_conv);
 
         Mat weights[1] = {dft_weight};

--- a/src/layer/x86/spectrogram_x86.cpp
+++ b/src/layer/x86/spectrogram_x86.cpp
@@ -77,7 +77,12 @@ int Spectrogram_x86::create_pipeline(const Option& opt)
 {
     if (conv1d)
     {
-        int ret = conv1d->create_pipeline(opt);
+        // the nested conv must not build bf16 weights while this layer runs in fp32
+        Option opt_bf16 = opt;
+        opt_bf16.use_bf16_storage = false;
+        opt_bf16.use_bf16_packed = false;
+
+        int ret = conv1d->create_pipeline(opt_bf16);
         if (ret != 0)
             return ret;
 
@@ -121,7 +126,11 @@ int Spectrogram_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option
     Mat conv_out;
     {
         Mat conv_out_packed;
-        int ret = conv1d->forward(bottom_blob_bordered, conv_out_packed, opt);
+        Option opt_bf16 = opt;
+        opt_bf16.use_bf16_storage = false;
+        opt_bf16.use_bf16_packed = false;
+
+        int ret = conv1d->forward(bottom_blob_bordered, conv_out_packed, opt_bf16);
         if (ret != 0)
             return ret;
 

--- a/src/layer/x86/spectrogram_x86.cpp
+++ b/src/layer/x86/spectrogram_x86.cpp
@@ -51,6 +51,8 @@ int Spectrogram_x86::load_param(const ParamDict& pd)
     }
 
     conv1d = create_layer_cpu(LayerType::Convolution1D);
+    if (!conv1d)
+        return -100;
     {
         ParamDict pd_conv;
         pd_conv.set(0, num_output);         // num_output

--- a/src/layer/x86/spectrogram_x86.cpp
+++ b/src/layer/x86/spectrogram_x86.cpp
@@ -1,0 +1,211 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "spectrogram_x86.h"
+
+#include "cpu.h"
+#include "layer_type.h"
+
+#include <math.h>
+
+namespace ncnn {
+
+Spectrogram_x86::Spectrogram_x86()
+{
+    conv1d = 0;
+}
+
+int Spectrogram_x86::load_param(const ParamDict& pd)
+{
+    int ret = Spectrogram::load_param(pd);
+    if (ret != 0)
+        return ret;
+
+    // stft as conv1d: kernel=n_fft stride=hoplen
+    // re[i] = sum_k x[k] * window[k] * cos(2*pi*i*k/n_fft) * norm
+    // im[i] = sum_k x[k] * (-window[k] * sin(2*pi*i*k/n_fft)) * norm
+    const int freqs_onesided = n_fft / 2 + 1;
+    const int num_output = freqs_onesided * 2;
+
+    float norm = 1.f;
+    if (normalized == 1)
+        norm = 1.f / sqrt((float)n_fft);
+    if (normalized == 2)
+        norm = window_data[n_fft];
+
+    dft_weight.create(num_output * n_fft);
+    {
+        // planar: row i = re_i, row freqs_onesided + i = im_i
+        float* weight = dft_weight;
+        for (int i = 0; i < freqs_onesided; i++)
+        {
+            float* re_row = weight + i * n_fft;
+            float* im_row = weight + (freqs_onesided + i) * n_fft;
+            for (int k = 0; k < n_fft; k++)
+            {
+                double angle = 2 * 3.14159265358979323846 * i * k / n_fft;
+                re_row[k] = (float)(window_data[k] * cos(angle) * norm);
+                im_row[k] = (float)(-window_data[k] * sin(angle) * norm);
+            }
+        }
+    }
+
+    conv1d = create_layer_cpu(LayerType::Convolution1D);
+    {
+        ParamDict pd_conv;
+        pd_conv.set(0, num_output);             // num_output
+        pd_conv.set(1, n_fft);                  // kernel_w
+        pd_conv.set(2, 1);                      // dilation_w
+        pd_conv.set(3, hoplen);                 // stride_w
+        pd_conv.set(4, 0);                      // pad_left
+        pd_conv.set(15, 0);                     // pad_right
+        pd_conv.set(5, 0);                      // bias_term
+        pd_conv.set(6, num_output * n_fft);     // weight_data_size
+        pd_conv.set(9, 0);                      // activation_type
+        conv1d->load_param(pd_conv);
+
+        Mat weights[1] = {dft_weight};
+        conv1d->load_model(ModelBinFromMatArray(weights));
+    }
+
+    return 0;
+}
+
+int Spectrogram_x86::create_pipeline(const Option& opt)
+{
+    if (conv1d)
+        conv1d->create_pipeline(opt);
+
+    return 0;
+}
+
+int Spectrogram_x86::destroy_pipeline(const Option& opt)
+{
+    if (conv1d)
+    {
+        conv1d->destroy_pipeline(opt);
+        delete conv1d;
+        conv1d = 0;
+    }
+
+    return 0;
+}
+
+int Spectrogram_x86::forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const
+{
+    // https://pytorch.org/audio/stable/generated/torchaudio.functional.spectrogram.html
+
+    Mat bottom_blob_bordered = bottom_blob;
+    if (center == 1)
+    {
+        Option opt_b = opt;
+        opt_b.blob_allocator = opt.workspace_allocator;
+        if (pad_type == 0)
+            copy_make_border(bottom_blob, bottom_blob_bordered, 0, 0, n_fft / 2, n_fft / 2, BORDER_CONSTANT, 0.f, opt_b);
+        if (pad_type == 1)
+            copy_make_border(bottom_blob, bottom_blob_bordered, 0, 0, n_fft / 2, n_fft / 2, BORDER_REPLICATE, 0.f, opt_b);
+        if (pad_type == 2)
+            copy_make_border(bottom_blob, bottom_blob_bordered, 0, 0, n_fft / 2, n_fft / 2, BORDER_REFLECT, 0.f, opt_b);
+    }
+
+    // conv1d: [w=frames, h=2*freqs_onesided]
+    Mat conv_out;
+    {
+        Mat conv_out_packed;
+        int ret = conv1d->forward(bottom_blob_bordered, conv_out_packed, opt);
+        if (ret != 0)
+            return ret;
+
+        // x86 conv1d may produce pack4/8/16 output, unpack to pack1
+        if (conv_out_packed.elempack != 1)
+        {
+            convert_packing(conv_out_packed, conv_out, 1, opt);
+        }
+        else
+        {
+            conv_out = conv_out_packed;
+        }
+    }
+
+    const int frames = conv_out.w;
+    const int freqs_onesided = n_fft / 2 + 1;
+    const int freqs = onesided ? freqs_onesided : n_fft;
+
+    const size_t elemsize = bottom_blob_bordered.elemsize;
+
+    if (power == 0)
+    {
+        top_blob.create(2, frames, freqs, elemsize, opt.blob_allocator);
+    }
+    else
+    {
+        top_blob.create(frames, freqs, elemsize, opt.blob_allocator);
+    }
+    if (top_blob.empty())
+        return -100;
+
+    #pragma omp parallel for num_threads(opt.num_threads)
+    for (int i = 0; i < freqs_onesided; i++)
+    {
+        const float* re_ptr = conv_out.row(i);
+        const float* im_ptr = conv_out.row(freqs_onesided + i);
+        float* outptr = power == 0 ? top_blob.channel(i) : top_blob.row(i);
+
+        if (power == 0)
+        {
+            for (int j = 0; j < frames; j++)
+            {
+                outptr[0] = re_ptr[j];
+                outptr[1] = im_ptr[j];
+                outptr += 2;
+            }
+        }
+        if (power == 1)
+        {
+            for (int j = 0; j < frames; j++)
+            {
+                outptr[j] = sqrt(re_ptr[j] * re_ptr[j] + im_ptr[j] * im_ptr[j]);
+            }
+        }
+        if (power == 2)
+        {
+            for (int j = 0; j < frames; j++)
+            {
+                outptr[j] = re_ptr[j] * re_ptr[j] + im_ptr[j] * im_ptr[j];
+            }
+        }
+    }
+
+    if (!onesided)
+    {
+        #pragma omp parallel for num_threads(opt.num_threads)
+        for (int i = freqs_onesided; i < n_fft; i++)
+        {
+            if (power == 0)
+            {
+                const float* ptr = top_blob.channel(n_fft - i);
+                float* outptr = top_blob.channel(i);
+
+                for (int j = 0; j < frames; j++)
+                {
+                    // complex as real
+                    outptr[0] = ptr[0];
+                    outptr[1] = -ptr[1];
+                    ptr += 2;
+                    outptr += 2;
+                }
+            }
+            else // if (power == 1 || power == 2)
+            {
+                const float* ptr = top_blob.row(n_fft - i);
+                float* outptr = top_blob.row(i);
+
+                memcpy(outptr, ptr, frames * sizeof(float));
+            }
+        }
+    }
+
+    return 0;
+}
+
+} // namespace ncnn

--- a/src/layer/x86/spectrogram_x86.h
+++ b/src/layer/x86/spectrogram_x86.h
@@ -1,0 +1,33 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef LAYER_SPECTROGRAM_X86_H
+#define LAYER_SPECTROGRAM_X86_H
+
+#include "spectrogram.h"
+
+namespace ncnn {
+
+class Spectrogram_x86 : virtual public Spectrogram
+{
+public:
+    Spectrogram_x86();
+
+    virtual int load_param(const ParamDict& pd);
+
+    virtual int create_pipeline(const Option& opt);
+    virtual int destroy_pipeline(const Option& opt);
+
+    virtual int forward(const Mat& bottom_blob, Mat& top_blob, const Option& opt) const;
+
+public:
+    // stft as conv1d: kernel=n_fft stride=hoplen
+    // out channel [0, freqs)         = real part = window[k] * cos(2*pi*i*k/n_fft)
+    // out channel [freqs, 2*freqs)   = imag part = -window[k] * sin(2*pi*i*k/n_fft)
+    Layer* conv1d;
+    Mat dft_weight;
+};
+
+} // namespace ncnn
+
+#endif // LAYER_SPECTROGRAM_X86_H


### PR DESCRIPTION
 Implement fast STFT/ISTFT for the Spectrogram and InverseSpectrogram
  layers on both x86 and Vulkan. The existing naive CPU implementations
  are kept untouched as reference.

  x86:
  - STFT is expressed as an embedded Convolution1D: the DFT basis is
    precomputed at load_param into a weight matrix (kernel = n_fft,
    stride = hop_len, out channels = 2 * freqs), so the whole forward is a
    single optimized conv1d instead of a per-frame FFT loop.
  - ISTFT is expressed as a 1x1 Convolution1D (2*n_fft -> 2*n_fft, the
    inverse-DFT basis including window), followed by overlap-add with
    window^2 normalization.

  Vulkan:
  - Dedicated shaders: STFT launches one invocation per (frame, bin);
    ISTFT uses a gather-style overlap-add with window^2 normalization.

  Both paths honor the existing layer parameters: center padding
  (constant / replicate / reflect), onesided, power (magnitude) mode and
  the normalized flag.

  Files:
  - src/layer/x86/spectrogram_x86.cpp/.h, inversespectrogram_x86.cpp/.h
  - src/layer/vulkan/spectrogram_vulkan.cpp/.h, inversespectrogram_vulkan.cpp/.h
  - src/layer/vulkan/shader/spectrogram_conv.comp, inversespectrogram_conv.comp

  Motivation: torchaudio-style spectrogram/ISTFT are hot spots in
  voice/audio pipelines (e.g. RVC); these implementations avoid the naive
  per-frame loops and keep the computation on-device.