### PR TITLE
vulkan 1D convolution family: conv1d winograd/subgroup, convolutiondepthwise1d, deconvolution1d

### DIFF
--- a/src/layer/vulkan/convolution1d_vulkan.cpp
+++ b/src/layer/vulkan/convolution1d_vulkan.cpp
@@ -19,6 +19,13 @@ Convolution1D_vulkan::Convolution1D_vulkan()
     pipeline_convolution1d_1x1s1d1 = 0;
     pipeline_convolution1d_gemm = 0;
 
+    pipeline_convolution1d_3s1d1_winograd23_transform_input = 0;
+    pipeline_convolution1d_3s1d1_winograd23_gemm = 0;
+    pipeline_convolution1d_3s1d1_winograd23_transform_output = 0;
+    pipeline_convolution1d_3s1d1_winograd43_transform_input = 0;
+    pipeline_convolution1d_3s1d1_winograd43_gemm = 0;
+    pipeline_convolution1d_3s1d1_winograd43_transform_output = 0;
+
     use_cooperative_matrix = false;
     coopmat_M = 0;
     coopmat_N = 0;
@@ -124,6 +131,479 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
             UNROLL_SG_M = 2;
             UNROLL_SG_N = 2;
             UNROLL_SG_K = 2;
+        }
+    }
+
+    bool is_conv3s1d1 = kernel_w == 3 && stride_w == 1 && dilation_w == 1;
+
+    if (opt.use_winograd_convolution && (opt.use_winograd23_convolution || opt.use_winograd43_convolution) && is_conv3s1d1 && num_input >= 16 && num_output >= 16)
+    {
+        use_cooperative_matrix = vkdev->info.support_cooperative_matrix() && opt.use_cooperative_matrix && (opt.use_fp16_storage || opt.use_fp16_packed);
+
+        if (use_cooperative_matrix)
+        {
+            int size = 1024;
+            vkdev->info.get_optimal_cooperative_matrix_mnk(size, num_output, num_input, VK_COMPONENT_TYPE_FLOAT16_KHR, opt.use_fp16_arithmetic ? VK_COMPONENT_TYPE_FLOAT16_KHR : VK_COMPONENT_TYPE_FLOAT32_KHR, VK_SCOPE_SUBGROUP_KHR, coopmat_M, coopmat_N, coopmat_K, coopmat_subgroup_size);
+
+            UNROLL_SG_M = std::min((size + coopmat_M - 1) / coopmat_M, 2);
+            UNROLL_SG_N = std::min((num_output + coopmat_N - 1) / coopmat_N, 2);
+            UNROLL_SG_K = std::min((num_input + coopmat_K - 1) / coopmat_K, 2);
+
+            UNROLL_WG_M = std::min((size + coopmat_M * UNROLL_SG_M - 1) / (coopmat_M * UNROLL_SG_M), 2);
+            UNROLL_WG_N = std::min((num_output + coopmat_N * UNROLL_SG_N - 1) / (coopmat_N * UNROLL_SG_N), 2);
+        }
+
+        // === F(4,3) ===
+        if (opt.use_winograd43_convolution)
+        {
+            // 1D weight transform: G (6x3) applied once
+            Mat weight_data_tm;
+            weight_data_tm.create(6, num_input, num_output);
+
+            const float sq2 = 1.41421356237f;
+            const float ktm[6][3] = {
+                {1.0f, 0.0f, 0.0f},
+                {-2.0f / 3, -sq2 / 3, -1.0f / 3},
+                {-2.0f / 3, sq2 / 3, -1.0f / 3},
+                {1.0f / 6, sq2 / 6, 1.0f / 3},
+                {1.0f / 6, -sq2 / 6, 1.0f / 3},
+                {0.0f, 0.0f, 1.0f}
+            };
+
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int p = 0; p < num_output; p++)
+            {
+                for (int q = 0; q < num_input; q++)
+                {
+                    const float* kernel0 = (const float*)weight_data + p * num_input * 3 + q * 3;
+                    float* kernel_tm0 = weight_data_tm.channel(p).row(q);
+
+                    for (int i = 0; i < 6; i++)
+                    {
+                        kernel_tm0[i] = kernel0[0] * ktm[i][0] + kernel0[1] * ktm[i][1] + kernel0[2] * ktm[i][2];
+                    }
+                }
+            }
+
+            // Weight packing - follow 2D pattern but with 6 instead of 36
+            if (use_cooperative_matrix)
+            {
+                // from 6-inch-outch to inch-outch-6
+                Mat weight_data_tm_r2(num_input, num_output, 6);
+                for (int k = 0; k < 6; k++)
+                {
+                    float* g00 = weight_data_tm_r2.channel(k);
+                    for (int q = 0; q < num_output; q++)
+                    {
+                        for (int p = 0; p < num_input; p++)
+                        {
+                            *g00++ = weight_data_tm[(q * num_input + p) * 6 + k];
+                        }
+                    }
+                }
+
+                const int blocks_n = (num_output + coopmat_N * UNROLL_SG_N * UNROLL_WG_N - 1) / (coopmat_N * UNROLL_SG_N * UNROLL_WG_N);
+                const int kk = (num_input + coopmat_K - 1) / coopmat_K;
+
+                weight_winograd43_data_packed.create(coopmat_N * coopmat_K * UNROLL_SG_N * UNROLL_WG_N * kk, blocks_n, 6);
+                for (int b = 0; b < 6; b++)
+                {
+                    for (int bn = 0; bn < blocks_n; bn++)
+                    {
+                        float* p = weight_winograd43_data_packed.channel(b).row(bn);
+                        int k = 0;
+                        for (; k + UNROLL_SG_K - 1 < kk; k += UNROLL_SG_K)
+                        {
+                            for (int wn = 0; wn < UNROLL_WG_N; wn++)
+                            {
+                                for (int zk = 0; zk < UNROLL_SG_K; zk++)
+                                {
+                                    for (int zn = 0; zn < UNROLL_SG_N; zn++)
+                                    {
+                                        for (int i = 0; i < coopmat_K; i++)
+                                        {
+                                            for (int j = 0; j < coopmat_N; j++)
+                                            {
+                                                const int gni = ((bn * UNROLL_WG_N + wn) * UNROLL_SG_N + zn) * coopmat_N + j;
+                                                const int gki = (k + zk) * coopmat_K + i;
+                                                if (gni < num_output && gki < num_input)
+                                                    *p++ = weight_data_tm_r2.channel(b)[gni * num_input + gki];
+                                                else
+                                                    *p++ = 0.f;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        for (; k < kk; k++)
+                        {
+                            for (int wn = 0; wn < UNROLL_WG_N; wn++)
+                            {
+                                for (int zn = 0; zn < UNROLL_SG_N; zn++)
+                                {
+                                    for (int i = 0; i < coopmat_K; i++)
+                                    {
+                                        for (int j = 0; j < coopmat_N; j++)
+                                        {
+                                            const int gni = ((bn * UNROLL_WG_N + wn) * UNROLL_SG_N + zn) * coopmat_N + j;
+                                            const int gki = k * coopmat_K + i;
+                                            if (gni < num_output && gki < num_input)
+                                                *p++ = weight_data_tm_r2.channel(b)[gni * num_input + gki];
+                                            else
+                                                *p++ = 0.f;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                // non-cm packing
+                weight_winograd43_data_packed.create(num_input / elempack, num_output / out_elempack, 6, (size_t)4 * elempack * out_elempack, elempack * out_elempack);
+                for (int k = 0; k < 6; k++)
+                {
+                    float* g00 = weight_winograd43_data_packed.channel(k);
+                    for (int q = 0; q + (out_elempack - 1) < num_output; q += out_elempack)
+                    {
+                        for (int p = 0; p + (elempack - 1) < num_input; p += elempack)
+                        {
+                            for (int i = 0; i < out_elempack; i++)
+                            {
+                                const Mat k0 = weight_data_tm.channel(q + i);
+                                for (int j = 0; j < elempack; j++)
+                                {
+                                    const float* k00 = k0.row(p + j);
+                                    g00[0] = k00[k];
+                                    g00++;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Create F(4,3) pipelines
+            // transform_input
+            {
+                std::vector<vk_specialization_type> specializations(1 + 4);
+                specializations[0].i = num_input / elempack;
+                specializations[1 + 0].i = 0; // w
+                specializations[1 + 1].i = 0; // cstep
+                specializations[1 + 2].i = 0; // outcstep
+                specializations[1 + 3].i = 0; // block_x
+
+                int shader_type_index = -1;
+                if (elempack == 1) shader_type_index = LayerShaderType::convolution1d_3s1d1_winograd43_transform_input;
+                if (elempack == 4) shader_type_index = LayerShaderType::convolution1d_packed_3s1d1_winograd43_transform_input;
+
+                pipeline_convolution1d_3s1d1_winograd43_transform_input = new Pipeline(vkdev);
+                pipeline_convolution1d_3s1d1_winograd43_transform_input->set_local_size_xyz(8, 8, 1);
+                pipeline_convolution1d_3s1d1_winograd43_transform_input->create(shader_type_index, opt, specializations);
+            }
+
+            // gemm
+            if (use_cooperative_matrix)
+            {
+                Mat weight_winograd43_data_packed_fp16 = Mat(weight_winograd43_data_packed.w, weight_winograd43_data_packed.h, weight_winograd43_data_packed.c, (void*)0, 2u, 1);
+
+                std::vector<vk_specialization_type> specializations(15 + 3);
+                specializations[0].u32 = 6; // batch = number of transformed positions
+                specializations[1].u32 = coopmat_M;
+                specializations[2].u32 = coopmat_N;
+                specializations[3].u32 = coopmat_K;
+                specializations[4].u32 = UNROLL_SG_M;
+                specializations[5].u32 = UNROLL_SG_N;
+                specializations[6].u32 = UNROLL_SG_K;
+                specializations[7].u32 = UNROLL_WG_M;
+                specializations[8].u32 = UNROLL_WG_N;
+                specializations[9].u32 = coopmat_subgroup_size;
+                specializations[10].u32 = num_input;
+                specializations[11].u32 = num_output;
+                specializations[12].u32 = elempack;
+                specializations[13].u32 = out_elempack;
+                specializations[14].u32 = weight_winograd43_data_packed_fp16.cstep;
+                specializations[15 + 0].u32 = 0; // size
+                specializations[15 + 1].u32 = 0; // cstep
+                specializations[15 + 2].u32 = 0; // outcstep
+
+                pipeline_convolution1d_3s1d1_winograd43_gemm = new Pipeline(vkdev);
+                pipeline_convolution1d_3s1d1_winograd43_gemm->set_subgroup_size(coopmat_subgroup_size);
+                pipeline_convolution1d_3s1d1_winograd43_gemm->set_local_size_xyz(coopmat_subgroup_size * UNROLL_WG_M * UNROLL_WG_N, 1, 1);
+                pipeline_convolution1d_3s1d1_winograd43_gemm->create(LayerShaderType::convolution_winograd_gemm_cm, opt, specializations);
+            }
+            else
+            {
+                std::vector<vk_specialization_type> specializations(3 + 3);
+                specializations[0].i = 6; // batch
+                specializations[1].i = num_input / elempack;
+                specializations[2].i = num_output / out_elempack;
+                specializations[3 + 0].i = 0; // cstep
+                specializations[3 + 1].i = 0; // outw
+                specializations[3 + 2].i = 0; // outcstep
+
+                int shader_type_index = -1;
+                if (elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::convolution_3x3s1d1_winograd_gemm;
+                if (elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::convolution_pack4_3x3s1d1_winograd_gemm;
+                if (elempack == 1 && out_elempack == 4) shader_type_index = LayerShaderType::convolution_pack1to4_3x3s1d1_winograd_gemm;
+                if (elempack == 4 && out_elempack == 1) shader_type_index = LayerShaderType::convolution_pack4to1_3x3s1d1_winograd_gemm;
+
+                pipeline_convolution1d_3s1d1_winograd43_gemm = new Pipeline(vkdev);
+                if (opt.use_shader_local_memory)
+                    pipeline_convolution1d_3s1d1_winograd43_gemm->set_local_size_xyz(8, 8, 1);
+                else
+                    pipeline_convolution1d_3s1d1_winograd43_gemm->set_local_size_xyz(4, std::min(4, num_output / out_elempack), 4);
+                pipeline_convolution1d_3s1d1_winograd43_gemm->create(shader_type_index, opt, specializations);
+            }
+
+            // transform_output
+            {
+                std::vector<vk_specialization_type> specializations(5 + 4);
+                specializations[0].i = bias_term;
+                specializations[1].i = activation_type;
+                specializations[2].f = activation_params.w >= 1 ? activation_params[0] : 0.f;
+                specializations[3].f = activation_params.w == 2 ? activation_params[1] : 0.f;
+                specializations[4].i = num_output / out_elempack;
+                specializations[5 + 0].i = 0; // cstep
+                specializations[5 + 1].i = 0; // block_x
+                specializations[5 + 2].i = 0; // outw
+                specializations[5 + 3].i = 0; // outcstep
+
+                int shader_type_index = -1;
+                if (out_elempack == 1) shader_type_index = LayerShaderType::convolution1d_3s1d1_winograd43_transform_output;
+                if (out_elempack == 4) shader_type_index = LayerShaderType::convolution1d_packed_3s1d1_winograd43_transform_output;
+
+                pipeline_convolution1d_3s1d1_winograd43_transform_output = new Pipeline(vkdev);
+                pipeline_convolution1d_3s1d1_winograd43_transform_output->set_local_size_xyz(8, 8, 1);
+                pipeline_convolution1d_3s1d1_winograd43_transform_output->create(shader_type_index, opt, specializations);
+            }
+        }
+
+        // === F(2,3) ===
+        if (opt.use_winograd23_convolution)
+        {
+            // 1D weight transform: G (4x3) applied once
+            Mat weight_data_tm;
+            weight_data_tm.create(4, num_input, num_output);
+
+            const float ktm[4][3] = {
+                {1.0f, 0.0f, 0.0f},
+                {1.0f / 2, 1.0f / 2, 1.0f / 2},
+                {1.0f / 2, -1.0f / 2, 1.0f / 2},
+                {0.0f, 0.0f, 1.0f}
+            };
+
+            #pragma omp parallel for num_threads(opt.num_threads)
+            for (int p = 0; p < num_output; p++)
+            {
+                for (int q = 0; q < num_input; q++)
+                {
+                    const float* kernel0 = (const float*)weight_data + p * num_input * 3 + q * 3;
+                    float* kernel_tm0 = weight_data_tm.channel(p).row(q);
+
+                    for (int i = 0; i < 4; i++)
+                    {
+                        kernel_tm0[i] = kernel0[0] * ktm[i][0] + kernel0[1] * ktm[i][1] + kernel0[2] * ktm[i][2];
+                    }
+                }
+            }
+
+            // Weight packing - same pattern as F(4,3) but with 4 instead of 6
+            if (use_cooperative_matrix)
+            {
+                Mat weight_data_tm_r2(num_input, num_output, 4);
+                for (int k = 0; k < 4; k++)
+                {
+                    float* g00 = weight_data_tm_r2.channel(k);
+                    for (int q = 0; q < num_output; q++)
+                    {
+                        for (int p = 0; p < num_input; p++)
+                        {
+                            *g00++ = weight_data_tm[(q * num_input + p) * 4 + k];
+                        }
+                    }
+                }
+
+                const int blocks_n = (num_output + coopmat_N * UNROLL_SG_N * UNROLL_WG_N - 1) / (coopmat_N * UNROLL_SG_N * UNROLL_WG_N);
+                const int kk = (num_input + coopmat_K - 1) / coopmat_K;
+
+                weight_winograd23_data_packed.create(coopmat_N * coopmat_K * UNROLL_SG_N * UNROLL_WG_N * kk, blocks_n, 4);
+                for (int b = 0; b < 4; b++)
+                {
+                    for (int bn = 0; bn < blocks_n; bn++)
+                    {
+                        float* p = weight_winograd23_data_packed.channel(b).row(bn);
+                        int k = 0;
+                        for (; k + UNROLL_SG_K - 1 < kk; k += UNROLL_SG_K)
+                        {
+                            for (int wn = 0; wn < UNROLL_WG_N; wn++)
+                            {
+                                for (int zk = 0; zk < UNROLL_SG_K; zk++)
+                                {
+                                    for (int zn = 0; zn < UNROLL_SG_N; zn++)
+                                    {
+                                        for (int i = 0; i < coopmat_K; i++)
+                                        {
+                                            for (int j = 0; j < coopmat_N; j++)
+                                            {
+                                                const int gni = ((bn * UNROLL_WG_N + wn) * UNROLL_SG_N + zn) * coopmat_N + j;
+                                                const int gki = (k + zk) * coopmat_K + i;
+                                                if (gni < num_output && gki < num_input)
+                                                    *p++ = weight_data_tm_r2.channel(b)[gni * num_input + gki];
+                                                else
+                                                    *p++ = 0.f;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        for (; k < kk; k++)
+                        {
+                            for (int wn = 0; wn < UNROLL_WG_N; wn++)
+                            {
+                                for (int zn = 0; zn < UNROLL_SG_N; zn++)
+                                {
+                                    for (int i = 0; i < coopmat_K; i++)
+                                    {
+                                        for (int j = 0; j < coopmat_N; j++)
+                                        {
+                                            const int gni = ((bn * UNROLL_WG_N + wn) * UNROLL_SG_N + zn) * coopmat_N + j;
+                                            const int gki = k * coopmat_K + i;
+                                            if (gni < num_output && gki < num_input)
+                                                *p++ = weight_data_tm_r2.channel(b)[gni * num_input + gki];
+                                            else
+                                                *p++ = 0.f;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                weight_winograd23_data_packed.create(num_input / elempack, num_output / out_elempack, 4, (size_t)4 * elempack * out_elempack, elempack * out_elempack);
+                for (int k = 0; k < 4; k++)
+                {
+                    float* g00 = weight_winograd23_data_packed.channel(k);
+                    for (int q = 0; q + (out_elempack - 1) < num_output; q += out_elempack)
+                    {
+                        for (int p = 0; p + (elempack - 1) < num_input; p += elempack)
+                        {
+                            for (int i = 0; i < out_elempack; i++)
+                            {
+                                const Mat k0 = weight_data_tm.channel(q + i);
+                                for (int j = 0; j < elempack; j++)
+                                {
+                                    const float* k00 = k0.row(p + j);
+                                    g00[0] = k00[k];
+                                    g00++;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Create F(2,3) pipelines (same pattern as F(4,3) but with 4 instead of 6, and winograd23 shader names)
+            // transform_input
+            {
+                std::vector<vk_specialization_type> specializations(1 + 4);
+                specializations[0].i = num_input / elempack;
+                specializations[1 + 0].i = 0;
+                specializations[1 + 1].i = 0;
+                specializations[1 + 2].i = 0;
+                specializations[1 + 3].i = 0;
+
+                int shader_type_index = -1;
+                if (elempack == 1) shader_type_index = LayerShaderType::convolution1d_3s1d1_winograd23_transform_input;
+                if (elempack == 4) shader_type_index = LayerShaderType::convolution1d_packed_3s1d1_winograd23_transform_input;
+
+                pipeline_convolution1d_3s1d1_winograd23_transform_input = new Pipeline(vkdev);
+                pipeline_convolution1d_3s1d1_winograd23_transform_input->set_local_size_xyz(8, 8, 1);
+                pipeline_convolution1d_3s1d1_winograd23_transform_input->create(shader_type_index, opt, specializations);
+            }
+
+            // gemm
+            if (use_cooperative_matrix)
+            {
+                Mat weight_winograd23_data_packed_fp16 = Mat(weight_winograd23_data_packed.w, weight_winograd23_data_packed.h, weight_winograd23_data_packed.c, (void*)0, 2u, 1);
+
+                std::vector<vk_specialization_type> specializations(15 + 3);
+                specializations[0].u32 = 4; // batch
+                specializations[1].u32 = coopmat_M;
+                specializations[2].u32 = coopmat_N;
+                specializations[3].u32 = coopmat_K;
+                specializations[4].u32 = UNROLL_SG_M;
+                specializations[5].u32 = UNROLL_SG_N;
+                specializations[6].u32 = UNROLL_SG_K;
+                specializations[7].u32 = UNROLL_WG_M;
+                specializations[8].u32 = UNROLL_WG_N;
+                specializations[9].u32 = coopmat_subgroup_size;
+                specializations[10].u32 = num_input;
+                specializations[11].u32 = num_output;
+                specializations[12].u32 = elempack;
+                specializations[13].u32 = out_elempack;
+                specializations[14].u32 = weight_winograd23_data_packed_fp16.cstep;
+                specializations[15 + 0].u32 = 0;
+                specializations[15 + 1].u32 = 0;
+                specializations[15 + 2].u32 = 0;
+
+                pipeline_convolution1d_3s1d1_winograd23_gemm = new Pipeline(vkdev);
+                pipeline_convolution1d_3s1d1_winograd23_gemm->set_subgroup_size(coopmat_subgroup_size);
+                pipeline_convolution1d_3s1d1_winograd23_gemm->set_local_size_xyz(coopmat_subgroup_size * UNROLL_WG_M * UNROLL_WG_N, 1, 1);
+                pipeline_convolution1d_3s1d1_winograd23_gemm->create(LayerShaderType::convolution_winograd_gemm_cm, opt, specializations);
+            }
+            else
+            {
+                std::vector<vk_specialization_type> specializations(3 + 3);
+                specializations[0].i = 4;
+                specializations[1].i = num_input / elempack;
+                specializations[2].i = num_output / out_elempack;
+                specializations[3 + 0].i = 0;
+                specializations[3 + 1].i = 0;
+                specializations[3 + 2].i = 0;
+
+                int shader_type_index = -1;
+                if (elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::convolution_3x3s1d1_winograd_gemm;
+                if (elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::convolution_pack4_3x3s1d1_winograd_gemm;
+                if (elempack == 1 && out_elempack == 4) shader_type_index = LayerShaderType::convolution_pack1to4_3x3s1d1_winograd_gemm;
+                if (elempack == 4 && out_elempack == 1) shader_type_index = LayerShaderType::convolution_pack4to1_3x3s1d1_winograd_gemm;
+
+                pipeline_convolution1d_3s1d1_winograd23_gemm = new Pipeline(vkdev);
+                if (opt.use_shader_local_memory)
+                    pipeline_convolution1d_3s1d1_winograd23_gemm->set_local_size_xyz(8, 8, 1);
+                else
+                    pipeline_convolution1d_3s1d1_winograd23_gemm->set_local_size_xyz(4, std::min(4, num_output / out_elempack), 4);
+                pipeline_convolution1d_3s1d1_winograd23_gemm->create(shader_type_index, opt, specializations);
+            }
+
+            // transform_output
+            {
+                std::vector<vk_specialization_type> specializations(5 + 4);
+                specializations[0].i = bias_term;
+                specializations[1].i = activation_type;
+                specializations[2].f = activation_params.w >= 1 ? activation_params[0] : 0.f;
+                specializations[3].f = activation_params.w == 2 ? activation_params[1] : 0.f;
+                specializations[4].i = num_output / out_elempack;
+                specializations[5 + 0].i = 0;
+                specializations[5 + 1].i = 0;
+                specializations[5 + 2].i = 0;
+                specializations[5 + 3].i = 0;
+
+                int shader_type_index = -1;
+                if (out_elempack == 1) shader_type_index = LayerShaderType::convolution1d_3s1d1_winograd23_transform_output;
+                if (out_elempack == 4) shader_type_index = LayerShaderType::convolution1d_packed_3s1d1_winograd23_transform_output;
+
+                pipeline_convolution1d_3s1d1_winograd23_transform_output = new Pipeline(vkdev);
+                pipeline_convolution1d_3s1d1_winograd23_transform_output->set_local_size_xyz(8, 8, 1);
+                pipeline_convolution1d_3s1d1_winograd23_transform_output->create(shader_type_index, opt, specializations);
+            }
         }
     }
 
@@ -618,6 +1098,20 @@ int Convolution1D_vulkan::destroy_pipeline(const Option& opt)
     delete pipeline_convolution1d_gemm;
     pipeline_convolution1d_gemm = 0;
 
+    delete pipeline_convolution1d_3s1d1_winograd23_transform_input;
+    delete pipeline_convolution1d_3s1d1_winograd23_gemm;
+    delete pipeline_convolution1d_3s1d1_winograd23_transform_output;
+    pipeline_convolution1d_3s1d1_winograd23_transform_input = 0;
+    pipeline_convolution1d_3s1d1_winograd23_gemm = 0;
+    pipeline_convolution1d_3s1d1_winograd23_transform_output = 0;
+
+    delete pipeline_convolution1d_3s1d1_winograd43_transform_input;
+    delete pipeline_convolution1d_3s1d1_winograd43_gemm;
+    delete pipeline_convolution1d_3s1d1_winograd43_transform_output;
+    pipeline_convolution1d_3s1d1_winograd43_transform_input = 0;
+    pipeline_convolution1d_3s1d1_winograd43_gemm = 0;
+    pipeline_convolution1d_3s1d1_winograd43_transform_output = 0;
+
     use_cooperative_matrix = false;
     coopmat_M = 0;
     coopmat_N = 0;
@@ -644,6 +1138,18 @@ int Convolution1D_vulkan::upload_model(VkTransfer& cmd, const Option& opt)
     cmd.record_upload(weight_data_packed, weight_data_gpu, opt);
 
     weight_data_packed.release();
+
+    if (pipeline_convolution1d_3s1d1_winograd43_gemm)
+    {
+        cmd.record_upload(weight_winograd43_data_packed, weight_data_gpu_tm_winograd43, opt);
+        weight_winograd43_data_packed.release();
+    }
+
+    if (pipeline_convolution1d_3s1d1_winograd23_gemm)
+    {
+        cmd.record_upload(weight_winograd23_data_packed, weight_data_gpu_tm_winograd23, opt);
+        weight_winograd23_data_packed.release();
+    }
 
     if (bias_term)
     {
@@ -734,6 +1240,236 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
     size_t out_elemsize = elemsize / elempack * out_elempack;
 
     const int num_input = bottom_blob_bordered.h * elempack;
+
+    bool is_conv3s1d1 = kernel_w == 3 && stride_w == 1 && dilation_w == 1;
+
+    if (opt.use_winograd_convolution && (opt.use_winograd23_convolution || opt.use_winograd43_convolution) && is_conv3s1d1 && num_input >= 16 && num_output >= 16)
+    {
+        bool pre_winograd43 = opt.use_winograd43_convolution;
+        if (opt.use_winograd23_convolution)
+        {
+            if (vkdev->info.type() == 0 && w <= 18)
+                pre_winograd43 = false;
+            if (vkdev->info.type() != 0 && w <= 12)
+                pre_winograd43 = false;
+
+            if (use_cooperative_matrix && w <= 18)
+                pre_winograd43 = false;
+        }
+
+        if (pre_winograd43)
+        {
+            // winograd43
+            int block_x = (outw + 3) / 4;
+
+            // transform input
+            VkMat bottom_tm_blob;
+            {
+                bottom_tm_blob.create(block_x, 1, num_input / elempack * 6, elemsize, elempack, opt.workspace_vkallocator);
+                if (bottom_tm_blob.empty())
+                    return -100;
+
+                std::vector<VkMat> bindings(2);
+                bindings[0] = bottom_blob_bordered;
+                bindings[1] = bottom_tm_blob;
+
+                std::vector<vk_constant_type> constants(4);
+                constants[0].i = bottom_blob_bordered.w;
+                constants[1].i = bottom_blob_bordered.cstep;
+                constants[2].i = bottom_tm_blob.cstep;
+                constants[3].i = block_x;
+
+                VkMat dispatcher;
+                dispatcher.w = block_x;
+                dispatcher.h = 1;
+                dispatcher.c = num_input / elempack;
+
+                cmd.record_pipeline(pipeline_convolution1d_3s1d1_winograd43_transform_input, bindings, constants, dispatcher);
+            }
+
+            // gemm
+            VkMat top_tm_blob;
+            {
+                top_tm_blob.create(block_x, 1, num_output / out_elempack * 6, out_elemsize, out_elempack, opt.workspace_vkallocator);
+                if (top_tm_blob.empty())
+                    return -100;
+
+                if (use_cooperative_matrix)
+                {
+                    std::vector<VkMat> bindings(3);
+                    bindings[0] = bottom_tm_blob;
+                    bindings[1] = top_tm_blob;
+                    bindings[2] = weight_data_gpu_tm_winograd43;
+
+                    std::vector<vk_constant_type> constants(3);
+                    constants[0].i = bottom_tm_blob.w;
+                    constants[1].i = bottom_tm_blob.cstep;
+                    constants[2].i = top_tm_blob.cstep;
+
+                    const int blocks_x = (bottom_tm_blob.w + coopmat_M * UNROLL_SG_M * UNROLL_WG_M - 1) / (coopmat_M * UNROLL_SG_M * UNROLL_WG_M);
+                    const int blocks_y = (num_output + coopmat_N * UNROLL_SG_N * UNROLL_WG_N - 1) / (coopmat_N * UNROLL_SG_N * UNROLL_WG_N);
+
+                    VkMat dispatcher;
+                    dispatcher.w = (blocks_x * blocks_y) * (coopmat_subgroup_size * UNROLL_WG_M * UNROLL_WG_N);
+                    dispatcher.h = 1;
+                    dispatcher.c = 6;
+
+                    cmd.record_pipeline(pipeline_convolution1d_3s1d1_winograd43_gemm, bindings, constants, dispatcher);
+                }
+                else
+                {
+                    std::vector<VkMat> bindings(3);
+                    bindings[0] = bottom_tm_blob;
+                    bindings[1] = top_tm_blob;
+                    bindings[2] = weight_data_gpu_tm_winograd43;
+
+                    std::vector<vk_constant_type> constants(3);
+                    constants[0].i = bottom_tm_blob.cstep;
+                    constants[1].i = top_tm_blob.w;
+                    constants[2].i = top_tm_blob.cstep;
+
+                    VkMat dispatcher;
+                    dispatcher.w = (top_tm_blob.w + 3) / 4;
+                    dispatcher.h = num_output / out_elempack;
+                    dispatcher.c = 6;
+
+                    cmd.record_pipeline(pipeline_convolution1d_3s1d1_winograd43_gemm, bindings, constants, dispatcher);
+                }
+            }
+
+            // transform output
+            {
+                top_blob.create(outw, num_output / out_elempack, out_elemsize, out_elempack, opt.blob_vkallocator);
+                if (top_blob.empty())
+                    return -100;
+
+                std::vector<VkMat> bindings(3);
+                bindings[0] = top_tm_blob;
+                bindings[1] = top_blob;
+                bindings[2] = bias_data_gpu;
+
+                std::vector<vk_constant_type> constants(4);
+                constants[0].i = top_tm_blob.cstep;
+                constants[1].i = block_x;
+                constants[2].i = top_blob.w;
+                constants[3].i = top_blob.cstep;
+
+                VkMat dispatcher;
+                dispatcher.w = block_x;
+                dispatcher.h = 1;
+                dispatcher.c = num_output / out_elempack;
+
+                cmd.record_pipeline(pipeline_convolution1d_3s1d1_winograd43_transform_output, bindings, constants, dispatcher);
+            }
+        }
+        else
+        {
+            // winograd23
+            int block_x = (outw + 1) / 2;
+
+            // transform input
+            VkMat bottom_tm_blob;
+            {
+                bottom_tm_blob.create(block_x, 1, num_input / elempack * 4, elemsize, elempack, opt.workspace_vkallocator);
+                if (bottom_tm_blob.empty())
+                    return -100;
+
+                std::vector<VkMat> bindings(2);
+                bindings[0] = bottom_blob_bordered;
+                bindings[1] = bottom_tm_blob;
+
+                std::vector<vk_constant_type> constants(4);
+                constants[0].i = bottom_blob_bordered.w;
+                constants[1].i = bottom_blob_bordered.cstep;
+                constants[2].i = bottom_tm_blob.cstep;
+                constants[3].i = block_x;
+
+                VkMat dispatcher;
+                dispatcher.w = block_x;
+                dispatcher.h = 1;
+                dispatcher.c = num_input / elempack;
+
+                cmd.record_pipeline(pipeline_convolution1d_3s1d1_winograd23_transform_input, bindings, constants, dispatcher);
+            }
+
+            // gemm
+            VkMat top_tm_blob;
+            {
+                top_tm_blob.create(block_x, 1, num_output / out_elempack * 4, out_elemsize, out_elempack, opt.workspace_vkallocator);
+                if (top_tm_blob.empty())
+                    return -100;
+
+                if (use_cooperative_matrix)
+                {
+                    std::vector<VkMat> bindings(3);
+                    bindings[0] = bottom_tm_blob;
+                    bindings[1] = top_tm_blob;
+                    bindings[2] = weight_data_gpu_tm_winograd23;
+
+                    std::vector<vk_constant_type> constants(3);
+                    constants[0].i = bottom_tm_blob.w;
+                    constants[1].i = bottom_tm_blob.cstep;
+                    constants[2].i = top_tm_blob.cstep;
+
+                    const int blocks_x = (bottom_tm_blob.w + coopmat_M * UNROLL_SG_M * UNROLL_WG_M - 1) / (coopmat_M * UNROLL_SG_M * UNROLL_WG_M);
+                    const int blocks_y = (num_output + coopmat_N * UNROLL_SG_N * UNROLL_WG_N - 1) / (coopmat_N * UNROLL_SG_N * UNROLL_WG_N);
+
+                    VkMat dispatcher;
+                    dispatcher.w = (blocks_x * blocks_y) * (coopmat_subgroup_size * UNROLL_WG_M * UNROLL_WG_N);
+                    dispatcher.h = 1;
+                    dispatcher.c = 4;
+
+                    cmd.record_pipeline(pipeline_convolution1d_3s1d1_winograd23_gemm, bindings, constants, dispatcher);
+                }
+                else
+                {
+                    std::vector<VkMat> bindings(3);
+                    bindings[0] = bottom_tm_blob;
+                    bindings[1] = top_tm_blob;
+                    bindings[2] = weight_data_gpu_tm_winograd23;
+
+                    std::vector<vk_constant_type> constants(3);
+                    constants[0].i = bottom_tm_blob.cstep;
+                    constants[1].i = top_tm_blob.w;
+                    constants[2].i = top_tm_blob.cstep;
+
+                    VkMat dispatcher;
+                    dispatcher.w = (top_tm_blob.w + 3) / 4;
+                    dispatcher.h = num_output / out_elempack;
+                    dispatcher.c = 4;
+
+                    cmd.record_pipeline(pipeline_convolution1d_3s1d1_winograd23_gemm, bindings, constants, dispatcher);
+                }
+            }
+
+            // transform output
+            {
+                top_blob.create(outw, num_output / out_elempack, out_elemsize, out_elempack, opt.blob_vkallocator);
+                if (top_blob.empty())
+                    return -100;
+
+                std::vector<VkMat> bindings(3);
+                bindings[0] = top_tm_blob;
+                bindings[1] = top_blob;
+                bindings[2] = bias_data_gpu;
+
+                std::vector<vk_constant_type> constants(4);
+                constants[0].i = top_tm_blob.cstep;
+                constants[1].i = block_x;
+                constants[2].i = top_blob.w;
+                constants[3].i = top_blob.cstep;
+
+                VkMat dispatcher;
+                dispatcher.w = block_x;
+                dispatcher.h = 1;
+                dispatcher.c = num_output / out_elempack;
+
+                cmd.record_pipeline(pipeline_convolution1d_3s1d1_winograd23_transform_output, bindings, constants, dispatcher);
+            }
+        }
+
+        return 0;
+    }
 
     bool is_conv1x1s1d1 = kernel_w == 1 && stride_w == 1 && dilation_w == 1;
 

--- a/src/layer/vulkan/convolution1d_vulkan.cpp
+++ b/src/layer/vulkan/convolution1d_vulkan.cpp
@@ -38,6 +38,16 @@ Convolution1D_vulkan::Convolution1D_vulkan()
     UNROLL_WG_N = 1;
 
     use_subgroup_ops = false;
+    winograd_use_cooperative_matrix = false;
+    winograd_coopmat_M = 0;
+    winograd_coopmat_N = 0;
+    winograd_coopmat_K = 0;
+    winograd_coopmat_subgroup_size = 0;
+    winograd_UNROLL_SG_M = 1;
+    winograd_UNROLL_SG_N = 1;
+    winograd_UNROLL_SG_K = 1;
+    winograd_UNROLL_WG_M = 1;
+    winograd_UNROLL_WG_N = 1;
 }
 
 int Convolution1D_vulkan::load_param(const ParamDict& pd)
@@ -138,19 +148,19 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
 
     if (opt.use_winograd_convolution && (opt.use_winograd23_convolution || opt.use_winograd43_convolution) && is_conv3s1d1 && num_input >= 16 && num_output >= 16)
     {
-        use_cooperative_matrix = vkdev->info.support_cooperative_matrix() && opt.use_cooperative_matrix && (opt.use_fp16_storage || opt.use_fp16_packed);
+        winograd_use_cooperative_matrix = vkdev->info.support_cooperative_matrix() && opt.use_cooperative_matrix && (opt.use_fp16_storage || opt.use_fp16_packed);
 
-        if (use_cooperative_matrix)
+        if (winograd_use_cooperative_matrix)
         {
             int size = 1024;
-            vkdev->info.get_optimal_cooperative_matrix_mnk(size, num_output, num_input, VK_COMPONENT_TYPE_FLOAT16_KHR, opt.use_fp16_arithmetic ? VK_COMPONENT_TYPE_FLOAT16_KHR : VK_COMPONENT_TYPE_FLOAT32_KHR, VK_SCOPE_SUBGROUP_KHR, coopmat_M, coopmat_N, coopmat_K, coopmat_subgroup_size);
+            vkdev->info.get_optimal_cooperative_matrix_mnk(size, num_output, num_input, VK_COMPONENT_TYPE_FLOAT16_KHR, opt.use_fp16_arithmetic ? VK_COMPONENT_TYPE_FLOAT16_KHR : VK_COMPONENT_TYPE_FLOAT32_KHR, VK_SCOPE_SUBGROUP_KHR, winograd_coopmat_M, winograd_coopmat_N, winograd_coopmat_K, winograd_coopmat_subgroup_size);
 
-            UNROLL_SG_M = std::min((size + coopmat_M - 1) / coopmat_M, 2);
-            UNROLL_SG_N = std::min((num_output + coopmat_N - 1) / coopmat_N, 2);
-            UNROLL_SG_K = std::min((num_input + coopmat_K - 1) / coopmat_K, 2);
+            winograd_UNROLL_SG_M = std::min((size + winograd_coopmat_M - 1) / winograd_coopmat_M, 2);
+            winograd_UNROLL_SG_N = std::min((num_output + winograd_coopmat_N - 1) / winograd_coopmat_N, 2);
+            winograd_UNROLL_SG_K = std::min((num_input + winograd_coopmat_K - 1) / winograd_coopmat_K, 2);
 
-            UNROLL_WG_M = std::min((size + coopmat_M * UNROLL_SG_M - 1) / (coopmat_M * UNROLL_SG_M), 2);
-            UNROLL_WG_N = std::min((num_output + coopmat_N * UNROLL_SG_N - 1) / (coopmat_N * UNROLL_SG_N), 2);
+            winograd_UNROLL_WG_M = std::min((size + winograd_coopmat_M * winograd_UNROLL_SG_M - 1) / (winograd_coopmat_M * winograd_UNROLL_SG_M), 2);
+            winograd_UNROLL_WG_N = std::min((num_output + winograd_coopmat_N * winograd_UNROLL_SG_N - 1) / (winograd_coopmat_N * winograd_UNROLL_SG_N), 2);
         }
 
         // === F(4,3) ===
@@ -186,7 +196,7 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
             }
 
             // Weight packing - follow 2D pattern but with 6 instead of 36
-            if (use_cooperative_matrix)
+            if (winograd_use_cooperative_matrix)
             {
                 // from 6-inch-outch to inch-outch-6
                 Mat weight_data_tm_r2(num_input, num_output, 6);
@@ -202,30 +212,30 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
                     }
                 }
 
-                const int blocks_n = (num_output + coopmat_N * UNROLL_SG_N * UNROLL_WG_N - 1) / (coopmat_N * UNROLL_SG_N * UNROLL_WG_N);
-                const int kk = (num_input + coopmat_K - 1) / coopmat_K;
+                const int blocks_n = (num_output + winograd_coopmat_N * winograd_UNROLL_SG_N * winograd_UNROLL_WG_N - 1) / (winograd_coopmat_N * winograd_UNROLL_SG_N * winograd_UNROLL_WG_N);
+                const int kk = (num_input + winograd_coopmat_K - 1) / winograd_coopmat_K;
 
-                weight_winograd43_data_packed.create(coopmat_N * coopmat_K * UNROLL_SG_N * UNROLL_WG_N * kk, blocks_n, 6);
+                weight_winograd43_data_packed.create(winograd_coopmat_N * winograd_coopmat_K * winograd_UNROLL_SG_N * winograd_UNROLL_WG_N * kk, blocks_n, 6);
                 for (int b = 0; b < 6; b++)
                 {
                     for (int bn = 0; bn < blocks_n; bn++)
                     {
                         float* p = weight_winograd43_data_packed.channel(b).row(bn);
                         int k = 0;
-                        for (; k + UNROLL_SG_K - 1 < kk; k += UNROLL_SG_K)
+                        for (; k + winograd_UNROLL_SG_K - 1 < kk; k += winograd_UNROLL_SG_K)
                         {
-                            for (int wn = 0; wn < UNROLL_WG_N; wn++)
+                            for (int wn = 0; wn < winograd_UNROLL_WG_N; wn++)
                             {
-                                for (int zk = 0; zk < UNROLL_SG_K; zk++)
+                                for (int zk = 0; zk < winograd_UNROLL_SG_K; zk++)
                                 {
-                                    for (int zn = 0; zn < UNROLL_SG_N; zn++)
+                                    for (int zn = 0; zn < winograd_UNROLL_SG_N; zn++)
                                     {
-                                        for (int i = 0; i < coopmat_K; i++)
+                                        for (int i = 0; i < winograd_coopmat_K; i++)
                                         {
-                                            for (int j = 0; j < coopmat_N; j++)
+                                            for (int j = 0; j < winograd_coopmat_N; j++)
                                             {
-                                                const int gni = ((bn * UNROLL_WG_N + wn) * UNROLL_SG_N + zn) * coopmat_N + j;
-                                                const int gki = (k + zk) * coopmat_K + i;
+                                                const int gni = ((bn * winograd_UNROLL_WG_N + wn) * winograd_UNROLL_SG_N + zn) * winograd_coopmat_N + j;
+                                                const int gki = (k + zk) * winograd_coopmat_K + i;
                                                 if (gni < num_output && gki < num_input)
                                                     *p++ = weight_data_tm_r2.channel(b)[gni * num_input + gki];
                                                 else
@@ -238,16 +248,16 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
                         }
                         for (; k < kk; k++)
                         {
-                            for (int wn = 0; wn < UNROLL_WG_N; wn++)
+                            for (int wn = 0; wn < winograd_UNROLL_WG_N; wn++)
                             {
-                                for (int zn = 0; zn < UNROLL_SG_N; zn++)
+                                for (int zn = 0; zn < winograd_UNROLL_SG_N; zn++)
                                 {
-                                    for (int i = 0; i < coopmat_K; i++)
+                                    for (int i = 0; i < winograd_coopmat_K; i++)
                                     {
-                                        for (int j = 0; j < coopmat_N; j++)
+                                        for (int j = 0; j < winograd_coopmat_N; j++)
                                         {
-                                            const int gni = ((bn * UNROLL_WG_N + wn) * UNROLL_SG_N + zn) * coopmat_N + j;
-                                            const int gki = k * coopmat_K + i;
+                                            const int gni = ((bn * winograd_UNROLL_WG_N + wn) * winograd_UNROLL_SG_N + zn) * winograd_coopmat_N + j;
+                                            const int gki = k * winograd_coopmat_K + i;
                                             if (gni < num_output && gki < num_input)
                                                 *p++ = weight_data_tm_r2.channel(b)[gni * num_input + gki];
                                             else
@@ -306,21 +316,21 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
             }
 
             // gemm
-            if (use_cooperative_matrix)
+            if (winograd_use_cooperative_matrix)
             {
                 Mat weight_winograd43_data_packed_fp16 = Mat(weight_winograd43_data_packed.w, weight_winograd43_data_packed.h, weight_winograd43_data_packed.c, (void*)0, 2u, 1);
 
                 std::vector<vk_specialization_type> specializations(15 + 3);
                 specializations[0].u32 = 6; // batch = number of transformed positions
-                specializations[1].u32 = coopmat_M;
-                specializations[2].u32 = coopmat_N;
-                specializations[3].u32 = coopmat_K;
-                specializations[4].u32 = UNROLL_SG_M;
-                specializations[5].u32 = UNROLL_SG_N;
-                specializations[6].u32 = UNROLL_SG_K;
-                specializations[7].u32 = UNROLL_WG_M;
-                specializations[8].u32 = UNROLL_WG_N;
-                specializations[9].u32 = coopmat_subgroup_size;
+                specializations[1].u32 = winograd_coopmat_M;
+                specializations[2].u32 = winograd_coopmat_N;
+                specializations[3].u32 = winograd_coopmat_K;
+                specializations[4].u32 = winograd_UNROLL_SG_M;
+                specializations[5].u32 = winograd_UNROLL_SG_N;
+                specializations[6].u32 = winograd_UNROLL_SG_K;
+                specializations[7].u32 = winograd_UNROLL_WG_M;
+                specializations[8].u32 = winograd_UNROLL_WG_N;
+                specializations[9].u32 = winograd_coopmat_subgroup_size;
                 specializations[10].u32 = num_input;
                 specializations[11].u32 = num_output;
                 specializations[12].u32 = elempack;
@@ -331,8 +341,8 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
                 specializations[15 + 2].u32 = 0; // outcstep
 
                 pipeline_convolution1d_3s1d1_winograd43_gemm = new Pipeline(vkdev);
-                pipeline_convolution1d_3s1d1_winograd43_gemm->set_subgroup_size(coopmat_subgroup_size);
-                pipeline_convolution1d_3s1d1_winograd43_gemm->set_local_size_xyz(coopmat_subgroup_size * UNROLL_WG_M * UNROLL_WG_N, 1, 1);
+                pipeline_convolution1d_3s1d1_winograd43_gemm->set_subgroup_size(winograd_coopmat_subgroup_size);
+                pipeline_convolution1d_3s1d1_winograd43_gemm->set_local_size_xyz(winograd_coopmat_subgroup_size * winograd_UNROLL_WG_M * winograd_UNROLL_WG_N, 1, 1);
                 pipeline_convolution1d_3s1d1_winograd43_gemm->create(LayerShaderType::convolution_winograd_gemm_cm, opt, specializations);
             }
             else
@@ -412,7 +422,7 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
             }
 
             // Weight packing - same pattern as F(4,3) but with 4 instead of 6
-            if (use_cooperative_matrix)
+            if (winograd_use_cooperative_matrix)
             {
                 Mat weight_data_tm_r2(num_input, num_output, 4);
                 for (int k = 0; k < 4; k++)
@@ -427,30 +437,30 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
                     }
                 }
 
-                const int blocks_n = (num_output + coopmat_N * UNROLL_SG_N * UNROLL_WG_N - 1) / (coopmat_N * UNROLL_SG_N * UNROLL_WG_N);
-                const int kk = (num_input + coopmat_K - 1) / coopmat_K;
+                const int blocks_n = (num_output + winograd_coopmat_N * winograd_UNROLL_SG_N * winograd_UNROLL_WG_N - 1) / (winograd_coopmat_N * winograd_UNROLL_SG_N * winograd_UNROLL_WG_N);
+                const int kk = (num_input + winograd_coopmat_K - 1) / winograd_coopmat_K;
 
-                weight_winograd23_data_packed.create(coopmat_N * coopmat_K * UNROLL_SG_N * UNROLL_WG_N * kk, blocks_n, 4);
+                weight_winograd23_data_packed.create(winograd_coopmat_N * winograd_coopmat_K * winograd_UNROLL_SG_N * winograd_UNROLL_WG_N * kk, blocks_n, 4);
                 for (int b = 0; b < 4; b++)
                 {
                     for (int bn = 0; bn < blocks_n; bn++)
                     {
                         float* p = weight_winograd23_data_packed.channel(b).row(bn);
                         int k = 0;
-                        for (; k + UNROLL_SG_K - 1 < kk; k += UNROLL_SG_K)
+                        for (; k + winograd_UNROLL_SG_K - 1 < kk; k += winograd_UNROLL_SG_K)
                         {
-                            for (int wn = 0; wn < UNROLL_WG_N; wn++)
+                            for (int wn = 0; wn < winograd_UNROLL_WG_N; wn++)
                             {
-                                for (int zk = 0; zk < UNROLL_SG_K; zk++)
+                                for (int zk = 0; zk < winograd_UNROLL_SG_K; zk++)
                                 {
-                                    for (int zn = 0; zn < UNROLL_SG_N; zn++)
+                                    for (int zn = 0; zn < winograd_UNROLL_SG_N; zn++)
                                     {
-                                        for (int i = 0; i < coopmat_K; i++)
+                                        for (int i = 0; i < winograd_coopmat_K; i++)
                                         {
-                                            for (int j = 0; j < coopmat_N; j++)
+                                            for (int j = 0; j < winograd_coopmat_N; j++)
                                             {
-                                                const int gni = ((bn * UNROLL_WG_N + wn) * UNROLL_SG_N + zn) * coopmat_N + j;
-                                                const int gki = (k + zk) * coopmat_K + i;
+                                                const int gni = ((bn * winograd_UNROLL_WG_N + wn) * winograd_UNROLL_SG_N + zn) * winograd_coopmat_N + j;
+                                                const int gki = (k + zk) * winograd_coopmat_K + i;
                                                 if (gni < num_output && gki < num_input)
                                                     *p++ = weight_data_tm_r2.channel(b)[gni * num_input + gki];
                                                 else
@@ -463,16 +473,16 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
                         }
                         for (; k < kk; k++)
                         {
-                            for (int wn = 0; wn < UNROLL_WG_N; wn++)
+                            for (int wn = 0; wn < winograd_UNROLL_WG_N; wn++)
                             {
-                                for (int zn = 0; zn < UNROLL_SG_N; zn++)
+                                for (int zn = 0; zn < winograd_UNROLL_SG_N; zn++)
                                 {
-                                    for (int i = 0; i < coopmat_K; i++)
+                                    for (int i = 0; i < winograd_coopmat_K; i++)
                                     {
-                                        for (int j = 0; j < coopmat_N; j++)
+                                        for (int j = 0; j < winograd_coopmat_N; j++)
                                         {
-                                            const int gni = ((bn * UNROLL_WG_N + wn) * UNROLL_SG_N + zn) * coopmat_N + j;
-                                            const int gki = k * coopmat_K + i;
+                                            const int gni = ((bn * winograd_UNROLL_WG_N + wn) * winograd_UNROLL_SG_N + zn) * winograd_coopmat_N + j;
+                                            const int gki = k * winograd_coopmat_K + i;
                                             if (gni < num_output && gki < num_input)
                                                 *p++ = weight_data_tm_r2.channel(b)[gni * num_input + gki];
                                             else
@@ -530,21 +540,21 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
             }
 
             // gemm
-            if (use_cooperative_matrix)
+            if (winograd_use_cooperative_matrix)
             {
                 Mat weight_winograd23_data_packed_fp16 = Mat(weight_winograd23_data_packed.w, weight_winograd23_data_packed.h, weight_winograd23_data_packed.c, (void*)0, 2u, 1);
 
                 std::vector<vk_specialization_type> specializations(15 + 3);
                 specializations[0].u32 = 4; // batch
-                specializations[1].u32 = coopmat_M;
-                specializations[2].u32 = coopmat_N;
-                specializations[3].u32 = coopmat_K;
-                specializations[4].u32 = UNROLL_SG_M;
-                specializations[5].u32 = UNROLL_SG_N;
-                specializations[6].u32 = UNROLL_SG_K;
-                specializations[7].u32 = UNROLL_WG_M;
-                specializations[8].u32 = UNROLL_WG_N;
-                specializations[9].u32 = coopmat_subgroup_size;
+                specializations[1].u32 = winograd_coopmat_M;
+                specializations[2].u32 = winograd_coopmat_N;
+                specializations[3].u32 = winograd_coopmat_K;
+                specializations[4].u32 = winograd_UNROLL_SG_M;
+                specializations[5].u32 = winograd_UNROLL_SG_N;
+                specializations[6].u32 = winograd_UNROLL_SG_K;
+                specializations[7].u32 = winograd_UNROLL_WG_M;
+                specializations[8].u32 = winograd_UNROLL_WG_N;
+                specializations[9].u32 = winograd_coopmat_subgroup_size;
                 specializations[10].u32 = num_input;
                 specializations[11].u32 = num_output;
                 specializations[12].u32 = elempack;
@@ -555,8 +565,8 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
                 specializations[15 + 2].u32 = 0;
 
                 pipeline_convolution1d_3s1d1_winograd23_gemm = new Pipeline(vkdev);
-                pipeline_convolution1d_3s1d1_winograd23_gemm->set_subgroup_size(coopmat_subgroup_size);
-                pipeline_convolution1d_3s1d1_winograd23_gemm->set_local_size_xyz(coopmat_subgroup_size * UNROLL_WG_M * UNROLL_WG_N, 1, 1);
+                pipeline_convolution1d_3s1d1_winograd23_gemm->set_subgroup_size(winograd_coopmat_subgroup_size);
+                pipeline_convolution1d_3s1d1_winograd23_gemm->set_local_size_xyz(winograd_coopmat_subgroup_size * winograd_UNROLL_WG_M * winograd_UNROLL_WG_N, 1, 1);
                 pipeline_convolution1d_3s1d1_winograd23_gemm->create(LayerShaderType::convolution_winograd_gemm_cm, opt, specializations);
             }
             else
@@ -1253,7 +1263,7 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
             if (vkdev->info.type() != 0 && w <= 12)
                 pre_winograd43 = false;
 
-            if (use_cooperative_matrix && w <= 18)
+            if (winograd_use_cooperative_matrix && w <= 18)
                 pre_winograd43 = false;
         }
 
@@ -1294,7 +1304,7 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
                 if (top_tm_blob.empty())
                     return -100;
 
-                if (use_cooperative_matrix)
+                if (winograd_use_cooperative_matrix)
                 {
                     std::vector<VkMat> bindings(3);
                     bindings[0] = bottom_tm_blob;
@@ -1306,11 +1316,11 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
                     constants[1].i = bottom_tm_blob.cstep;
                     constants[2].i = top_tm_blob.cstep;
 
-                    const int blocks_x = (bottom_tm_blob.w + coopmat_M * UNROLL_SG_M * UNROLL_WG_M - 1) / (coopmat_M * UNROLL_SG_M * UNROLL_WG_M);
-                    const int blocks_y = (num_output + coopmat_N * UNROLL_SG_N * UNROLL_WG_N - 1) / (coopmat_N * UNROLL_SG_N * UNROLL_WG_N);
+                    const int blocks_x = (bottom_tm_blob.w + winograd_coopmat_M * winograd_UNROLL_SG_M * winograd_UNROLL_WG_M - 1) / (winograd_coopmat_M * winograd_UNROLL_SG_M * winograd_UNROLL_WG_M);
+                    const int blocks_y = (num_output + winograd_coopmat_N * winograd_UNROLL_SG_N * winograd_UNROLL_WG_N - 1) / (winograd_coopmat_N * winograd_UNROLL_SG_N * winograd_UNROLL_WG_N);
 
                     VkMat dispatcher;
-                    dispatcher.w = (blocks_x * blocks_y) * (coopmat_subgroup_size * UNROLL_WG_M * UNROLL_WG_N);
+                    dispatcher.w = (blocks_x * blocks_y) * (winograd_coopmat_subgroup_size * winograd_UNROLL_WG_M * winograd_UNROLL_WG_N);
                     dispatcher.h = 1;
                     dispatcher.c = 6;
 
@@ -1399,7 +1409,7 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
                 if (top_tm_blob.empty())
                     return -100;
 
-                if (use_cooperative_matrix)
+                if (winograd_use_cooperative_matrix)
                 {
                     std::vector<VkMat> bindings(3);
                     bindings[0] = bottom_tm_blob;
@@ -1411,11 +1421,11 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
                     constants[1].i = bottom_tm_blob.cstep;
                     constants[2].i = top_tm_blob.cstep;
 
-                    const int blocks_x = (bottom_tm_blob.w + coopmat_M * UNROLL_SG_M * UNROLL_WG_M - 1) / (coopmat_M * UNROLL_SG_M * UNROLL_WG_M);
-                    const int blocks_y = (num_output + coopmat_N * UNROLL_SG_N * UNROLL_WG_N - 1) / (coopmat_N * UNROLL_SG_N * UNROLL_WG_N);
+                    const int blocks_x = (bottom_tm_blob.w + winograd_coopmat_M * winograd_UNROLL_SG_M * winograd_UNROLL_WG_M - 1) / (winograd_coopmat_M * winograd_UNROLL_SG_M * winograd_UNROLL_WG_M);
+                    const int blocks_y = (num_output + winograd_coopmat_N * winograd_UNROLL_SG_N * winograd_UNROLL_WG_N - 1) / (winograd_coopmat_N * winograd_UNROLL_SG_N * winograd_UNROLL_WG_N);
 
                     VkMat dispatcher;
-                    dispatcher.w = (blocks_x * blocks_y) * (coopmat_subgroup_size * UNROLL_WG_M * UNROLL_WG_N);
+                    dispatcher.w = (blocks_x * blocks_y) * (winograd_coopmat_subgroup_size * winograd_UNROLL_WG_M * winograd_UNROLL_WG_N);
                     dispatcher.h = 1;
                     dispatcher.c = 4;
 

--- a/src/layer/vulkan/convolution1d_vulkan.cpp
+++ b/src/layer/vulkan/convolution1d_vulkan.cpp
@@ -1275,7 +1275,7 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
 
                 std::vector<vk_constant_type> constants(4);
                 constants[0].i = bottom_blob_bordered.w;
-                constants[1].i = bottom_blob_bordered.cstep;
+                constants[1].i = bottom_blob_bordered.w;
                 constants[2].i = bottom_tm_blob.cstep;
                 constants[3].i = block_x;
 
@@ -1352,7 +1352,7 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
                 constants[0].i = top_tm_blob.cstep;
                 constants[1].i = block_x;
                 constants[2].i = top_blob.w;
-                constants[3].i = top_blob.cstep;
+                constants[3].i = top_blob.w;
 
                 VkMat dispatcher;
                 dispatcher.w = block_x;
@@ -1380,7 +1380,7 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
 
                 std::vector<vk_constant_type> constants(4);
                 constants[0].i = bottom_blob_bordered.w;
-                constants[1].i = bottom_blob_bordered.cstep;
+                constants[1].i = bottom_blob_bordered.w;
                 constants[2].i = bottom_tm_blob.cstep;
                 constants[3].i = block_x;
 
@@ -1457,7 +1457,7 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
                 constants[0].i = top_tm_blob.cstep;
                 constants[1].i = block_x;
                 constants[2].i = top_blob.w;
-                constants[3].i = top_blob.cstep;
+                constants[3].i = top_blob.w;
 
                 VkMat dispatcher;
                 dispatcher.w = block_x;

--- a/src/layer/vulkan/convolution1d_vulkan.cpp
+++ b/src/layer/vulkan/convolution1d_vulkan.cpp
@@ -301,7 +301,7 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
                 if (elempack == 4) shader_type_index = LayerShaderType::convolution1d_packed_3s1d1_winograd43_transform_input;
 
                 pipeline_convolution1d_3s1d1_winograd43_transform_input = new Pipeline(vkdev);
-                pipeline_convolution1d_3s1d1_winograd43_transform_input->set_local_size_xyz(8, 8, 1);
+                pipeline_convolution1d_3s1d1_winograd43_transform_input->set_local_size_xyz(8, 1, 8);
                 pipeline_convolution1d_3s1d1_winograd43_transform_input->create(shader_type_index, opt, specializations);
             }
 
@@ -346,10 +346,10 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
                 specializations[3 + 2].i = 0; // outcstep
 
                 int shader_type_index = -1;
-                if (elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::convolution_3x3s1d1_winograd_gemm;
-                if (elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::convolution_pack4_3x3s1d1_winograd_gemm;
-                if (elempack == 1 && out_elempack == 4) shader_type_index = LayerShaderType::convolution_pack1to4_3x3s1d1_winograd_gemm;
-                if (elempack == 4 && out_elempack == 1) shader_type_index = LayerShaderType::convolution_pack4to1_3x3s1d1_winograd_gemm;
+                if (elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::convolution1d_3s1d1_winograd_gemm;
+                if (elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::convolution1d_pack4_3s1d1_winograd_gemm;
+                if (elempack == 1 && out_elempack == 4) shader_type_index = LayerShaderType::convolution1d_pack1to4_3s1d1_winograd_gemm;
+                if (elempack == 4 && out_elempack == 1) shader_type_index = LayerShaderType::convolution1d_pack4to1_3s1d1_winograd_gemm;
 
                 pipeline_convolution1d_3s1d1_winograd43_gemm = new Pipeline(vkdev);
                 if (opt.use_shader_local_memory)
@@ -377,7 +377,7 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
                 if (out_elempack == 4) shader_type_index = LayerShaderType::convolution1d_packed_3s1d1_winograd43_transform_output;
 
                 pipeline_convolution1d_3s1d1_winograd43_transform_output = new Pipeline(vkdev);
-                pipeline_convolution1d_3s1d1_winograd43_transform_output->set_local_size_xyz(8, 8, 1);
+                pipeline_convolution1d_3s1d1_winograd43_transform_output->set_local_size_xyz(8, 1, 8);
                 pipeline_convolution1d_3s1d1_winograd43_transform_output->create(shader_type_index, opt, specializations);
             }
         }
@@ -525,7 +525,7 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
                 if (elempack == 4) shader_type_index = LayerShaderType::convolution1d_packed_3s1d1_winograd23_transform_input;
 
                 pipeline_convolution1d_3s1d1_winograd23_transform_input = new Pipeline(vkdev);
-                pipeline_convolution1d_3s1d1_winograd23_transform_input->set_local_size_xyz(8, 8, 1);
+                pipeline_convolution1d_3s1d1_winograd23_transform_input->set_local_size_xyz(8, 1, 8);
                 pipeline_convolution1d_3s1d1_winograd23_transform_input->create(shader_type_index, opt, specializations);
             }
 
@@ -570,10 +570,10 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
                 specializations[3 + 2].i = 0;
 
                 int shader_type_index = -1;
-                if (elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::convolution_3x3s1d1_winograd_gemm;
-                if (elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::convolution_pack4_3x3s1d1_winograd_gemm;
-                if (elempack == 1 && out_elempack == 4) shader_type_index = LayerShaderType::convolution_pack1to4_3x3s1d1_winograd_gemm;
-                if (elempack == 4 && out_elempack == 1) shader_type_index = LayerShaderType::convolution_pack4to1_3x3s1d1_winograd_gemm;
+                if (elempack == 1 && out_elempack == 1) shader_type_index = LayerShaderType::convolution1d_3s1d1_winograd_gemm;
+                if (elempack == 4 && out_elempack == 4) shader_type_index = LayerShaderType::convolution1d_pack4_3s1d1_winograd_gemm;
+                if (elempack == 1 && out_elempack == 4) shader_type_index = LayerShaderType::convolution1d_pack1to4_3s1d1_winograd_gemm;
+                if (elempack == 4 && out_elempack == 1) shader_type_index = LayerShaderType::convolution1d_pack4to1_3s1d1_winograd_gemm;
 
                 pipeline_convolution1d_3s1d1_winograd23_gemm = new Pipeline(vkdev);
                 if (opt.use_shader_local_memory)
@@ -601,7 +601,7 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
                 if (out_elempack == 4) shader_type_index = LayerShaderType::convolution1d_packed_3s1d1_winograd23_transform_output;
 
                 pipeline_convolution1d_3s1d1_winograd23_transform_output = new Pipeline(vkdev);
-                pipeline_convolution1d_3s1d1_winograd23_transform_output->set_local_size_xyz(8, 8, 1);
+                pipeline_convolution1d_3s1d1_winograd23_transform_output->set_local_size_xyz(8, 1, 8);
                 pipeline_convolution1d_3s1d1_winograd23_transform_output->create(shader_type_index, opt, specializations);
             }
         }

--- a/src/layer/vulkan/convolution1d_vulkan.cpp
+++ b/src/layer/vulkan/convolution1d_vulkan.cpp
@@ -1337,7 +1337,7 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
                     constants[0].i = bottom_tm_blob.cstep;
                     constants[1].i = top_tm_blob.w;
                     constants[2].i = top_tm_blob.cstep;
-                    constants[3].i = weight_data_gpu_tm_winograd43.cstep;
+                    constants[3].i = (num_input / elempack) * (num_output / out_elempack);
 
                     VkMat dispatcher;
                     dispatcher.w = (top_tm_blob.w + 3) / 4;
@@ -1443,7 +1443,7 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
                     constants[0].i = bottom_tm_blob.cstep;
                     constants[1].i = top_tm_blob.w;
                     constants[2].i = top_tm_blob.cstep;
-                    constants[3].i = weight_data_gpu_tm_winograd23.cstep;
+                    constants[3].i = (num_input / elempack) * (num_output / out_elempack);
 
                     VkMat dispatcher;
                     dispatcher.w = (top_tm_blob.w + 3) / 4;

--- a/src/layer/vulkan/convolution1d_vulkan.cpp
+++ b/src/layer/vulkan/convolution1d_vulkan.cpp
@@ -29,6 +29,8 @@ Convolution1D_vulkan::Convolution1D_vulkan()
     UNROLL_SG_K = 1;
     UNROLL_WG_M = 1;
     UNROLL_WG_N = 1;
+
+    use_subgroup_ops = false;
 }
 
 int Convolution1D_vulkan::load_param(const ParamDict& pd)
@@ -68,6 +70,61 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
         padding->load_param(pd);
 
         padding->create_pipeline(opt);
+    }
+
+    const int subgroup_size = vkdev->info.subgroup_size();
+    const uint32_t support_subgroup_ops = vkdev->info.support_subgroup_ops();
+    const uint32_t required_subgroup_ops = VK_SUBGROUP_FEATURE_BASIC_BIT | VK_SUBGROUP_FEATURE_SHUFFLE_BIT;
+    use_subgroup_ops = opt.use_subgroup_ops && ((support_subgroup_ops & required_subgroup_ops) == required_subgroup_ops);
+    if (subgroup_size < 4 || subgroup_size > 128)
+    {
+        // sanitize wired subgroup_size
+        use_subgroup_ops = false;
+    }
+    if (opt.use_fp16_arithmetic && !opt.use_bf16_storage && !opt.use_bf16_packed && !vkdev->info.queryShaderSubgroupExtendedTypesFeatures().shaderSubgroupExtendedTypes)
+    {
+        // sg shaders shuffle fp16 vectors, which requires subgroup extended types
+        use_subgroup_ops = false;
+    }
+
+    if (use_subgroup_ops)
+    {
+        if (subgroup_size == 128)
+        {
+            UNROLL_SG_M = 16;
+            UNROLL_SG_N = 8;
+            UNROLL_SG_K = 8;
+        }
+        if (subgroup_size == 64)
+        {
+            UNROLL_SG_M = 8;
+            UNROLL_SG_N = 8;
+            UNROLL_SG_K = 8;
+        }
+        if (subgroup_size == 32)
+        {
+            UNROLL_SG_M = 8;
+            UNROLL_SG_N = 4;
+            UNROLL_SG_K = 4;
+        }
+        if (subgroup_size == 16)
+        {
+            UNROLL_SG_M = 4;
+            UNROLL_SG_N = 4;
+            UNROLL_SG_K = 4;
+        }
+        if (subgroup_size == 8)
+        {
+            UNROLL_SG_M = 4;
+            UNROLL_SG_N = 2;
+            UNROLL_SG_K = 2;
+        }
+        if (subgroup_size == 4)
+        {
+            UNROLL_SG_M = 2;
+            UNROLL_SG_N = 2;
+            UNROLL_SG_K = 2;
+        }
     }
 
     bool is_conv1x1s1d1 = kernel_w == 1 && stride_w == 1 && dilation_w == 1;
@@ -484,25 +541,55 @@ int Convolution1D_vulkan::create_pipeline(const Option& _opt)
             }
         }
 
-        std::vector<vk_specialization_type> specializations(9 + 5);
-        specializations[0].i = kernel_w;
-        specializations[1].i = dilation_w;
-        specializations[2].i = stride_w;
-        specializations[3].i = bias_term;
-        specializations[4].i = activation_type;
-        specializations[5].f = activation_params.w >= 1 ? activation_params[0] : 0.f;
-        specializations[6].f = activation_params.w == 2 ? activation_params[1] : 0.f;
-        specializations[7].i = elempack;
-        specializations[8].i = out_elempack;
-        specializations[9 + 0].i = 0;
-        specializations[9 + 1].i = 0;
-        specializations[9 + 2].i = 0;
-        specializations[9 + 3].i = 0;
-        specializations[9 + 4].i = num_output;
+        if (use_subgroup_ops && opt.use_fp16_arithmetic)
+        {
+            std::vector<vk_specialization_type> specializations(9 + 5 + 4);
+            specializations[0].i = kernel_w;
+            specializations[1].i = dilation_w;
+            specializations[2].i = stride_w;
+            specializations[3].i = bias_term;
+            specializations[4].i = activation_type;
+            specializations[5].f = activation_params.w >= 1 ? activation_params[0] : 0.f;
+            specializations[6].f = activation_params.w == 2 ? activation_params[1] : 0.f;
+            specializations[7].i = elempack;
+            specializations[8].i = out_elempack;
+            specializations[9 + 0].i = 0;
+            specializations[9 + 1].i = 0;
+            specializations[9 + 2].i = 0;
+            specializations[9 + 3].i = 0;
+            specializations[9 + 4].i = num_output;
+            specializations[14].i = 0;
+            specializations[15].u32 = UNROLL_SG_M;
+            specializations[16].u32 = UNROLL_SG_N;
+            specializations[17].u32 = UNROLL_SG_K;
 
-        pipeline_convolution1d = new Pipeline(vkdev);
-        pipeline_convolution1d->set_optimal_local_size_xyz(1, 1, 1);
-        pipeline_convolution1d->create(LayerShaderType::convolution1d_packed, opt, specializations);
+            pipeline_convolution1d = new Pipeline(vkdev);
+            pipeline_convolution1d->set_subgroup_size(subgroup_size);
+            pipeline_convolution1d->set_local_size_xyz(subgroup_size, 1, 1);
+            pipeline_convolution1d->create(LayerShaderType::convolution1d_packed_sg, opt, specializations);
+        }
+        else
+        {
+            std::vector<vk_specialization_type> specializations(9 + 5);
+            specializations[0].i = kernel_w;
+            specializations[1].i = dilation_w;
+            specializations[2].i = stride_w;
+            specializations[3].i = bias_term;
+            specializations[4].i = activation_type;
+            specializations[5].f = activation_params.w >= 1 ? activation_params[0] : 0.f;
+            specializations[6].f = activation_params.w == 2 ? activation_params[1] : 0.f;
+            specializations[7].i = elempack;
+            specializations[8].i = out_elempack;
+            specializations[9 + 0].i = 0;
+            specializations[9 + 1].i = 0;
+            specializations[9 + 2].i = 0;
+            specializations[9 + 3].i = 0;
+            specializations[9 + 4].i = num_output;
+
+            pipeline_convolution1d = new Pipeline(vkdev);
+            pipeline_convolution1d->set_optimal_local_size_xyz(1, 1, 1);
+            pipeline_convolution1d->create(LayerShaderType::convolution1d_packed, opt, specializations);
+        }
     }
 
     if (opt.lightmode)
@@ -541,6 +628,8 @@ int Convolution1D_vulkan::destroy_pipeline(const Option& opt)
     UNROLL_SG_K = 1;
     UNROLL_WG_M = 1;
     UNROLL_WG_N = 1;
+
+    use_subgroup_ops = false;
 
     return 0;
 }
@@ -644,10 +733,11 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
 
     size_t out_elemsize = elemsize / elempack * out_elempack;
 
-    const int maxk = kernel_w;
     const int num_input = bottom_blob_bordered.h * elempack;
 
     bool is_conv1x1s1d1 = kernel_w == 1 && stride_w == 1 && dilation_w == 1;
+
+    const int maxk = kernel_w;
 
     bool use_gemm = opt.use_sgemm_convolution
                     && !is_conv1x1s1d1
@@ -819,9 +909,21 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
     constants[4].i = num_output;
 
     VkMat dispatcher;
-    dispatcher.w = (top_blob.w + 1) / 2;
-    dispatcher.h = (outh_pack4 + 1) / 2;
-    dispatcher.c = 1;
+    if (use_subgroup_ops && opt.use_fp16_arithmetic)
+    {
+        const int blocks_x = (top_blob.w + UNROLL_SG_M * 4 - 1) / (UNROLL_SG_M * 4);
+        const int blocks_y = (outh_pack4 + UNROLL_SG_N - 1) / UNROLL_SG_N;
+
+        dispatcher.w = (blocks_x * blocks_y) * vkdev->info.subgroup_size();
+        dispatcher.h = 1;
+        dispatcher.c = 1;
+    }
+    else
+    {
+        dispatcher.w = (top_blob.w + 1) / 2;
+        dispatcher.h = (outh_pack4 + 1) / 2;
+        dispatcher.c = 1;
+    }
 
     cmd.record_pipeline(pipeline_convolution1d, bindings, constants, dispatcher);
 

--- a/src/layer/vulkan/convolution1d_vulkan.cpp
+++ b/src/layer/vulkan/convolution1d_vulkan.cpp
@@ -1333,10 +1333,11 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
                     bindings[1] = top_tm_blob;
                     bindings[2] = weight_data_gpu_tm_winograd43;
 
-                    std::vector<vk_constant_type> constants(3);
+                    std::vector<vk_constant_type> constants(4);
                     constants[0].i = bottom_tm_blob.cstep;
                     constants[1].i = top_tm_blob.w;
                     constants[2].i = top_tm_blob.cstep;
+                    constants[3].i = weight_data_gpu_tm_winograd43.cstep;
 
                     VkMat dispatcher;
                     dispatcher.w = (top_tm_blob.w + 3) / 4;
@@ -1438,10 +1439,11 @@ int Convolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkC
                     bindings[1] = top_tm_blob;
                     bindings[2] = weight_data_gpu_tm_winograd23;
 
-                    std::vector<vk_constant_type> constants(3);
+                    std::vector<vk_constant_type> constants(4);
                     constants[0].i = bottom_tm_blob.cstep;
                     constants[1].i = top_tm_blob.w;
                     constants[2].i = top_tm_blob.cstep;
+                    constants[3].i = weight_data_gpu_tm_winograd23.cstep;
 
                     VkMat dispatcher;
                     dispatcher.w = (top_tm_blob.w + 3) / 4;

--- a/src/layer/vulkan/convolution1d_vulkan.h
+++ b/src/layer/vulkan/convolution1d_vulkan.h
@@ -62,6 +62,17 @@ public:
 
     // subgroup ops (shuffle), UNROLL_SG_M/N/K shared with cooperative matrix
     bool use_subgroup_ops;
+    // winograd cooperative matrix (separate from generic gemm, see review fix)
+    bool winograd_use_cooperative_matrix;
+    int winograd_coopmat_M;
+    int winograd_coopmat_N;
+    int winograd_coopmat_K;
+    int winograd_coopmat_subgroup_size;
+    int winograd_UNROLL_SG_M;
+    int winograd_UNROLL_SG_N;
+    int winograd_UNROLL_SG_K;
+    int winograd_UNROLL_WG_M;
+    int winograd_UNROLL_WG_N;
 };
 
 } // namespace ncnn

--- a/src/layer/vulkan/convolution1d_vulkan.h
+++ b/src/layer/vulkan/convolution1d_vulkan.h
@@ -46,6 +46,9 @@ public:
     int UNROLL_SG_K;
     int UNROLL_WG_M;
     int UNROLL_WG_N;
+
+    // subgroup ops (shuffle), UNROLL_SG_M/N/K shared with cooperative matrix
+    bool use_subgroup_ops;
 };
 
 } // namespace ncnn

--- a/src/layer/vulkan/convolution1d_vulkan.h
+++ b/src/layer/vulkan/convolution1d_vulkan.h
@@ -27,13 +27,26 @@ public:
     ncnn::Layer* padding;
 
     Mat weight_data_packed;
+    Mat weight_winograd23_data_packed;
+    Mat weight_winograd43_data_packed;
 
     VkMat weight_data_gpu;
     VkMat bias_data_gpu;
+    VkMat weight_data_gpu_tm_winograd23;
+    VkMat weight_data_gpu_tm_winograd43;
 
     Pipeline* pipeline_convolution1d;
     Pipeline* pipeline_convolution1d_1x1s1d1;
     Pipeline* pipeline_convolution1d_gemm;
+
+    // winograd23 and winograd43
+    Pipeline* pipeline_convolution1d_3s1d1_winograd23_transform_input;
+    Pipeline* pipeline_convolution1d_3s1d1_winograd23_gemm;
+    Pipeline* pipeline_convolution1d_3s1d1_winograd23_transform_output;
+
+    Pipeline* pipeline_convolution1d_3s1d1_winograd43_transform_input;
+    Pipeline* pipeline_convolution1d_3s1d1_winograd43_gemm;
+    Pipeline* pipeline_convolution1d_3s1d1_winograd43_transform_output;
 
     // cooperative matrix
     bool use_cooperative_matrix;

--- a/src/layer/vulkan/convolutiondepthwise1d_vulkan.cpp
+++ b/src/layer/vulkan/convolutiondepthwise1d_vulkan.cpp
@@ -1,0 +1,532 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "convolutiondepthwise1d_vulkan.h"
+
+#include "layer_shader_type.h"
+#include "layer_type.h"
+
+namespace ncnn {
+
+ConvolutionDepthWise1D_vulkan::ConvolutionDepthWise1D_vulkan()
+{
+    support_vulkan = true;
+    support_vulkan_packing = true;
+
+    padding = 0;
+
+    pipeline_convolutiondepthwise1d = 0;
+    pipeline_convolutiondepthwise1d_pack4 = 0;
+
+    pipeline_convolutiondepthwise1d_group = 0;
+    pipeline_convolutiondepthwise1d_group_pack4 = 0;
+    pipeline_convolutiondepthwise1d_group_pack1to4 = 0;
+    pipeline_convolutiondepthwise1d_group_pack4to1 = 0;
+}
+
+int ConvolutionDepthWise1D_vulkan::load_param(const ParamDict& pd)
+{
+    int ret = ConvolutionDepthWise1D::load_param(pd);
+
+    if (dynamic_weight)
+    {
+        support_vulkan = false;
+    }
+
+    return ret;
+}
+
+int ConvolutionDepthWise1D_vulkan::create_pipeline(const Option& _opt)
+{
+    Option opt = _opt;
+
+    const Mat& shape = bottom_shapes.empty() ? Mat() : bottom_shapes[0];
+    const Mat& out_shape = top_shapes.empty() ? Mat() : top_shapes[0];
+
+    // the shape after padding
+    Mat shape_bordered;
+    if (shape.dims != 0)
+    {
+        const int kernel_extent_w = dilation_w * (kernel_w - 1) + 1;
+
+        if (pad_left > 0 || pad_right > 0)
+        {
+            shape_bordered = Mat(shape.w + pad_left + pad_right, shape.h, (void*)0, shape.elemsize, shape.elempack);
+        }
+        else if ((pad_left == -233 && pad_right == -233) || (pad_left == -234 && pad_right == -234))
+        {
+            int wpad = kernel_extent_w + (shape.w - 1) / stride_w * stride_w - shape.w;
+            if (wpad > 0)
+            {
+                shape_bordered = Mat(shape.w + wpad, shape.h, (void*)0, shape.elemsize, shape.elempack);
+            }
+        }
+        else
+        {
+            shape_bordered = shape;
+        }
+    }
+
+    const int maxk = kernel_w;
+    int channels = (weight_data_size / group) / maxk / (num_output / group) * group;
+
+    int elempack = channels % 4 == 0 ? 4 : 1;
+    int out_elempack = num_output % 4 == 0 ? 4 : 1;
+
+    // group convolution
+    const int channels_g = channels / group;
+    const int num_output_g = num_output / group;
+
+    int elempack_g = channels_g % 4 == 0 ? 4 : 1;
+    int out_elempack_g = num_output_g % 4 == 0 ? 4 : 1;
+
+    size_t elemsize_g;
+    size_t out_elemsize_g;
+    if (opt.use_fp16_storage || opt.use_fp16_packed || opt.use_bf16_storage || opt.use_bf16_packed)
+    {
+        elemsize_g = elempack_g * 2u;
+        out_elemsize_g = out_elempack_g * 2u;
+    }
+    else
+    {
+        elemsize_g = elempack_g * 4u;
+        out_elemsize_g = out_elempack_g * 4u;
+    }
+
+    Mat shape_bordered_g;
+    if (shape_bordered.dims == 2) shape_bordered_g = Mat(shape_bordered.w, shape_bordered.h * elempack / elempack_g, (void*)0, elemsize_g, elempack_g);
+
+    Mat out_shape_g;
+    if (out_shape.dims == 2) out_shape_g = Mat(out_shape.w, out_shape.h * out_elempack / out_elempack_g, (void*)0, out_elemsize_g, out_elempack_g);
+
+    {
+        padding = ncnn::create_layer_vulkan(ncnn::LayerType::Padding);
+        padding->vkdev = vkdev;
+
+        padding->bottom_shapes.resize(1);
+        padding->bottom_shapes[0] = shape;
+        padding->top_shapes.resize(1);
+        padding->top_shapes[0] = shape_bordered;
+
+        ncnn::ParamDict pd;
+        pd.set(0, 0);
+        pd.set(1, 0);
+        pd.set(2, pad_left);
+        pd.set(3, pad_right);
+        pd.set(4, 0);
+        pd.set(5, pad_value);
+
+        padding->load_param(pd);
+
+        padding->create_pipeline(opt);
+    }
+
+    std::vector<vk_specialization_type> specializations(8 + 10);
+    specializations[0].i = kernel_w;
+    specializations[1].i = dilation_w;
+    specializations[2].i = stride_w;
+    specializations[3].i = bias_term;
+    specializations[4].i = group;
+    specializations[5].i = activation_type;
+    specializations[6].f = activation_params.w >= 1 ? activation_params[0] : 0.f;
+    specializations[7].f = activation_params.w == 2 ? activation_params[1] : 0.f;
+
+    // depth-wise
+    if (channels == group && group == num_output)
+    {
+        Mat weight_data_r2 = weight_data.reshape(maxk, group);
+        convert_packing(weight_data_r2, weight_data_packed, elempack, opt);
+
+        specializations[8 + 0].i = shape_bordered.dims;
+        specializations[8 + 1].i = shape_bordered.w;
+        specializations[8 + 2].i = shape_bordered.h;
+        specializations[8 + 3].i = shape_bordered.c;
+        specializations[8 + 4].i = shape_bordered.cstep;
+        specializations[8 + 5].i = out_shape.dims;
+        specializations[8 + 6].i = out_shape.w;
+        specializations[8 + 7].i = out_shape.h;
+        specializations[8 + 8].i = out_shape.c;
+        specializations[8 + 9].i = out_shape.cstep;
+
+        Mat local_size_xyz(8, 8, 1, (void*)0);
+        if (out_shape.dims != 0)
+        {
+            local_size_xyz.w = std::min(8, out_shape.w);
+            local_size_xyz.h = std::min(8, out_shape.h);
+            local_size_xyz.c = 1;
+        }
+
+        // pack1
+        if (elempack == 1)
+        {
+            pipeline_convolutiondepthwise1d = new Pipeline(vkdev);
+            pipeline_convolutiondepthwise1d->set_optimal_local_size_xyz(local_size_xyz);
+            pipeline_convolutiondepthwise1d->create(LayerShaderType::convolutiondepthwise1d, opt, specializations);
+        }
+
+        // pack4
+        if (elempack == 4)
+        {
+            pipeline_convolutiondepthwise1d_pack4 = new Pipeline(vkdev);
+            pipeline_convolutiondepthwise1d_pack4->set_optimal_local_size_xyz(local_size_xyz);
+            pipeline_convolutiondepthwise1d_pack4->create(LayerShaderType::convolutiondepthwise1d_pack4, opt, specializations);
+        }
+
+        if (opt.lightmode)
+        {
+            weight_data.release();
+        }
+
+        return 0;
+    }
+
+    // src = kw-inch/pa-outch/pb
+    // dst = pa-pb-kw-inch/pa-outch/pb
+    {
+        Mat weight_data_r2_groups = weight_data.reshape(maxk, channels_g, num_output_g * group);
+
+        weight_data_packed_groups.create(maxk, channels_g / elempack_g, num_output_g / out_elempack_g * group, (size_t)4 * elempack_g * out_elempack_g, elempack_g * out_elempack_g);
+
+        for (int g = 0; g < group; g++)
+        {
+            const Mat weight_data_r2 = weight_data_r2_groups.channel_range(num_output_g * g, num_output_g);
+
+            Mat weight_data_packed = weight_data_packed_groups.channel_range(num_output_g / out_elempack_g * g, num_output_g / out_elempack_g);
+
+            for (int q = 0; q + (out_elempack_g - 1) < num_output_g; q += out_elempack_g)
+            {
+                float* g00 = weight_data_packed.channel(q / out_elempack_g);
+
+                for (int p = 0; p + (elempack_g - 1) < channels_g; p += elempack_g)
+                {
+                    for (int k = 0; k < maxk; k++)
+                    {
+                        for (int i = 0; i < out_elempack_g; i++)
+                        {
+                            const Mat k0 = weight_data_r2.channel(q + i);
+
+                            for (int j = 0; j < elempack_g; j++)
+                            {
+                                const float* k00 = k0.row(p + j);
+
+                                g00[0] = k00[k];
+
+                                g00++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    specializations[8 + 0].i = shape_bordered_g.dims;
+    specializations[8 + 1].i = shape_bordered_g.w;
+    specializations[8 + 2].i = shape_bordered_g.h;
+    specializations[8 + 3].i = shape_bordered_g.c;
+    specializations[8 + 4].i = shape_bordered_g.cstep;
+    specializations[8 + 5].i = out_shape_g.dims;
+    specializations[8 + 6].i = out_shape_g.w;
+    specializations[8 + 7].i = out_shape_g.h;
+    specializations[8 + 8].i = out_shape_g.c;
+    specializations[8 + 9].i = out_shape_g.cstep;
+
+    Mat local_size_xyz(8, 8, 1, (void*)0);
+    if (out_shape_g.dims != 0)
+    {
+        local_size_xyz.w = std::min(8, out_shape_g.w);
+        local_size_xyz.h = std::min(8, out_shape_g.h);
+        local_size_xyz.c = 1;
+    }
+
+    // pack1
+    if (elempack_g == 1 && out_elempack_g == 1)
+    {
+        pipeline_convolutiondepthwise1d_group = new Pipeline(vkdev);
+        pipeline_convolutiondepthwise1d_group->set_optimal_local_size_xyz(local_size_xyz);
+        pipeline_convolutiondepthwise1d_group->create(LayerShaderType::convolutiondepthwise1d_group, opt, specializations);
+    }
+
+    // pack4
+    if (elempack_g == 4 && out_elempack_g == 4)
+    {
+        pipeline_convolutiondepthwise1d_group_pack4 = new Pipeline(vkdev);
+        pipeline_convolutiondepthwise1d_group_pack4->set_optimal_local_size_xyz(local_size_xyz);
+        pipeline_convolutiondepthwise1d_group_pack4->create(LayerShaderType::convolutiondepthwise1d_group_pack4, opt, specializations);
+    }
+
+    // pack1to4
+    if (elempack_g == 1 && out_elempack_g == 4)
+    {
+        pipeline_convolutiondepthwise1d_group_pack1to4 = new Pipeline(vkdev);
+        pipeline_convolutiondepthwise1d_group_pack1to4->set_optimal_local_size_xyz(local_size_xyz);
+        pipeline_convolutiondepthwise1d_group_pack1to4->create(LayerShaderType::convolutiondepthwise1d_group_pack1to4, opt, specializations);
+    }
+
+    // pack4to1
+    if (elempack_g == 4 && out_elempack_g == 1)
+    {
+        pipeline_convolutiondepthwise1d_group_pack4to1 = new Pipeline(vkdev);
+        pipeline_convolutiondepthwise1d_group_pack4to1->set_optimal_local_size_xyz(local_size_xyz);
+        pipeline_convolutiondepthwise1d_group_pack4to1->create(LayerShaderType::convolutiondepthwise1d_group_pack4to1, opt, specializations);
+    }
+
+    if (opt.lightmode)
+    {
+        weight_data.release();
+    }
+
+    return 0;
+}
+
+int ConvolutionDepthWise1D_vulkan::destroy_pipeline(const Option& opt)
+{
+    if (padding)
+    {
+        padding->destroy_pipeline(opt);
+        delete padding;
+        padding = 0;
+    }
+
+    delete pipeline_convolutiondepthwise1d;
+    pipeline_convolutiondepthwise1d = 0;
+
+    delete pipeline_convolutiondepthwise1d_pack4;
+    pipeline_convolutiondepthwise1d_pack4 = 0;
+
+    delete pipeline_convolutiondepthwise1d_group;
+    pipeline_convolutiondepthwise1d_group = 0;
+
+    delete pipeline_convolutiondepthwise1d_group_pack4;
+    pipeline_convolutiondepthwise1d_group_pack4 = 0;
+
+    delete pipeline_convolutiondepthwise1d_group_pack1to4;
+    pipeline_convolutiondepthwise1d_group_pack1to4 = 0;
+
+    delete pipeline_convolutiondepthwise1d_group_pack4to1;
+    pipeline_convolutiondepthwise1d_group_pack4to1 = 0;
+
+    return 0;
+}
+
+int ConvolutionDepthWise1D_vulkan::upload_model(VkTransfer& cmd, const Option& opt)
+{
+    if (padding)
+    {
+        padding->upload_model(cmd, opt);
+    }
+
+    const int maxk = kernel_w;
+    int channels = (weight_data_size / group) / maxk / (num_output / group) * group;
+
+    // depth-wise
+    if (channels == group && group == num_output)
+    {
+        cmd.record_upload(weight_data_packed, weight_data_gpu, opt);
+
+        weight_data_packed.release();
+    }
+    else
+    {
+        cmd.record_upload(weight_data_packed_groups, weight_data_gpu, opt);
+
+        weight_data_packed_groups.release();
+    }
+
+    if (bias_term)
+    {
+        cmd.record_upload(bias_data, bias_data_gpu, opt);
+
+        bias_data.release();
+    }
+
+    return 0;
+}
+
+int ConvolutionDepthWise1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const
+{
+    int w = bottom_blob.w;
+    int channels = bottom_blob.h;
+    size_t elemsize = bottom_blob.elemsize;
+    int elempack = bottom_blob.elempack;
+
+    const int kernel_extent_w = dilation_w * (kernel_w - 1) + 1;
+
+    VkMat bottom_blob_bordered = bottom_blob;
+    if (pad_left > 0 || pad_right > 0)
+    {
+        Option opt_pad = opt;
+        opt_pad.blob_vkallocator = opt.workspace_vkallocator;
+
+        padding->forward(bottom_blob, bottom_blob_bordered, cmd, opt_pad);
+    }
+    else if (pad_left == -233 && pad_right == -233)
+    {
+        int wpad = kernel_extent_w + (w - 1) / stride_w * stride_w - w;
+        if (wpad > 0)
+        {
+            Option opt_pad = opt;
+            opt_pad.blob_vkallocator = opt.workspace_vkallocator;
+
+            VkMat padding_param_blob(6, (size_t)4u, 1, opt.staging_vkallocator);
+            int* padding_params = padding_param_blob.mapped();
+
+            padding_params[0] = 0;
+            padding_params[1] = 0;
+            padding_params[2] = wpad / 2;
+            padding_params[3] = wpad - wpad / 2;
+            padding_params[4] = 0;
+            padding_params[5] = 0;
+
+            std::vector<VkMat> padding_inputs(2);
+            padding_inputs[0] = bottom_blob;
+            padding_inputs[1] = padding_param_blob;
+
+            std::vector<VkMat> padding_outputs(1);
+            padding->forward(padding_inputs, padding_outputs, cmd, opt_pad);
+            bottom_blob_bordered = padding_outputs[0];
+        }
+    }
+    else if (pad_left == -234 && pad_right == -234)
+    {
+        int wpad = kernel_extent_w + (w - 1) / stride_w * stride_w - w;
+        if (wpad > 0)
+        {
+            Option opt_pad = opt;
+            opt_pad.blob_vkallocator = opt.workspace_vkallocator;
+
+            VkMat padding_param_blob(6, (size_t)4u, 1, opt.staging_vkallocator);
+            int* padding_params = padding_param_blob.mapped();
+
+            padding_params[0] = 0;
+            padding_params[1] = 0;
+            padding_params[2] = wpad - wpad / 2;
+            padding_params[3] = wpad / 2;
+            padding_params[4] = 0;
+            padding_params[5] = 0;
+
+            std::vector<VkMat> padding_inputs(2);
+            padding_inputs[0] = bottom_blob;
+            padding_inputs[1] = padding_param_blob;
+
+            std::vector<VkMat> padding_outputs(1);
+            padding->forward(padding_inputs, padding_outputs, cmd, opt_pad);
+            bottom_blob_bordered = padding_outputs[0];
+        }
+    }
+
+    w = bottom_blob_bordered.w;
+
+    int outw = (w - kernel_extent_w) / stride_w + 1;
+    int out_elempack = num_output % 4 == 0 ? 4 : 1;
+    size_t out_elemsize = elemsize / elempack * out_elempack;
+
+    top_blob.create(outw, num_output / out_elempack, out_elemsize, out_elempack, opt.blob_vkallocator);
+    if (top_blob.empty())
+        return -100;
+
+    // depth-wise
+    if (channels == group / elempack && group / elempack == num_output / elempack)
+    {
+        std::vector<VkMat> bindings(4);
+        bindings[0] = bottom_blob_bordered;
+        bindings[1] = top_blob;
+        bindings[2] = weight_data_gpu;
+        bindings[3] = bias_data_gpu;
+
+        std::vector<vk_constant_type> constants(10);
+        constants[0].i = bottom_blob_bordered.dims;
+        constants[1].i = bottom_blob_bordered.w;
+        constants[2].i = bottom_blob_bordered.h;
+        constants[3].i = bottom_blob_bordered.c;
+        constants[4].i = bottom_blob_bordered.cstep;
+        constants[5].i = top_blob.dims;
+        constants[6].i = top_blob.w;
+        constants[7].i = top_blob.h;
+        constants[8].i = top_blob.c;
+        constants[9].i = top_blob.cstep;
+
+        const Pipeline* pipeline = elempack == 4 ? pipeline_convolutiondepthwise1d_pack4 : pipeline_convolutiondepthwise1d;
+
+        cmd.record_pipeline(pipeline, bindings, constants, top_blob);
+
+        return 0;
+    }
+
+    const int channels_g = channels * elempack / group;
+    const int num_output_g = num_output / group;
+
+    int elempack_g = channels_g % 4 == 0 ? 4 : 1;
+    int out_elempack_g = num_output_g % 4 == 0 ? 4 : 1;
+    size_t out_elemsize_g = elemsize / elempack * out_elempack_g;
+
+    // unpacking
+    VkMat bottom_blob_bordered_unpacked = bottom_blob_bordered;
+    if (elempack > elempack_g)
+    {
+        Option opt_pack1 = opt;
+        opt_pack1.blob_vkallocator = opt.workspace_vkallocator;
+
+        vkdev->convert_packing(bottom_blob_bordered, bottom_blob_bordered_unpacked, elempack_g, cmd, opt_pack1);
+    }
+
+    VkMat top_blob_unpacked = top_blob;
+    if (out_elempack_g < out_elempack)
+    {
+        top_blob_unpacked.create(outw, num_output / out_elempack_g, out_elemsize_g, out_elempack_g, opt.workspace_vkallocator);
+        if (top_blob_unpacked.empty())
+            return -100;
+    }
+
+    std::vector<VkMat> bindings(4);
+    bindings[0] = bottom_blob_bordered_unpacked;
+    bindings[1] = top_blob_unpacked;
+    bindings[2] = weight_data_gpu;
+    bindings[3] = bias_data_gpu;
+
+    std::vector<vk_constant_type> constants(10);
+    constants[0].i = bottom_blob_bordered_unpacked.dims;
+    constants[1].i = bottom_blob_bordered_unpacked.w;
+    constants[2].i = bottom_blob_bordered_unpacked.h;
+    constants[3].i = bottom_blob_bordered_unpacked.c;
+    constants[4].i = bottom_blob_bordered_unpacked.cstep;
+    constants[5].i = top_blob_unpacked.dims;
+    constants[6].i = top_blob_unpacked.w;
+    constants[7].i = top_blob_unpacked.h;
+    constants[8].i = top_blob_unpacked.c;
+    constants[9].i = top_blob_unpacked.cstep;
+
+    const Pipeline* pipeline = 0;
+    if (elempack_g == 1 && out_elempack_g == 1)
+    {
+        pipeline = pipeline_convolutiondepthwise1d_group;
+    }
+    else if (elempack_g == 4 && out_elempack_g == 4)
+    {
+        pipeline = pipeline_convolutiondepthwise1d_group_pack4;
+    }
+    else if (elempack_g == 1 && out_elempack_g == 4)
+    {
+        pipeline = pipeline_convolutiondepthwise1d_group_pack1to4;
+    }
+    else if (elempack_g == 4 && out_elempack_g == 1)
+    {
+        pipeline = pipeline_convolutiondepthwise1d_group_pack4to1;
+    }
+
+    cmd.record_pipeline(pipeline, bindings, constants, top_blob_unpacked);
+
+    // packing
+    if (out_elempack_g < out_elempack)
+    {
+        vkdev->convert_packing(top_blob_unpacked, top_blob, out_elempack, cmd, opt);
+    }
+    else
+    {
+        top_blob = top_blob_unpacked;
+    }
+
+    return 0;
+}
+
+} // namespace ncnn

--- a/src/layer/vulkan/convolutiondepthwise1d_vulkan.h
+++ b/src/layer/vulkan/convolutiondepthwise1d_vulkan.h
@@ -1,0 +1,45 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef LAYER_CONVOLUTIONDEPTHWISE1D_VULKAN_H
+#define LAYER_CONVOLUTIONDEPTHWISE1D_VULKAN_H
+
+#include "convolutiondepthwise1d.h"
+
+namespace ncnn {
+
+class ConvolutionDepthWise1D_vulkan : public ConvolutionDepthWise1D
+{
+public:
+    ConvolutionDepthWise1D_vulkan();
+
+    virtual int load_param(const ParamDict& pd);
+
+    virtual int create_pipeline(const Option& opt);
+    virtual int destroy_pipeline(const Option& opt);
+
+    virtual int upload_model(VkTransfer& cmd, const Option& opt);
+
+    using ConvolutionDepthWise1D::forward;
+    virtual int forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const;
+
+public:
+    Mat weight_data_packed;
+    Mat weight_data_packed_groups;
+
+    VkMat weight_data_gpu;
+    VkMat bias_data_gpu;
+
+    ncnn::Layer* padding;
+
+    Pipeline* pipeline_convolutiondepthwise1d;
+    Pipeline* pipeline_convolutiondepthwise1d_pack4;
+    Pipeline* pipeline_convolutiondepthwise1d_group;
+    Pipeline* pipeline_convolutiondepthwise1d_group_pack4;
+    Pipeline* pipeline_convolutiondepthwise1d_group_pack1to4;
+    Pipeline* pipeline_convolutiondepthwise1d_group_pack4to1;
+};
+
+} // namespace ncnn
+
+#endif // LAYER_CONVOLUTIONDEPTHWISE1D_VULKAN_H

--- a/src/layer/vulkan/deconvolution1d_vulkan.cpp
+++ b/src/layer/vulkan/deconvolution1d_vulkan.cpp
@@ -521,7 +521,6 @@ int Deconvolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, V
     {
         // gemm + col2im
 
-
         // reinterpret 2D input as 3D with channel step = w (rows are contiguous)
         VkMat bottom_blob_3d = bottom_blob;
         bottom_blob_3d.dims = 3;

--- a/src/layer/vulkan/deconvolution1d_vulkan.cpp
+++ b/src/layer/vulkan/deconvolution1d_vulkan.cpp
@@ -1,0 +1,649 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "deconvolution1d_vulkan.h"
+
+#include "layer_shader_type.h"
+
+namespace ncnn {
+
+Deconvolution1D_vulkan::Deconvolution1D_vulkan()
+{
+    support_vulkan = true;
+    support_vulkan_packing = true;
+
+    pipeline_deconvolution1d = 0;
+
+    pipeline_deconvolution1d_gemm = 0;
+    pipeline_deconvolution1d_col2im = 0;
+
+    use_cooperative_matrix = false;
+    coopmat_M = 0;
+    coopmat_N = 0;
+    coopmat_K = 0;
+    coopmat_subgroup_size = 0;
+    UNROLL_SG_M = 1;
+    UNROLL_SG_N = 1;
+    UNROLL_SG_K = 1;
+    UNROLL_WG_M = 1;
+    UNROLL_WG_N = 1;
+}
+
+int Deconvolution1D_vulkan::load_param(const ParamDict& pd)
+{
+    int ret = Deconvolution1D::load_param(pd);
+
+    if (dynamic_weight)
+    {
+        support_vulkan = false;
+    }
+
+    return ret;
+}
+
+int Deconvolution1D_vulkan::create_pipeline(const Option& opt)
+{
+    const Mat& shape = bottom_shapes.empty() ? Mat() : bottom_shapes[0];
+    const Mat& out_shape = top_shapes.empty() ? Mat() : top_shapes[0];
+
+    const int maxk = kernel_w;
+    int num_input = weight_data_size / maxk / num_output;
+
+    int elempack = num_input % 4 == 0 ? 4 : 1;
+    int out_elempack = num_output % 4 == 0 ? 4 : 1;
+
+    const int num_output_packed = (num_output + 3) / 4 * 4;
+    const int outc_pack4 = num_output_packed / 4;
+
+    // input is 2D (w, num_input/elempack) with rows contiguous,
+    // reinterpret as 3D (w, 1, num_input/elempack) with channel step = w
+    Mat shape_3d;
+    if (shape.dims != 0)
+    {
+        shape_3d.dims = 3;
+        shape_3d.w = shape.w;
+        shape_3d.h = 1;
+        shape_3d.c = shape.h;
+        shape_3d.elemsize = shape.elemsize;
+        shape_3d.elempack = shape.elempack;
+        shape_3d.cstep = shape.w;
+    }
+
+    // gemm path output col shape (w, 1, maxk*num_output/out_elempack)
+    Mat out_shape_col;
+    if (shape.dims != 0 && out_shape.dims != 0)
+    {
+        out_shape_col = Mat(shape.w, 1, maxk * num_output / out_elempack, (void*)0, out_shape.elemsize, out_elempack);
+    }
+
+    if (opt.use_sgemm_convolution && num_input >= 8 && maxk * num_output >= 8)
+    {
+        use_cooperative_matrix = vkdev->info.support_cooperative_matrix() && opt.use_cooperative_matrix && (opt.use_fp16_storage || opt.use_fp16_packed);
+
+        if (use_cooperative_matrix)
+        {
+            int size = 1024;
+            if (shape.dims != 0)
+                size = shape.w;
+
+            vkdev->info.get_optimal_cooperative_matrix_mnk(size, maxk * num_output, num_input, VK_COMPONENT_TYPE_FLOAT16_KHR, opt.use_fp16_arithmetic ? VK_COMPONENT_TYPE_FLOAT16_KHR : VK_COMPONENT_TYPE_FLOAT32_KHR, VK_SCOPE_SUBGROUP_KHR, coopmat_M, coopmat_N, coopmat_K, coopmat_subgroup_size);
+
+            // assert coopmat_M != 0 && coopmat_N != 0 && coopmat_K != 0
+
+            UNROLL_SG_M = std::min((size + coopmat_M - 1) / coopmat_M, 2);
+            UNROLL_SG_N = std::min((maxk * num_output + coopmat_N - 1) / coopmat_N, 2);
+            UNROLL_SG_K = std::min((num_input + coopmat_K - 1) / coopmat_K, 2);
+
+            UNROLL_WG_M = std::min((size + coopmat_M * UNROLL_SG_M - 1) / (coopmat_M * UNROLL_SG_M), 2);
+            UNROLL_WG_N = std::min((maxk * num_output + coopmat_N * UNROLL_SG_N - 1) / (coopmat_N * UNROLL_SG_N), 2);
+
+            const int blocks_n = (maxk * num_output + coopmat_N * UNROLL_SG_N * UNROLL_WG_N - 1) / (coopmat_N * UNROLL_SG_N * UNROLL_WG_N);
+            // const int blocks_k = (num_input + coopmat_K * UNROLL_SG_K - 1) / (coopmat_K * UNROLL_SG_K);
+            const int kk = (num_input + coopmat_K - 1) / coopmat_K;
+
+            Mat weight_data_r2;
+
+            if (out_elempack == 4)
+            {
+                // from maxk-inch-outch to inch-4*maxk-outch/4
+                weight_data_r2.create(num_input * 4 * maxk * (num_output / 4));
+                for (int i = 0; i < num_output / 4; i++)
+                {
+                    for (int j = 0; j < maxk; j++)
+                    {
+                        for (int ii = 0; ii < 4; ii++)
+                        {
+                            for (int k = 0; k < num_input; k++)
+                            {
+                                weight_data_r2[((i * maxk + j) * 4 + ii) * num_input + k] = weight_data[((i * 4 + ii) * num_input + k) * maxk + j];
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                // from maxk-inch-outch to inch-maxk-outch
+                weight_data_r2.create(num_input * maxk * num_output);
+                for (int i = 0; i < num_output; i++)
+                {
+                    for (int j = 0; j < maxk; j++)
+                    {
+                        for (int k = 0; k < num_input; k++)
+                        {
+                            weight_data_r2[(i * maxk + j) * num_input + k] = weight_data[(i * num_input + k) * maxk + j];
+                        }
+                    }
+                }
+            }
+
+            weight_data_packed.create(coopmat_N * coopmat_K * UNROLL_SG_N * UNROLL_WG_N * kk, blocks_n);
+            for (int bn = 0; bn < blocks_n; bn++)
+            {
+                float* p = weight_data_packed.row(bn);
+
+                int k = 0;
+                for (; k + UNROLL_SG_K - 1 < kk; k += UNROLL_SG_K)
+                {
+                    // const int ki = k * coopmat_K;
+
+                    for (int wn = 0; wn < UNROLL_WG_N; wn++)
+                    {
+                        for (int zk = 0; zk < UNROLL_SG_K; zk++)
+                        {
+                            for (int zn = 0; zn < UNROLL_SG_N; zn++)
+                            {
+                                for (int i = 0; i < coopmat_K; i++)
+                                {
+                                    for (int j = 0; j < coopmat_N; j++)
+                                    {
+                                        const int gni = ((bn * UNROLL_WG_N + wn) * UNROLL_SG_N + zn) * coopmat_N + j;
+                                        const int gki = (k + zk) * coopmat_K + i;
+
+                                        if (gni < maxk * num_output && gki < num_input)
+                                        {
+                                            *p++ = weight_data_r2[gni * num_input + gki];
+                                        }
+                                        else
+                                        {
+                                            *p++ = 0.f;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                for (; k < kk; k++)
+                {
+                    // const int ki = k * coopmat_K;
+
+                    for (int wn = 0; wn < UNROLL_WG_N; wn++)
+                    {
+                        // for (int zk = 0; zk < UNROLL_SG_K; zk++)
+                        {
+                            for (int zn = 0; zn < UNROLL_SG_N; zn++)
+                            {
+                                for (int i = 0; i < coopmat_K; i++)
+                                {
+                                    for (int j = 0; j < coopmat_N; j++)
+                                    {
+                                        const int gni = ((bn * UNROLL_WG_N + wn) * UNROLL_SG_N + zn) * coopmat_N + j;
+                                        // const int gki = k * coopmat_K + i;
+                                        const int gki = k * coopmat_K + i;
+
+                                        if (gni < maxk * num_output && gki < num_input)
+                                        {
+                                            *p++ = weight_data_r2[gni * num_input + gki];
+                                        }
+                                        else
+                                        {
+                                            *p++ = 0.f;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            std::vector<vk_specialization_type> specializations(13 + 3);
+            specializations[0].u32 = coopmat_M;
+            specializations[1].u32 = coopmat_N;
+            specializations[2].u32 = coopmat_K;
+            specializations[3].u32 = coopmat_subgroup_size;
+            specializations[4].u32 = UNROLL_SG_M;
+            specializations[5].u32 = UNROLL_SG_N;
+            specializations[6].u32 = UNROLL_SG_K;
+            specializations[7].u32 = UNROLL_WG_M;
+            specializations[8].u32 = UNROLL_WG_N;
+            specializations[9].u32 = num_input;
+            specializations[10].u32 = maxk * num_output;
+            specializations[11].u32 = elempack;
+            specializations[12].u32 = out_elempack;
+            specializations[13 + 0].u32 = shape_3d.dims != 0 ? shape_3d.w : 0;
+            specializations[13 + 1].u32 = shape_3d.dims != 0 ? shape_3d.w : 0; // cstep = w
+            specializations[13 + 2].u32 = out_shape_col.cstep;
+
+            pipeline_deconvolution1d_gemm = new Pipeline(vkdev);
+            pipeline_deconvolution1d_gemm->set_subgroup_size(coopmat_subgroup_size);
+            pipeline_deconvolution1d_gemm->set_local_size_xyz(coopmat_subgroup_size * UNROLL_WG_M * UNROLL_WG_N, 1, 1);
+            pipeline_deconvolution1d_gemm->create(LayerShaderType::deconvolution1d_gemm_cm, opt, specializations);
+        }
+        else
+        {
+            Mat weight_data_r2 = weight_data.reshape(maxk, num_input, num_output);
+
+            // unified pack4x4 weight layout: always group input channels by 4
+            const int num_input_packed = (num_input + 3) / 4 * 4;
+
+            weight_data_packed.create(num_input_packed / 4, maxk * num_output / out_elempack, (size_t)4 * 4 * 4, 4 * 4);
+
+            for (int q = 0; q + (out_elempack - 1) < num_output; q += out_elempack)
+            {
+                for (int k = 0; k < maxk; k++)
+                {
+                    float* g00 = weight_data_packed.row(q / out_elempack * maxk + k);
+
+                    for (int p = 0; p < num_input_packed; p += 4)
+                    {
+                        for (int i = 0; i < 4; i++)
+                        {
+                            for (int j = 0; j < 4; j++)
+                            {
+                                if (q + i < num_output && p + j < num_input)
+                                {
+                                    const float* k00 = weight_data_r2.channel(q + i).row(p + j);
+                                    g00[0] = k00[k];
+                                }
+                                else
+                                {
+                                    g00[0] = 0.f;
+                                }
+                                g00++;
+                            }
+                        }
+                    }
+                }
+            }
+
+            const int c_packed = num_input_packed / 4;
+
+            std::vector<vk_specialization_type> specializations(3 + 7);
+            specializations[0].i = maxk;
+            specializations[1].i = elempack;
+            specializations[2].i = out_elempack;
+            specializations[3 + 0].i = shape_3d.w;
+            specializations[3 + 1].i = shape_3d.dims != 0 ? 1 : 0;
+            specializations[3 + 2].i = c_packed;
+            specializations[3 + 3].i = shape_3d.dims != 0 ? shape_3d.w : 0; // cstep = w
+            specializations[3 + 4].i = out_shape_col.cstep;
+            specializations[3 + 5].i = out_shape_col.c;
+            specializations[3 + 6].i = num_input;
+
+            Mat local_size_xyz(8, std::min(4, num_output / out_elempack), 1, (void*)0);
+            if (out_shape_col.dims != 0)
+            {
+                local_size_xyz.w = std::min(8, out_shape_col.w);
+                local_size_xyz.h = std::min(4, out_shape_col.c);
+            }
+
+            pipeline_deconvolution1d_gemm = new Pipeline(vkdev);
+            if (opt.use_shader_local_memory)
+            {
+                pipeline_deconvolution1d_gemm->set_local_size_xyz(8, 8, 1);
+            }
+            else
+            {
+                pipeline_deconvolution1d_gemm->set_optimal_local_size_xyz(local_size_xyz);
+            }
+            pipeline_deconvolution1d_gemm->create(LayerShaderType::deconvolution1d_gemm_packed, opt, specializations);
+        }
+
+        {
+            std::vector<vk_specialization_type> specializations(8 + 3);
+            specializations[0].i = kernel_w;
+            specializations[1].i = dilation_w;
+            specializations[2].i = stride_w;
+            specializations[3].i = bias_term;
+            specializations[4].i = activation_type;
+            specializations[5].f = activation_params.w >= 1 ? activation_params[0] : 0.f;
+            specializations[6].f = activation_params.w == 2 ? activation_params[1] : 0.f;
+            specializations[7].i = num_output / out_elempack;
+            specializations[8 + 0].i = shape_3d.w;
+            specializations[8 + 1].i = out_shape_col.cstep;
+            specializations[8 + 2].i = out_shape.w;
+
+            Mat local_size_xyz(8, std::min(4, num_output / out_elempack), 1, (void*)0);
+            if (out_shape.dims != 0)
+            {
+                local_size_xyz.w = std::min(8, out_shape.w);
+                local_size_xyz.h = std::min(4, num_output / out_elempack);
+            }
+
+            int shader_type_index = -1;
+            if (out_elempack == 1) shader_type_index = LayerShaderType::deconvolution1d_col2im;
+            if (out_elempack == 4) shader_type_index = LayerShaderType::deconvolution1d_pack4_col2im;
+
+            pipeline_deconvolution1d_col2im = new Pipeline(vkdev);
+            pipeline_deconvolution1d_col2im->set_optimal_local_size_xyz(local_size_xyz);
+            pipeline_deconvolution1d_col2im->create(shader_type_index, opt, specializations);
+        }
+
+        if (opt.lightmode)
+        {
+            weight_data.release();
+        }
+
+        return 0;
+    }
+
+    Mat weight_data_transposed(weight_data.w);
+    {
+        float* pt = weight_data_transposed;
+        const float* p = weight_data;
+
+        for (int i = 0; i < num_input * num_output; i++)
+        {
+            for (int k = 0; k < maxk; k++)
+            {
+                pt[maxk - 1 - k] = p[k];
+            }
+
+            p += maxk;
+            pt += maxk;
+        }
+    }
+
+    // unified pack4 weight layout: output channels always packed by 4
+    {
+        Mat weight_data_r2 = weight_data_transposed.reshape(maxk, num_input, num_output);
+
+        weight_data_packed.create(maxk, num_input / elempack, num_output_packed / 4, (size_t)4 * 4 * elempack, 4 * elempack);
+
+        for (int q = 0; q < num_output_packed; q += 4)
+        {
+            float* g00 = weight_data_packed.channel(q / 4);
+
+            for (int p = 0; p + (elempack - 1) < num_input; p += elempack)
+            {
+                for (int k = 0; k < maxk; k++)
+                {
+                    for (int i = 0; i < 4; i++)
+                    {
+                        for (int j = 0; j < elempack; j++)
+                        {
+                            if (q + i < num_output)
+                            {
+                                const float* k00 = weight_data_r2.channel(q + i).row(p + j);
+                                g00[0] = k00[k];
+                            }
+                            else
+                            {
+                                g00[0] = 0.f;
+                            }
+                            g00++;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::vector<vk_specialization_type> specializations(10 + 4);
+    specializations[0].i = kernel_w;
+    specializations[1].i = dilation_w;
+    specializations[2].i = stride_w;
+    specializations[3].i = bias_term;
+    specializations[4].i = activation_type;
+    specializations[5].f = activation_params.w >= 1 ? activation_params[0] : 0.f;
+    specializations[6].f = activation_params.w == 2 ? activation_params[1] : 0.f;
+    specializations[7].i = elempack;
+    specializations[8].i = out_elempack;
+    specializations[9].i = num_output;
+    specializations[10 + 0].i = shape_3d.w;
+    specializations[10 + 1].i = num_input / elempack;
+    specializations[10 + 2].i = out_shape.w;
+    specializations[10 + 3].i = outc_pack4;
+
+    Mat local_size_xyz(std::min(8, out_shape.dims != 0 ? out_shape.w : 8), std::min(4, (outc_pack4 + 1) / 2), 1, (void*)0);
+
+    pipeline_deconvolution1d = new Pipeline(vkdev);
+    pipeline_deconvolution1d->set_optimal_local_size_xyz(local_size_xyz);
+    pipeline_deconvolution1d->create(LayerShaderType::deconvolution1d, opt, specializations);
+
+    if (opt.lightmode)
+    {
+        weight_data.release();
+    }
+
+    return 0;
+}
+
+int Deconvolution1D_vulkan::destroy_pipeline(const Option& /*opt*/)
+{
+    delete pipeline_deconvolution1d;
+    pipeline_deconvolution1d = 0;
+
+    delete pipeline_deconvolution1d_gemm;
+    pipeline_deconvolution1d_gemm = 0;
+
+    delete pipeline_deconvolution1d_col2im;
+    pipeline_deconvolution1d_col2im = 0;
+
+    use_cooperative_matrix = false;
+    coopmat_M = 0;
+    coopmat_N = 0;
+    coopmat_K = 0;
+    coopmat_subgroup_size = 0;
+    UNROLL_SG_M = 1;
+    UNROLL_SG_N = 1;
+    UNROLL_SG_K = 1;
+    UNROLL_WG_M = 1;
+    UNROLL_WG_N = 1;
+
+    return 0;
+}
+
+int Deconvolution1D_vulkan::upload_model(VkTransfer& cmd, const Option& opt)
+{
+    cmd.record_upload(weight_data_packed, weight_data_gpu, opt);
+
+    weight_data_packed.release();
+
+    if (bias_term)
+    {
+        // pad bias to multiple of 4 for the unified packed shader
+        const int num_output_packed = (num_output + 3) / 4 * 4;
+        Mat bias_data_packed(num_output_packed, (size_t)4u, 1);
+        float* bias_ptr = bias_data_packed;
+        for (int i = 0; i < num_output; i++)
+        {
+            bias_ptr[i] = bias_data[i];
+        }
+        for (int i = num_output; i < num_output_packed; i++)
+        {
+            bias_ptr[i] = 0.f;
+        }
+
+        cmd.record_upload(bias_data_packed, bias_data_gpu, opt);
+
+        bias_data.release();
+    }
+
+    return 0;
+}
+
+int Deconvolution1D_vulkan::forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const
+{
+    const int w = bottom_blob.w;
+    const int h = bottom_blob.h;
+    size_t elemsize = bottom_blob.elemsize;
+    int elempack = bottom_blob.elempack;
+
+    const int num_input = h * elempack;
+    const int maxk = kernel_w;
+
+    const int kernel_extent_w = dilation_w * (kernel_w - 1) + 1;
+
+    const int outw_full = (w - 1) * stride_w + kernel_extent_w + output_pad_right;
+
+    int front_cut = 0;
+    int outw = outw_full;
+    if (pad_left > 0 || pad_right > 0)
+    {
+        front_cut = pad_left;
+        outw = outw_full - pad_left - pad_right;
+    }
+    else if (output_w > 0)
+    {
+        const int wcut = outw_full - output_w;
+
+        if (pad_left == -233 || pad_right == -233)
+        {
+            // onnx padding=SAME_UPPER
+            front_cut = wcut / 2;
+        }
+        else
+        {
+            // onnx padding=SAME_LOWER
+            front_cut = wcut - wcut / 2;
+        }
+
+        outw = output_w;
+    }
+
+    const int out_elempack = num_output % 4 == 0 ? 4 : 1;
+    size_t out_elemsize = elemsize / elempack * out_elempack;
+
+    if (opt.use_sgemm_convolution && num_input >= 8 && maxk * num_output >= 8)
+    {
+        // gemm + col2im
+
+
+        // reinterpret 2D input as 3D with channel step = w (rows are contiguous)
+        VkMat bottom_blob_3d = bottom_blob;
+        bottom_blob_3d.dims = 3;
+        bottom_blob_3d.c = h;
+        bottom_blob_3d.h = 1;
+        bottom_blob_3d.cstep = w;
+
+        VkMat top_blob_col;
+        top_blob_col.create(w, 1, maxk * num_output / out_elempack, out_elemsize, out_elempack, opt.workspace_vkallocator);
+        if (top_blob_col.empty())
+            return -100;
+
+        if (use_cooperative_matrix)
+        {
+            const int size = w;
+
+            std::vector<VkMat> bindings(4);
+            bindings[0] = bottom_blob_3d;
+            bindings[1] = top_blob_col;
+            bindings[2] = weight_data_gpu;
+            bindings[3] = bottom_blob_3d; // scalar view for elempack == 1
+
+            std::vector<vk_constant_type> constants(3);
+            constants[0].u32 = size;
+            constants[1].u32 = w; // cstep = w
+            constants[2].u32 = top_blob_col.cstep;
+
+            const int blocks_x = (size + coopmat_M * UNROLL_SG_M * UNROLL_WG_M - 1) / (coopmat_M * UNROLL_SG_M * UNROLL_WG_M);
+            const int blocks_y = (maxk * num_output + coopmat_N * UNROLL_SG_N * UNROLL_WG_N - 1) / (coopmat_N * UNROLL_SG_N * UNROLL_WG_N);
+
+            VkMat dispatcher;
+            dispatcher.w = (blocks_x * blocks_y) * (coopmat_subgroup_size * UNROLL_WG_M * UNROLL_WG_N);
+            dispatcher.h = 1;
+            dispatcher.c = 1;
+
+            cmd.record_pipeline(pipeline_deconvolution1d_gemm, bindings, constants, dispatcher);
+        }
+        else
+        {
+            const int num_input_packed = (num_input + 3) / 4 * 4;
+
+            std::vector<VkMat> bindings(5);
+            bindings[0] = bottom_blob_3d;
+            bindings[1] = top_blob_col;
+            bindings[2] = bottom_blob_3d;
+            bindings[3] = top_blob_col;
+            bindings[4] = weight_data_gpu;
+
+            std::vector<vk_constant_type> constants(7);
+            constants[0].i = w;
+            constants[1].i = 1;
+            constants[2].i = num_input_packed / 4;
+            constants[3].i = w; // cstep = w
+            constants[4].i = top_blob_col.cstep;
+            constants[5].i = top_blob_col.c;
+            constants[6].i = num_input;
+
+            VkMat dispatcher;
+            dispatcher.w = (top_blob_col.cstep + 3) / 4;
+            dispatcher.h = top_blob_col.c;
+            dispatcher.c = 1;
+
+            cmd.record_pipeline(pipeline_deconvolution1d_gemm, bindings, constants, dispatcher);
+        }
+
+        // col2im
+        top_blob.create(outw, num_output / out_elempack, out_elemsize, out_elempack, opt.blob_vkallocator);
+        if (top_blob.empty())
+            return -100;
+
+        std::vector<VkMat> bindings(3);
+        bindings[0] = top_blob_col;
+        bindings[1] = top_blob;
+        bindings[2] = bias_data_gpu;
+
+        std::vector<vk_constant_type> constants(4);
+        constants[0].i = w;
+        constants[1].i = top_blob_col.cstep;
+        constants[2].i = outw;
+        constants[3].i = front_cut;
+
+        VkMat dispatcher;
+        dispatcher.w = outw;
+        dispatcher.h = num_output / out_elempack;
+        dispatcher.c = 1;
+
+        cmd.record_pipeline(pipeline_deconvolution1d_col2im, bindings, constants, dispatcher);
+
+        return 0;
+    }
+
+    // direct
+    top_blob.create(outw, num_output / out_elempack, out_elemsize, out_elempack, opt.blob_vkallocator);
+    if (top_blob.empty())
+        return -100;
+
+    const int num_output_packed = (num_output + 3) / 4 * 4;
+    const int outc_pack4 = num_output_packed / 4;
+
+    std::vector<VkMat> bindings(6);
+    bindings[0] = bottom_blob;
+    bindings[1] = top_blob;
+    bindings[2] = bottom_blob;
+    bindings[3] = top_blob;
+    bindings[4] = weight_data_gpu;
+    bindings[5] = bias_data_gpu;
+
+    std::vector<vk_constant_type> constants(5);
+    constants[0].i = w;
+    constants[1].i = num_input / elempack;
+    constants[2].i = outw;
+    constants[3].i = outc_pack4;
+    constants[4].i = front_cut;
+
+    VkMat dispatcher;
+    dispatcher.w = (outw + 1) / 2;
+    dispatcher.h = (outc_pack4 + 1) / 2;
+    dispatcher.c = 1;
+
+    cmd.record_pipeline(pipeline_deconvolution1d, bindings, constants, dispatcher);
+
+    return 0;
+}
+
+} // namespace ncnn

--- a/src/layer/vulkan/deconvolution1d_vulkan.cpp
+++ b/src/layer/vulkan/deconvolution1d_vulkan.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 Tencent
+// Copyright 2026 Futz12 <pchar.cn>
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "deconvolution1d_vulkan.h"

--- a/src/layer/vulkan/deconvolution1d_vulkan.h
+++ b/src/layer/vulkan/deconvolution1d_vulkan.h
@@ -1,4 +1,4 @@
-// Copyright 2026 Tencent
+// Copyright 2026 Futz12 <pchar.cn>
 // SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef LAYER_DECONVOLUTION1D_VULKAN_H

--- a/src/layer/vulkan/deconvolution1d_vulkan.h
+++ b/src/layer/vulkan/deconvolution1d_vulkan.h
@@ -1,0 +1,52 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef LAYER_DECONVOLUTION1D_VULKAN_H
+#define LAYER_DECONVOLUTION1D_VULKAN_H
+
+#include "deconvolution1d.h"
+
+namespace ncnn {
+
+class Deconvolution1D_vulkan : public Deconvolution1D
+{
+public:
+    Deconvolution1D_vulkan();
+
+    virtual int load_param(const ParamDict& pd);
+
+    virtual int create_pipeline(const Option& opt);
+    virtual int destroy_pipeline(const Option& opt);
+
+    virtual int upload_model(VkTransfer& cmd, const Option& opt);
+
+    using Deconvolution1D::forward;
+    virtual int forward(const VkMat& bottom_blob, VkMat& top_blob, VkCompute& cmd, const Option& opt) const;
+
+public:
+    Mat weight_data_packed;
+
+    VkMat weight_data_gpu;
+    VkMat bias_data_gpu;
+
+    Pipeline* pipeline_deconvolution1d;
+
+    Pipeline* pipeline_deconvolution1d_gemm;
+    Pipeline* pipeline_deconvolution1d_col2im;
+
+    // cooperative matrix
+    bool use_cooperative_matrix;
+    int coopmat_M;
+    int coopmat_N;
+    int coopmat_K;
+    int coopmat_subgroup_size;
+    int UNROLL_SG_M;
+    int UNROLL_SG_N;
+    int UNROLL_SG_K;
+    int UNROLL_WG_M;
+    int UNROLL_WG_N;
+};
+
+} // namespace ncnn
+
+#endif // LAYER_DECONVOLUTION1D_VULKAN_H

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd23_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd23_transform_input.comp
@@ -1,0 +1,56 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+layout(constant_id = 0) const int c = 0;
+
+#define shape_constant_id_offset 1
+layout(constant_id = shape_constant_id_offset + 0) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outcstep = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int block_x = 0;
+
+layout(binding = 0) readonly buffer bottom_blob { sfp bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer bottom_tm_blob { sfp bottom_tm_blob_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int w;
+    int cstep;
+    int outcstep;
+    int block_x;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= psc(block_x) || gz >= c)
+        return;
+
+    // load 4 elements from input (1D: only x dimension)
+    int sx = gx * 2;  // each tile produces 2 output elements, needs 4 input elements
+
+    int v_offset = gz * psc(cstep) + sx;
+
+    afp d0 = buffer_ld1(bottom_blob_data, v_offset + 0);
+    afp d1 = sx + 1 < psc(w) ? buffer_ld1(bottom_blob_data, v_offset + 1) : afp(0.f);
+    afp d2 = sx + 2 < psc(w) ? buffer_ld1(bottom_blob_data, v_offset + 2) : afp(0.f);
+    afp d3 = sx + 3 < psc(w) ? buffer_ld1(bottom_blob_data, v_offset + 3) : afp(0.f);
+
+    // B^T transform (4x4) - only once (1D)
+    afp v0 = d0 - d2;
+    afp v1 = d1 + d2;
+    afp v2 = d2 - d1;
+    afp v3 = d3 - d1;
+
+    // store 4 transformed values
+    int v_tm_offset = gz * psc(outcstep) + gx;
+
+    buffer_st1(bottom_tm_blob_data, v_tm_offset + 0 * psc(outcstep) * c, v0);
+    buffer_st1(bottom_tm_blob_data, v_tm_offset + 1 * psc(outcstep) * c, v1);
+    buffer_st1(bottom_tm_blob_data, v_tm_offset + 2 * psc(outcstep) * c, v2);
+    buffer_st1(bottom_tm_blob_data, v_tm_offset + 3 * psc(outcstep) * c, v3);
+}

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd23_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd23_transform_input.comp
@@ -31,7 +31,7 @@ void main()
         return;
 
     // load 4 elements from input (1D: only x dimension)
-    int sx = gx * 2;  // each tile produces 2 output elements, needs 4 input elements
+    int sx = gx * 2; // each tile produces 2 output elements, needs 4 input elements
 
     int v_offset = gz * psc(cstep) + sx;
 

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd23_transform_output.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd23_transform_output.comp
@@ -1,0 +1,71 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int bias_term = 0;
+layout(constant_id = 1) const int activation_type = 0;
+layout(constant_id = 2) const float activation_param_0 = 0;
+layout(constant_id = 3) const float activation_param_1 = 0;
+layout(constant_id = 4) const int c = 0;
+
+#define shape_constant_id_offset 5
+layout(constant_id = shape_constant_id_offset + 0) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int block_x = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer top_tm_blob { sfp top_tm_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfp top_blob_data[]; };
+layout(binding = 2) readonly buffer bias_blob { sfp bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int cstep;
+    int block_x;
+    int outw;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= psc(block_x) || gz >= c)
+        return;
+
+    // load 4 accumulated values from transform domain
+    int v_tm_offset = gz * psc(cstep) + gx;
+
+    afp m0 = buffer_ld1(top_tm_blob_data, v_tm_offset + 0 * psc(cstep) * c);
+    afp m1 = buffer_ld1(top_tm_blob_data, v_tm_offset + 1 * psc(cstep) * c);
+    afp m2 = buffer_ld1(top_tm_blob_data, v_tm_offset + 2 * psc(cstep) * c);
+    afp m3 = buffer_ld1(top_tm_blob_data, v_tm_offset + 3 * psc(cstep) * c);
+
+    // A^T transform (2x4) - only once (1D)
+    afp y0 = m0 + m1 + m2;
+    afp y1 = m1 - m2 + m3;
+
+    // bias
+    if (bias_term == 1)
+    {
+        const afp bias_value = buffer_ld1(bias_data, gz);
+        y0 = bias_value + y0;
+        y1 = bias_value + y1;
+    }
+
+    // activation
+    y0 = activation_afp(y0, activation_type, activation_param_0, activation_param_1);
+    y1 = activation_afp(y1, activation_type, activation_param_0, activation_param_1);
+
+    // store 2 output elements
+    int x = gx * 2;
+    int v_offset = gz * psc(outcstep) + x;
+
+    buffer_st1(top_blob_data, v_offset + 0, y0);
+    if (x + 1 < psc(outw)) buffer_st1(top_blob_data, v_offset + 1, y1);
+}

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd43_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd43_transform_input.comp
@@ -1,0 +1,74 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+layout(constant_id = 0) const int c = 0;
+
+#define shape_constant_id_offset 1
+layout(constant_id = shape_constant_id_offset + 0) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outcstep = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int block_x = 0;
+
+layout(binding = 0) readonly buffer bottom_blob { sfp bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer bottom_tm_blob { sfp bottom_tm_blob_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int w;
+    int cstep;
+    int outcstep;
+    int block_x;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= psc(block_x) || gz >= c)
+        return;
+
+    // load 6 elements (1D: only x dimension)
+    int sx = gx * 4;  // each tile produces 4 output elements
+
+    int v_offset = gz * psc(cstep) + sx;
+
+    afp d0 = buffer_ld1(bottom_blob_data, v_offset + 0);
+    afp d1 = sx + 1 < psc(w) ? buffer_ld1(bottom_blob_data, v_offset + 1) : afp(0.f);
+    afp d2 = sx + 2 < psc(w) ? buffer_ld1(bottom_blob_data, v_offset + 2) : afp(0.f);
+    afp d3 = sx + 3 < psc(w) ? buffer_ld1(bottom_blob_data, v_offset + 3) : afp(0.f);
+    afp d4 = sx + 4 < psc(w) ? buffer_ld1(bottom_blob_data, v_offset + 4) : afp(0.f);
+    afp d5 = sx + 5 < psc(w) ? buffer_ld1(bottom_blob_data, v_offset + 5) : afp(0.f);
+
+#define sq2    1.41421356237
+#define sq2_d2 1.41421356237 / 2
+
+    // const float itm[6][6] = {
+    //     {1.0f,  0.0f,  -2.5f,  0.0f,  1.0f, 0.0f},
+    //     {0.0f, -sq2,   -2.0f,  sq2/2, 1.0f, 0.0f},
+    //     {0.0f,  sq2,   -2.0f, -sq2/2, 1.0f, 0.0f},
+    //     {0.0f, -sq2/2, -0.5f,  sq2,   1.0f, 0.0f},
+    //     {0.0f,  sq2/2, -0.5f, -sq2,   1.0f, 0.0f},
+    //     {0.0f,  1.0f,   0.0f,  -2.5f, 0.0f, 1.0f}
+    // };
+
+    // B^T transform (6x6) - only once (1D)
+    afp v0 = d0 - d2 * afp(2.5) + d4;
+    afp v1 = d4 - d2 * afp(2) + d3 * afp(sq2_d2) - d1 * afp(sq2);
+    afp v2 = d4 - d2 * afp(2) - d3 * afp(sq2_d2) + d1 * afp(sq2);
+    afp v3 = d4 - d2 * afp(0.5) + d3 * afp(sq2) - d1 * afp(sq2_d2);
+    afp v4 = d4 - d2 * afp(0.5) - d3 * afp(sq2) + d1 * afp(sq2_d2);
+    afp v5 = d1 - d3 * afp(2.5) + d5;
+
+    // store 6 transformed values
+    int v_tm_offset = gz * psc(outcstep) + gx;
+
+    buffer_st1(bottom_tm_blob_data, v_tm_offset + 0 * psc(outcstep) * c, v0);
+    buffer_st1(bottom_tm_blob_data, v_tm_offset + 1 * psc(outcstep) * c, v1);
+    buffer_st1(bottom_tm_blob_data, v_tm_offset + 2 * psc(outcstep) * c, v2);
+    buffer_st1(bottom_tm_blob_data, v_tm_offset + 3 * psc(outcstep) * c, v3);
+    buffer_st1(bottom_tm_blob_data, v_tm_offset + 4 * psc(outcstep) * c, v4);
+    buffer_st1(bottom_tm_blob_data, v_tm_offset + 5 * psc(outcstep) * c, v5);
+}

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd43_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd43_transform_input.comp
@@ -31,7 +31,7 @@ void main()
         return;
 
     // load 6 elements (1D: only x dimension)
-    int sx = gx * 4;  // each tile produces 4 output elements
+    int sx = gx * 4; // each tile produces 4 output elements
 
     int v_offset = gz * psc(cstep) + sx;
 

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd43_transform_output.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd43_transform_output.comp
@@ -1,0 +1,94 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int bias_term = 0;
+layout(constant_id = 1) const int activation_type = 0;
+layout(constant_id = 2) const float activation_param_0 = 0;
+layout(constant_id = 3) const float activation_param_1 = 0;
+layout(constant_id = 4) const int c = 0;
+
+#define shape_constant_id_offset 5
+layout(constant_id = shape_constant_id_offset + 0) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int block_x = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer top_tm_blob { sfp top_tm_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfp top_blob_data[]; };
+layout(binding = 2) readonly buffer bias_blob { sfp bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int cstep;
+    int block_x;
+    int outw;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= psc(block_x) || gz >= c)
+        return;
+
+    // load 6 accumulated values from transform domain
+    int v_tm_offset = gz * psc(cstep) + gx;
+
+    afp m0 = buffer_ld1(top_tm_blob_data, v_tm_offset + 0 * psc(cstep) * c);
+    afp m1 = buffer_ld1(top_tm_blob_data, v_tm_offset + 1 * psc(cstep) * c);
+    afp m2 = buffer_ld1(top_tm_blob_data, v_tm_offset + 2 * psc(cstep) * c);
+    afp m3 = buffer_ld1(top_tm_blob_data, v_tm_offset + 3 * psc(cstep) * c);
+    afp m4 = buffer_ld1(top_tm_blob_data, v_tm_offset + 4 * psc(cstep) * c);
+    afp m5 = buffer_ld1(top_tm_blob_data, v_tm_offset + 5 * psc(cstep) * c);
+
+#define sq2    1.41421356237
+#define sq2_m2 1.41421356237 * 2
+#define sq2_d2 1.41421356237 / 2
+#define sq2_d4 1.41421356237 / 4
+
+    // const float otm[4][6] = {
+    //     {1.0f, 1.0f,   1.0f,  1.0f,  1.0f,   0.0f},
+    //     {0.0f, sq2/2, -sq2/2, sq2,   -sq2,   0.0f},
+    //     {0.0f, 0.5f,   0.5f,  2.0f,  2.0f,   0.0f},
+    //     {0.0f, sq2/4, -sq2/4, sq2*2, -sq2*2, 1.0f}
+    // };
+
+    // A^T transform (4x6) - only once (1D)
+    afp y0 = m0 + m1 + m2 + m3 + m4;
+    afp y1 = (m1 - m2) * afp(sq2_d2) + (m3 - m4) * afp(sq2);
+    afp y2 = (m1 + m2) * afp(0.5) + (m3 + m4) * afp(2);
+    afp y3 = m5 + (m1 - m2) * afp(sq2_d4) + (m3 - m4) * afp(sq2_m2);
+
+    // bias
+    if (bias_term == 1)
+    {
+        const afp bias_value = buffer_ld1(bias_data, gz);
+
+        y0 = bias_value + y0;
+        y1 = bias_value + y1;
+        y2 = bias_value + y2;
+        y3 = bias_value + y3;
+    }
+
+    // activation
+    y0 = activation_afp(y0, activation_type, activation_param_0, activation_param_1);
+    y1 = activation_afp(y1, activation_type, activation_param_0, activation_param_1);
+    y2 = activation_afp(y2, activation_type, activation_param_0, activation_param_1);
+    y3 = activation_afp(y3, activation_type, activation_param_0, activation_param_1);
+
+    // store 4 output elements
+    int x = gx * 4;
+    int v_offset = gz * psc(outcstep) + x;
+
+    buffer_st1(top_blob_data, v_offset + 0, y0);
+    if (x + 1 < psc(outw)) buffer_st1(top_blob_data, v_offset + 1, y1);
+    if (x + 2 < psc(outw)) buffer_st1(top_blob_data, v_offset + 2, y2);
+    if (x + 3 < psc(outw)) buffer_st1(top_blob_data, v_offset + 3, y3);
+}

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
@@ -1,0 +1,166 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#define LOCAL_MEMORY_UNROLL_INCH 8
+
+layout(constant_id = 0) const int batch = 6;
+layout(constant_id = 1) const int c = 0;
+layout(constant_id = 2) const int outc = 0;
+
+#define shape_constant_id_offset 3
+layout(constant_id = shape_constant_id_offset + 0) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer bottom_tm_blob { sfp bottom_tm_blob_data[]; };
+layout(binding = 1) writeonly buffer top_tm_blob { sfp top_tm_blob_data[]; };
+layout(binding = 2) readonly buffer weight_tm_blob { sfp weight_tm_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int cstep;
+    int outw;
+    int outcstep;
+} p;
+
+#if NCNN_shader_local_memory
+shared lfp tmp_v[8][LOCAL_MEMORY_UNROLL_INCH][4];
+shared lfp tmp_k[8][LOCAL_MEMORY_UNROLL_INCH];
+#endif
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x) * 4;
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+#if !NCNN_shader_local_memory
+    if (gx >= psc(outw) || gy >= outc || gz >= batch)
+        return;
+#endif
+
+    afp sum0 = afp(0.f);
+    afp sum1 = afp(0.f);
+    afp sum2 = afp(0.f);
+    afp sum3 = afp(0.f);
+
+    int v_offset = gz * c * psc(cstep) + gx;
+    int w_offset = gz * c * outc + gy * c;
+
+#if NCNN_shader_local_memory
+    const int lx = int(gl_LocalInvocationID.x);
+    const int ly = int(gl_LocalInvocationID.y);
+
+    int z = 0;
+    for (; z + (LOCAL_MEMORY_UNROLL_INCH - 1) < c; z += LOCAL_MEMORY_UNROLL_INCH)
+    {
+        if (ly < 4)
+        {
+            for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+            {
+                tmp_v[lx][z4][ly] = buffer_sm1(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+            }
+        }
+
+        if (lx == 0)
+        {
+            for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+            {
+                tmp_k[ly][z4] = buffer_sm1(weight_tm_data, w_offset + z4);
+            }
+        }
+
+        barrier();
+
+        for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+        {
+            afp v0 = lfp2afp(tmp_v[lx][z4][0]);
+            afp v1 = lfp2afp(tmp_v[lx][z4][1]);
+            afp v2 = lfp2afp(tmp_v[lx][z4][2]);
+            afp v3 = lfp2afp(tmp_v[lx][z4][3]);
+
+            afp k = lfp2afp(tmp_k[ly][z4]);
+
+            sum0 += v0 * k;
+            sum1 += v1 * k;
+            sum2 += v2 * k;
+            sum3 += v3 * k;
+        }
+
+        v_offset += LOCAL_MEMORY_UNROLL_INCH * psc(cstep);
+        w_offset += LOCAL_MEMORY_UNROLL_INCH;
+
+        barrier();
+    }
+
+    if (z < c)
+    {
+        const int remain = c - z;
+
+        if (ly < 4)
+        {
+            for (int z4 = 0; z4 < remain; z4++)
+            {
+                tmp_v[lx][z4][ly] = buffer_sm1(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+            }
+        }
+
+        if (lx == 0)
+        {
+            for (int z4 = 0; z4 < remain; z4++)
+            {
+                tmp_k[ly][z4] = buffer_sm1(weight_tm_data, w_offset + z4);
+            }
+        }
+
+        barrier();
+
+        for (int z4 = 0; z4 < remain; z4++)
+        {
+            afp v0 = lfp2afp(tmp_v[lx][z4][0]);
+            afp v1 = lfp2afp(tmp_v[lx][z4][1]);
+            afp v2 = lfp2afp(tmp_v[lx][z4][2]);
+            afp v3 = lfp2afp(tmp_v[lx][z4][3]);
+
+            afp k = lfp2afp(tmp_k[ly][z4]);
+
+            sum0 += v0 * k;
+            sum1 += v1 * k;
+            sum2 += v2 * k;
+            sum3 += v3 * k;
+        }
+    }
+#else
+    for (int z = 0; z < c; z++)
+    {
+        afp v0 = buffer_ld1(bottom_tm_blob_data, v_offset + 0);
+        afp v1 = buffer_ld1(bottom_tm_blob_data, v_offset + 1);
+        afp v2 = buffer_ld1(bottom_tm_blob_data, v_offset + 2);
+        afp v3 = buffer_ld1(bottom_tm_blob_data, v_offset + 3);
+
+        afp k = buffer_ld1(weight_tm_data, w_offset);
+
+        sum0 += v0 * k;
+        sum1 += v1 * k;
+        sum2 += v2 * k;
+        sum3 += v3 * k;
+
+        v_offset += psc(cstep);
+        w_offset += 1;
+    }
+#endif
+
+#if NCNN_shader_local_memory
+    if (gx >= psc(outw) || gy >= outc || gz >= batch)
+        return;
+#endif
+
+    int gi = gz * outc * psc(outcstep) + gy * psc(outcstep) + gx;
+
+    buffer_st1(top_tm_blob_data, gi + 0, sum0);
+    if (gx + 1 < psc(outw)) buffer_st1(top_tm_blob_data, gi + 1, sum1);
+    if (gx + 2 < psc(outw)) buffer_st1(top_tm_blob_data, gi + 2, sum2);
+    if (gx + 3 < psc(outw)) buffer_st1(top_tm_blob_data, gi + 3, sum3);
+}

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
@@ -135,17 +135,28 @@ void main()
 #else
     for (int z = 0; z < c; z++)
     {
-        afp v0 = buffer_ld1(bottom_tm_blob_data, v_offset + 0);
-        afp v1 = buffer_ld1(bottom_tm_blob_data, v_offset + 1);
-        afp v2 = buffer_ld1(bottom_tm_blob_data, v_offset + 2);
-        afp v3 = buffer_ld1(bottom_tm_blob_data, v_offset + 3);
-
         afp k = buffer_ld1(weight_tm_data, w_offset);
 
-        sum0 += v0 * k;
-        sum1 += v1 * k;
-        sum2 += v2 * k;
-        sum3 += v3 * k;
+        if (gx + 0 < psc(outw))
+        {
+            afp v0 = buffer_ld1(bottom_tm_blob_data, v_offset + 0);
+            sum0 += v0 * k;
+        }
+        if (gx + 1 < psc(outw))
+        {
+            afp v1 = buffer_ld1(bottom_tm_blob_data, v_offset + 1);
+            sum1 += v1 * k;
+        }
+        if (gx + 2 < psc(outw))
+        {
+            afp v2 = buffer_ld1(bottom_tm_blob_data, v_offset + 2);
+            sum2 += v2 * k;
+        }
+        if (gx + 3 < psc(outw))
+        {
+            afp v3 = buffer_ld1(bottom_tm_blob_data, v_offset + 3);
+            sum3 += v3 * k;
+        }
 
         v_offset += psc(cstep);
         w_offset += 1;

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
@@ -23,6 +23,7 @@ layout(push_constant) uniform parameter
     int cstep;
     int outw;
     int outcstep;
+    int wcstep;
 } p;
 
 #if NCNN_shader_local_memory
@@ -47,7 +48,7 @@ void main()
     afp sum3 = afp(0.f);
 
     int v_offset = gz * c * psc(cstep) + gx;
-    int w_offset = gz * c * outc + gy * c;
+    int w_offset = gz * psc(wcstep) + gy * c;
 
 #if NCNN_shader_local_memory
     const int lx = int(gl_LocalInvocationID.x);

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
@@ -148,10 +148,10 @@ void main()
 #else
     for (int z = 0; z < c; z++)
     {
-        afp v0 = buffer_ld1(bottom_tm_blob_data, v_offset + 0);
-        afp v1 = buffer_ld1(bottom_tm_blob_data, v_offset + 1);
-        afp v2 = buffer_ld1(bottom_tm_blob_data, v_offset + 2);
-        afp v3 = buffer_ld1(bottom_tm_blob_data, v_offset + 3);
+        afp v0 = (gx + 0 < psc(outw)) ? buffer_ld1(bottom_tm_blob_data, v_offset + 0) : afp(0.f);
+        afp v1 = (gx + 1 < psc(outw)) ? buffer_ld1(bottom_tm_blob_data, v_offset + 1) : afp(0.f);
+        afp v2 = (gx + 2 < psc(outw)) ? buffer_ld1(bottom_tm_blob_data, v_offset + 2) : afp(0.f);
+        afp v3 = (gx + 3 < psc(outw)) ? buffer_ld1(bottom_tm_blob_data, v_offset + 3) : afp(0.f);
 
         afp k = buffer_ld1(weight_tm_data, w_offset);
 

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
@@ -135,28 +135,17 @@ void main()
 #else
     for (int z = 0; z < c; z++)
     {
+        afp v0 = buffer_ld1(bottom_tm_blob_data, v_offset + 0);
+        afp v1 = buffer_ld1(bottom_tm_blob_data, v_offset + 1);
+        afp v2 = buffer_ld1(bottom_tm_blob_data, v_offset + 2);
+        afp v3 = buffer_ld1(bottom_tm_blob_data, v_offset + 3);
+
         afp k = buffer_ld1(weight_tm_data, w_offset);
 
-        if (gx + 0 < psc(outw))
-        {
-            afp v0 = buffer_ld1(bottom_tm_blob_data, v_offset + 0);
-            sum0 += v0 * k;
-        }
-        if (gx + 1 < psc(outw))
-        {
-            afp v1 = buffer_ld1(bottom_tm_blob_data, v_offset + 1);
-            sum1 += v1 * k;
-        }
-        if (gx + 2 < psc(outw))
-        {
-            afp v2 = buffer_ld1(bottom_tm_blob_data, v_offset + 2);
-            sum2 += v2 * k;
-        }
-        if (gx + 3 < psc(outw))
-        {
-            afp v3 = buffer_ld1(bottom_tm_blob_data, v_offset + 3);
-            sum3 += v3 * k;
-        }
+        sum0 += v0 * k;
+        sum1 += v1 * k;
+        sum2 += v2 * k;
+        sum3 += v3 * k;
 
         v_offset += psc(cstep);
         w_offset += 1;

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
@@ -48,7 +48,7 @@ void main()
     afp sum3 = afp(0.f);
 
     int v_offset = gz * c * psc(cstep) + gx;
-    int w_offset = gz * psc(wcstep) + gy * c;
+    int w_offset = gz * p.wcstep + gy * c;
 
 #if NCNN_shader_local_memory
     const int lx = int(gl_LocalInvocationID.x);

--- a/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_3s1d1_winograd_gemm.comp
@@ -61,7 +61,10 @@ void main()
         {
             for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
             {
-                tmp_v[lx][z4][ly] = buffer_sm1(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                if (gx + ly < psc(outw))
+                    tmp_v[lx][z4][ly] = buffer_sm1(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                else
+                    tmp_v[lx][z4][ly] = lfp(0.f);
             }
         }
 
@@ -69,7 +72,10 @@ void main()
         {
             for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
             {
-                tmp_k[ly][z4] = buffer_sm1(weight_tm_data, w_offset + z4);
+                if (gy < outc)
+                    tmp_k[ly][z4] = buffer_sm1(weight_tm_data, w_offset + z4);
+                else
+                    tmp_k[ly][z4] = lfp(0.f);
             }
         }
 
@@ -104,7 +110,10 @@ void main()
         {
             for (int z4 = 0; z4 < remain; z4++)
             {
-                tmp_v[lx][z4][ly] = buffer_sm1(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                if (gx + ly < psc(outw))
+                    tmp_v[lx][z4][ly] = buffer_sm1(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                else
+                    tmp_v[lx][z4][ly] = lfp(0.f);
             }
         }
 
@@ -112,7 +121,10 @@ void main()
         {
             for (int z4 = 0; z4 < remain; z4++)
             {
-                tmp_k[ly][z4] = buffer_sm1(weight_tm_data, w_offset + z4);
+                if (gy < outc)
+                    tmp_k[ly][z4] = buffer_sm1(weight_tm_data, w_offset + z4);
+                else
+                    tmp_k[ly][z4] = lfp(0.f);
             }
         }
 

--- a/src/layer/vulkan/shader/convolution1d_pack1to4_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack1to4_3s1d1_winograd_gemm.comp
@@ -23,6 +23,7 @@ layout(push_constant) uniform parameter
     int cstep;
     int outw;
     int outcstep;
+    int wcstep;
 } p;
 
 #if NCNN_shader_local_memory
@@ -47,7 +48,7 @@ void main()
     afpvec4 sum3 = afpvec4(0.f);
 
     int v_offset = gz * c * psc(cstep) + gx;
-    int w_offset = gz * c * outc + gy * c;
+    int w_offset = gz * psc(wcstep) + gy * c;
 
 #if NCNN_shader_local_memory
     const int lx = int(gl_LocalInvocationID.x);

--- a/src/layer/vulkan/shader/convolution1d_pack1to4_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack1to4_3s1d1_winograd_gemm.comp
@@ -148,10 +148,10 @@ void main()
 #else
     for (int z = 0; z < c; z++)
     {
-        afp v0 = buffer_ld1(bottom_tm_blob_data, v_offset + 0);
-        afp v1 = buffer_ld1(bottom_tm_blob_data, v_offset + 1);
-        afp v2 = buffer_ld1(bottom_tm_blob_data, v_offset + 2);
-        afp v3 = buffer_ld1(bottom_tm_blob_data, v_offset + 3);
+        afp v0 = (gx + 0 < psc(outw)) ? buffer_ld1(bottom_tm_blob_data, v_offset + 0) : afp(0.f);
+        afp v1 = (gx + 1 < psc(outw)) ? buffer_ld1(bottom_tm_blob_data, v_offset + 1) : afp(0.f);
+        afp v2 = (gx + 2 < psc(outw)) ? buffer_ld1(bottom_tm_blob_data, v_offset + 2) : afp(0.f);
+        afp v3 = (gx + 3 < psc(outw)) ? buffer_ld1(bottom_tm_blob_data, v_offset + 3) : afp(0.f);
 
         afpvec4 k = buffer_ld4(weight_tm_data, w_offset);
 

--- a/src/layer/vulkan/shader/convolution1d_pack1to4_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack1to4_3s1d1_winograd_gemm.comp
@@ -61,7 +61,10 @@ void main()
         {
             for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
             {
-                tmp_v[lx][z4][ly] = buffer_sm1(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                if (gx + ly < psc(outw))
+                    tmp_v[lx][z4][ly] = buffer_sm1(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                else
+                    tmp_v[lx][z4][ly] = lfp(0.f);
             }
         }
 
@@ -69,7 +72,10 @@ void main()
         {
             for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
             {
-                tmp_k[ly][z4] = buffer_sm4(weight_tm_data, w_offset + z4);
+                if (gy < outc)
+                    tmp_k[ly][z4] = buffer_sm4(weight_tm_data, w_offset + z4);
+                else
+                    tmp_k[ly][z4] = lfpvec4(0.f);
             }
         }
 
@@ -104,7 +110,10 @@ void main()
         {
             for (int z4 = 0; z4 < remain; z4++)
             {
-                tmp_v[lx][z4][ly] = buffer_sm1(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                if (gx + ly < psc(outw))
+                    tmp_v[lx][z4][ly] = buffer_sm1(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                else
+                    tmp_v[lx][z4][ly] = lfp(0.f);
             }
         }
 
@@ -112,7 +121,10 @@ void main()
         {
             for (int z4 = 0; z4 < remain; z4++)
             {
-                tmp_k[ly][z4] = buffer_sm4(weight_tm_data, w_offset + z4);
+                if (gy < outc)
+                    tmp_k[ly][z4] = buffer_sm4(weight_tm_data, w_offset + z4);
+                else
+                    tmp_k[ly][z4] = lfpvec4(0.f);
             }
         }
 

--- a/src/layer/vulkan/shader/convolution1d_pack1to4_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack1to4_3s1d1_winograd_gemm.comp
@@ -1,0 +1,166 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#define LOCAL_MEMORY_UNROLL_INCH 8
+
+layout(constant_id = 0) const int batch = 6;
+layout(constant_id = 1) const int c = 0;
+layout(constant_id = 2) const int outc = 0;
+
+#define shape_constant_id_offset 3
+layout(constant_id = shape_constant_id_offset + 0) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer bottom_tm_blob { sfp bottom_tm_blob_data[]; };
+layout(binding = 1) writeonly buffer top_tm_blob { sfpvec4 top_tm_blob_data[]; };
+layout(binding = 2) readonly buffer weight_tm_blob { sfpvec4 weight_tm_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int cstep;
+    int outw;
+    int outcstep;
+} p;
+
+#if NCNN_shader_local_memory
+shared lfp tmp_v[8][LOCAL_MEMORY_UNROLL_INCH][4];
+shared lfpvec4 tmp_k[8][LOCAL_MEMORY_UNROLL_INCH];
+#endif
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x) * 4;
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+#if !NCNN_shader_local_memory
+    if (gx >= psc(outw) || gy >= outc || gz >= batch)
+        return;
+#endif
+
+    afpvec4 sum0 = afpvec4(0.f);
+    afpvec4 sum1 = afpvec4(0.f);
+    afpvec4 sum2 = afpvec4(0.f);
+    afpvec4 sum3 = afpvec4(0.f);
+
+    int v_offset = gz * c * psc(cstep) + gx;
+    int w_offset = gz * c * outc + gy * c;
+
+#if NCNN_shader_local_memory
+    const int lx = int(gl_LocalInvocationID.x);
+    const int ly = int(gl_LocalInvocationID.y);
+
+    int z = 0;
+    for (; z + (LOCAL_MEMORY_UNROLL_INCH - 1) < c; z += LOCAL_MEMORY_UNROLL_INCH)
+    {
+        if (ly < 4)
+        {
+            for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+            {
+                tmp_v[lx][z4][ly] = buffer_sm1(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+            }
+        }
+
+        if (lx == 0)
+        {
+            for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+            {
+                tmp_k[ly][z4] = buffer_sm4(weight_tm_data, w_offset + z4);
+            }
+        }
+
+        barrier();
+
+        for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+        {
+            afp v0 = lfp2afp(tmp_v[lx][z4][0]);
+            afp v1 = lfp2afp(tmp_v[lx][z4][1]);
+            afp v2 = lfp2afp(tmp_v[lx][z4][2]);
+            afp v3 = lfp2afp(tmp_v[lx][z4][3]);
+
+            afpvec4 k = lfp2afpvec4(tmp_k[ly][z4]);
+
+            sum0 += v0 * k;
+            sum1 += v1 * k;
+            sum2 += v2 * k;
+            sum3 += v3 * k;
+        }
+
+        v_offset += LOCAL_MEMORY_UNROLL_INCH * psc(cstep);
+        w_offset += LOCAL_MEMORY_UNROLL_INCH;
+
+        barrier();
+    }
+
+    if (z < c)
+    {
+        const int remain = c - z;
+
+        if (ly < 4)
+        {
+            for (int z4 = 0; z4 < remain; z4++)
+            {
+                tmp_v[lx][z4][ly] = buffer_sm1(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+            }
+        }
+
+        if (lx == 0)
+        {
+            for (int z4 = 0; z4 < remain; z4++)
+            {
+                tmp_k[ly][z4] = buffer_sm4(weight_tm_data, w_offset + z4);
+            }
+        }
+
+        barrier();
+
+        for (int z4 = 0; z4 < remain; z4++)
+        {
+            afp v0 = lfp2afp(tmp_v[lx][z4][0]);
+            afp v1 = lfp2afp(tmp_v[lx][z4][1]);
+            afp v2 = lfp2afp(tmp_v[lx][z4][2]);
+            afp v3 = lfp2afp(tmp_v[lx][z4][3]);
+
+            afpvec4 k = lfp2afpvec4(tmp_k[ly][z4]);
+
+            sum0 += v0 * k;
+            sum1 += v1 * k;
+            sum2 += v2 * k;
+            sum3 += v3 * k;
+        }
+    }
+#else
+    for (int z = 0; z < c; z++)
+    {
+        afp v0 = buffer_ld1(bottom_tm_blob_data, v_offset + 0);
+        afp v1 = buffer_ld1(bottom_tm_blob_data, v_offset + 1);
+        afp v2 = buffer_ld1(bottom_tm_blob_data, v_offset + 2);
+        afp v3 = buffer_ld1(bottom_tm_blob_data, v_offset + 3);
+
+        afpvec4 k = buffer_ld4(weight_tm_data, w_offset);
+
+        sum0 += v0 * k;
+        sum1 += v1 * k;
+        sum2 += v2 * k;
+        sum3 += v3 * k;
+
+        v_offset += psc(cstep);
+        w_offset += 1;
+    }
+#endif
+
+#if NCNN_shader_local_memory
+    if (gx >= psc(outw) || gy >= outc || gz >= batch)
+        return;
+#endif
+
+    int gi = gz * outc * psc(outcstep) + gy * psc(outcstep) + gx;
+
+    buffer_st4(top_tm_blob_data, gi + 0, sum0);
+    if (gx + 1 < psc(outw)) buffer_st4(top_tm_blob_data, gi + 1, sum1);
+    if (gx + 2 < psc(outw)) buffer_st4(top_tm_blob_data, gi + 2, sum2);
+    if (gx + 3 < psc(outw)) buffer_st4(top_tm_blob_data, gi + 3, sum3);
+}

--- a/src/layer/vulkan/shader/convolution1d_pack1to4_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack1to4_3s1d1_winograd_gemm.comp
@@ -48,7 +48,7 @@ void main()
     afpvec4 sum3 = afpvec4(0.f);
 
     int v_offset = gz * c * psc(cstep) + gx;
-    int w_offset = gz * psc(wcstep) + gy * c;
+    int w_offset = gz * p.wcstep + gy * c;
 
 #if NCNN_shader_local_memory
     const int lx = int(gl_LocalInvocationID.x);

--- a/src/layer/vulkan/shader/convolution1d_pack4_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack4_3s1d1_winograd_gemm.comp
@@ -23,6 +23,7 @@ layout(push_constant) uniform parameter
     int cstep;
     int outw;
     int outcstep;
+    int wcstep;
 } p;
 
 #if NCNN_shader_local_memory
@@ -47,7 +48,7 @@ void main()
     afpvec4 sum3 = afpvec4(0.f);
 
     int v_offset = gz * c * psc(cstep) + gx;
-    int w_offset = (gz * c * outc + gy * c) * 4;
+    int w_offset = (gz * psc(wcstep) + gy * c) * 4;
 
 #if NCNN_shader_local_memory
     const int lx = int(gl_LocalInvocationID.x);

--- a/src/layer/vulkan/shader/convolution1d_pack4_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack4_3s1d1_winograd_gemm.comp
@@ -48,7 +48,7 @@ void main()
     afpvec4 sum3 = afpvec4(0.f);
 
     int v_offset = gz * c * psc(cstep) + gx;
-    int w_offset = (gz * psc(wcstep) + gy * c) * 4;
+    int w_offset = (gz * p.wcstep + gy * c) * 4;
 
 #if NCNN_shader_local_memory
     const int lx = int(gl_LocalInvocationID.x);

--- a/src/layer/vulkan/shader/convolution1d_pack4_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack4_3s1d1_winograd_gemm.comp
@@ -61,7 +61,10 @@ void main()
         {
             for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
             {
-                tmp_v[lx][z4][ly] = buffer_sm4(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                if (gx + ly < psc(outw))
+                    tmp_v[lx][z4][ly] = buffer_sm4(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                else
+                    tmp_v[lx][z4][ly] = lfpvec4(0.f);
             }
         }
 
@@ -69,7 +72,10 @@ void main()
         {
             for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
             {
-                tmp_k[ly][z4][lx] = buffer_sm4(weight_tm_data, w_offset + z4 * 4 + lx);
+                if (gy < outc)
+                    tmp_k[ly][z4][lx] = buffer_sm4(weight_tm_data, w_offset + z4 * 4 + lx);
+                else
+                    tmp_k[ly][z4][lx] = lfpvec4(0.f);
             }
         }
 
@@ -109,7 +115,10 @@ void main()
         {
             for (int z4 = 0; z4 < remain; z4++)
             {
-                tmp_v[lx][z4][ly] = buffer_sm4(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                if (gx + ly < psc(outw))
+                    tmp_v[lx][z4][ly] = buffer_sm4(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                else
+                    tmp_v[lx][z4][ly] = lfpvec4(0.f);
             }
         }
 
@@ -117,7 +126,10 @@ void main()
         {
             for (int z4 = 0; z4 < remain; z4++)
             {
-                tmp_k[ly][z4][lx] = buffer_sm4(weight_tm_data, w_offset + z4 * 4 + lx);
+                if (gy < outc)
+                    tmp_k[ly][z4][lx] = buffer_sm4(weight_tm_data, w_offset + z4 * 4 + lx);
+                else
+                    tmp_k[ly][z4][lx] = lfpvec4(0.f);
             }
         }
 

--- a/src/layer/vulkan/shader/convolution1d_pack4_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack4_3s1d1_winograd_gemm.comp
@@ -1,0 +1,180 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#define LOCAL_MEMORY_UNROLL_INCH 8
+
+layout(constant_id = 0) const int batch = 6;
+layout(constant_id = 1) const int c = 0;
+layout(constant_id = 2) const int outc = 0;
+
+#define shape_constant_id_offset 3
+layout(constant_id = shape_constant_id_offset + 0) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer bottom_tm_blob { sfpvec4 bottom_tm_blob_data[]; };
+layout(binding = 1) writeonly buffer top_tm_blob { sfpvec4 top_tm_blob_data[]; };
+layout(binding = 2) readonly buffer weight_tm_blob { sfpvec4 weight_tm_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int cstep;
+    int outw;
+    int outcstep;
+} p;
+
+#if NCNN_shader_local_memory
+shared lfpvec4 tmp_v[8][LOCAL_MEMORY_UNROLL_INCH][4];
+shared lfpvec4 tmp_k[8][LOCAL_MEMORY_UNROLL_INCH][4];
+#endif
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x) * 4;
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+#if !NCNN_shader_local_memory
+    if (gx >= psc(outw) || gy >= outc || gz >= batch)
+        return;
+#endif
+
+    afpvec4 sum0 = afpvec4(0.f);
+    afpvec4 sum1 = afpvec4(0.f);
+    afpvec4 sum2 = afpvec4(0.f);
+    afpvec4 sum3 = afpvec4(0.f);
+
+    int v_offset = gz * c * psc(cstep) + gx;
+    int w_offset = (gz * c * outc + gy * c) * 4;
+
+#if NCNN_shader_local_memory
+    const int lx = int(gl_LocalInvocationID.x);
+    const int ly = int(gl_LocalInvocationID.y);
+
+    int z = 0;
+    for (; z + (LOCAL_MEMORY_UNROLL_INCH - 1) < c; z += LOCAL_MEMORY_UNROLL_INCH)
+    {
+        if (ly < 4)
+        {
+            for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+            {
+                tmp_v[lx][z4][ly] = buffer_sm4(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+            }
+        }
+
+        if (lx < 4)
+        {
+            for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+            {
+                tmp_k[ly][z4][lx] = buffer_sm4(weight_tm_data, w_offset + z4 * 4 + lx);
+            }
+        }
+
+        barrier();
+
+        for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+        {
+            afpvec4 v0 = lfp2afpvec4(tmp_v[lx][z4][0]);
+            afpvec4 v1 = lfp2afpvec4(tmp_v[lx][z4][1]);
+            afpvec4 v2 = lfp2afpvec4(tmp_v[lx][z4][2]);
+            afpvec4 v3 = lfp2afpvec4(tmp_v[lx][z4][3]);
+
+            afpvec4 k0 = lfp2afpvec4(tmp_k[ly][z4][0]);
+            afpvec4 k1 = lfp2afpvec4(tmp_k[ly][z4][1]);
+            afpvec4 k2 = lfp2afpvec4(tmp_k[ly][z4][2]);
+            afpvec4 k3 = lfp2afpvec4(tmp_k[ly][z4][3]);
+
+            afpmat4 k = afpmat4(k0, k1, k2, k3);
+
+            sum0 += v0 * k;
+            sum1 += v1 * k;
+            sum2 += v2 * k;
+            sum3 += v3 * k;
+        }
+
+        v_offset += LOCAL_MEMORY_UNROLL_INCH * psc(cstep);
+        w_offset += LOCAL_MEMORY_UNROLL_INCH * 4;
+
+        barrier();
+    }
+
+    if (z < c)
+    {
+        const int remain = c - z;
+
+        if (ly < 4)
+        {
+            for (int z4 = 0; z4 < remain; z4++)
+            {
+                tmp_v[lx][z4][ly] = buffer_sm4(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+            }
+        }
+
+        if (lx < 4)
+        {
+            for (int z4 = 0; z4 < remain; z4++)
+            {
+                tmp_k[ly][z4][lx] = buffer_sm4(weight_tm_data, w_offset + z4 * 4 + lx);
+            }
+        }
+
+        barrier();
+
+        for (int z4 = 0; z4 < remain; z4++)
+        {
+            afpvec4 v0 = lfp2afpvec4(tmp_v[lx][z4][0]);
+            afpvec4 v1 = lfp2afpvec4(tmp_v[lx][z4][1]);
+            afpvec4 v2 = lfp2afpvec4(tmp_v[lx][z4][2]);
+            afpvec4 v3 = lfp2afpvec4(tmp_v[lx][z4][3]);
+
+            afpvec4 k0 = lfp2afpvec4(tmp_k[ly][z4][0]);
+            afpvec4 k1 = lfp2afpvec4(tmp_k[ly][z4][1]);
+            afpvec4 k2 = lfp2afpvec4(tmp_k[ly][z4][2]);
+            afpvec4 k3 = lfp2afpvec4(tmp_k[ly][z4][3]);
+
+            afpmat4 k = afpmat4(k0, k1, k2, k3);
+
+            sum0 += v0 * k;
+            sum1 += v1 * k;
+            sum2 += v2 * k;
+            sum3 += v3 * k;
+        }
+    }
+#else
+    for (int z = 0; z < c; z++)
+    {
+        afpvec4 v0 = buffer_ld4(bottom_tm_blob_data, v_offset + 0);
+        afpvec4 v1 = buffer_ld4(bottom_tm_blob_data, v_offset + 1);
+        afpvec4 v2 = buffer_ld4(bottom_tm_blob_data, v_offset + 2);
+        afpvec4 v3 = buffer_ld4(bottom_tm_blob_data, v_offset + 3);
+
+        afpmat4 k = afpmat4(
+            buffer_ld4(weight_tm_data, w_offset + 0),
+            buffer_ld4(weight_tm_data, w_offset + 1),
+            buffer_ld4(weight_tm_data, w_offset + 2),
+            buffer_ld4(weight_tm_data, w_offset + 3));
+
+        sum0 += v0 * k;
+        sum1 += v1 * k;
+        sum2 += v2 * k;
+        sum3 += v3 * k;
+
+        v_offset += psc(cstep);
+        w_offset += 4;
+    }
+#endif
+
+#if NCNN_shader_local_memory
+    if (gx >= psc(outw) || gy >= outc || gz >= batch)
+        return;
+#endif
+
+    int gi = gz * outc * psc(outcstep) + gy * psc(outcstep) + gx;
+
+    buffer_st4(top_tm_blob_data, gi + 0, sum0);
+    if (gx + 1 < psc(outw)) buffer_st4(top_tm_blob_data, gi + 1, sum1);
+    if (gx + 2 < psc(outw)) buffer_st4(top_tm_blob_data, gi + 2, sum2);
+    if (gx + 3 < psc(outw)) buffer_st4(top_tm_blob_data, gi + 3, sum3);
+}

--- a/src/layer/vulkan/shader/convolution1d_pack4_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack4_3s1d1_winograd_gemm.comp
@@ -158,10 +158,10 @@ void main()
 #else
     for (int z = 0; z < c; z++)
     {
-        afpvec4 v0 = buffer_ld4(bottom_tm_blob_data, v_offset + 0);
-        afpvec4 v1 = buffer_ld4(bottom_tm_blob_data, v_offset + 1);
-        afpvec4 v2 = buffer_ld4(bottom_tm_blob_data, v_offset + 2);
-        afpvec4 v3 = buffer_ld4(bottom_tm_blob_data, v_offset + 3);
+        afpvec4 v0 = (gx + 0 < psc(outw)) ? buffer_ld4(bottom_tm_blob_data, v_offset + 0) : afpvec4(0.f);
+        afpvec4 v1 = (gx + 1 < psc(outw)) ? buffer_ld4(bottom_tm_blob_data, v_offset + 1) : afpvec4(0.f);
+        afpvec4 v2 = (gx + 2 < psc(outw)) ? buffer_ld4(bottom_tm_blob_data, v_offset + 2) : afpvec4(0.f);
+        afpvec4 v3 = (gx + 3 < psc(outw)) ? buffer_ld4(bottom_tm_blob_data, v_offset + 3) : afpvec4(0.f);
 
         afpmat4 k = afpmat4(
             buffer_ld4(weight_tm_data, w_offset + 0),

--- a/src/layer/vulkan/shader/convolution1d_pack4to1_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack4to1_3s1d1_winograd_gemm.comp
@@ -61,7 +61,10 @@ void main()
         {
             for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
             {
-                tmp_v[lx][z4][ly] = buffer_sm4(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                if (gx + ly < psc(outw))
+                    tmp_v[lx][z4][ly] = buffer_sm4(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                else
+                    tmp_v[lx][z4][ly] = lfpvec4(0.f);
             }
         }
 
@@ -69,7 +72,10 @@ void main()
         {
             for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
             {
-                tmp_k[ly][z4] = buffer_sm4(weight_tm_data, w_offset + z4);
+                if (gy < outc)
+                    tmp_k[ly][z4] = buffer_sm4(weight_tm_data, w_offset + z4);
+                else
+                    tmp_k[ly][z4] = lfpvec4(0.f);
             }
         }
 
@@ -104,7 +110,10 @@ void main()
         {
             for (int z4 = 0; z4 < remain; z4++)
             {
-                tmp_v[lx][z4][ly] = buffer_sm4(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                if (gx + ly < psc(outw))
+                    tmp_v[lx][z4][ly] = buffer_sm4(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+                else
+                    tmp_v[lx][z4][ly] = lfpvec4(0.f);
             }
         }
 
@@ -112,7 +121,10 @@ void main()
         {
             for (int z4 = 0; z4 < remain; z4++)
             {
-                tmp_k[ly][z4] = buffer_sm4(weight_tm_data, w_offset + z4);
+                if (gy < outc)
+                    tmp_k[ly][z4] = buffer_sm4(weight_tm_data, w_offset + z4);
+                else
+                    tmp_k[ly][z4] = lfpvec4(0.f);
             }
         }
 

--- a/src/layer/vulkan/shader/convolution1d_pack4to1_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack4to1_3s1d1_winograd_gemm.comp
@@ -148,10 +148,10 @@ void main()
 #else
     for (int z = 0; z < c; z++)
     {
-        afpvec4 v0 = buffer_ld4(bottom_tm_blob_data, v_offset + 0);
-        afpvec4 v1 = buffer_ld4(bottom_tm_blob_data, v_offset + 1);
-        afpvec4 v2 = buffer_ld4(bottom_tm_blob_data, v_offset + 2);
-        afpvec4 v3 = buffer_ld4(bottom_tm_blob_data, v_offset + 3);
+        afpvec4 v0 = (gx + 0 < psc(outw)) ? buffer_ld4(bottom_tm_blob_data, v_offset + 0) : afpvec4(0.f);
+        afpvec4 v1 = (gx + 1 < psc(outw)) ? buffer_ld4(bottom_tm_blob_data, v_offset + 1) : afpvec4(0.f);
+        afpvec4 v2 = (gx + 2 < psc(outw)) ? buffer_ld4(bottom_tm_blob_data, v_offset + 2) : afpvec4(0.f);
+        afpvec4 v3 = (gx + 3 < psc(outw)) ? buffer_ld4(bottom_tm_blob_data, v_offset + 3) : afpvec4(0.f);
 
         afpvec4 k = buffer_ld4(weight_tm_data, w_offset);
 

--- a/src/layer/vulkan/shader/convolution1d_pack4to1_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack4to1_3s1d1_winograd_gemm.comp
@@ -23,6 +23,7 @@ layout(push_constant) uniform parameter
     int cstep;
     int outw;
     int outcstep;
+    int wcstep;
 } p;
 
 #if NCNN_shader_local_memory
@@ -47,7 +48,7 @@ void main()
     afp sum3 = afp(0.f);
 
     int v_offset = gz * c * psc(cstep) + gx;
-    int w_offset = gz * c * outc + gy * c;
+    int w_offset = gz * psc(wcstep) + gy * c;
 
 #if NCNN_shader_local_memory
     const int lx = int(gl_LocalInvocationID.x);

--- a/src/layer/vulkan/shader/convolution1d_pack4to1_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack4to1_3s1d1_winograd_gemm.comp
@@ -48,7 +48,7 @@ void main()
     afp sum3 = afp(0.f);
 
     int v_offset = gz * c * psc(cstep) + gx;
-    int w_offset = gz * psc(wcstep) + gy * c;
+    int w_offset = gz * p.wcstep + gy * c;
 
 #if NCNN_shader_local_memory
     const int lx = int(gl_LocalInvocationID.x);

--- a/src/layer/vulkan/shader/convolution1d_pack4to1_3s1d1_winograd_gemm.comp
+++ b/src/layer/vulkan/shader/convolution1d_pack4to1_3s1d1_winograd_gemm.comp
@@ -1,0 +1,166 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#define LOCAL_MEMORY_UNROLL_INCH 8
+
+layout(constant_id = 0) const int batch = 6;
+layout(constant_id = 1) const int c = 0;
+layout(constant_id = 2) const int outc = 0;
+
+#define shape_constant_id_offset 3
+layout(constant_id = shape_constant_id_offset + 0) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer bottom_tm_blob { sfpvec4 bottom_tm_blob_data[]; };
+layout(binding = 1) writeonly buffer top_tm_blob { sfp top_tm_blob_data[]; };
+layout(binding = 2) readonly buffer weight_tm_blob { sfpvec4 weight_tm_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int cstep;
+    int outw;
+    int outcstep;
+} p;
+
+#if NCNN_shader_local_memory
+shared lfpvec4 tmp_v[8][LOCAL_MEMORY_UNROLL_INCH][4];
+shared lfpvec4 tmp_k[8][LOCAL_MEMORY_UNROLL_INCH];
+#endif
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x) * 4;
+    int gy = int(gl_GlobalInvocationID.y);
+    int gz = int(gl_GlobalInvocationID.z);
+
+#if !NCNN_shader_local_memory
+    if (gx >= psc(outw) || gy >= outc || gz >= batch)
+        return;
+#endif
+
+    afp sum0 = afp(0.f);
+    afp sum1 = afp(0.f);
+    afp sum2 = afp(0.f);
+    afp sum3 = afp(0.f);
+
+    int v_offset = gz * c * psc(cstep) + gx;
+    int w_offset = gz * c * outc + gy * c;
+
+#if NCNN_shader_local_memory
+    const int lx = int(gl_LocalInvocationID.x);
+    const int ly = int(gl_LocalInvocationID.y);
+
+    int z = 0;
+    for (; z + (LOCAL_MEMORY_UNROLL_INCH - 1) < c; z += LOCAL_MEMORY_UNROLL_INCH)
+    {
+        if (ly < 4)
+        {
+            for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+            {
+                tmp_v[lx][z4][ly] = buffer_sm4(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+            }
+        }
+
+        if (lx == 0)
+        {
+            for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+            {
+                tmp_k[ly][z4] = buffer_sm4(weight_tm_data, w_offset + z4);
+            }
+        }
+
+        barrier();
+
+        for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+        {
+            afpvec4 v0 = lfp2afpvec4(tmp_v[lx][z4][0]);
+            afpvec4 v1 = lfp2afpvec4(tmp_v[lx][z4][1]);
+            afpvec4 v2 = lfp2afpvec4(tmp_v[lx][z4][2]);
+            afpvec4 v3 = lfp2afpvec4(tmp_v[lx][z4][3]);
+
+            afpvec4 k = lfp2afpvec4(tmp_k[ly][z4]);
+
+            sum0 += dot(v0, k);
+            sum1 += dot(v1, k);
+            sum2 += dot(v2, k);
+            sum3 += dot(v3, k);
+        }
+
+        v_offset += LOCAL_MEMORY_UNROLL_INCH * psc(cstep);
+        w_offset += LOCAL_MEMORY_UNROLL_INCH;
+
+        barrier();
+    }
+
+    if (z < c)
+    {
+        const int remain = c - z;
+
+        if (ly < 4)
+        {
+            for (int z4 = 0; z4 < remain; z4++)
+            {
+                tmp_v[lx][z4][ly] = buffer_sm4(bottom_tm_blob_data, v_offset + z4 * psc(cstep) + ly);
+            }
+        }
+
+        if (lx == 0)
+        {
+            for (int z4 = 0; z4 < remain; z4++)
+            {
+                tmp_k[ly][z4] = buffer_sm4(weight_tm_data, w_offset + z4);
+            }
+        }
+
+        barrier();
+
+        for (int z4 = 0; z4 < remain; z4++)
+        {
+            afpvec4 v0 = lfp2afpvec4(tmp_v[lx][z4][0]);
+            afpvec4 v1 = lfp2afpvec4(tmp_v[lx][z4][1]);
+            afpvec4 v2 = lfp2afpvec4(tmp_v[lx][z4][2]);
+            afpvec4 v3 = lfp2afpvec4(tmp_v[lx][z4][3]);
+
+            afpvec4 k = lfp2afpvec4(tmp_k[ly][z4]);
+
+            sum0 += dot(v0, k);
+            sum1 += dot(v1, k);
+            sum2 += dot(v2, k);
+            sum3 += dot(v3, k);
+        }
+    }
+#else
+    for (int z = 0; z < c; z++)
+    {
+        afpvec4 v0 = buffer_ld4(bottom_tm_blob_data, v_offset + 0);
+        afpvec4 v1 = buffer_ld4(bottom_tm_blob_data, v_offset + 1);
+        afpvec4 v2 = buffer_ld4(bottom_tm_blob_data, v_offset + 2);
+        afpvec4 v3 = buffer_ld4(bottom_tm_blob_data, v_offset + 3);
+
+        afpvec4 k = buffer_ld4(weight_tm_data, w_offset);
+
+        sum0 += dot(v0, k);
+        sum1 += dot(v1, k);
+        sum2 += dot(v2, k);
+        sum3 += dot(v3, k);
+
+        v_offset += psc(cstep);
+        w_offset += 1;
+    }
+#endif
+
+#if NCNN_shader_local_memory
+    if (gx >= psc(outw) || gy >= outc || gz >= batch)
+        return;
+#endif
+
+    int gi = gz * outc * psc(outcstep) + gy * psc(outcstep) + gx;
+
+    buffer_st1(top_tm_blob_data, gi + 0, sum0);
+    if (gx + 1 < psc(outw)) buffer_st1(top_tm_blob_data, gi + 1, sum1);
+    if (gx + 2 < psc(outw)) buffer_st1(top_tm_blob_data, gi + 2, sum2);
+    if (gx + 3 < psc(outw)) buffer_st1(top_tm_blob_data, gi + 3, sum3);
+}

--- a/src/layer/vulkan/shader/convolution1d_packed.comp
+++ b/src/layer/vulkan/shader/convolution1d_packed.comp
@@ -55,24 +55,26 @@ void main()
     const ivec2 gx2 = gx + ivec2(0, 1);
     const ivec2 gy2 = gy + ivec2(0, 1);
 
-    afpvec4 sum0;
-    afpvec4 sum1;
-    afpvec4 sum2;
-    afpvec4 sum3;
+    // Use fp32 accumulators to avoid precision loss when use_fp16_arithmetic=true
+    // Storage remains fp16 for bandwidth efficiency, but accumulation happens in fp32
+    vec4 sum0;
+    vec4 sum1;
+    vec4 sum2;
+    vec4 sum3;
 
     if (bias_term == 1)
     {
-        sum0 = buffer_ld4(bias_data, gy2.x);
-        sum2 = buffer_ld4(bias_data, gy2.y);
+        sum0 = vec4(buffer_ld4(bias_data, gy2.x));
+        sum2 = vec4(buffer_ld4(bias_data, gy2.y));
         sum1 = sum0;
         sum3 = sum2;
     }
     else
     {
-        sum0 = afpvec4(0.f);
-        sum1 = afpvec4(0.f);
-        sum2 = afpvec4(0.f);
-        sum3 = afpvec4(0.f);
+        sum0 = vec4(0.f);
+        sum1 = vec4(0.f);
+        sum2 = vec4(0.f);
+        sum3 = vec4(0.f);
     }
 
     ivec2 v_offset = gx2 * stride_w;
@@ -98,10 +100,11 @@ void main()
                     buffer_ld4(weight_data, (w_offset.y + x) * 4 + 2),
                     buffer_ld4(weight_data, (w_offset.y + x) * 4 + 3));
 
-                sum0 += v0 * k0;
-                sum1 += v1 * k0;
-                sum2 += v0 * k1;
-                sum3 += v1 * k1;
+                // Convert to fp32 for accumulation
+                sum0 += vec4(v0) * mat4(k0);
+                sum1 += vec4(v1) * mat4(k0);
+                sum2 += vec4(v0) * mat4(k1);
+                sum3 += vec4(v1) * mat4(k1);
             }
             else
             {
@@ -111,29 +114,36 @@ void main()
                 afpvec4 k0 = buffer_ld4(weight_data, w_offset.x + x);
                 afpvec4 k1 = buffer_ld4(weight_data, w_offset.y + x);
 
-                sum0 += v0 * k0;
-                sum1 += v1 * k0;
-                sum2 += v0 * k1;
-                sum3 += v1 * k1;
+                // Convert to fp32 for accumulation
+                sum0 += vec4(v0) * vec4(k0);
+                sum1 += vec4(v1) * vec4(k0);
+                sum2 += vec4(v0) * vec4(k1);
+                sum3 += vec4(v1) * vec4(k1);
             }
         }
         v_offset += psc(w);
         w_offset += kernel_w;
     }
 
-    sum0 = activation_afpvec4(sum0, activation_type, activation_param_0, activation_param_1);
-    sum1 = activation_afpvec4(sum1, activation_type, activation_param_0, activation_param_1);
-    sum2 = activation_afpvec4(sum2, activation_type, activation_param_0, activation_param_1);
-    sum3 = activation_afpvec4(sum3, activation_type, activation_param_0, activation_param_1);
+    // Convert fp32 accumulators back to afpvec4 for activation and output
+    afpvec4 sum0_afp = afpvec4(sum0);
+    afpvec4 sum1_afp = afpvec4(sum1);
+    afpvec4 sum2_afp = afpvec4(sum2);
+    afpvec4 sum3_afp = afpvec4(sum3);
+
+    sum0_afp = activation_afpvec4(sum0_afp, activation_type, activation_param_0, activation_param_1);
+    sum1_afp = activation_afpvec4(sum1_afp, activation_type, activation_param_0, activation_param_1);
+    sum2_afp = activation_afpvec4(sum2_afp, activation_type, activation_param_0, activation_param_1);
+    sum3_afp = activation_afpvec4(sum3_afp, activation_type, activation_param_0, activation_param_1);
 
     if (out_elempack == 4)
     {
         const int gi = gy * psc(outw) + gx;
 
-        buffer_st4(top_blob_data_4, gi, sum0);
-        if (gx + 1 < psc(outw)) buffer_st4(top_blob_data_4, gi + 1, sum1);
-        if (gy + 1 < psc(outh)) buffer_st4(top_blob_data_4, gi + psc(outw), sum2);
-        if (gy + 1 < psc(outh) && gx + 1 < psc(outw)) buffer_st4(top_blob_data_4, gi + psc(outw) + 1, sum3);
+        buffer_st4(top_blob_data_4, gi, sum0_afp);
+        if (gx + 1 < psc(outw)) buffer_st4(top_blob_data_4, gi + 1, sum1_afp);
+        if (gy + 1 < psc(outh)) buffer_st4(top_blob_data_4, gi + psc(outw), sum2_afp);
+        if (gy + 1 < psc(outh) && gx + 1 < psc(outw)) buffer_st4(top_blob_data_4, gi + psc(outw) + 1, sum3_afp);
     }
     else
     {
@@ -143,33 +153,33 @@ void main()
         const ivec2 base_ch = gy2 * 4;
         const int nout = psc(num_output);
 
-        buffer_st1(top_blob_data_1, gi, sum0.r);
-        if (base_ch.x + 1 < nout) buffer_st1(top_blob_data_1, gi + outcstep, sum0.g);
-        if (base_ch.x + 2 < nout) buffer_st1(top_blob_data_1, gi + outcstep * 2, sum0.b);
-        if (base_ch.x + 3 < nout) buffer_st1(top_blob_data_1, gi + outcstep * 3, sum0.a);
+        buffer_st1(top_blob_data_1, gi, sum0_afp.r);
+        if (base_ch.x + 1 < nout) buffer_st1(top_blob_data_1, gi + outcstep, sum0_afp.g);
+        if (base_ch.x + 2 < nout) buffer_st1(top_blob_data_1, gi + outcstep * 2, sum0_afp.b);
+        if (base_ch.x + 3 < nout) buffer_st1(top_blob_data_1, gi + outcstep * 3, sum0_afp.a);
 
         if (gx + 1 < psc(outw))
         {
-            buffer_st1(top_blob_data_1, gi + 1, sum1.r);
-            if (base_ch.x + 1 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep, sum1.g);
-            if (base_ch.x + 2 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep * 2, sum1.b);
-            if (base_ch.x + 3 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep * 3, sum1.a);
+            buffer_st1(top_blob_data_1, gi + 1, sum1_afp.r);
+            if (base_ch.x + 1 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep, sum1_afp.g);
+            if (base_ch.x + 2 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep * 2, sum1_afp.b);
+            if (base_ch.x + 3 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep * 3, sum1_afp.a);
         }
         if (gy + 1 < psc(outh))
         {
             int gi2 = gi + outcstep * 4;
-            if (base_ch.y < nout) buffer_st1(top_blob_data_1, gi2, sum2.r);
-            if (base_ch.y + 1 < nout) buffer_st1(top_blob_data_1, gi2 + outcstep, sum2.g);
-            if (base_ch.y + 2 < nout) buffer_st1(top_blob_data_1, gi2 + outcstep * 2, sum2.b);
-            if (base_ch.y + 3 < nout) buffer_st1(top_blob_data_1, gi2 + outcstep * 3, sum2.a);
+            if (base_ch.y < nout) buffer_st1(top_blob_data_1, gi2, sum2_afp.r);
+            if (base_ch.y + 1 < nout) buffer_st1(top_blob_data_1, gi2 + outcstep, sum2_afp.g);
+            if (base_ch.y + 2 < nout) buffer_st1(top_blob_data_1, gi2 + outcstep * 2, sum2_afp.b);
+            if (base_ch.y + 3 < nout) buffer_st1(top_blob_data_1, gi2 + outcstep * 3, sum2_afp.a);
         }
         if (gy + 1 < psc(outh) && gx + 1 < psc(outw))
         {
             int gi3 = gi + outcstep * 4 + 1;
-            if (base_ch.y < nout) buffer_st1(top_blob_data_1, gi3, sum3.r);
-            if (base_ch.y + 1 < nout) buffer_st1(top_blob_data_1, gi3 + outcstep, sum3.g);
-            if (base_ch.y + 2 < nout) buffer_st1(top_blob_data_1, gi3 + outcstep * 2, sum3.b);
-            if (base_ch.y + 3 < nout) buffer_st1(top_blob_data_1, gi3 + outcstep * 3, sum3.a);
+            if (base_ch.y < nout) buffer_st1(top_blob_data_1, gi3, sum3_afp.r);
+            if (base_ch.y + 1 < nout) buffer_st1(top_blob_data_1, gi3 + outcstep, sum3_afp.g);
+            if (base_ch.y + 2 < nout) buffer_st1(top_blob_data_1, gi3 + outcstep * 2, sum3_afp.b);
+            if (base_ch.y + 3 < nout) buffer_st1(top_blob_data_1, gi3 + outcstep * 3, sum3_afp.a);
         }
     }
 }

--- a/src/layer/vulkan/shader/convolution1d_packed_3s1d1_winograd23_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution1d_packed_3s1d1_winograd23_transform_input.comp
@@ -1,0 +1,56 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+layout(constant_id = 0) const int c = 0;
+
+#define shape_constant_id_offset 1
+layout(constant_id = shape_constant_id_offset + 0) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outcstep = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int block_x = 0;
+
+layout(binding = 0) readonly buffer bottom_blob { sfpvec4 bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer bottom_tm_blob { sfpvec4 bottom_tm_blob_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int w;
+    int cstep;
+    int outcstep;
+    int block_x;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= psc(block_x) || gz >= c)
+        return;
+
+    // load 4 elements from input (1D: only x dimension)
+    int sx = gx * 2;  // each tile produces 2 output elements, needs 4 input elements
+
+    int v_offset = gz * psc(cstep) + sx;
+
+    afpvec4 d0 = buffer_ld4(bottom_blob_data, v_offset + 0);
+    afpvec4 d1 = sx + 1 < psc(w) ? buffer_ld4(bottom_blob_data, v_offset + 1) : afpvec4(0.f);
+    afpvec4 d2 = sx + 2 < psc(w) ? buffer_ld4(bottom_blob_data, v_offset + 2) : afpvec4(0.f);
+    afpvec4 d3 = sx + 3 < psc(w) ? buffer_ld4(bottom_blob_data, v_offset + 3) : afpvec4(0.f);
+
+    // B^T transform (4x4) - only once (1D)
+    afpvec4 v0 = d0 - d2;
+    afpvec4 v1 = d1 + d2;
+    afpvec4 v2 = d2 - d1;
+    afpvec4 v3 = d3 - d1;
+
+    // store 4 transformed values
+    int v_tm_offset = gz * psc(outcstep) + gx;
+
+    buffer_st4(bottom_tm_blob_data, v_tm_offset + 0 * psc(outcstep) * c, v0);
+    buffer_st4(bottom_tm_blob_data, v_tm_offset + 1 * psc(outcstep) * c, v1);
+    buffer_st4(bottom_tm_blob_data, v_tm_offset + 2 * psc(outcstep) * c, v2);
+    buffer_st4(bottom_tm_blob_data, v_tm_offset + 3 * psc(outcstep) * c, v3);
+}

--- a/src/layer/vulkan/shader/convolution1d_packed_3s1d1_winograd23_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution1d_packed_3s1d1_winograd23_transform_input.comp
@@ -31,7 +31,7 @@ void main()
         return;
 
     // load 4 elements from input (1D: only x dimension)
-    int sx = gx * 2;  // each tile produces 2 output elements, needs 4 input elements
+    int sx = gx * 2; // each tile produces 2 output elements, needs 4 input elements
 
     int v_offset = gz * psc(cstep) + sx;
 

--- a/src/layer/vulkan/shader/convolution1d_packed_3s1d1_winograd23_transform_output.comp
+++ b/src/layer/vulkan/shader/convolution1d_packed_3s1d1_winograd23_transform_output.comp
@@ -1,0 +1,71 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int bias_term = 0;
+layout(constant_id = 1) const int activation_type = 0;
+layout(constant_id = 2) const float activation_param_0 = 0;
+layout(constant_id = 3) const float activation_param_1 = 0;
+layout(constant_id = 4) const int c = 0;
+
+#define shape_constant_id_offset 5
+layout(constant_id = shape_constant_id_offset + 0) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int block_x = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer top_tm_blob { sfpvec4 top_tm_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfpvec4 top_blob_data[]; };
+layout(binding = 2) readonly buffer bias_blob { sfpvec4 bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int cstep;
+    int block_x;
+    int outw;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= psc(block_x) || gz >= c)
+        return;
+
+    // load 4 accumulated values from transform domain
+    int v_tm_offset = gz * psc(cstep) + gx;
+
+    afpvec4 m0 = buffer_ld4(top_tm_blob_data, v_tm_offset + 0 * psc(cstep) * c);
+    afpvec4 m1 = buffer_ld4(top_tm_blob_data, v_tm_offset + 1 * psc(cstep) * c);
+    afpvec4 m2 = buffer_ld4(top_tm_blob_data, v_tm_offset + 2 * psc(cstep) * c);
+    afpvec4 m3 = buffer_ld4(top_tm_blob_data, v_tm_offset + 3 * psc(cstep) * c);
+
+    // A^T transform (2x4) - only once (1D)
+    afpvec4 y0 = m0 + m1 + m2;
+    afpvec4 y1 = m1 - m2 + m3;
+
+    // bias
+    if (bias_term == 1)
+    {
+        const afpvec4 bias_value = buffer_ld4(bias_data, gz);
+        y0 = bias_value + y0;
+        y1 = bias_value + y1;
+    }
+
+    // activation
+    y0 = activation_afpvec4(y0, activation_type, activation_param_0, activation_param_1);
+    y1 = activation_afpvec4(y1, activation_type, activation_param_0, activation_param_1);
+
+    // store 2 output elements
+    int x = gx * 2;
+    int v_offset = gz * psc(outcstep) + x;
+
+    buffer_st4(top_blob_data, v_offset + 0, y0);
+    if (x + 1 < psc(outw)) buffer_st4(top_blob_data, v_offset + 1, y1);
+}

--- a/src/layer/vulkan/shader/convolution1d_packed_3s1d1_winograd43_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution1d_packed_3s1d1_winograd43_transform_input.comp
@@ -31,7 +31,7 @@ void main()
         return;
 
     // load 6 elements (1D: only x dimension)
-    int sx = gx * 4;  // each tile produces 4 output elements
+    int sx = gx * 4; // each tile produces 4 output elements
 
     int v_offset = gz * psc(cstep) + sx;
 

--- a/src/layer/vulkan/shader/convolution1d_packed_3s1d1_winograd43_transform_input.comp
+++ b/src/layer/vulkan/shader/convolution1d_packed_3s1d1_winograd43_transform_input.comp
@@ -1,0 +1,74 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+layout(constant_id = 0) const int c = 0;
+
+#define shape_constant_id_offset 1
+layout(constant_id = shape_constant_id_offset + 0) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outcstep = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int block_x = 0;
+
+layout(binding = 0) readonly buffer bottom_blob { sfpvec4 bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer bottom_tm_blob { sfpvec4 bottom_tm_blob_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int w;
+    int cstep;
+    int outcstep;
+    int block_x;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= psc(block_x) || gz >= c)
+        return;
+
+    // load 6 elements (1D: only x dimension)
+    int sx = gx * 4;  // each tile produces 4 output elements
+
+    int v_offset = gz * psc(cstep) + sx;
+
+    afpvec4 d0 = buffer_ld4(bottom_blob_data, v_offset + 0);
+    afpvec4 d1 = sx + 1 < psc(w) ? buffer_ld4(bottom_blob_data, v_offset + 1) : afpvec4(0.f);
+    afpvec4 d2 = sx + 2 < psc(w) ? buffer_ld4(bottom_blob_data, v_offset + 2) : afpvec4(0.f);
+    afpvec4 d3 = sx + 3 < psc(w) ? buffer_ld4(bottom_blob_data, v_offset + 3) : afpvec4(0.f);
+    afpvec4 d4 = sx + 4 < psc(w) ? buffer_ld4(bottom_blob_data, v_offset + 4) : afpvec4(0.f);
+    afpvec4 d5 = sx + 5 < psc(w) ? buffer_ld4(bottom_blob_data, v_offset + 5) : afpvec4(0.f);
+
+#define sq2    1.41421356237
+#define sq2_d2 1.41421356237 / 2
+
+    // const float itm[6][6] = {
+    //     {1.0f,  0.0f,  -2.5f,  0.0f,  1.0f, 0.0f},
+    //     {0.0f, -sq2,   -2.0f,  sq2/2, 1.0f, 0.0f},
+    //     {0.0f,  sq2,   -2.0f, -sq2/2, 1.0f, 0.0f},
+    //     {0.0f, -sq2/2, -0.5f,  sq2,   1.0f, 0.0f},
+    //     {0.0f,  sq2/2, -0.5f, -sq2,   1.0f, 0.0f},
+    //     {0.0f,  1.0f,   0.0f,  -2.5f, 0.0f, 1.0f}
+    // };
+
+    // B^T transform (6x6) - only once (1D)
+    afpvec4 v0 = d0 - d2 * afp(2.5) + d4;
+    afpvec4 v1 = d4 - d2 * afp(2) + d3 * afp(sq2_d2) - d1 * afp(sq2);
+    afpvec4 v2 = d4 - d2 * afp(2) - d3 * afp(sq2_d2) + d1 * afp(sq2);
+    afpvec4 v3 = d4 - d2 * afp(0.5) + d3 * afp(sq2) - d1 * afp(sq2_d2);
+    afpvec4 v4 = d4 - d2 * afp(0.5) - d3 * afp(sq2) + d1 * afp(sq2_d2);
+    afpvec4 v5 = d1 - d3 * afp(2.5) + d5;
+
+    // store 6 transformed values
+    int v_tm_offset = gz * psc(outcstep) + gx;
+
+    buffer_st4(bottom_tm_blob_data, v_tm_offset + 0 * psc(outcstep) * c, v0);
+    buffer_st4(bottom_tm_blob_data, v_tm_offset + 1 * psc(outcstep) * c, v1);
+    buffer_st4(bottom_tm_blob_data, v_tm_offset + 2 * psc(outcstep) * c, v2);
+    buffer_st4(bottom_tm_blob_data, v_tm_offset + 3 * psc(outcstep) * c, v3);
+    buffer_st4(bottom_tm_blob_data, v_tm_offset + 4 * psc(outcstep) * c, v4);
+    buffer_st4(bottom_tm_blob_data, v_tm_offset + 5 * psc(outcstep) * c, v5);
+}

--- a/src/layer/vulkan/shader/convolution1d_packed_3s1d1_winograd43_transform_output.comp
+++ b/src/layer/vulkan/shader/convolution1d_packed_3s1d1_winograd43_transform_output.comp
@@ -1,0 +1,94 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int bias_term = 0;
+layout(constant_id = 1) const int activation_type = 0;
+layout(constant_id = 2) const float activation_param_0 = 0;
+layout(constant_id = 3) const float activation_param_1 = 0;
+layout(constant_id = 4) const int c = 0;
+
+#define shape_constant_id_offset 5
+layout(constant_id = shape_constant_id_offset + 0) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int block_x = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer top_tm_blob { sfpvec4 top_tm_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfpvec4 top_blob_data[]; };
+layout(binding = 2) readonly buffer bias_blob { sfpvec4 bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int cstep;
+    int block_x;
+    int outw;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gz = int(gl_GlobalInvocationID.z);
+
+    if (gx >= psc(block_x) || gz >= c)
+        return;
+
+    // load 6 accumulated values from transform domain
+    int v_tm_offset = gz * psc(cstep) + gx;
+
+    afpvec4 m0 = buffer_ld4(top_tm_blob_data, v_tm_offset + 0 * psc(cstep) * c);
+    afpvec4 m1 = buffer_ld4(top_tm_blob_data, v_tm_offset + 1 * psc(cstep) * c);
+    afpvec4 m2 = buffer_ld4(top_tm_blob_data, v_tm_offset + 2 * psc(cstep) * c);
+    afpvec4 m3 = buffer_ld4(top_tm_blob_data, v_tm_offset + 3 * psc(cstep) * c);
+    afpvec4 m4 = buffer_ld4(top_tm_blob_data, v_tm_offset + 4 * psc(cstep) * c);
+    afpvec4 m5 = buffer_ld4(top_tm_blob_data, v_tm_offset + 5 * psc(cstep) * c);
+
+#define sq2    1.41421356237
+#define sq2_m2 1.41421356237 * 2
+#define sq2_d2 1.41421356237 / 2
+#define sq2_d4 1.41421356237 / 4
+
+    // const float otm[4][6] = {
+    //     {1.0f, 1.0f,   1.0f,  1.0f,  1.0f,   0.0f},
+    //     {0.0f, sq2/2, -sq2/2, sq2,   -sq2,   0.0f},
+    //     {0.0f, 0.5f,   0.5f,  2.0f,  2.0f,   0.0f},
+    //     {0.0f, sq2/4, -sq2/4, sq2*2, -sq2*2, 1.0f}
+    // };
+
+    // A^T transform (4x6) - only once (1D)
+    afpvec4 y0 = m0 + m1 + m2 + m3 + m4;
+    afpvec4 y1 = (m1 - m2) * afp(sq2_d2) + (m3 - m4) * afp(sq2);
+    afpvec4 y2 = (m1 + m2) * afp(0.5) + (m3 + m4) * afp(2);
+    afpvec4 y3 = m5 + (m1 - m2) * afp(sq2_d4) + (m3 - m4) * afp(sq2_m2);
+
+    // bias
+    if (bias_term == 1)
+    {
+        const afpvec4 bias_value = buffer_ld4(bias_data, gz);
+
+        y0 = bias_value + y0;
+        y1 = bias_value + y1;
+        y2 = bias_value + y2;
+        y3 = bias_value + y3;
+    }
+
+    // activation
+    y0 = activation_afpvec4(y0, activation_type, activation_param_0, activation_param_1);
+    y1 = activation_afpvec4(y1, activation_type, activation_param_0, activation_param_1);
+    y2 = activation_afpvec4(y2, activation_type, activation_param_0, activation_param_1);
+    y3 = activation_afpvec4(y3, activation_type, activation_param_0, activation_param_1);
+
+    // store 4 output elements
+    int x = gx * 4;
+    int v_offset = gz * psc(outcstep) + x;
+
+    buffer_st4(top_blob_data, v_offset + 0, y0);
+    if (x + 1 < psc(outw)) buffer_st4(top_blob_data, v_offset + 1, y1);
+    if (x + 2 < psc(outw)) buffer_st4(top_blob_data, v_offset + 2, y2);
+    if (x + 3 < psc(outw)) buffer_st4(top_blob_data, v_offset + 3, y3);
+}

--- a/src/layer/vulkan/shader/convolution1d_packed_sg.comp
+++ b/src/layer/vulkan/shader/convolution1d_packed_sg.comp
@@ -85,25 +85,27 @@ void main()
 
     const int gy = int(wgni * UNROLL_SG_N + sni);
 
-    afpvec4 sum0;
-    afpvec4 sum1;
-    afpvec4 sum2;
-    afpvec4 sum3;
+    // Use fp32 accumulators to avoid precision loss when use_fp16_arithmetic=true
+    // Storage remains fp16 for bandwidth efficiency, but accumulation happens in fp32
+    vec4 sum0;
+    vec4 sum1;
+    vec4 sum2;
+    vec4 sum3;
 
     if (bias_term == 1 && gy < psc(outh))
     {
         afpvec4 b = buffer_ld4(bias_data, gy);
-        sum0 = b;
-        sum1 = b;
-        sum2 = b;
-        sum3 = b;
+        sum0 = vec4(b);
+        sum1 = vec4(b);
+        sum2 = vec4(b);
+        sum3 = vec4(b);
     }
     else
     {
-        sum0 = afpvec4(0.f);
-        sum1 = afpvec4(0.f);
-        sum2 = afpvec4(0.f);
-        sum3 = afpvec4(0.f);
+        sum0 = vec4(0.f);
+        sum1 = vec4(0.f);
+        sum2 = vec4(0.f);
+        sum3 = vec4(0.f);
     }
 
     const int maxk = kernel_w;
@@ -187,17 +189,19 @@ void main()
 
                 const afpmat4 k = afpmat4(b0s, k1, k2, k3);
 
-                sum0 += v0 * k;
-                sum1 += v1 * k;
-                sum2 += v2 * k;
-                sum3 += v3 * k;
+                // Convert to fp32 for accumulation
+                sum0 += vec4(v0) * mat4(k);
+                sum1 += vec4(v1) * mat4(k);
+                sum2 += vec4(v2) * mat4(k);
+                sum3 += vec4(v3) * mat4(k);
             }
             else
             {
-                sum0 += v0.r * b0s;
-                sum1 += v0.g * b0s;
-                sum2 += v0.b * b0s;
-                sum3 += v0.a * b0s;
+                // Convert to fp32 for accumulation
+                sum0 += vec4(v0).r * vec4(b0s);
+                sum1 += vec4(v0).g * vec4(b0s);
+                sum2 += vec4(v0).b * vec4(b0s);
+                sum3 += vec4(v0).a * vec4(b0s);
             }
         }
     }
@@ -276,17 +280,19 @@ void main()
 
                 const afpmat4 k = afpmat4(b0s, k1, k2, k3);
 
-                sum0 += v0 * k;
-                sum1 += v1 * k;
-                sum2 += v2 * k;
-                sum3 += v3 * k;
+                // Convert to fp32 for accumulation
+                sum0 += vec4(v0) * mat4(k);
+                sum1 += vec4(v1) * mat4(k);
+                sum2 += vec4(v2) * mat4(k);
+                sum3 += vec4(v3) * mat4(k);
             }
             else
             {
-                sum0 += v0.r * b0s;
-                sum1 += v0.g * b0s;
-                sum2 += v0.b * b0s;
-                sum3 += v0.a * b0s;
+                // Convert to fp32 for accumulation
+                sum0 += vec4(v0).r * vec4(b0s);
+                sum1 += vec4(v0).g * vec4(b0s);
+                sum2 += vec4(v0).b * vec4(b0s);
+                sum3 += vec4(v0).a * vec4(b0s);
             }
         }
     }
@@ -296,19 +302,25 @@ void main()
     if (gx4.r >= psc(outw) || gy >= psc(outh))
         return;
 
-    sum0 = activation_afpvec4(sum0, activation_type, activation_param_0, activation_param_1);
-    sum1 = activation_afpvec4(sum1, activation_type, activation_param_0, activation_param_1);
-    sum2 = activation_afpvec4(sum2, activation_type, activation_param_0, activation_param_1);
-    sum3 = activation_afpvec4(sum3, activation_type, activation_param_0, activation_param_1);
+    // Convert fp32 accumulators back to afpvec4 for activation and output
+    afpvec4 sum0_afp = afpvec4(sum0);
+    afpvec4 sum1_afp = afpvec4(sum1);
+    afpvec4 sum2_afp = afpvec4(sum2);
+    afpvec4 sum3_afp = afpvec4(sum3);
+
+    sum0_afp = activation_afpvec4(sum0_afp, activation_type, activation_param_0, activation_param_1);
+    sum1_afp = activation_afpvec4(sum1_afp, activation_type, activation_param_0, activation_param_1);
+    sum2_afp = activation_afpvec4(sum2_afp, activation_type, activation_param_0, activation_param_1);
+    sum3_afp = activation_afpvec4(sum3_afp, activation_type, activation_param_0, activation_param_1);
 
     if (out_elempack == 4)
     {
         const int gi = gy * psc(outw) + gx4.r;
 
-        buffer_st4(top_blob_data_4, gi, sum0);
-        if (gx4.g < psc(outw)) buffer_st4(top_blob_data_4, gi + 1, sum1);
-        if (gx4.b < psc(outw)) buffer_st4(top_blob_data_4, gi + 2, sum2);
-        if (gx4.a < psc(outw)) buffer_st4(top_blob_data_4, gi + 3, sum3);
+        buffer_st4(top_blob_data_4, gi, sum0_afp);
+        if (gx4.g < psc(outw)) buffer_st4(top_blob_data_4, gi + 1, sum1_afp);
+        if (gx4.b < psc(outw)) buffer_st4(top_blob_data_4, gi + 2, sum2_afp);
+        if (gx4.a < psc(outw)) buffer_st4(top_blob_data_4, gi + 3, sum3_afp);
     }
     else
     {
@@ -317,31 +329,31 @@ void main()
         const int outcstep = psc(outw);
         const int gi = base_ch * outcstep + gx4.r;
 
-        buffer_st1(top_blob_data_1, gi, sum0.r);
-        if (base_ch + 1 < nout) buffer_st1(top_blob_data_1, gi + outcstep, sum0.g);
-        if (base_ch + 2 < nout) buffer_st1(top_blob_data_1, gi + outcstep * 2, sum0.b);
-        if (base_ch + 3 < nout) buffer_st1(top_blob_data_1, gi + outcstep * 3, sum0.a);
+        buffer_st1(top_blob_data_1, gi, sum0_afp.r);
+        if (base_ch + 1 < nout) buffer_st1(top_blob_data_1, gi + outcstep, sum0_afp.g);
+        if (base_ch + 2 < nout) buffer_st1(top_blob_data_1, gi + outcstep * 2, sum0_afp.b);
+        if (base_ch + 3 < nout) buffer_st1(top_blob_data_1, gi + outcstep * 3, sum0_afp.a);
 
         if (gx4.g < psc(outw))
         {
-            buffer_st1(top_blob_data_1, gi + 1, sum1.r);
-            if (base_ch + 1 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep, sum1.g);
-            if (base_ch + 2 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep * 2, sum1.b);
-            if (base_ch + 3 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep * 3, sum1.a);
+            buffer_st1(top_blob_data_1, gi + 1, sum1_afp.r);
+            if (base_ch + 1 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep, sum1_afp.g);
+            if (base_ch + 2 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep * 2, sum1_afp.b);
+            if (base_ch + 3 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep * 3, sum1_afp.a);
         }
         if (gx4.b < psc(outw))
         {
-            buffer_st1(top_blob_data_1, gi + 2, sum2.r);
-            if (base_ch + 1 < nout) buffer_st1(top_blob_data_1, gi + 2 + outcstep, sum2.g);
-            if (base_ch + 2 < nout) buffer_st1(top_blob_data_1, gi + 2 + outcstep * 2, sum2.b);
-            if (base_ch + 3 < nout) buffer_st1(top_blob_data_1, gi + 2 + outcstep * 3, sum2.a);
+            buffer_st1(top_blob_data_1, gi + 2, sum2_afp.r);
+            if (base_ch + 1 < nout) buffer_st1(top_blob_data_1, gi + 2 + outcstep, sum2_afp.g);
+            if (base_ch + 2 < nout) buffer_st1(top_blob_data_1, gi + 2 + outcstep * 2, sum2_afp.b);
+            if (base_ch + 3 < nout) buffer_st1(top_blob_data_1, gi + 2 + outcstep * 3, sum2_afp.a);
         }
         if (gx4.a < psc(outw))
         {
-            buffer_st1(top_blob_data_1, gi + 3, sum3.r);
-            if (base_ch + 1 < nout) buffer_st1(top_blob_data_1, gi + 3 + outcstep, sum3.g);
-            if (base_ch + 2 < nout) buffer_st1(top_blob_data_1, gi + 3 + outcstep * 2, sum3.b);
-            if (base_ch + 3 < nout) buffer_st1(top_blob_data_1, gi + 3 + outcstep * 3, sum3.a);
+            buffer_st1(top_blob_data_1, gi + 3, sum3_afp.r);
+            if (base_ch + 1 < nout) buffer_st1(top_blob_data_1, gi + 3 + outcstep, sum3_afp.g);
+            if (base_ch + 2 < nout) buffer_st1(top_blob_data_1, gi + 3 + outcstep * 2, sum3_afp.b);
+            if (base_ch + 3 < nout) buffer_st1(top_blob_data_1, gi + 3 + outcstep * 3, sum3_afp.a);
         }
     }
 }

--- a/src/layer/vulkan/shader/convolution1d_packed_sg.comp
+++ b/src/layer/vulkan/shader/convolution1d_packed_sg.comp
@@ -1,0 +1,347 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+#include "vulkan_activation.comp"
+
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_shuffle : require
+#if NCNN_fp16_arithmetic && !NCNN_bf16_storage && !NCNN_bf16_packed
+#extension GL_EXT_shader_subgroup_extended_types_float16 : require
+#endif
+
+// direct conv1d with subgroup cooperative loading
+// each workgroup (one subgroup) computes a tile of
+//   (UNROLL_SG_M * 4 spatial positions) x (UNROLL_SG_N * 4 output channels)
+// lane (smi, sni) accumulates 4 spatial positions x 1 output channel pack
+// per k-step, lanes cooperatively load UNROLL_SG_K slices of input/weight
+// and share them via subgroup shuffle
+//
+// weight layout is identical to convolution1d_packed:
+//   elempack == 4: per (out pack, z) there are 4 vec4, vec4 #i holds the
+//                  4 input channel weights of output channel i
+//   elempack == 1: per (out pack, z) there is 1 vec4 of 4 output channels
+//   z = input channel (pack) * kernel_w + kernel pos
+
+layout(constant_id = 0) const int kernel_w = 1;
+layout(constant_id = 1) const int dilation_w = 1;
+layout(constant_id = 2) const int stride_w = 1;
+layout(constant_id = 3) const int bias_term = 0;
+layout(constant_id = 4) const int activation_type = 0;
+layout(constant_id = 5) const float activation_param_0 = 0;
+layout(constant_id = 6) const float activation_param_1 = 0;
+layout(constant_id = 7) const int elempack = 1;
+layout(constant_id = 8) const int out_elempack = 1;
+
+#define shape_constant_id_offset 9
+layout(constant_id = shape_constant_id_offset + 0) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int h = 0;
+
+layout(constant_id = shape_constant_id_offset + 2) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int outh = 0;
+
+layout(constant_id = shape_constant_id_offset + 4) const int num_output = 0;
+
+layout(constant_id = 15) const uint UNROLL_SG_M = 4;
+layout(constant_id = 16) const uint UNROLL_SG_N = 4;
+layout(constant_id = 17) const uint UNROLL_SG_K = 4;
+
+layout(binding = 0) readonly buffer bottom_blob_1 { sfp bottom_blob_data_1[]; };
+layout(binding = 1) writeonly buffer top_blob_1 { sfp top_blob_data_1[]; };
+
+layout(binding = 2) readonly buffer bottom_blob_4 { sfpvec4 bottom_blob_data_4[]; };
+layout(binding = 3) writeonly buffer top_blob_4 { sfpvec4 top_blob_data_4[]; };
+layout(binding = 4) readonly buffer weight_blob { sfpvec4 weight_data[]; };
+layout(binding = 5) readonly buffer bias_blob { sfpvec4 bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int w;
+    int h;
+
+    int outw;
+    int outh;
+
+    int num_output;
+} p;
+
+void main()
+{
+    const uint wgi = gl_WorkGroupID.x;
+    const uint si = gl_SubgroupInvocationID;
+
+    const uint wgnn = (uint(psc(outh)) + UNROLL_SG_N - 1) / UNROLL_SG_N;
+
+    const uint wgmi = wgi / wgnn;
+    const uint wgni = wgi % wgnn;
+
+    const uint smi = si / UNROLL_SG_N;
+    const uint sni = si % UNROLL_SG_N;
+
+    // assert gl_SubgroupID == 0
+    // assert gl_LocalInvocationID.x == si
+
+    const int gy = int(wgni * UNROLL_SG_N + sni);
+
+    afpvec4 sum0;
+    afpvec4 sum1;
+    afpvec4 sum2;
+    afpvec4 sum3;
+
+    if (bias_term == 1 && gy < psc(outh))
+    {
+        afpvec4 b = buffer_ld4(bias_data, gy);
+        sum0 = b;
+        sum1 = b;
+        sum2 = b;
+        sum3 = b;
+    }
+    else
+    {
+        sum0 = afpvec4(0.f);
+        sum1 = afpvec4(0.f);
+        sum2 = afpvec4(0.f);
+        sum3 = afpvec4(0.f);
+    }
+
+    const int maxk = kernel_w;
+    const int N = psc(h) * maxk;
+
+    const uint smni = si / UNROLL_SG_K;
+
+    int z = 0;
+    for (; z + int(UNROLL_SG_K) - 1 < N; z += int(UNROLL_SG_K))
+    {
+        const int slk = z + int(si % UNROLL_SG_K);
+
+        const int sz = slk / maxk;
+        const int kx = slk % maxk;
+
+        const ivec4 am4 = ivec4(int(wgmi * UNROLL_SG_M * 4 + smni * 4)) + ivec4(0, 1, 2, 3);
+        const ivec4 apos4 = min(am4 * stride_w + kx * dilation_w, ivec4(psc(w) - 1));
+
+        afpvec4 a0;
+        afpvec4 a1;
+        afpvec4 a2;
+        afpvec4 a3;
+        if (elempack == 4)
+        {
+            a0 = buffer_ld4(bottom_blob_data_4, sz * psc(w) + apos4.r);
+            a1 = buffer_ld4(bottom_blob_data_4, sz * psc(w) + apos4.g);
+            a2 = buffer_ld4(bottom_blob_data_4, sz * psc(w) + apos4.b);
+            a3 = buffer_ld4(bottom_blob_data_4, sz * psc(w) + apos4.a);
+        }
+        else
+        {
+            a0.r = buffer_ld1(bottom_blob_data_1, sz * psc(w) + apos4.r);
+            a0.g = buffer_ld1(bottom_blob_data_1, sz * psc(w) + apos4.g);
+            a0.b = buffer_ld1(bottom_blob_data_1, sz * psc(w) + apos4.b);
+            a0.a = buffer_ld1(bottom_blob_data_1, sz * psc(w) + apos4.a);
+
+            a1 = afpvec4(0.f);
+            a2 = afpvec4(0.f);
+            a3 = afpvec4(0.f);
+        }
+
+        afpvec4 b0 = afpvec4(0.f);
+        afpvec4 b1 = afpvec4(0.f);
+        afpvec4 b2 = afpvec4(0.f);
+        afpvec4 b3 = afpvec4(0.f);
+        {
+            const int bgy = int(wgni * UNROLL_SG_N + smni);
+
+            if (bgy < psc(outh))
+            {
+                if (elempack == 4)
+                {
+                    const int w_offset = (bgy * N + slk) * 4;
+
+                    b0 = buffer_ld4(weight_data, w_offset + 0);
+                    b1 = buffer_ld4(weight_data, w_offset + 1);
+                    b2 = buffer_ld4(weight_data, w_offset + 2);
+                    b3 = buffer_ld4(weight_data, w_offset + 3);
+                }
+                else
+                {
+                    b0 = buffer_ld4(weight_data, bgy * N + slk);
+                }
+            }
+        }
+
+        for (uint z4 = 0; z4 < UNROLL_SG_K; z4++)
+        {
+            const afpvec4 v0 = subgroupShuffle(a0, smi * UNROLL_SG_K + z4);
+            const afpvec4 b0s = subgroupShuffle(b0, sni * UNROLL_SG_K + z4);
+
+            if (elempack == 4)
+            {
+                const afpvec4 v1 = subgroupShuffle(a1, smi * UNROLL_SG_K + z4);
+                const afpvec4 v2 = subgroupShuffle(a2, smi * UNROLL_SG_K + z4);
+                const afpvec4 v3 = subgroupShuffle(a3, smi * UNROLL_SG_K + z4);
+
+                const afpvec4 k1 = subgroupShuffle(b1, sni * UNROLL_SG_K + z4);
+                const afpvec4 k2 = subgroupShuffle(b2, sni * UNROLL_SG_K + z4);
+                const afpvec4 k3 = subgroupShuffle(b3, sni * UNROLL_SG_K + z4);
+
+                const afpmat4 k = afpmat4(b0s, k1, k2, k3);
+
+                sum0 += v0 * k;
+                sum1 += v1 * k;
+                sum2 += v2 * k;
+                sum3 += v3 * k;
+            }
+            else
+            {
+                sum0 += v0.r * b0s;
+                sum1 += v0.g * b0s;
+                sum2 += v0.b * b0s;
+                sum3 += v0.a * b0s;
+            }
+        }
+    }
+
+    if (z < N)
+    {
+        const int slk = z + int(si % UNROLL_SG_K);
+
+        afpvec4 a0 = afpvec4(0.f);
+        afpvec4 a1 = afpvec4(0.f);
+        afpvec4 a2 = afpvec4(0.f);
+        afpvec4 a3 = afpvec4(0.f);
+        if (slk < N)
+        {
+            const int sz = slk / maxk;
+            const int kx = slk % maxk;
+
+            const ivec4 am4 = ivec4(int(wgmi * UNROLL_SG_M * 4 + smni * 4)) + ivec4(0, 1, 2, 3);
+            const ivec4 apos4 = min(am4 * stride_w + kx * dilation_w, ivec4(psc(w) - 1));
+
+            if (elempack == 4)
+            {
+                a0 = buffer_ld4(bottom_blob_data_4, sz * psc(w) + apos4.r);
+                a1 = buffer_ld4(bottom_blob_data_4, sz * psc(w) + apos4.g);
+                a2 = buffer_ld4(bottom_blob_data_4, sz * psc(w) + apos4.b);
+                a3 = buffer_ld4(bottom_blob_data_4, sz * psc(w) + apos4.a);
+            }
+            else
+            {
+                a0.r = buffer_ld1(bottom_blob_data_1, sz * psc(w) + apos4.r);
+                a0.g = buffer_ld1(bottom_blob_data_1, sz * psc(w) + apos4.g);
+                a0.b = buffer_ld1(bottom_blob_data_1, sz * psc(w) + apos4.b);
+                a0.a = buffer_ld1(bottom_blob_data_1, sz * psc(w) + apos4.a);
+            }
+        }
+
+        afpvec4 b0 = afpvec4(0.f);
+        afpvec4 b1 = afpvec4(0.f);
+        afpvec4 b2 = afpvec4(0.f);
+        afpvec4 b3 = afpvec4(0.f);
+        {
+            const int bgy = int(wgni * UNROLL_SG_N + smni);
+
+            if (slk < N && bgy < psc(outh))
+            {
+                if (elempack == 4)
+                {
+                    const int w_offset = (bgy * N + slk) * 4;
+
+                    b0 = buffer_ld4(weight_data, w_offset + 0);
+                    b1 = buffer_ld4(weight_data, w_offset + 1);
+                    b2 = buffer_ld4(weight_data, w_offset + 2);
+                    b3 = buffer_ld4(weight_data, w_offset + 3);
+                }
+                else
+                {
+                    b0 = buffer_ld4(weight_data, bgy * N + slk);
+                }
+            }
+        }
+
+        for (uint z4 = 0; z4 < UNROLL_SG_K && z + int(z4) < N; z4++)
+        {
+            const afpvec4 v0 = subgroupShuffle(a0, smi * UNROLL_SG_K + z4);
+            const afpvec4 b0s = subgroupShuffle(b0, sni * UNROLL_SG_K + z4);
+
+            if (elempack == 4)
+            {
+                const afpvec4 v1 = subgroupShuffle(a1, smi * UNROLL_SG_K + z4);
+                const afpvec4 v2 = subgroupShuffle(a2, smi * UNROLL_SG_K + z4);
+                const afpvec4 v3 = subgroupShuffle(a3, smi * UNROLL_SG_K + z4);
+
+                const afpvec4 k1 = subgroupShuffle(b1, sni * UNROLL_SG_K + z4);
+                const afpvec4 k2 = subgroupShuffle(b2, sni * UNROLL_SG_K + z4);
+                const afpvec4 k3 = subgroupShuffle(b3, sni * UNROLL_SG_K + z4);
+
+                const afpmat4 k = afpmat4(b0s, k1, k2, k3);
+
+                sum0 += v0 * k;
+                sum1 += v1 * k;
+                sum2 += v2 * k;
+                sum3 += v3 * k;
+            }
+            else
+            {
+                sum0 += v0.r * b0s;
+                sum1 += v0.g * b0s;
+                sum2 += v0.b * b0s;
+                sum3 += v0.a * b0s;
+            }
+        }
+    }
+
+    const ivec4 gx4 = ivec4(int(wgmi * UNROLL_SG_M * 4 + smi * 4)) + ivec4(0, 1, 2, 3);
+
+    if (gx4.r >= psc(outw) || gy >= psc(outh))
+        return;
+
+    sum0 = activation_afpvec4(sum0, activation_type, activation_param_0, activation_param_1);
+    sum1 = activation_afpvec4(sum1, activation_type, activation_param_0, activation_param_1);
+    sum2 = activation_afpvec4(sum2, activation_type, activation_param_0, activation_param_1);
+    sum3 = activation_afpvec4(sum3, activation_type, activation_param_0, activation_param_1);
+
+    if (out_elempack == 4)
+    {
+        const int gi = gy * psc(outw) + gx4.r;
+
+        buffer_st4(top_blob_data_4, gi, sum0);
+        if (gx4.g < psc(outw)) buffer_st4(top_blob_data_4, gi + 1, sum1);
+        if (gx4.b < psc(outw)) buffer_st4(top_blob_data_4, gi + 2, sum2);
+        if (gx4.a < psc(outw)) buffer_st4(top_blob_data_4, gi + 3, sum3);
+    }
+    else
+    {
+        const int base_ch = gy * 4;
+        const int nout = psc(num_output);
+        const int outcstep = psc(outw);
+        const int gi = base_ch * outcstep + gx4.r;
+
+        buffer_st1(top_blob_data_1, gi, sum0.r);
+        if (base_ch + 1 < nout) buffer_st1(top_blob_data_1, gi + outcstep, sum0.g);
+        if (base_ch + 2 < nout) buffer_st1(top_blob_data_1, gi + outcstep * 2, sum0.b);
+        if (base_ch + 3 < nout) buffer_st1(top_blob_data_1, gi + outcstep * 3, sum0.a);
+
+        if (gx4.g < psc(outw))
+        {
+            buffer_st1(top_blob_data_1, gi + 1, sum1.r);
+            if (base_ch + 1 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep, sum1.g);
+            if (base_ch + 2 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep * 2, sum1.b);
+            if (base_ch + 3 < nout) buffer_st1(top_blob_data_1, gi + 1 + outcstep * 3, sum1.a);
+        }
+        if (gx4.b < psc(outw))
+        {
+            buffer_st1(top_blob_data_1, gi + 2, sum2.r);
+            if (base_ch + 1 < nout) buffer_st1(top_blob_data_1, gi + 2 + outcstep, sum2.g);
+            if (base_ch + 2 < nout) buffer_st1(top_blob_data_1, gi + 2 + outcstep * 2, sum2.b);
+            if (base_ch + 3 < nout) buffer_st1(top_blob_data_1, gi + 2 + outcstep * 3, sum2.a);
+        }
+        if (gx4.a < psc(outw))
+        {
+            buffer_st1(top_blob_data_1, gi + 3, sum3.r);
+            if (base_ch + 1 < nout) buffer_st1(top_blob_data_1, gi + 3 + outcstep, sum3.g);
+            if (base_ch + 2 < nout) buffer_st1(top_blob_data_1, gi + 3 + outcstep * 2, sum3.b);
+            if (base_ch + 3 < nout) buffer_st1(top_blob_data_1, gi + 3 + outcstep * 3, sum3.a);
+        }
+    }
+}

--- a/src/layer/vulkan/shader/convolution1d_packed_sg.comp
+++ b/src/layer/vulkan/shader/convolution1d_packed_sg.comp
@@ -1,4 +1,4 @@
-// Copyright 2026 Tencent
+// Copyright 2026 Futz12 <pchar.cn>
 // SPDX-License-Identifier: BSD-3-Clause
 
 #version 450

--- a/src/layer/vulkan/shader/convolutiondepthwise1d.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise1d.comp
@@ -1,0 +1,84 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int kernel_w = 1;
+layout(constant_id = 1) const int dilation_w = 1;
+layout(constant_id = 2) const int stride_w = 1;
+layout(constant_id = 3) const int bias_term = 0;
+layout(constant_id = 4) const int group = 1;
+layout(constant_id = 5) const int activation_type = 0;
+layout(constant_id = 6) const float activation_param_0 = 0;
+layout(constant_id = 7) const float activation_param_1 = 0;
+
+#define shape_constant_id_offset 8
+layout(constant_id = shape_constant_id_offset + 0) const int dims = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int h = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int c = 0;
+layout(constant_id = shape_constant_id_offset + 4) const int cstep = 0;
+
+layout(constant_id = shape_constant_id_offset + 5) const int outdims = 0;
+layout(constant_id = shape_constant_id_offset + 6) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 7) const int outh = 0;
+layout(constant_id = shape_constant_id_offset + 8) const int outc = 0;
+layout(constant_id = shape_constant_id_offset + 9) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer bottom_blob { sfp bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfp top_blob_data[]; };
+layout(binding = 2) readonly buffer weight_blob { sfp weight_data[]; };
+layout(binding = 3) readonly buffer bias_blob { sfp bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+
+    if (gx >= psc(outw) || gy >= psc(outh))
+        return;
+
+    afp sum;
+
+    if (bias_term == 1)
+    {
+        sum = buffer_ld1(bias_data, gy);
+    }
+    else
+    {
+        sum = afp(0.f);
+    }
+
+    // depth-wise convolution
+    int w_offset = gy * kernel_w;
+    int v_offset = gy * psc(w) + gx * stride_w;
+
+    for (int x = 0; x < kernel_w; x++)
+    {
+        sum += buffer_ld1(weight_data, w_offset + x) * buffer_ld1(bottom_blob_data, v_offset + x * dilation_w);
+    }
+
+    sum = activation_afp(sum, activation_type, activation_param_0, activation_param_1);
+
+    const int gi = gy * psc(outw) + gx;
+
+    buffer_st1(top_blob_data, gi, sum);
+}

--- a/src/layer/vulkan/shader/convolutiondepthwise1d_group.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise1d_group.comp
@@ -1,0 +1,102 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int kernel_w = 1;
+layout(constant_id = 1) const int dilation_w = 1;
+layout(constant_id = 2) const int stride_w = 1;
+layout(constant_id = 3) const int bias_term = 0;
+layout(constant_id = 4) const int group = 1;
+layout(constant_id = 5) const int activation_type = 0;
+layout(constant_id = 6) const float activation_param_0 = 0;
+layout(constant_id = 7) const float activation_param_1 = 0;
+
+#define shape_constant_id_offset 8
+layout(constant_id = shape_constant_id_offset + 0) const int dims = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int h = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int c = 0;
+layout(constant_id = shape_constant_id_offset + 4) const int cstep = 0;
+
+layout(constant_id = shape_constant_id_offset + 5) const int outdims = 0;
+layout(constant_id = shape_constant_id_offset + 6) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 7) const int outh = 0;
+layout(constant_id = shape_constant_id_offset + 8) const int outc = 0;
+layout(constant_id = shape_constant_id_offset + 9) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer bottom_blob { sfp bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfp top_blob_data[]; };
+layout(binding = 2) readonly buffer weight_blob { sfp weight_data[]; };
+layout(binding = 3) readonly buffer bias_blob { sfp bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+
+    if (gx >= psc(outw) || gy >= psc(outh))
+        return;
+
+    afp sum;
+
+    if (bias_term == 1)
+    {
+        sum = buffer_ld1(bias_data, gy);
+    }
+    else
+    {
+        sum = afp(0.f);
+    }
+
+    // group convolution
+    const int channels_g = psc(h) / group;
+    const int num_output_g = psc(outh) / group;
+
+    // group id
+    const int gg = gy / num_output_g;
+
+    int w_offset = gy * channels_g * kernel_w;
+    int v_offset_0 = gg * channels_g * psc(w);
+
+    for (int z = 0; z < channels_g; z++)
+    {
+        int v_offset = v_offset_0 + gx * stride_w;
+
+        for (int x = 0; x < kernel_w; x++)
+        {
+            afp v = buffer_ld1(bottom_blob_data, v_offset + x * dilation_w);
+
+            afp w = buffer_ld1(weight_data, w_offset + x);
+
+            sum += v * w;
+        }
+
+        w_offset += kernel_w;
+        v_offset_0 += psc(w);
+    }
+
+    sum = activation_afp(sum, activation_type, activation_param_0, activation_param_1);
+
+    const int gi = gy * psc(outw) + gx;
+
+    buffer_st1(top_blob_data, gi, sum);
+}

--- a/src/layer/vulkan/shader/convolutiondepthwise1d_group_pack1to4.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise1d_group_pack1to4.comp
@@ -1,0 +1,116 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int kernel_w = 1;
+layout(constant_id = 1) const int dilation_w = 1;
+layout(constant_id = 2) const int stride_w = 1;
+layout(constant_id = 3) const int bias_term = 0;
+layout(constant_id = 4) const int group = 1;
+layout(constant_id = 5) const int activation_type = 0;
+layout(constant_id = 6) const float activation_param_0 = 0;
+layout(constant_id = 7) const float activation_param_1 = 0;
+
+#define shape_constant_id_offset 8
+layout(constant_id = shape_constant_id_offset + 0) const int dims = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int h = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int c = 0;
+layout(constant_id = shape_constant_id_offset + 4) const int cstep = 0;
+
+layout(constant_id = shape_constant_id_offset + 5) const int outdims = 0;
+layout(constant_id = shape_constant_id_offset + 6) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 7) const int outh = 0;
+layout(constant_id = shape_constant_id_offset + 8) const int outc = 0;
+layout(constant_id = shape_constant_id_offset + 9) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer bottom_blob { sfp bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfpvec4 top_blob_data[]; };
+#if NCNN_fp16_packed || (NCNN_fp16_storage && !NCNN_fp16_arithmetic) || NCNN_bf16_packed || NCNN_bf16_storage
+// GL_EXT_shader_16bit_storage does not define f16mat4 type :(
+layout(binding = 2) readonly buffer weight_blob { sfpvec4 weight_data[]; };
+#else
+layout(binding = 2) readonly buffer weight_blob { sfpmat4 weight_data[]; };
+#endif
+layout(binding = 3) readonly buffer bias_blob { sfpvec4 bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+
+    if (gx >= psc(outw) || gy >= psc(outh))
+        return;
+
+    afpvec4 sum;
+
+    if (bias_term == 1)
+    {
+        sum = buffer_ld4(bias_data, gy);
+    }
+    else
+    {
+        sum = afpvec4(0.f);
+    }
+
+    // group convolution
+    const int channels_g = psc(h) / group;
+    const int num_output_g = psc(outh) / group;
+
+    // group id
+    const int gg = gy / num_output_g;
+
+    int w_offset = gy * channels_g * kernel_w;
+    int v_offset_0 = gg * channels_g * psc(w);
+
+    for (int z = 0; z < channels_g; z++)
+    {
+        int v_offset = v_offset_0 + gx * stride_w;
+
+        for (int x = 0; x < kernel_w; x++)
+        {
+            afp v = buffer_ld1(bottom_blob_data, v_offset + x * dilation_w);
+
+#if NCNN_fp16_packed || (NCNN_fp16_storage && !NCNN_fp16_arithmetic) || NCNN_bf16_packed || NCNN_bf16_storage
+            // GL_EXT_shader_16bit_storage does not define f16mat4 type :(
+            afpmat4 k = afpmat4(
+                buffer_ld4(weight_data, (w_offset + x) * 4 + 0),
+                buffer_ld4(weight_data, (w_offset + x) * 4 + 1),
+                buffer_ld4(weight_data, (w_offset + x) * 4 + 2),
+                buffer_ld4(weight_data, (w_offset + x) * 4 + 3));
+#else
+            afpmat4 k = afpmat4(weight_data[w_offset + x]);
+#endif
+
+            sum += v * k;
+        }
+
+        w_offset += kernel_w;
+        v_offset_0 += psc(w);
+    }
+
+    sum = activation_afpvec4(sum, activation_type, activation_param_0, activation_param_1);
+
+    const int gi = gy * psc(outw) + gx;
+
+    buffer_st4(top_blob_data, gi, sum);
+}

--- a/src/layer/vulkan/shader/convolutiondepthwise1d_group_pack4.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise1d_group_pack4.comp
@@ -1,0 +1,116 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int kernel_w = 1;
+layout(constant_id = 1) const int dilation_w = 1;
+layout(constant_id = 2) const int stride_w = 1;
+layout(constant_id = 3) const int bias_term = 0;
+layout(constant_id = 4) const int group = 1;
+layout(constant_id = 5) const int activation_type = 0;
+layout(constant_id = 6) const float activation_param_0 = 0;
+layout(constant_id = 7) const float activation_param_1 = 0;
+
+#define shape_constant_id_offset 8
+layout(constant_id = shape_constant_id_offset + 0) const int dims = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int h = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int c = 0;
+layout(constant_id = shape_constant_id_offset + 4) const int cstep = 0;
+
+layout(constant_id = shape_constant_id_offset + 5) const int outdims = 0;
+layout(constant_id = shape_constant_id_offset + 6) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 7) const int outh = 0;
+layout(constant_id = shape_constant_id_offset + 8) const int outc = 0;
+layout(constant_id = shape_constant_id_offset + 9) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer bottom_blob { sfpvec4 bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfpvec4 top_blob_data[]; };
+#if NCNN_fp16_packed || (NCNN_fp16_storage && !NCNN_fp16_arithmetic) || NCNN_bf16_packed || NCNN_bf16_storage
+// GL_EXT_shader_16bit_storage does not define f16mat4 type :(
+layout(binding = 2) readonly buffer weight_blob { sfpvec4 weight_data[]; };
+#else
+layout(binding = 2) readonly buffer weight_blob { sfpmat4 weight_data[]; };
+#endif
+layout(binding = 3) readonly buffer bias_blob { sfpvec4 bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+
+    if (gx >= psc(outw) || gy >= psc(outh))
+        return;
+
+    afpvec4 sum;
+
+    if (bias_term == 1)
+    {
+        sum = buffer_ld4(bias_data, gy);
+    }
+    else
+    {
+        sum = afpvec4(0.f);
+    }
+
+    // group convolution
+    const int channels_g = psc(h) / group;
+    const int num_output_g = psc(outh) / group;
+
+    // group id
+    const int gg = gy / num_output_g;
+
+    int w_offset = gy * channels_g * kernel_w;
+    int v_offset_0 = gg * channels_g * psc(w);
+
+    for (int z = 0; z < channels_g; z++)
+    {
+        int v_offset = v_offset_0 + gx * stride_w;
+
+        for (int x = 0; x < kernel_w; x++)
+        {
+            afpvec4 v = buffer_ld4(bottom_blob_data, v_offset + x * dilation_w);
+
+#if NCNN_fp16_packed || (NCNN_fp16_storage && !NCNN_fp16_arithmetic) || NCNN_bf16_packed || NCNN_bf16_storage
+            // GL_EXT_shader_16bit_storage does not define f16mat4 type :(
+            afpmat4 k = afpmat4(
+                buffer_ld4(weight_data, (w_offset + x) * 4 + 0),
+                buffer_ld4(weight_data, (w_offset + x) * 4 + 1),
+                buffer_ld4(weight_data, (w_offset + x) * 4 + 2),
+                buffer_ld4(weight_data, (w_offset + x) * 4 + 3));
+#else
+            afpmat4 k = afpmat4(weight_data[w_offset + x]);
+#endif
+
+            sum += v * k;
+        }
+
+        w_offset += kernel_w;
+        v_offset_0 += psc(w);
+    }
+
+    sum = activation_afpvec4(sum, activation_type, activation_param_0, activation_param_1);
+
+    const int gi = gy * psc(outw) + gx;
+
+    buffer_st4(top_blob_data, gi, sum);
+}

--- a/src/layer/vulkan/shader/convolutiondepthwise1d_group_pack4to1.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise1d_group_pack4to1.comp
@@ -1,0 +1,102 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int kernel_w = 1;
+layout(constant_id = 1) const int dilation_w = 1;
+layout(constant_id = 2) const int stride_w = 1;
+layout(constant_id = 3) const int bias_term = 0;
+layout(constant_id = 4) const int group = 1;
+layout(constant_id = 5) const int activation_type = 0;
+layout(constant_id = 6) const float activation_param_0 = 0;
+layout(constant_id = 7) const float activation_param_1 = 0;
+
+#define shape_constant_id_offset 8
+layout(constant_id = shape_constant_id_offset + 0) const int dims = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int h = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int c = 0;
+layout(constant_id = shape_constant_id_offset + 4) const int cstep = 0;
+
+layout(constant_id = shape_constant_id_offset + 5) const int outdims = 0;
+layout(constant_id = shape_constant_id_offset + 6) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 7) const int outh = 0;
+layout(constant_id = shape_constant_id_offset + 8) const int outc = 0;
+layout(constant_id = shape_constant_id_offset + 9) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer bottom_blob { sfpvec4 bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfp top_blob_data[]; };
+layout(binding = 2) readonly buffer weight_blob { sfpvec4 weight_data[]; };
+layout(binding = 3) readonly buffer bias_blob { sfp bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+
+    if (gx >= psc(outw) || gy >= psc(outh))
+        return;
+
+    afp sum;
+
+    if (bias_term == 1)
+    {
+        sum = buffer_ld1(bias_data, gy);
+    }
+    else
+    {
+        sum = afp(0.f);
+    }
+
+    // group convolution
+    const int channels_g = psc(h) / group;
+    const int num_output_g = psc(outh) / group;
+
+    // group id
+    const int gg = gy / num_output_g;
+
+    int w_offset = gy * channels_g * kernel_w;
+    int v_offset_0 = gg * channels_g * psc(w);
+
+    for (int z = 0; z < channels_g; z++)
+    {
+        int v_offset = v_offset_0 + gx * stride_w;
+
+        for (int x = 0; x < kernel_w; x++)
+        {
+            afpvec4 v = buffer_ld4(bottom_blob_data, v_offset + x * dilation_w);
+
+            afpvec4 k = buffer_ld4(weight_data, w_offset + x);
+
+            sum += dot(v, k);
+        }
+
+        w_offset += kernel_w;
+        v_offset_0 += psc(w);
+    }
+
+    sum = activation_afp(sum, activation_type, activation_param_0, activation_param_1);
+
+    const int gi = gy * psc(outw) + gx;
+
+    buffer_st1(top_blob_data, gi, sum);
+}

--- a/src/layer/vulkan/shader/convolutiondepthwise1d_pack4.comp
+++ b/src/layer/vulkan/shader/convolutiondepthwise1d_pack4.comp
@@ -1,0 +1,88 @@
+// Copyright 2026 Futz12 <pchar.cn>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int kernel_w = 1;
+layout(constant_id = 1) const int dilation_w = 1;
+layout(constant_id = 2) const int stride_w = 1;
+layout(constant_id = 3) const int bias_term = 0;
+layout(constant_id = 4) const int group = 1;
+layout(constant_id = 5) const int activation_type = 0;
+layout(constant_id = 6) const float activation_param_0 = 0;
+layout(constant_id = 7) const float activation_param_1 = 0;
+
+#define shape_constant_id_offset 8
+layout(constant_id = shape_constant_id_offset + 0) const int dims = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int h = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int c = 0;
+layout(constant_id = shape_constant_id_offset + 4) const int cstep = 0;
+
+layout(constant_id = shape_constant_id_offset + 5) const int outdims = 0;
+layout(constant_id = shape_constant_id_offset + 6) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 7) const int outh = 0;
+layout(constant_id = shape_constant_id_offset + 8) const int outc = 0;
+layout(constant_id = shape_constant_id_offset + 9) const int outcstep = 0;
+
+layout(binding = 0) readonly buffer bottom_blob { sfpvec4 bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfpvec4 top_blob_data[]; };
+layout(binding = 2) readonly buffer weight_blob { sfpvec4 weight_data[]; };
+layout(binding = 3) readonly buffer bias_blob { sfpvec4 bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int dims;
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outdims;
+    int outw;
+    int outh;
+    int outc;
+    int outcstep;
+} p;
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gy = int(gl_GlobalInvocationID.y);
+
+    if (gx >= psc(outw) || gy >= psc(outh))
+        return;
+
+    afpvec4 sum;
+
+    if (bias_term == 1)
+    {
+        sum = buffer_ld4(bias_data, gy);
+    }
+    else
+    {
+        sum = afpvec4(0.f);
+    }
+
+    // depth-wise convolution
+    int w_offset = gy * kernel_w;
+    int v_offset = gy * psc(w) + gx * stride_w;
+
+    for (int x = 0; x < kernel_w; x++)
+    {
+        afpvec4 v = buffer_ld4(bottom_blob_data, v_offset + x * dilation_w);
+
+        afpvec4 k = buffer_ld4(weight_data, w_offset + x);
+
+        sum += v * k;
+    }
+
+    sum = activation_afpvec4(sum, activation_type, activation_param_0, activation_param_1);
+
+    const int gi = gy * psc(outw) + gx;
+
+    buffer_st4(top_blob_data, gi, sum);
+}

--- a/src/layer/vulkan/shader/deconvolution1d.comp
+++ b/src/layer/vulkan/shader/deconvolution1d.comp
@@ -36,9 +36,9 @@ layout(binding = 5) readonly buffer bias_blob { sfpvec4 bias_data[]; };
 layout(push_constant) uniform parameter
 {
     int w;
-    int c;      // input channels / elempack (input rows)
+    int c; // input channels / elempack (input rows)
     int outw;
-    int outc;   // num_output_packed / 4
+    int outc; // num_output_packed / 4
     int front_cut;
 } p;
 

--- a/src/layer/vulkan/shader/deconvolution1d.comp
+++ b/src/layer/vulkan/shader/deconvolution1d.comp
@@ -1,0 +1,222 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int kernel_w = 1;
+layout(constant_id = 1) const int dilation_w = 1;
+layout(constant_id = 2) const int stride_w = 1;
+layout(constant_id = 3) const int bias_term = 0;
+layout(constant_id = 4) const int activation_type = 0;
+layout(constant_id = 5) const float activation_param_0 = 0;
+layout(constant_id = 6) const float activation_param_1 = 0;
+layout(constant_id = 7) const int elempack = 1;
+layout(constant_id = 8) const int out_elempack = 1;
+layout(constant_id = 9) const int num_output = 0;
+
+#define shape_constant_id_offset 10
+layout(constant_id = shape_constant_id_offset + 0) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int c = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outw = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int outc = 0;
+
+// scalar view (for pack1 input/output access)
+layout(binding = 0) readonly buffer bottom_blob_1 { sfp bottom_blob_data_1[]; };
+layout(binding = 1) writeonly buffer top_blob_1 { sfp top_blob_data_1[]; };
+
+// vec4 view (for pack4 input/output access, weight/bias always vec4)
+layout(binding = 2) readonly buffer bottom_blob_4 { sfpvec4 bottom_blob_data_4[]; };
+layout(binding = 3) writeonly buffer top_blob_4 { sfpvec4 top_blob_data_4[]; };
+layout(binding = 4) readonly buffer weight_blob { sfpvec4 weight_data[]; };
+layout(binding = 5) readonly buffer bias_blob { sfpvec4 bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int w;
+    int c;      // input channels / elempack (input rows)
+    int outw;
+    int outc;   // num_output_packed / 4
+    int front_cut;
+} p;
+
+// input is 2D (w, c*elempack) with rows contiguous: row z at z * w
+// output is 2D (outw, num_output/out_elempack): row gz at gz * outw
+// weight layout: (outc, c, kernel_w), each element is 4*elempack floats
+//   kernel taps are flipped (k -> kernel_w-1-k), as in deconvolution_packed
+// deconv with flipped taps: sx * stride_w = xf - (kernel_extent_w - 1) + x * dilation_w
+//   where xf = gx + front_cut
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x) * 2;
+    int gz = int(gl_GlobalInvocationID.y) * 2;
+
+    if (gx >= psc(outw) || gz >= psc(outc))
+        return;
+
+    const ivec2 gx2 = gx + ivec2(0, 1);
+    const ivec2 gz2 = gz + ivec2(0, 1);
+
+    afpvec4 sum0;
+    afpvec4 sum1;
+    afpvec4 sum2;
+    afpvec4 sum3;
+
+    if (bias_term == 1)
+    {
+        // bias is always packed as vec4
+        sum0 = buffer_ld4(bias_data, gz2.x);
+        sum1 = sum0;
+        if (gz + 1 < psc(outc))
+        {
+            sum2 = buffer_ld4(bias_data, gz2.y);
+            sum3 = sum2;
+        }
+        else
+        {
+            sum2 = afpvec4(0.f);
+            sum3 = afpvec4(0.f);
+        }
+    }
+    else
+    {
+        sum0 = afpvec4(0.f);
+        sum1 = afpvec4(0.f);
+        sum2 = afpvec4(0.f);
+        sum3 = afpvec4(0.f);
+    }
+
+    const int kernel_extent_w = dilation_w * (kernel_w - 1) + 1;
+
+    // w_offset in element units, each element is elempack vec4
+    ivec2 w_offset_0 = gz2 * psc(c) * kernel_w;
+
+    for (int x = 0; x < kernel_w; x++)
+    {
+        // for output position gx, find input position sx (weight taps flipped)
+        ivec2 sxs0 = gx2 + p.front_cut + x * dilation_w - (kernel_extent_w - 1);
+
+        bvec2 valid;
+        valid.x = (sxs0.x >= 0 && sxs0.x % stride_w == 0 && sxs0.x / stride_w < psc(w));
+        valid.y = (sxs0.y >= 0 && sxs0.y % stride_w == 0 && sxs0.y / stride_w < psc(w));
+
+        if (!any(valid))
+        {
+            continue;
+        }
+
+        ivec2 sx = sxs0 / stride_w;
+
+        ivec2 w_offset = w_offset_0 + x;
+
+        for (int z = 0; z < psc(c); z++)
+        {
+            ivec2 v_offset = z * psc(w) + sx;
+
+            if (elempack == 4)
+            {
+                afpvec4 v0 = valid.x ? buffer_ld4(bottom_blob_data_4, v_offset.x) : afpvec4(0.f);
+                afpvec4 v1 = valid.y ? buffer_ld4(bottom_blob_data_4, v_offset.y) : afpvec4(0.f);
+
+                // weight is 4x4 mat, load from 4 consecutive vec4
+                afpmat4 k0 = afpmat4(
+                    buffer_ld4(weight_data, (w_offset.x + z * kernel_w) * 4 + 0),
+                    buffer_ld4(weight_data, (w_offset.x + z * kernel_w) * 4 + 1),
+                    buffer_ld4(weight_data, (w_offset.x + z * kernel_w) * 4 + 2),
+                    buffer_ld4(weight_data, (w_offset.x + z * kernel_w) * 4 + 3));
+
+                sum0 += v0 * k0;
+                sum1 += v1 * k0;
+
+                if (gz + 1 < psc(outc))
+                {
+                    afpmat4 k1 = afpmat4(
+                        buffer_ld4(weight_data, (w_offset.y + z * kernel_w) * 4 + 0),
+                        buffer_ld4(weight_data, (w_offset.y + z * kernel_w) * 4 + 1),
+                        buffer_ld4(weight_data, (w_offset.y + z * kernel_w) * 4 + 2),
+                        buffer_ld4(weight_data, (w_offset.y + z * kernel_w) * 4 + 3));
+
+                    sum2 += v0 * k1;
+                    sum3 += v1 * k1;
+                }
+            }
+            else // elempack == 1
+            {
+                afp v0 = valid.x ? buffer_ld1(bottom_blob_data_1, v_offset.x) : afp(0.f);
+                afp v1 = valid.y ? buffer_ld1(bottom_blob_data_1, v_offset.y) : afp(0.f);
+
+                // weight is vec4 (4 output channels per input channel)
+                afpvec4 k0 = buffer_ld4(weight_data, w_offset.x + z * kernel_w);
+
+                sum0 += v0 * k0;
+                sum1 += v1 * k0;
+
+                if (gz + 1 < psc(outc))
+                {
+                    afpvec4 k1 = buffer_ld4(weight_data, w_offset.y + z * kernel_w);
+
+                    sum2 += v0 * k1;
+                    sum3 += v1 * k1;
+                }
+            }
+        }
+    }
+
+    sum0 = activation_afpvec4(sum0, activation_type, activation_param_0, activation_param_1);
+    sum1 = activation_afpvec4(sum1, activation_type, activation_param_0, activation_param_1);
+    sum2 = activation_afpvec4(sum2, activation_type, activation_param_0, activation_param_1);
+    sum3 = activation_afpvec4(sum3, activation_type, activation_param_0, activation_param_1);
+
+    if (out_elempack == 4)
+    {
+        const ivec2 gi = gz2 * psc(outw) + gx;
+
+        buffer_st4(top_blob_data_4, gi.x, sum0);
+        if (gx + 1 < psc(outw)) buffer_st4(top_blob_data_4, gi.x + 1, sum1);
+        if (gz + 1 < psc(outc))
+        {
+            buffer_st4(top_blob_data_4, gi.y, sum2);
+            if (gx + 1 < psc(outw)) buffer_st4(top_blob_data_4, gi.y + 1, sum3);
+        }
+    }
+    else // out_elempack == 1
+    {
+        // each pack4 group spans 4 scalar channels, channel stride is outw
+        const ivec2 base_ch = gz2 * 4;
+        const int nout = num_output;
+
+        const ivec2 gi = gz2 * 4 * psc(outw) + gx;
+
+        buffer_st1(top_blob_data_1, gi.x, sum0.r);
+        if (base_ch.x + 1 < nout) buffer_st1(top_blob_data_1, gi.x + psc(outw), sum0.g);
+        if (base_ch.x + 2 < nout) buffer_st1(top_blob_data_1, gi.x + psc(outw) * 2, sum0.b);
+        if (base_ch.x + 3 < nout) buffer_st1(top_blob_data_1, gi.x + psc(outw) * 3, sum0.a);
+
+        if (gx + 1 < psc(outw))
+        {
+            buffer_st1(top_blob_data_1, gi.x + 1, sum1.r);
+            if (base_ch.x + 1 < nout) buffer_st1(top_blob_data_1, gi.x + 1 + psc(outw), sum1.g);
+            if (base_ch.x + 2 < nout) buffer_st1(top_blob_data_1, gi.x + 1 + psc(outw) * 2, sum1.b);
+            if (base_ch.x + 3 < nout) buffer_st1(top_blob_data_1, gi.x + 1 + psc(outw) * 3, sum1.a);
+        }
+
+        if (gz + 1 < psc(outc))
+        {
+            if (base_ch.y < nout) buffer_st1(top_blob_data_1, gi.y, sum2.r);
+            if (base_ch.y + 1 < nout) buffer_st1(top_blob_data_1, gi.y + psc(outw), sum2.g);
+            if (base_ch.y + 2 < nout) buffer_st1(top_blob_data_1, gi.y + psc(outw) * 2, sum2.b);
+            if (base_ch.y + 3 < nout) buffer_st1(top_blob_data_1, gi.y + psc(outw) * 3, sum2.a);
+
+            if (gx + 1 < psc(outw))
+            {
+                if (base_ch.y < nout) buffer_st1(top_blob_data_1, gi.y + 1, sum3.r);
+                if (base_ch.y + 1 < nout) buffer_st1(top_blob_data_1, gi.y + 1 + psc(outw), sum3.g);
+                if (base_ch.y + 2 < nout) buffer_st1(top_blob_data_1, gi.y + 1 + psc(outw) * 2, sum3.b);
+                if (base_ch.y + 3 < nout) buffer_st1(top_blob_data_1, gi.y + 1 + psc(outw) * 3, sum3.a);
+            }
+        }
+    }
+}

--- a/src/layer/vulkan/shader/deconvolution1d.comp
+++ b/src/layer/vulkan/shader/deconvolution1d.comp
@@ -1,4 +1,4 @@
-// Copyright 2026 Tencent
+// Copyright 2026 Futz12 <pchar.cn>
 // SPDX-License-Identifier: BSD-3-Clause
 
 #version 450

--- a/src/layer/vulkan/shader/deconvolution1d_col2im.comp
+++ b/src/layer/vulkan/shader/deconvolution1d_col2im.comp
@@ -1,0 +1,82 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int kernel_w = 1;
+layout(constant_id = 1) const int dilation_w = 1;
+layout(constant_id = 2) const int stride_w = 1;
+layout(constant_id = 3) const int bias_term = 0;
+layout(constant_id = 4) const int activation_type = 0;
+layout(constant_id = 5) const float activation_param_0 = 0;
+layout(constant_id = 6) const float activation_param_1 = 0;
+layout(constant_id = 7) const int outc = 0;
+
+#define shape_constant_id_offset 8
+layout(constant_id = shape_constant_id_offset + 0) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outw = 0;
+
+layout(binding = 0) readonly buffer col_blob { sfp col_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfp top_blob_data[]; };
+layout(binding = 2) readonly buffer bias_blob { sfp bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int w;
+    int cstep; // col channel stride
+    int outw;
+    int front_cut;
+} p;
+
+// col layout: 3D (w, 1, kernel_w*num_output), channel (o * kernel_w + k)
+// out[o][x] = bias[o] + sum_{sx} col[o * kernel_w + k][sx]
+//   where xf = x + front_cut, k = xf - sx * stride_w, k % dilation_w == 0
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gz = int(gl_GlobalInvocationID.y);
+
+    if (gx >= psc(outw) || gz >= outc)
+        return;
+
+    afp sum;
+
+    if (bias_term == 1)
+    {
+        sum = buffer_ld1(bias_data, gz);
+    }
+    else
+    {
+        sum = afp(0.f);
+    }
+
+    const int xf = gx + p.front_cut;
+
+    const int kernel_extent_w = dilation_w * (kernel_w - 1) + 1;
+
+    const int sx_start = (xf < kernel_extent_w) ? 0 : (xf - kernel_extent_w) / stride_w + 1;
+    const int sx_end = min(xf / stride_w + 1, psc(w));
+
+    for (int sx = sx_start; sx < sx_end; sx += 1)
+    {
+        int w_k = xf - sx * stride_w;
+
+        if (w_k % dilation_w == 0)
+        {
+            w_k /= dilation_w;
+
+            const int gi = (gz * kernel_w + w_k) * psc(cstep) + sx;
+
+            sum += buffer_ld1(col_blob_data, gi);
+        }
+    }
+
+    sum = activation_afp(sum, activation_type, activation_param_0, activation_param_1);
+
+    buffer_st1(top_blob_data, gz * psc(outw) + gx, sum);
+}

--- a/src/layer/vulkan/shader/deconvolution1d_col2im.comp
+++ b/src/layer/vulkan/shader/deconvolution1d_col2im.comp
@@ -1,4 +1,4 @@
-// Copyright 2026 Tencent
+// Copyright 2026 Futz12 <pchar.cn>
 // SPDX-License-Identifier: BSD-3-Clause
 
 #version 450

--- a/src/layer/vulkan/shader/deconvolution1d_gemm_cm.comp
+++ b/src/layer/vulkan/shader/deconvolution1d_gemm_cm.comp
@@ -1,4 +1,4 @@
-// Copyright 2025 Tencent
+// Copyright 2025 Futz12 <pchar.cn>
 // SPDX-License-Identifier: BSD-3-Clause
 
 #version 450

--- a/src/layer/vulkan/shader/deconvolution1d_gemm_cm.comp
+++ b/src/layer/vulkan/shader/deconvolution1d_gemm_cm.comp
@@ -1,0 +1,1221 @@
+// Copyright 2025 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+#include "vulkan_activation.comp"
+
+#extension GL_EXT_control_flow_attributes : require
+
+#extension GL_KHR_shader_subgroup_basic : require
+
+#extension GL_KHR_memory_scope_semantics : require
+#extension GL_EXT_shader_explicit_arithmetic_types : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#if ncnn_VK_KHR_cooperative_matrix
+#extension GL_KHR_cooperative_matrix : require
+#elif ncnn_VK_NV_cooperative_matrix
+#extension GL_NV_cooperative_matrix : require
+#endif
+
+layout(constant_id = 0) const uint M = 1;
+layout(constant_id = 1) const uint N = 1;
+layout(constant_id = 2) const uint K = 1;
+layout(constant_id = 3) const uint subgroup_size = 32;
+layout(constant_id = 4) const uint UNROLL_SG_M = 2;
+layout(constant_id = 5) const uint UNROLL_SG_N = 2;
+layout(constant_id = 6) const uint UNROLL_SG_K = 2;
+layout(constant_id = 7) const uint UNROLL_WG_M = 2;
+layout(constant_id = 8) const uint UNROLL_WG_N = 2;
+layout(constant_id = 9) const uint inch = 1;
+layout(constant_id = 10) const uint outch = 1;
+layout(constant_id = 11) const uint elempack = 1;
+layout(constant_id = 12) const uint out_elempack = 1;
+
+#define shape_constant_id_offset 13
+layout(constant_id = shape_constant_id_offset + 0) const uint size = 0;
+layout(constant_id = shape_constant_id_offset + 1) const uint cstep = 0;
+layout(constant_id = shape_constant_id_offset + 2) const uint outcstep = 0;
+
+layout(binding = 0) readonly buffer bottom_blob { uvec2 bottom_blob_data[]; };
+layout(binding = 1) writeonly buffer col_blob { uvec2 col_blob_data[]; };
+layout(binding = 2) readonly buffer weight_blob { uvec2 weight_data[]; };
+
+// scalar view for elempack == 1 input with unaligned row step (cstep may not be multiple of 4)
+layout(binding = 3) readonly buffer bottom_blob_scalar { sfp bottom_blob_data_1[]; };
+
+layout(push_constant) uniform parameter
+{
+    uint size;
+    uint cstep;
+    uint outcstep;
+} p;
+
+shared uvec2 tmp_v[UNROLL_WG_M][UNROLL_SG_M * UNROLL_SG_K * M * K / 4];
+
+shared uvec2 tmp_k[UNROLL_WG_N][UNROLL_SG_N * UNROLL_SG_K * K * N / 4];
+
+shared uvec2 tmp_o[UNROLL_WG_N * UNROLL_WG_M][UNROLL_SG_N * UNROLL_SG_M * M * N / 4];
+
+void main()
+{
+    // assert gl_WorkGroupSize.x == gl_SubgroupSize
+    // but neither gl_SubgroupSize nor gl_WorkGroupSize.x is a constant
+    const uint local_size = subgroup_size * UNROLL_WG_M * UNROLL_WG_N;
+
+    // [ WG_UN * WG_UM * [ SG_UN * SG_UM * subgroup ] ]
+
+    //                     <----WG_UN---->
+    //       +---N--+-SG_UN+------+------+
+    //       |      |      |      |XXXXXX|
+    //       M             |       XXXX<----coopmat<M,N>
+    //       |      |      |      |XXXXXX|
+    //       +-- --SG0-- --+-- --SG2-- --+
+    //       |      |      |      |      |
+    //      SG_UM          |             |
+    //       |      |      |      |      |
+    //    ^  +------+--WORKGROUP--+------+
+    //    |  |      |      |      |      |
+    //    |  |             |             |
+    //    |  |      |      |      |      |
+    //  WG_UM+-- --SG1-- --+-- --SG3-- --+
+    //    |  |      |      |      |      |
+    //    |  |             |             |
+    //    |  |      |      |      |      |
+    //    v  +------+------+------+------+
+    //
+
+    const uint wgi = gl_WorkGroupID.x;
+    const uint sgi = gl_SubgroupID;
+
+    const uint wgmm = (psc(size) + M * UNROLL_SG_M * UNROLL_WG_M - 1) / (M * UNROLL_SG_M * UNROLL_WG_M);
+    const uint wgnn = (outch + N * UNROLL_SG_N * UNROLL_WG_N - 1) / (N * UNROLL_SG_N * UNROLL_WG_N);
+
+    const uint wgmi = wgi / wgnn;
+    const uint wgni = wgi % wgnn;
+
+    const uint sgmi = sgi / UNROLL_WG_N;
+    const uint sgni = sgi % UNROLL_WG_N;
+
+    //     const uint mm = (psc(size) + M - 1) / M;
+    //     const uint nn = (outch + N - 1) / N;
+    const uint kk = (inch + K - 1) / K;
+
+    if (wgmi >= wgmm)
+        return;
+
+    const uint li = gl_LocalInvocationID.x;
+    const uint si = gl_SubgroupInvocationID;
+
+    const uint Md4 = M / 4;
+    const uint Nd4 = N / 4;
+    const uint Kd4 = K / 4;
+
+    const uint ni = (wgni * UNROLL_WG_N + sgni) * UNROLL_SG_N;
+    const uint mi = (wgmi * UNROLL_WG_M + sgmi) * UNROLL_SG_M;
+
+#if ncnn_VK_KHR_cooperative_matrix
+    coopmat<afp, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> sum[UNROLL_SG_N][UNROLL_SG_M];
+#elif ncnn_VK_NV_cooperative_matrix
+#if NCNN_fp16_arithmetic
+    fcoopmatNV<16, gl_ScopeSubgroup, M, N> sum[UNROLL_SG_N][UNROLL_SG_M];
+#else
+    fcoopmatNV<32, gl_ScopeSubgroup, M, N> sum[UNROLL_SG_N][UNROLL_SG_M];
+#endif
+#endif
+
+    [[unroll]] for (uint zn = 0; zn < UNROLL_SG_N; zn++)
+    {
+        [[unroll]] for (uint zm = 0; zm < UNROLL_SG_M; zm++)
+        {
+#if ncnn_VK_KHR_cooperative_matrix
+            sum[zn][zm] = coopmat<afp, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(0.f);
+#elif ncnn_VK_NV_cooperative_matrix
+#if NCNN_fp16_arithmetic
+            sum[zn][zm] = fcoopmatNV<16, gl_ScopeSubgroup, M, N>(0.f);
+#else
+            sum[zn][zm] = fcoopmatNV<32, gl_ScopeSubgroup, M, N>(0.f);
+#endif
+#endif
+        }
+    }
+
+    uint k = 0;
+
+    if (kk >= UNROLL_SG_K * 2)
+    {
+        // local stack and shared memory ping-pong
+
+        // prefetch
+        uvec2 prefetch_tmp_v[(UNROLL_SG_M * UNROLL_SG_K * M * K / 4 + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N)];
+        uvec2 prefetch_tmp_k[(UNROLL_SG_N * UNROLL_SG_K * K * N / 4 + (subgroup_size * UNROLL_WG_M - 1)) / (subgroup_size * UNROLL_WG_M)];
+
+        // prefetch the very first
+        {
+            const uint ki = 0;
+
+            // load bottom_blob
+            {
+                if (elempack == 1)
+                {
+                    //        +-M-+
+                    //        K   |
+                    //        +SG_UM
+                    //        |   |
+                    //     ^  +---+
+                    //     |  |   |
+                    //   SG_UK+- -+
+                    //     |  |   |
+                    //   ^ v  +---+
+                    //   |    |   |
+                    //   |    +- -+
+                    //   |    |   |
+                    // WG_UM  +---+
+                    //   |    |   |
+                    //   |    +- -+
+                    //   |    |   |
+                    //   v    +---+
+
+                    const uint Md4_K_USGM_USGK = Md4 * K * UNROLL_SG_M * UNROLL_SG_K;
+                    const uint Md4_K_USGM_USGK_d_subgroupsize = (Md4_K_USGM_USGK + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N);
+                    [[unroll]] for (uint q = 0; q < Md4_K_USGM_USGK_d_subgroupsize; q++)
+                    {
+                        const uint siq = (q * UNROLL_WG_N + sgni) * subgroup_size + si;
+
+                        if (Md4_K_USGM_USGK % (subgroup_size * UNROLL_WG_N) == 0 || siq < Md4_K_USGM_USGK)
+                        {
+                            const uint zk = siq / (Md4 * K * UNROLL_SG_M);
+                            const uint zmij = siq % (Md4 * K * UNROLL_SG_M);
+                            const uint zm = zmij / (Md4 * K);
+                            const uint ij = zmij % (Md4 * K);
+                            const uint i = ij / Md4;
+                            const uint j = ij % Md4;
+
+                            const uint gk = ki + zk * K + i;
+                            const uint gm = (mi + zm) * Md4 + j;
+
+                            // scalar loads, row step cstep is in element units and may not be multiple of 4
+                            uvec2 v = uvec2(0);
+                            if (gk < inch)
+                            {
+                                const uint gm4 = gm * 4;
+                                const uint v_offset = gk * psc(cstep) + gm4;
+                                vec4 v4 = vec4(0.f);
+                                if (gm4 + 0 < psc(size)) v4.r = float(buffer_ld1(bottom_blob_data_1, v_offset + 0));
+                                if (gm4 + 1 < psc(size)) v4.g = float(buffer_ld1(bottom_blob_data_1, v_offset + 1));
+                                if (gm4 + 2 < psc(size)) v4.b = float(buffer_ld1(bottom_blob_data_1, v_offset + 2));
+                                if (gm4 + 3 < psc(size)) v4.a = float(buffer_ld1(bottom_blob_data_1, v_offset + 3));
+                                v = uvec2(packHalf2x16(v4.rg), packHalf2x16(v4.ba));
+                            }
+
+                            prefetch_tmp_v[q] = v;
+                        }
+                    }
+                }
+                else // if (elempack == 4)
+                {
+                    //        +-K-+
+                    //        M   |
+                    //        +- -+
+                    //      SG_UM |
+                    //     ^  +---+
+                    //     |  |   |
+                    //   SG_UK+- -+
+                    //     |  |   |
+                    //   ^ v  +---+
+                    //   |    |   |
+                    //   |    +- -+
+                    //   |    |   |
+                    // WG_UM  +---+
+                    //   |    |   |
+                    //   |    +- -+
+                    //   |    |   |
+                    //   v    +---+
+
+                    const uint inchd4 = inch / 4;
+
+                    const uint Kd4_M_USGM_USGK = Kd4 * M * UNROLL_SG_M * UNROLL_SG_K;
+                    const uint Kd4_M_USGM_USGK_d_subgroupsize = (Kd4_M_USGM_USGK + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N);
+                    [[unroll]] for (uint q = 0; q < Kd4_M_USGM_USGK_d_subgroupsize; q++)
+                    {
+                        const uint siq = (q * UNROLL_WG_N + sgni) * subgroup_size + si;
+
+                        if (Kd4_M_USGM_USGK % (subgroup_size * UNROLL_WG_N) == 0 || siq < Kd4_M_USGM_USGK)
+                        {
+                            const uint zk = siq / (Kd4 * M * UNROLL_SG_M);
+                            const uint zmij = siq % (Kd4 * M * UNROLL_SG_M);
+                            const uint zmi = zmij / Kd4;
+                            const uint j = zmij % Kd4;
+
+                            const uint gm = mi * M + zmi;
+                            const uint gk = ki / 4 + zk * Kd4 + j;
+
+                            uvec2 v = gk < inchd4 && gm < psc(cstep) ? bottom_blob_data[gk * psc(cstep) + gm] : uvec2(0);
+
+                            prefetch_tmp_v[q] = v;
+                        }
+                    }
+                }
+            }
+
+            // load weight
+            {
+                //        +-N-+
+                //        K   |
+                //        +SG_UN
+                //        |   |
+                //     ^  +---+
+                //     |  |   |
+                //   SG_UK+- -+
+                //     |  |   |
+                //   ^ v  +---+
+                //   |    |   |
+                //   |    +- -+
+                //   |    |   |
+                // WG_UN  +---+
+                //   |    |   |
+                //   |    +- -+
+                //   |    |   |
+                //   v    +---+
+
+                // weight_data   coopmat_N * coopmat_K * UNROLL_SG_N * UNROLL_WG_N * kk, blocks_n
+
+                const uint Nd4_K_USGN = Nd4 * K * UNROLL_SG_N;
+                const uint Nd4_K_USGN_USGK = Nd4 * K * UNROLL_SG_N * UNROLL_SG_K;
+
+                const uint w_offset = ((wgni * kk) * UNROLL_WG_N) * Nd4_K_USGN + ((k / UNROLL_SG_K) * UNROLL_WG_N + sgni) * Nd4_K_USGN_USGK;
+
+                const uint Nd4_K_USGN_USGK_d_subgroupsize = (Nd4_K_USGN_USGK + (subgroup_size * UNROLL_WG_M - 1)) / (subgroup_size * UNROLL_WG_M);
+                [[unroll]] for (uint q = 0; q < Nd4_K_USGN_USGK_d_subgroupsize; q++)
+                {
+                    const uint siq = (q * UNROLL_WG_M + sgmi) * subgroup_size + si;
+
+                    if (Nd4_K_USGN_USGK % (subgroup_size * UNROLL_WG_M) == 0 || siq < Nd4_K_USGN_USGK)
+                    {
+                        prefetch_tmp_k[q] = weight_data[w_offset + siq];
+                    }
+                }
+            }
+        }
+
+        k += UNROLL_SG_K;
+
+        for (; k + UNROLL_SG_K - 1 < kk; k += UNROLL_SG_K)
+        {
+            barrier();
+
+            // copy prefetch to shared memory
+            {
+                // load bottom_blob
+                {
+                    if (elempack == 1)
+                    {
+                        const uint Md4_K_USGM_USGK = Md4 * K * UNROLL_SG_M * UNROLL_SG_K;
+                        const uint Md4_K_USGM_USGK_d_subgroupsize = (Md4_K_USGM_USGK + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N);
+                        [[unroll]] for (uint q = 0; q < Md4_K_USGM_USGK_d_subgroupsize; q++)
+                        {
+                            const uint siq = (q * UNROLL_WG_N + sgni) * subgroup_size + si;
+
+                            if (Md4_K_USGM_USGK % (subgroup_size * UNROLL_WG_N) == 0 || siq < Md4_K_USGM_USGK)
+                            {
+                                tmp_v[sgmi][siq] = prefetch_tmp_v[q];
+                            }
+                        }
+                    }
+                    else // if (elempack == 4)
+                    {
+                        const uint Kd4_M_USGM_USGK = Kd4 * M * UNROLL_SG_M * UNROLL_SG_K;
+                        const uint Kd4_M_USGM_USGK_d_subgroupsize = (Kd4_M_USGM_USGK + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N);
+                        [[unroll]] for (uint q = 0; q < Kd4_M_USGM_USGK_d_subgroupsize; q++)
+                        {
+                            const uint siq = (q * UNROLL_WG_N + sgni) * subgroup_size + si;
+
+                            if (Kd4_M_USGM_USGK % (subgroup_size * UNROLL_WG_N) == 0 || siq < Kd4_M_USGM_USGK)
+                            {
+                                tmp_v[sgmi][siq] = prefetch_tmp_v[q];
+                            }
+                        }
+                    }
+                }
+
+                // load weight
+                {
+                    const uint Nd4_K_USGN_USGK = Nd4 * K * UNROLL_SG_N * UNROLL_SG_K;
+                    const uint Nd4_K_USGN_USGK_d_subgroupsize = (Nd4_K_USGN_USGK + (subgroup_size * UNROLL_WG_M - 1)) / (subgroup_size * UNROLL_WG_M);
+                    [[unroll]] for (uint q = 0; q < Nd4_K_USGN_USGK_d_subgroupsize; q++)
+                    {
+                        const uint siq = (q * UNROLL_WG_M + sgmi) * subgroup_size + si;
+
+                        if (Nd4_K_USGN_USGK % (subgroup_size * UNROLL_WG_M) == 0 || siq < Nd4_K_USGN_USGK)
+                        {
+                            tmp_k[sgni][siq] = prefetch_tmp_k[q];
+                        }
+                    }
+                }
+            }
+
+            barrier();
+
+            // prefetch the next
+            {
+                const uint ki = k * K;
+
+                // load bottom_blob
+                {
+                    if (elempack == 1)
+                    {
+                        //        +-M-+
+                        //        K   |
+                        //        +SG_UM
+                        //        |   |
+                        //     ^  +---+
+                        //     |  |   |
+                        //   SG_UK+- -+
+                        //     |  |   |
+                        //   ^ v  +---+
+                        //   |    |   |
+                        //   |    +- -+
+                        //   |    |   |
+                        // WG_UM  +---+
+                        //   |    |   |
+                        //   |    +- -+
+                        //   |    |   |
+                        //   v    +---+
+
+                        const uint Md4_K_USGM_USGK = Md4 * K * UNROLL_SG_M * UNROLL_SG_K;
+                        const uint Md4_K_USGM_USGK_d_subgroupsize = (Md4_K_USGM_USGK + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N);
+                        [[unroll]] for (uint q = 0; q < Md4_K_USGM_USGK_d_subgroupsize; q++)
+                        {
+                            const uint siq = (q * UNROLL_WG_N + sgni) * subgroup_size + si;
+
+                            if (Md4_K_USGM_USGK % (subgroup_size * UNROLL_WG_N) == 0 || siq < Md4_K_USGM_USGK)
+                            {
+                                const uint zk = siq / (Md4 * K * UNROLL_SG_M);
+                                const uint zmij = siq % (Md4 * K * UNROLL_SG_M);
+                                const uint zm = zmij / (Md4 * K);
+                                const uint ij = zmij % (Md4 * K);
+                                const uint i = ij / Md4;
+                                const uint j = ij % Md4;
+
+                                const uint gk = ki + zk * K + i;
+                                const uint gm = (mi + zm) * Md4 + j;
+
+                                // scalar loads, row step cstep is in element units and may not be multiple of 4
+                                uvec2 v = uvec2(0);
+                                if (gk < inch)
+                                {
+                                    const uint gm4 = gm * 4;
+                                    const uint v_offset = gk * psc(cstep) + gm4;
+                                    vec4 v4 = vec4(0.f);
+                                    if (gm4 + 0 < psc(size)) v4.r = float(buffer_ld1(bottom_blob_data_1, v_offset + 0));
+                                    if (gm4 + 1 < psc(size)) v4.g = float(buffer_ld1(bottom_blob_data_1, v_offset + 1));
+                                    if (gm4 + 2 < psc(size)) v4.b = float(buffer_ld1(bottom_blob_data_1, v_offset + 2));
+                                    if (gm4 + 3 < psc(size)) v4.a = float(buffer_ld1(bottom_blob_data_1, v_offset + 3));
+                                    v = uvec2(packHalf2x16(v4.rg), packHalf2x16(v4.ba));
+                                }
+
+                                prefetch_tmp_v[q] = v;
+                            }
+                        }
+                    }
+                    else // if (elempack == 4)
+                    {
+                        //        +-K-+
+                        //        M   |
+                        //        +- -+
+                        //      SG_UM |
+                        //     ^  +---+
+                        //     |  |   |
+                        //   SG_UK+- -+
+                        //     |  |   |
+                        //   ^ v  +---+
+                        //   |    |   |
+                        //   |    +- -+
+                        //   |    |   |
+                        // WG_UM  +---+
+                        //   |    |   |
+                        //   |    +- -+
+                        //   |    |   |
+                        //   v    +---+
+
+                        const uint inchd4 = inch / 4;
+
+                        const uint Kd4_M_USGM_USGK = Kd4 * M * UNROLL_SG_M * UNROLL_SG_K;
+                        const uint Kd4_M_USGM_USGK_d_subgroupsize = (Kd4_M_USGM_USGK + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N);
+                        [[unroll]] for (uint q = 0; q < Kd4_M_USGM_USGK_d_subgroupsize; q++)
+                        {
+                            const uint siq = (q * UNROLL_WG_N + sgni) * subgroup_size + si;
+
+                            if (Kd4_M_USGM_USGK % (subgroup_size * UNROLL_WG_N) == 0 || siq < Kd4_M_USGM_USGK)
+                            {
+                                const uint zk = siq / (Kd4 * M * UNROLL_SG_M);
+                                const uint zmij = siq % (Kd4 * M * UNROLL_SG_M);
+                                const uint zmi = zmij / Kd4;
+                                const uint j = zmij % Kd4;
+
+                                const uint gm = mi * M + zmi;
+                                const uint gk = ki / 4 + zk * Kd4 + j;
+
+                                uvec2 v = gk < inchd4 && gm < psc(cstep) ? bottom_blob_data[gk * psc(cstep) + gm] : uvec2(0);
+
+                                prefetch_tmp_v[q] = v;
+                            }
+                        }
+                    }
+                }
+
+                // load weight
+                {
+                    //        +-N-+
+                    //        K   |
+                    //        +SG_UN
+                    //        |   |
+                    //     ^  +---+
+                    //     |  |   |
+                    //   SG_UK+- -+
+                    //     |  |   |
+                    //   ^ v  +---+
+                    //   |    |   |
+                    //   |    +- -+
+                    //   |    |   |
+                    // WG_UN  +---+
+                    //   |    |   |
+                    //   |    +- -+
+                    //   |    |   |
+                    //   v    +---+
+
+                    // weight_data   coopmat_N * coopmat_K * UNROLL_SG_N * UNROLL_WG_N * kk, blocks_n
+
+                    const uint Nd4_K_USGN = Nd4 * K * UNROLL_SG_N;
+                    const uint Nd4_K_USGN_USGK = Nd4 * K * UNROLL_SG_N * UNROLL_SG_K;
+
+                    const uint w_offset = ((wgni * kk) * UNROLL_WG_N) * Nd4_K_USGN + ((k / UNROLL_SG_K) * UNROLL_WG_N + sgni) * Nd4_K_USGN_USGK;
+
+                    const uint Nd4_K_USGN_USGK_d_subgroupsize = (Nd4_K_USGN_USGK + (subgroup_size * UNROLL_WG_M - 1)) / (subgroup_size * UNROLL_WG_M);
+                    [[unroll]] for (uint q = 0; q < Nd4_K_USGN_USGK_d_subgroupsize; q++)
+                    {
+                        const uint siq = (q * UNROLL_WG_M + sgmi) * subgroup_size + si;
+
+                        if (Nd4_K_USGN_USGK % (subgroup_size * UNROLL_WG_M) == 0 || siq < Nd4_K_USGN_USGK)
+                        {
+                            prefetch_tmp_k[q] = weight_data[w_offset + siq];
+                        }
+                    }
+                }
+            }
+
+#if ncnn_VK_KHR_cooperative_matrix
+            coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> A[UNROLL_SG_M];
+            coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> B[UNROLL_SG_N];
+#elif ncnn_VK_NV_cooperative_matrix
+            fcoopmatNV<16, gl_ScopeSubgroup, M, K> A[UNROLL_SG_M];
+            fcoopmatNV<16, gl_ScopeSubgroup, K, N> B[UNROLL_SG_N];
+#endif
+
+            [[unroll]] for (uint zk = 0; zk < UNROLL_SG_K; zk++)
+            {
+                [[unroll]] for (uint zm = 0; zm < UNROLL_SG_M; zm++)
+                {
+                    if (elempack == 1)
+                    {
+#if ncnn_VK_KHR_cooperative_matrix
+                        coopMatLoad(A[zm], tmp_v[sgmi], (zk * UNROLL_SG_M + zm) * (Md4 * K), Md4, gl_CooperativeMatrixLayoutColumnMajor);
+#elif ncnn_VK_NV_cooperative_matrix
+                        coopMatLoadNV(A[zm], tmp_v[sgmi], (zk * UNROLL_SG_M + zm) * (Md4 * K), Md4, true);
+#endif
+                    }
+                    else // if (elempack == 4)
+                    {
+#if ncnn_VK_KHR_cooperative_matrix
+                        coopMatLoad(A[zm], tmp_v[sgmi], (zk * UNROLL_SG_M + zm) * (Kd4 * M), Kd4, gl_CooperativeMatrixLayoutRowMajor);
+#elif ncnn_VK_NV_cooperative_matrix
+                        coopMatLoadNV(A[zm], tmp_v[sgmi], (zk * UNROLL_SG_M + zm) * (Kd4 * M), Kd4, false);
+#endif
+                    }
+                }
+
+                [[unroll]] for (uint zn = 0; zn < UNROLL_SG_N; zn++)
+                {
+#if ncnn_VK_KHR_cooperative_matrix
+                    coopMatLoad(B[zn], tmp_k[sgni], (zk * UNROLL_SG_N + zn) * (Nd4 * K), Nd4, gl_CooperativeMatrixLayoutRowMajor);
+#elif ncnn_VK_NV_cooperative_matrix
+                    coopMatLoadNV(B[zn], tmp_k[sgni], (zk * UNROLL_SG_N + zn) * (Nd4 * K), Nd4, false);
+#endif
+                }
+
+                // sum += k * v
+                [[unroll]] for (uint zn = 0; zn < UNROLL_SG_N; zn++)
+                {
+                    [[unroll]] for (uint zm = 0; zm < UNROLL_SG_M; zm++)
+                    {
+#if ncnn_VK_KHR_cooperative_matrix
+                        sum[zn][zm] = coopMatMulAdd(A[zm], B[zn], sum[zn][zm]);
+#elif ncnn_VK_NV_cooperative_matrix
+                        sum[zn][zm] = coopMatMulAddNV(A[zm], B[zn], sum[zn][zm]);
+#endif
+                    }
+                }
+            }
+        }
+
+        barrier();
+
+        // the last copy prefetch to shared memory
+        {
+            // load bottom_blob
+            {
+                if (elempack == 1)
+                {
+                    const uint Md4_K_USGM_USGK = Md4 * K * UNROLL_SG_M * UNROLL_SG_K;
+                    const uint Md4_K_USGM_USGK_d_subgroupsize = (Md4_K_USGM_USGK + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N);
+                    [[unroll]] for (uint q = 0; q < Md4_K_USGM_USGK_d_subgroupsize; q++)
+                    {
+                        const uint siq = (q * UNROLL_WG_N + sgni) * subgroup_size + si;
+
+                        if (Md4_K_USGM_USGK % (subgroup_size * UNROLL_WG_N) == 0 || siq < Md4_K_USGM_USGK)
+                        {
+                            tmp_v[sgmi][siq] = prefetch_tmp_v[q];
+                        }
+                    }
+                }
+                else // if (elempack == 4)
+                {
+                    const uint Kd4_M_USGM_USGK = Kd4 * M * UNROLL_SG_M * UNROLL_SG_K;
+                    const uint Kd4_M_USGM_USGK_d_subgroupsize = (Kd4_M_USGM_USGK + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N);
+                    [[unroll]] for (uint q = 0; q < Kd4_M_USGM_USGK_d_subgroupsize; q++)
+                    {
+                        const uint siq = (q * UNROLL_WG_N + sgni) * subgroup_size + si;
+
+                        if (Kd4_M_USGM_USGK % (subgroup_size * UNROLL_WG_N) == 0 || siq < Kd4_M_USGM_USGK)
+                        {
+                            tmp_v[sgmi][siq] = prefetch_tmp_v[q];
+                        }
+                    }
+                }
+            }
+
+            // load weight
+            {
+                const uint Nd4_K_USGN_USGK = Nd4 * K * UNROLL_SG_N * UNROLL_SG_K;
+                const uint Nd4_K_USGN_USGK_d_subgroupsize = (Nd4_K_USGN_USGK + (subgroup_size * UNROLL_WG_M - 1)) / (subgroup_size * UNROLL_WG_M);
+                [[unroll]] for (uint q = 0; q < Nd4_K_USGN_USGK_d_subgroupsize; q++)
+                {
+                    const uint siq = (q * UNROLL_WG_M + sgmi) * subgroup_size + si;
+
+                    if (Nd4_K_USGN_USGK % (subgroup_size * UNROLL_WG_M) == 0 || siq < Nd4_K_USGN_USGK)
+                    {
+                        tmp_k[sgni][siq] = prefetch_tmp_k[q];
+                    }
+                }
+            }
+        }
+
+        barrier();
+
+#if ncnn_VK_KHR_cooperative_matrix
+        coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> A[UNROLL_SG_M];
+        coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> B[UNROLL_SG_N];
+#elif ncnn_VK_NV_cooperative_matrix
+        fcoopmatNV<16, gl_ScopeSubgroup, M, K> A[UNROLL_SG_M];
+        fcoopmatNV<16, gl_ScopeSubgroup, K, N> B[UNROLL_SG_N];
+#endif
+
+        [[unroll]] for (uint zk = 0; zk < UNROLL_SG_K; zk++)
+        {
+            [[unroll]] for (uint zm = 0; zm < UNROLL_SG_M; zm++)
+            {
+                if (elempack == 1)
+                {
+#if ncnn_VK_KHR_cooperative_matrix
+                    coopMatLoad(A[zm], tmp_v[sgmi], (zk * UNROLL_SG_M + zm) * (Md4 * K), Md4, gl_CooperativeMatrixLayoutColumnMajor);
+#elif ncnn_VK_NV_cooperative_matrix
+                    coopMatLoadNV(A[zm], tmp_v[sgmi], (zk * UNROLL_SG_M + zm) * (Md4 * K), Md4, true);
+#endif
+                }
+                else // if (elempack == 4)
+                {
+#if ncnn_VK_KHR_cooperative_matrix
+                    coopMatLoad(A[zm], tmp_v[sgmi], (zk * UNROLL_SG_M + zm) * (Kd4 * M), Kd4, gl_CooperativeMatrixLayoutRowMajor);
+#elif ncnn_VK_NV_cooperative_matrix
+                    coopMatLoadNV(A[zm], tmp_v[sgmi], (zk * UNROLL_SG_M + zm) * (Kd4 * M), Kd4, false);
+#endif
+                }
+            }
+
+            [[unroll]] for (uint zn = 0; zn < UNROLL_SG_N; zn++)
+            {
+#if ncnn_VK_KHR_cooperative_matrix
+                coopMatLoad(B[zn], tmp_k[sgni], (zk * UNROLL_SG_N + zn) * (Nd4 * K), Nd4, gl_CooperativeMatrixLayoutRowMajor);
+#elif ncnn_VK_NV_cooperative_matrix
+                coopMatLoadNV(B[zn], tmp_k[sgni], (zk * UNROLL_SG_N + zn) * (Nd4 * K), Nd4, false);
+#endif
+            }
+
+            // sum += k * v
+            [[unroll]] for (uint zn = 0; zn < UNROLL_SG_N; zn++)
+            {
+                [[unroll]] for (uint zm = 0; zm < UNROLL_SG_M; zm++)
+                {
+#if ncnn_VK_KHR_cooperative_matrix
+                    sum[zn][zm] = coopMatMulAdd(A[zm], B[zn], sum[zn][zm]);
+#elif ncnn_VK_NV_cooperative_matrix
+                    sum[zn][zm] = coopMatMulAddNV(A[zm], B[zn], sum[zn][zm]);
+#endif
+                }
+            }
+        }
+    }
+    else if (kk >= UNROLL_SG_K)
+    {
+        // no ping-pong version
+
+        const uint ki = 0;
+
+        // load bottom_blob
+        {
+            if (elempack == 1)
+            {
+                //        +-M-+
+                //        K   |
+                //        +SG_UM
+                //        |   |
+                //     ^  +---+
+                //     |  |   |
+                //   SG_UK+- -+
+                //     |  |   |
+                //   ^ v  +---+
+                //   |    |   |
+                //   |    +- -+
+                //   |    |   |
+                // WG_UM  +---+
+                //   |    |   |
+                //   |    +- -+
+                //   |    |   |
+                //   v    +---+
+
+                const uint Md4_K_USGM_USGK = Md4 * K * UNROLL_SG_M * UNROLL_SG_K;
+                const uint Md4_K_USGM_USGK_d_subgroupsize = (Md4_K_USGM_USGK + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N);
+                [[unroll]] for (uint q = 0; q < Md4_K_USGM_USGK_d_subgroupsize; q++)
+                {
+                    const uint siq = (q * UNROLL_WG_N + sgni) * subgroup_size + si;
+
+                    if (Md4_K_USGM_USGK % (subgroup_size * UNROLL_WG_N) == 0 || siq < Md4_K_USGM_USGK)
+                    {
+                        const uint zk = siq / (Md4 * K * UNROLL_SG_M);
+                        const uint zmij = siq % (Md4 * K * UNROLL_SG_M);
+                        const uint zm = zmij / (Md4 * K);
+                        const uint ij = zmij % (Md4 * K);
+                        const uint i = ij / Md4;
+                        const uint j = ij % Md4;
+
+                        const uint gk = ki + zk * K + i;
+                        const uint gm = (mi + zm) * Md4 + j;
+
+                        // scalar loads, row step cstep is in element units and may not be multiple of 4
+                        uvec2 v = uvec2(0);
+                        if (gk < inch)
+                        {
+                            const uint gm4 = gm * 4;
+                            const uint v_offset = gk * psc(cstep) + gm4;
+                            vec4 v4 = vec4(0.f);
+                            if (gm4 + 0 < psc(size)) v4.r = float(buffer_ld1(bottom_blob_data_1, v_offset + 0));
+                            if (gm4 + 1 < psc(size)) v4.g = float(buffer_ld1(bottom_blob_data_1, v_offset + 1));
+                            if (gm4 + 2 < psc(size)) v4.b = float(buffer_ld1(bottom_blob_data_1, v_offset + 2));
+                            if (gm4 + 3 < psc(size)) v4.a = float(buffer_ld1(bottom_blob_data_1, v_offset + 3));
+                            v = uvec2(packHalf2x16(v4.rg), packHalf2x16(v4.ba));
+                        }
+
+                        tmp_v[sgmi][siq] = v;
+                    }
+                }
+            }
+            else // if (elempack == 4)
+            {
+                //        +-K-+
+                //        M   |
+                //        +- -+
+                //      SG_UM |
+                //     ^  +---+
+                //     |  |   |
+                //   SG_UK+- -+
+                //     |  |   |
+                //   ^ v  +---+
+                //   |    |   |
+                //   |    +- -+
+                //   |    |   |
+                // WG_UM  +---+
+                //   |    |   |
+                //   |    +- -+
+                //   |    |   |
+                //   v    +---+
+
+                const uint inchd4 = inch / 4;
+
+                const uint Kd4_M_USGM_USGK = Kd4 * M * UNROLL_SG_M * UNROLL_SG_K;
+                const uint Kd4_M_USGM_USGK_d_subgroupsize = (Kd4_M_USGM_USGK + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N);
+                [[unroll]] for (uint q = 0; q < Kd4_M_USGM_USGK_d_subgroupsize; q++)
+                {
+                    const uint siq = (q * UNROLL_WG_N + sgni) * subgroup_size + si;
+
+                    if (Kd4_M_USGM_USGK % (subgroup_size * UNROLL_WG_N) == 0 || siq < Kd4_M_USGM_USGK)
+                    {
+                        const uint zk = siq / (Kd4 * M * UNROLL_SG_M);
+                        const uint zmij = siq % (Kd4 * M * UNROLL_SG_M);
+                        const uint zmi = zmij / Kd4;
+                        const uint j = zmij % Kd4;
+
+                        const uint gm = mi * M + zmi;
+                        const uint gk = ki / 4 + zk * Kd4 + j;
+
+                        uvec2 v = gk < inchd4 && gm < psc(cstep) ? bottom_blob_data[gk * psc(cstep) + gm] : uvec2(0);
+
+                        tmp_v[sgmi][siq] = v;
+                    }
+                }
+            }
+        }
+
+        // load weight
+        {
+            //        +-N-+
+            //        K   |
+            //        +SG_UN
+            //        |   |
+            //     ^  +---+
+            //     |  |   |
+            //   SG_UK+- -+
+            //     |  |   |
+            //   ^ v  +---+
+            //   |    |   |
+            //   |    +- -+
+            //   |    |   |
+            // WG_UN  +---+
+            //   |    |   |
+            //   |    +- -+
+            //   |    |   |
+            //   v    +---+
+
+            // weight_data   coopmat_N * coopmat_K * UNROLL_SG_N * UNROLL_WG_N * kk, blocks_n
+
+            const uint Nd4_K_USGN = Nd4 * K * UNROLL_SG_N;
+            const uint Nd4_K_USGN_USGK = Nd4 * K * UNROLL_SG_N * UNROLL_SG_K;
+
+            const uint w_offset = ((wgni * kk) * UNROLL_WG_N) * Nd4_K_USGN + ((k / UNROLL_SG_K) * UNROLL_WG_N + sgni) * Nd4_K_USGN_USGK;
+
+            const uint Nd4_K_USGN_USGK_d_subgroupsize = (Nd4_K_USGN_USGK + (subgroup_size * UNROLL_WG_M - 1)) / (subgroup_size * UNROLL_WG_M);
+            [[unroll]] for (uint q = 0; q < Nd4_K_USGN_USGK_d_subgroupsize; q++)
+            {
+                const uint siq = (q * UNROLL_WG_M + sgmi) * subgroup_size + si;
+
+                if (Nd4_K_USGN_USGK % (subgroup_size * UNROLL_WG_M) == 0 || siq < Nd4_K_USGN_USGK)
+                {
+                    tmp_k[sgni][siq] = weight_data[w_offset + siq];
+                }
+            }
+        }
+
+        barrier();
+
+#if ncnn_VK_KHR_cooperative_matrix
+        coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> A[UNROLL_SG_M];
+        coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> B[UNROLL_SG_N];
+#elif ncnn_VK_NV_cooperative_matrix
+        fcoopmatNV<16, gl_ScopeSubgroup, M, K> A[UNROLL_SG_M];
+        fcoopmatNV<16, gl_ScopeSubgroup, K, N> B[UNROLL_SG_N];
+#endif
+
+        [[unroll]] for (uint zk = 0; zk < UNROLL_SG_K; zk++)
+        {
+            [[unroll]] for (uint zm = 0; zm < UNROLL_SG_M; zm++)
+            {
+                if (elempack == 1)
+                {
+#if ncnn_VK_KHR_cooperative_matrix
+                    coopMatLoad(A[zm], tmp_v[sgmi], (zk * UNROLL_SG_M + zm) * (Md4 * K), Md4, gl_CooperativeMatrixLayoutColumnMajor);
+#elif ncnn_VK_NV_cooperative_matrix
+                    coopMatLoadNV(A[zm], tmp_v[sgmi], (zk * UNROLL_SG_M + zm) * (Md4 * K), Md4, true);
+#endif
+                }
+                else // if (elempack == 4)
+                {
+#if ncnn_VK_KHR_cooperative_matrix
+                    coopMatLoad(A[zm], tmp_v[sgmi], (zk * UNROLL_SG_M + zm) * (Kd4 * M), Kd4, gl_CooperativeMatrixLayoutRowMajor);
+#elif ncnn_VK_NV_cooperative_matrix
+                    coopMatLoadNV(A[zm], tmp_v[sgmi], (zk * UNROLL_SG_M + zm) * (Kd4 * M), Kd4, false);
+#endif
+                }
+            }
+
+            [[unroll]] for (uint zn = 0; zn < UNROLL_SG_N; zn++)
+            {
+#if ncnn_VK_KHR_cooperative_matrix
+                coopMatLoad(B[zn], tmp_k[sgni], (zk * UNROLL_SG_N + zn) * (Nd4 * K), Nd4, gl_CooperativeMatrixLayoutRowMajor);
+#elif ncnn_VK_NV_cooperative_matrix
+                coopMatLoadNV(B[zn], tmp_k[sgni], (zk * UNROLL_SG_N + zn) * (Nd4 * K), Nd4, false);
+#endif
+            }
+
+            // sum += k * v
+            [[unroll]] for (uint zn = 0; zn < UNROLL_SG_N; zn++)
+            {
+                [[unroll]] for (uint zm = 0; zm < UNROLL_SG_M; zm++)
+                {
+#if ncnn_VK_KHR_cooperative_matrix
+                    sum[zn][zm] = coopMatMulAdd(A[zm], B[zn], sum[zn][zm]);
+#elif ncnn_VK_NV_cooperative_matrix
+                    sum[zn][zm] = coopMatMulAddNV(A[zm], B[zn], sum[zn][zm]);
+#endif
+                }
+            }
+        }
+
+        k += UNROLL_SG_K;
+    }
+
+    for (; k < kk; k++)
+    {
+        const uint ki = k * K;
+
+        barrier();
+
+        // load bottom_blob
+        {
+            if (elempack == 1)
+            {
+                //      +-M-+
+                //      K   |
+                //      +SG_UM
+                //      |   |
+                //   ^  +---+
+                //   |  |   |
+                // WG_UM+- -+
+                //   |  |   |
+                //   v  +---+
+
+                const uint Md4_K_USGM = Md4 * K * UNROLL_SG_M;
+                const uint Md4_K_USGM_d_subgroupsize = (Md4_K_USGM + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N);
+                [[unroll]] for (uint q = 0; q < Md4_K_USGM_d_subgroupsize; q++)
+                {
+                    const uint siq = (q * UNROLL_WG_N + sgni) * subgroup_size + si;
+
+                    if (Md4_K_USGM % (subgroup_size * UNROLL_WG_N) == 0 || siq < Md4_K_USGM)
+                    {
+                        const uint zm = siq / (Md4 * K);
+                        const uint ij = siq % (Md4 * K);
+                        const uint i = ij / Md4;
+                        const uint j = ij % Md4;
+
+                        const uint gk = ki + i;
+                        const uint gm = (mi + zm) * Md4 + j;
+
+                        // scalar loads, row step cstep is in element units and may not be multiple of 4
+                        uvec2 v = uvec2(0);
+                        if (gk < inch)
+                        {
+                            const uint gm4 = gm * 4;
+                            const uint v_offset = gk * psc(cstep) + gm4;
+                            vec4 v4 = vec4(0.f);
+                            if (gm4 + 0 < psc(size)) v4.r = float(buffer_ld1(bottom_blob_data_1, v_offset + 0));
+                            if (gm4 + 1 < psc(size)) v4.g = float(buffer_ld1(bottom_blob_data_1, v_offset + 1));
+                            if (gm4 + 2 < psc(size)) v4.b = float(buffer_ld1(bottom_blob_data_1, v_offset + 2));
+                            if (gm4 + 3 < psc(size)) v4.a = float(buffer_ld1(bottom_blob_data_1, v_offset + 3));
+                            v = uvec2(packHalf2x16(v4.rg), packHalf2x16(v4.ba));
+                        }
+
+                        tmp_v[sgmi][siq] = v;
+                    }
+                }
+            }
+            else // if (elempack == 4)
+            {
+                //      +-K-+
+                //      M   |
+                //      +- -+
+                //    SG_UM |
+                //   ^  +---+
+                //   |  |   |
+                // WG_UM+- -+
+                //   |  |   |
+                //   v  +---+
+
+                const uint inchd4 = inch / 4;
+
+                const uint Kd4_M_USGM = Kd4 * M * UNROLL_SG_M;
+                const uint Kd4_M_USGM_d_subgroupsize = (Kd4_M_USGM + (subgroup_size * UNROLL_WG_N - 1)) / (subgroup_size * UNROLL_WG_N);
+                [[unroll]] for (uint q = 0; q < Kd4_M_USGM_d_subgroupsize; q++)
+                {
+                    const uint siq = (q * UNROLL_WG_N + sgni) * subgroup_size + si;
+
+                    if (Kd4_M_USGM % (subgroup_size * UNROLL_WG_N) == 0 || siq < Kd4_M_USGM)
+                    {
+                        const uint zmi = siq / Kd4;
+                        const uint j = siq % Kd4;
+
+                        const uint gm = mi * M + zmi;
+                        const uint gk = ki / 4 + j;
+
+                        uvec2 v = gk < inchd4 && gm < psc(cstep) ? bottom_blob_data[gk * psc(cstep) + gm] : uvec2(0);
+
+                        tmp_v[sgmi][siq] = v;
+                    }
+                }
+            }
+        }
+
+        // load weight
+        {
+            //      +-N-+
+            //      K   |
+            //      +SG_UN
+            //      |   |
+            //   ^  +---+
+            //   |  |   |
+            // WG_UN+- -+
+            //   |  |   |
+            //   v  +---+
+
+            // weight_data   coopmat_N * coopmat_K * UNROLL_SG_N * UNROLL_WG_N * kk, blocks_n
+
+            const uint Nd4_K_USGN = Nd4 * K * UNROLL_SG_N;
+
+            const uint w_offset = ((wgni * kk + k) * UNROLL_WG_N + sgni) * Nd4_K_USGN;
+
+            const uint Nd4_K_USGN_d_subgroupsize = (Nd4_K_USGN + (subgroup_size * UNROLL_WG_M - 1)) / (subgroup_size * UNROLL_WG_M);
+            [[unroll]] for (uint q = 0; q < Nd4_K_USGN_d_subgroupsize; q++)
+            {
+                const uint siq = (q * UNROLL_WG_M + sgmi) * subgroup_size + si;
+
+                if (Nd4_K_USGN % (subgroup_size * UNROLL_WG_M) == 0 || siq < Nd4_K_USGN)
+                {
+                    tmp_k[sgni][siq] = weight_data[w_offset + siq];
+                }
+            }
+        }
+
+        barrier();
+
+#if ncnn_VK_KHR_cooperative_matrix
+        coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> A[UNROLL_SG_M];
+        coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> B[UNROLL_SG_N];
+#elif ncnn_VK_NV_cooperative_matrix
+        fcoopmatNV<16, gl_ScopeSubgroup, M, K> A[UNROLL_SG_M];
+        fcoopmatNV<16, gl_ScopeSubgroup, K, N> B[UNROLL_SG_N];
+#endif
+
+        [[unroll]] for (uint zm = 0; zm < UNROLL_SG_M; zm++)
+        {
+            if (elempack == 1)
+            {
+#if ncnn_VK_KHR_cooperative_matrix
+                coopMatLoad(A[zm], tmp_v[sgmi], zm * (Md4 * K), Md4, gl_CooperativeMatrixLayoutColumnMajor);
+#elif ncnn_VK_NV_cooperative_matrix
+                coopMatLoadNV(A[zm], tmp_v[sgmi], zm * (Md4 * K), Md4, true);
+#endif
+            }
+            else // if (elempack == 4)
+            {
+#if ncnn_VK_KHR_cooperative_matrix
+                coopMatLoad(A[zm], tmp_v[sgmi], zm * (Kd4 * M), Kd4, gl_CooperativeMatrixLayoutRowMajor);
+#elif ncnn_VK_NV_cooperative_matrix
+                coopMatLoadNV(A[zm], tmp_v[sgmi], zm * (Kd4 * M), Kd4, false);
+#endif
+            }
+        }
+
+        [[unroll]] for (uint zn = 0; zn < UNROLL_SG_N; zn++)
+        {
+#if ncnn_VK_KHR_cooperative_matrix
+            coopMatLoad(B[zn], tmp_k[sgni], zn * (Nd4 * K), Nd4, gl_CooperativeMatrixLayoutRowMajor);
+#elif ncnn_VK_NV_cooperative_matrix
+            coopMatLoadNV(B[zn], tmp_k[sgni], zn * (Nd4 * K), Nd4, false);
+#endif
+        }
+
+        // sum += k * v
+        [[unroll]] for (uint zn = 0; zn < UNROLL_SG_N; zn++)
+        {
+            [[unroll]] for (uint zm = 0; zm < UNROLL_SG_M; zm++)
+            {
+#if ncnn_VK_KHR_cooperative_matrix
+                sum[zn][zm] = coopMatMulAdd(A[zm], B[zn], sum[zn][zm]);
+#elif ncnn_VK_NV_cooperative_matrix
+                sum[zn][zm] = coopMatMulAddNV(A[zm], B[zn], sum[zn][zm]);
+#endif
+            }
+        }
+    }
+
+    [[unroll]] for (uint zn = 0; zn < UNROLL_SG_N; zn++)
+    {
+        [[unroll]] for (uint zm = 0; zm < UNROLL_SG_M; zm++)
+        {
+            if (out_elempack == 1)
+            {
+#if ncnn_VK_KHR_cooperative_matrix
+#if NCNN_fp16_arithmetic
+                coopMatStore(sum[zn][zm], tmp_o[sgi], (zn * UNROLL_SG_M + zm) * (Md4 * N), Md4, gl_CooperativeMatrixLayoutColumnMajor);
+#else
+                coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> sum_fp16 = coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(sum[zn][zm]);
+                coopMatStore(sum_fp16, tmp_o[sgi], (zn * UNROLL_SG_M + zm) * (Md4 * N), Md4, gl_CooperativeMatrixLayoutColumnMajor);
+#endif
+#elif ncnn_VK_NV_cooperative_matrix
+#if NCNN_fp16_arithmetic
+                coopMatStoreNV(sum[zn][zm], tmp_o[sgi], (zn * UNROLL_SG_M + zm) * (Md4 * N), Md4, true);
+#else
+                fcoopmatNV<16, gl_ScopeSubgroup, M, N> sum_fp16 = fcoopmatNV<16, gl_ScopeSubgroup, M, N>(sum[zn][zm]);
+                coopMatStoreNV(sum_fp16, tmp_o[sgi], (zn * UNROLL_SG_M + zm) * (Md4 * N), Md4, true);
+#endif
+#endif
+            }
+            else // if (out_elempack == 4)
+            {
+#if ncnn_VK_KHR_cooperative_matrix
+#if NCNN_fp16_arithmetic
+                coopMatStore(sum[zn][zm], tmp_o[sgi], (zn * UNROLL_SG_M + zm) * (Nd4 * M), Nd4, gl_CooperativeMatrixLayoutRowMajor);
+#else
+                coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> sum_fp16 = coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(sum[zn][zm]);
+                coopMatStore(sum_fp16, tmp_o[sgi], (zn * UNROLL_SG_M + zm) * (Nd4 * M), Nd4, gl_CooperativeMatrixLayoutRowMajor);
+#endif
+#elif ncnn_VK_NV_cooperative_matrix
+#if NCNN_fp16_arithmetic
+                coopMatStoreNV(sum[zn][zm], tmp_o[sgi], (zn * UNROLL_SG_M + zm) * (Nd4 * M), Nd4, false);
+#else
+                fcoopmatNV<16, gl_ScopeSubgroup, M, N> sum_fp16 = fcoopmatNV<16, gl_ScopeSubgroup, M, N>(sum[zn][zm]);
+                coopMatStoreNV(sum_fp16, tmp_o[sgi], (zn * UNROLL_SG_M + zm) * (Nd4 * M), Nd4, false);
+#endif
+#endif
+            }
+        }
+    }
+
+    barrier();
+
+    // store top_blob
+    {
+        if (out_elempack == 1)
+        {
+            //          +-M-+
+            //          N   |
+            //          +SG_UM
+            //          |   |
+            //       ^  +---+
+            //       |  |   |
+            //     SG_UN+- -+
+            //       |  |   |
+            //     ^ v  +---+
+            //     |    |   |
+            //     |    +- -+
+            //     |    |   |
+            //   WG_UM  +- -+
+            //     |    |   |
+            //     |    +- -+
+            //     |    |   |
+            //   ^ v    +---+
+            //   |      |   |
+            //   |      +- -+
+            //   |      |   |
+            //   |      +---+
+            //   |      |   |
+            //   |      +- -+
+            //   |      |   |
+            // WG_UN    +---+
+            //   |      |   |
+            //   |      +- -+
+            //   |      |   |
+            //   |      +---+
+            //   |      |   |
+            //   |      +- -+
+            //   |      |   |
+            //   v      +---+
+
+            const uint outcstepd4 = psc(outcstep) / 4;
+
+            const uint Md4_N_USGM_USGN = Md4 * N * UNROLL_SG_M * UNROLL_SG_N;
+            const uint Md4_N_USGM_USGN_d_subgroupsize = (Md4_N_USGM_USGN + subgroup_size - 1) / subgroup_size;
+            [[unroll]] for (uint q = 0; q < Md4_N_USGM_USGN_d_subgroupsize; q++)
+            {
+                const uint siq = si + q * subgroup_size;
+
+                if (Md4_N_USGM_USGN % subgroup_size == 0 || siq < Md4_N_USGM_USGN)
+                {
+                    const uint zn = siq / (Md4 * N * UNROLL_SG_M);
+                    const uint zmij = siq % (Md4 * N * UNROLL_SG_M);
+                    const uint zm = zmij / (Md4 * N);
+                    const uint ij = zmij % (Md4 * N);
+                    const uint i = ij / Md4;
+                    const uint j = ij % Md4;
+
+                    const uint gn = (ni + zn) * N + i;
+                    const uint gm = (mi + zm) * Md4 + j;
+
+                    if (gn < outch && gm < outcstepd4)
+                    {
+                        col_blob_data[gn * outcstepd4 + gm] = tmp_o[sgi][siq];
+                    }
+                }
+            }
+        }
+        else // if (out_elempack == 4)
+        {
+            //          +-N-+
+            //          M   |
+            //          +---+
+            //        SG_UM |
+            //       ^  +---+
+            //       |  |   |
+            //     SG_UN+---+
+            //       |  |   |
+            //     ^ v  +---+
+            //     |    |   |
+            //     |    +- -+
+            //     |    |   |
+            //   WG_UM  +---+
+            //     |    |   |
+            //     |    +---+
+            //     |    |   |
+            //   ^ v    +---+
+            //   |      |   |
+            //   |      +- -+
+            //   |      |   |
+            //   |      +---+
+            //   |      |   |
+            //   |      +---+
+            //   |      |   |
+            // WG_UN    +---+
+            //   |      |   |
+            //   |      +- -+
+            //   |      |   |
+            //   |      +---+
+            //   |      |   |
+            //   |      +---+
+            //   |      |   |
+            //   v      +---+
+
+            const uint outchd4 = outch / 4;
+
+            const uint Nd4_M_USGM_USGN = Nd4 * M * UNROLL_SG_M * UNROLL_SG_N;
+            const uint Nd4_M_USGM_USGN_d_subgroupsize = (Nd4_M_USGM_USGN + subgroup_size - 1) / subgroup_size;
+            [[unroll]] for (uint q = 0; q < Nd4_M_USGM_USGN_d_subgroupsize; q++)
+            {
+                const uint siq = si + q * subgroup_size;
+
+                if (Nd4_M_USGM_USGN % subgroup_size == 0 || siq < Nd4_M_USGM_USGN)
+                {
+                    const uint zn = siq / (Nd4 * M * UNROLL_SG_M);
+                    const uint zmij = siq % (Nd4 * M * UNROLL_SG_M);
+                    const uint zmi = zmij / Nd4;
+                    const uint j = zmij % Nd4;
+
+                    const uint gn = (ni + zn) * Nd4 + j;
+                    const uint gm = mi * M + zmi;
+
+                    if (gn < outchd4 && gm < psc(outcstep))
+                    {
+                        col_blob_data[gn * psc(outcstep) + gm] = tmp_o[sgi][siq];
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/layer/vulkan/shader/deconvolution1d_gemm_packed.comp
+++ b/src/layer/vulkan/shader/deconvolution1d_gemm_packed.comp
@@ -1,0 +1,266 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#define LOCAL_MEMORY_UNROLL_INCH 8
+
+layout(constant_id = 0) const int maxk = 1;
+layout(constant_id = 1) const int elempack = 1;
+layout(constant_id = 2) const int out_elempack = 1;
+
+#define shape_constant_id_offset 3
+layout(constant_id = shape_constant_id_offset + 0) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int h = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int c = 0;
+layout(constant_id = shape_constant_id_offset + 3) const int cstep = 0;
+
+layout(constant_id = shape_constant_id_offset + 4) const int outcstep = 0;
+layout(constant_id = shape_constant_id_offset + 5) const int outc = 0;
+layout(constant_id = shape_constant_id_offset + 6) const int num_input = 0;
+
+// scalar view (for pack1 input/output access)
+layout(binding = 0) readonly buffer bottom_blob_1 { sfp bottom_blob_data_1[]; };
+layout(binding = 1) writeonly buffer col_blob_1 { sfp col_blob_data_1[]; };
+
+// vec4 view (for pack4 input/output access, weight always vec4)
+layout(binding = 2) readonly buffer bottom_blob_4 { sfpvec4 bottom_blob_data_4[]; };
+layout(binding = 3) writeonly buffer col_blob_4 { sfpvec4 col_blob_data_4[]; };
+layout(binding = 4) readonly buffer weight_blob { sfpvec4 weight_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int w;
+    int h;
+    int c;
+    int cstep;
+
+    int outcstep;
+    int outc;
+    int num_input;
+} p;
+
+#if NCNN_shader_local_memory
+shared lfpvec4 tmp_v[8][LOCAL_MEMORY_UNROLL_INCH][4];
+shared lfpvec4 tmp_k[8][LOCAL_MEMORY_UNROLL_INCH][4];
+#endif
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x) * 4;
+    int gy = int(gl_GlobalInvocationID.y);
+
+#if !NCNN_shader_local_memory
+    if (gx >= psc(outcstep) || gy >= psc(outc))
+        return;
+#endif
+
+    afpvec4 sum0 = afpvec4(0.f);
+    afpvec4 sum1 = afpvec4(0.f);
+    afpvec4 sum2 = afpvec4(0.f);
+    afpvec4 sum3 = afpvec4(0.f);
+
+    int v_offset = gx;
+    int w_offset = gy * psc(c) * 4;
+
+#if NCNN_shader_local_memory
+    const int lx = int(gl_LocalInvocationID.x);
+    const int ly = int(gl_LocalInvocationID.y);
+
+    int z = 0;
+    for (; z + (LOCAL_MEMORY_UNROLL_INCH - 1) < psc(c); z += LOCAL_MEMORY_UNROLL_INCH)
+    {
+        if (ly < 4)
+        {
+            for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+            {
+                if (elempack == 4)
+                {
+                    tmp_v[lx][z4][ly] = buffer_sm4(bottom_blob_data_4, v_offset + z4 * psc(cstep) + ly);
+                }
+                else // elempack == 1
+                {
+                    const int ch0 = (z + z4) * 4;
+
+                    afp a0 = buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + ly);
+                    afp a1 = (ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + ly) : afp(0.f);
+                    afp a2 = (ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + ly) : afp(0.f);
+                    afp a3 = (ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + ly) : afp(0.f);
+
+                    tmp_v[lx][z4][ly] = afp2lfpvec4(afpvec4(a0, a1, a2, a3));
+                }
+            }
+        }
+
+        if (lx < 4)
+        {
+            for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+            {
+                tmp_k[ly][z4][lx] = buffer_sm4(weight_data, w_offset + z4 * 4 + lx);
+            }
+        }
+
+        barrier();
+
+        for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
+        {
+            afpvec4 v0 = lfp2afpvec4(tmp_v[lx][z4][0]);
+            afpvec4 v1 = lfp2afpvec4(tmp_v[lx][z4][1]);
+            afpvec4 v2 = lfp2afpvec4(tmp_v[lx][z4][2]);
+            afpvec4 v3 = lfp2afpvec4(tmp_v[lx][z4][3]);
+
+            afpvec4 k0 = lfp2afpvec4(tmp_k[ly][z4][0]);
+            afpvec4 k1 = lfp2afpvec4(tmp_k[ly][z4][1]);
+            afpvec4 k2 = lfp2afpvec4(tmp_k[ly][z4][2]);
+            afpvec4 k3 = lfp2afpvec4(tmp_k[ly][z4][3]);
+
+            afpmat4 k = afpmat4(k0, k1, k2, k3);
+
+            sum0 += v0 * k;
+            sum1 += v1 * k;
+            sum2 += v2 * k;
+            sum3 += v3 * k;
+        }
+
+        v_offset += LOCAL_MEMORY_UNROLL_INCH * psc(cstep);
+        w_offset += LOCAL_MEMORY_UNROLL_INCH * 4;
+
+        barrier();
+    }
+
+    if (z < psc(c))
+    {
+        const int remain = psc(c) - z;
+
+        if (ly < 4)
+        {
+            for (int z4 = 0; z4 < remain; z4++)
+            {
+                if (elempack == 4)
+                {
+                    tmp_v[lx][z4][ly] = buffer_sm4(bottom_blob_data_4, v_offset + z4 * psc(cstep) + ly);
+                }
+                else // elempack == 1
+                {
+                    const int ch0 = (z + z4) * 4;
+
+                    afp a0 = buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + ly);
+                    afp a1 = (ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + ly) : afp(0.f);
+                    afp a2 = (ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + ly) : afp(0.f);
+                    afp a3 = (ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + ly) : afp(0.f);
+
+                    tmp_v[lx][z4][ly] = afp2lfpvec4(afpvec4(a0, a1, a2, a3));
+                }
+            }
+        }
+
+        if (lx < 4)
+        {
+            for (int z4 = 0; z4 < remain; z4++)
+            {
+                tmp_k[ly][z4][lx] = buffer_sm4(weight_data, w_offset + z4 * 4 + lx);
+            }
+        }
+
+        barrier();
+
+        for (int z4 = 0; z4 < remain; z4++)
+        {
+            afpvec4 v0 = lfp2afpvec4(tmp_v[lx][z4][0]);
+            afpvec4 v1 = lfp2afpvec4(tmp_v[lx][z4][1]);
+            afpvec4 v2 = lfp2afpvec4(tmp_v[lx][z4][2]);
+            afpvec4 v3 = lfp2afpvec4(tmp_v[lx][z4][3]);
+
+            afpvec4 k0 = lfp2afpvec4(tmp_k[ly][z4][0]);
+            afpvec4 k1 = lfp2afpvec4(tmp_k[ly][z4][1]);
+            afpvec4 k2 = lfp2afpvec4(tmp_k[ly][z4][2]);
+            afpvec4 k3 = lfp2afpvec4(tmp_k[ly][z4][3]);
+
+            afpmat4 k = afpmat4(k0, k1, k2, k3);
+
+            sum0 += v0 * k;
+            sum1 += v1 * k;
+            sum2 += v2 * k;
+            sum3 += v3 * k;
+        }
+    }
+#else
+    for (int z = 0; z < psc(c); z++)
+    {
+        afpvec4 v0, v1, v2, v3;
+
+        if (elempack == 4)
+        {
+            v0 = buffer_ld4(bottom_blob_data_4, v_offset + 0);
+            v1 = buffer_ld4(bottom_blob_data_4, v_offset + 1);
+            v2 = buffer_ld4(bottom_blob_data_4, v_offset + 2);
+            v3 = buffer_ld4(bottom_blob_data_4, v_offset + 3);
+        }
+        else // elempack == 1
+        {
+            const int ch0 = z * 4;
+
+            afp v00 = buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx);
+            afp v01 = (ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx) : afp(0.f);
+            afp v02 = (ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx) : afp(0.f);
+            afp v03 = (ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx) : afp(0.f);
+
+            afp v10 = buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + 1);
+            afp v11 = (ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + 1) : afp(0.f);
+            afp v12 = (ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + 1) : afp(0.f);
+            afp v13 = (ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + 1) : afp(0.f);
+
+            afp v20 = buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + 2);
+            afp v21 = (ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + 2) : afp(0.f);
+            afp v22 = (ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + 2) : afp(0.f);
+            afp v23 = (ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + 2) : afp(0.f);
+
+            afp v30 = buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + 3);
+            afp v31 = (ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + 3) : afp(0.f);
+            afp v32 = (ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + 3) : afp(0.f);
+            afp v33 = (ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + 3) : afp(0.f);
+
+            v0 = afpvec4(v00, v01, v02, v03);
+            v1 = afpvec4(v10, v11, v12, v13);
+            v2 = afpvec4(v20, v21, v22, v23);
+            v3 = afpvec4(v30, v31, v32, v33);
+        }
+
+        afpmat4 k = afpmat4(
+            buffer_ld4(weight_data, w_offset + 0),
+            buffer_ld4(weight_data, w_offset + 1),
+            buffer_ld4(weight_data, w_offset + 2),
+            buffer_ld4(weight_data, w_offset + 3));
+
+        sum0 += v0 * k;
+        sum1 += v1 * k;
+        sum2 += v2 * k;
+        sum3 += v3 * k;
+
+        v_offset += psc(cstep);
+        w_offset += 4;
+    }
+#endif
+
+#if NCNN_shader_local_memory
+    if (gx >= psc(outcstep) || gy >= psc(outc))
+        return;
+#endif
+
+    const int gi = gy * psc(outcstep) + gx;
+
+    if (out_elempack == 4)
+    {
+        buffer_st4(col_blob_data_4, gi, sum0);
+        if (gx + 1 < psc(outcstep)) buffer_st4(col_blob_data_4, gi + 1, sum1);
+        if (gx + 2 < psc(outcstep)) buffer_st4(col_blob_data_4, gi + 2, sum2);
+        if (gx + 3 < psc(outcstep)) buffer_st4(col_blob_data_4, gi + 3, sum3);
+    }
+    else // out_elempack == 1
+    {
+        buffer_st1(col_blob_data_1, gi, sum0.x);
+        if (gx + 1 < psc(outcstep)) buffer_st1(col_blob_data_1, gi + 1, sum1.x);
+        if (gx + 2 < psc(outcstep)) buffer_st1(col_blob_data_1, gi + 2, sum2.x);
+        if (gx + 3 < psc(outcstep)) buffer_st1(col_blob_data_1, gi + 3, sum3.x);
+    }
+}

--- a/src/layer/vulkan/shader/deconvolution1d_gemm_packed.comp
+++ b/src/layer/vulkan/shader/deconvolution1d_gemm_packed.comp
@@ -99,7 +99,10 @@ void main()
         {
             for (int z4 = 0; z4 < LOCAL_MEMORY_UNROLL_INCH; z4++)
             {
-                tmp_k[ly][z4][lx] = buffer_sm4(weight_data, w_offset + z4 * 4 + lx);
+                if (gy < psc(outc))
+                    tmp_k[ly][z4][lx] = buffer_sm4(weight_data, w_offset + z4 * 4 + lx);
+                else
+                    tmp_k[ly][z4][lx] = lfpvec4(0.f);
             }
         }
 
@@ -164,7 +167,10 @@ void main()
         {
             for (int z4 = 0; z4 < remain; z4++)
             {
-                tmp_k[ly][z4][lx] = buffer_sm4(weight_data, w_offset + z4 * 4 + lx);
+                if (gy < psc(outc))
+                    tmp_k[ly][z4][lx] = buffer_sm4(weight_data, w_offset + z4 * 4 + lx);
+                else
+                    tmp_k[ly][z4][lx] = lfpvec4(0.f);
             }
         }
 

--- a/src/layer/vulkan/shader/deconvolution1d_gemm_packed.comp
+++ b/src/layer/vulkan/shader/deconvolution1d_gemm_packed.comp
@@ -76,16 +76,19 @@ void main()
             {
                 if (elempack == 4)
                 {
-                    tmp_v[lx][z4][ly] = buffer_sm4(bottom_blob_data_4, v_offset + z4 * psc(cstep) + ly);
+                    if (gx + ly < psc(w))
+                        tmp_v[lx][z4][ly] = buffer_sm4(bottom_blob_data_4, v_offset + z4 * psc(cstep) + ly);
+                    else
+                        tmp_v[lx][z4][ly] = lfpvec4(0.f);
                 }
                 else // elempack == 1
                 {
                     const int ch0 = (z + z4) * 4;
 
-                    afp a0 = buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + ly);
-                    afp a1 = (ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + ly) : afp(0.f);
-                    afp a2 = (ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + ly) : afp(0.f);
-                    afp a3 = (ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + ly) : afp(0.f);
+                    afp a0 = (gx + ly < psc(w)) ? buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + ly) : afp(0.f);
+                    afp a1 = (gx + ly < psc(w) && ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + ly) : afp(0.f);
+                    afp a2 = (gx + ly < psc(w) && ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + ly) : afp(0.f);
+                    afp a3 = (gx + ly < psc(w) && ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + ly) : afp(0.f);
 
                     tmp_v[lx][z4][ly] = afp2lfpvec4(afpvec4(a0, a1, a2, a3));
                 }
@@ -138,16 +141,19 @@ void main()
             {
                 if (elempack == 4)
                 {
-                    tmp_v[lx][z4][ly] = buffer_sm4(bottom_blob_data_4, v_offset + z4 * psc(cstep) + ly);
+                    if (gx + ly < psc(w))
+                        tmp_v[lx][z4][ly] = buffer_sm4(bottom_blob_data_4, v_offset + z4 * psc(cstep) + ly);
+                    else
+                        tmp_v[lx][z4][ly] = lfpvec4(0.f);
                 }
                 else // elempack == 1
                 {
                     const int ch0 = (z + z4) * 4;
 
-                    afp a0 = buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + ly);
-                    afp a1 = (ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + ly) : afp(0.f);
-                    afp a2 = (ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + ly) : afp(0.f);
-                    afp a3 = (ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + ly) : afp(0.f);
+                    afp a0 = (gx + ly < psc(w)) ? buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + ly) : afp(0.f);
+                    afp a1 = (gx + ly < psc(w) && ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + ly) : afp(0.f);
+                    afp a2 = (gx + ly < psc(w) && ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + ly) : afp(0.f);
+                    afp a3 = (gx + ly < psc(w) && ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + ly) : afp(0.f);
 
                     tmp_v[lx][z4][ly] = afp2lfpvec4(afpvec4(a0, a1, a2, a3));
                 }
@@ -191,34 +197,34 @@ void main()
 
         if (elempack == 4)
         {
-            v0 = buffer_ld4(bottom_blob_data_4, v_offset + 0);
-            v1 = buffer_ld4(bottom_blob_data_4, v_offset + 1);
-            v2 = buffer_ld4(bottom_blob_data_4, v_offset + 2);
-            v3 = buffer_ld4(bottom_blob_data_4, v_offset + 3);
+            v0 = (gx + 0 < psc(w)) ? buffer_ld4(bottom_blob_data_4, v_offset + 0) : afpvec4(0.f);
+            v1 = (gx + 1 < psc(w)) ? buffer_ld4(bottom_blob_data_4, v_offset + 1) : afpvec4(0.f);
+            v2 = (gx + 2 < psc(w)) ? buffer_ld4(bottom_blob_data_4, v_offset + 2) : afpvec4(0.f);
+            v3 = (gx + 3 < psc(w)) ? buffer_ld4(bottom_blob_data_4, v_offset + 3) : afpvec4(0.f);
         }
         else // elempack == 1
         {
             const int ch0 = z * 4;
 
-            afp v00 = buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx);
-            afp v01 = (ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx) : afp(0.f);
-            afp v02 = (ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx) : afp(0.f);
-            afp v03 = (ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx) : afp(0.f);
+            afp v00 = (gx + 0 < psc(w)) ? buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx) : afp(0.f);
+            afp v01 = (gx + 0 < psc(w) && ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx) : afp(0.f);
+            afp v02 = (gx + 0 < psc(w) && ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx) : afp(0.f);
+            afp v03 = (gx + 0 < psc(w) && ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx) : afp(0.f);
 
-            afp v10 = buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + 1);
-            afp v11 = (ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + 1) : afp(0.f);
-            afp v12 = (ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + 1) : afp(0.f);
-            afp v13 = (ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + 1) : afp(0.f);
+            afp v10 = (gx + 1 < psc(w)) ? buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + 1) : afp(0.f);
+            afp v11 = (gx + 1 < psc(w) && ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + 1) : afp(0.f);
+            afp v12 = (gx + 1 < psc(w) && ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + 1) : afp(0.f);
+            afp v13 = (gx + 1 < psc(w) && ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + 1) : afp(0.f);
 
-            afp v20 = buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + 2);
-            afp v21 = (ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + 2) : afp(0.f);
-            afp v22 = (ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + 2) : afp(0.f);
-            afp v23 = (ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + 2) : afp(0.f);
+            afp v20 = (gx + 2 < psc(w)) ? buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + 2) : afp(0.f);
+            afp v21 = (gx + 2 < psc(w) && ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + 2) : afp(0.f);
+            afp v22 = (gx + 2 < psc(w) && ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + 2) : afp(0.f);
+            afp v23 = (gx + 2 < psc(w) && ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + 2) : afp(0.f);
 
-            afp v30 = buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + 3);
-            afp v31 = (ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + 3) : afp(0.f);
-            afp v32 = (ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + 3) : afp(0.f);
-            afp v33 = (ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + 3) : afp(0.f);
+            afp v30 = (gx + 3 < psc(w)) ? buffer_ld1(bottom_blob_data_1, ch0 * psc(cstep) + gx + 3) : afp(0.f);
+            afp v31 = (gx + 3 < psc(w) && ch0 + 1 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 1) * psc(cstep) + gx + 3) : afp(0.f);
+            afp v32 = (gx + 3 < psc(w) && ch0 + 2 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 2) * psc(cstep) + gx + 3) : afp(0.f);
+            afp v33 = (gx + 3 < psc(w) && ch0 + 3 < psc(num_input)) ? buffer_ld1(bottom_blob_data_1, (ch0 + 3) * psc(cstep) + gx + 3) : afp(0.f);
 
             v0 = afpvec4(v00, v01, v02, v03);
             v1 = afpvec4(v10, v11, v12, v13);

--- a/src/layer/vulkan/shader/deconvolution1d_gemm_packed.comp
+++ b/src/layer/vulkan/shader/deconvolution1d_gemm_packed.comp
@@ -1,4 +1,4 @@
-// Copyright 2026 Tencent
+// Copyright 2026 Futz12 <pchar.cn>
 // SPDX-License-Identifier: BSD-3-Clause
 
 #version 450

--- a/src/layer/vulkan/shader/deconvolution1d_pack4_col2im.comp
+++ b/src/layer/vulkan/shader/deconvolution1d_pack4_col2im.comp
@@ -1,0 +1,82 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#version 450
+
+#extension GL_GOOGLE_include_directive : enable
+#include "vulkan_activation.comp"
+
+layout(constant_id = 0) const int kernel_w = 1;
+layout(constant_id = 1) const int dilation_w = 1;
+layout(constant_id = 2) const int stride_w = 1;
+layout(constant_id = 3) const int bias_term = 0;
+layout(constant_id = 4) const int activation_type = 0;
+layout(constant_id = 5) const float activation_param_0 = 0;
+layout(constant_id = 6) const float activation_param_1 = 0;
+layout(constant_id = 7) const int outc = 0;
+
+#define shape_constant_id_offset 8
+layout(constant_id = shape_constant_id_offset + 0) const int w = 0;
+layout(constant_id = shape_constant_id_offset + 1) const int cstep = 0;
+layout(constant_id = shape_constant_id_offset + 2) const int outw = 0;
+
+layout(binding = 0) readonly buffer col_blob { sfpvec4 col_blob_data[]; };
+layout(binding = 1) writeonly buffer top_blob { sfpvec4 top_blob_data[]; };
+layout(binding = 2) readonly buffer bias_blob { sfpvec4 bias_data[]; };
+
+layout(push_constant) uniform parameter
+{
+    int w;
+    int cstep; // col channel stride in vec4 units
+    int outw;
+    int front_cut;
+} p;
+
+// col layout: 3D (w, 1, kernel_w*num_output/4) elempack 4, channel (o * kernel_w + k)
+// out[o][x] = bias[o] + sum_{sx} col[o * kernel_w + k][sx]
+//   where xf = x + front_cut, k = xf - sx * stride_w, k % dilation_w == 0
+
+void main()
+{
+    int gx = int(gl_GlobalInvocationID.x);
+    int gz = int(gl_GlobalInvocationID.y);
+
+    if (gx >= psc(outw) || gz >= outc)
+        return;
+
+    afpvec4 sum;
+
+    if (bias_term == 1)
+    {
+        sum = buffer_ld4(bias_data, gz);
+    }
+    else
+    {
+        sum = afpvec4(0.f);
+    }
+
+    const int xf = gx + p.front_cut;
+
+    const int kernel_extent_w = dilation_w * (kernel_w - 1) + 1;
+
+    const int sx_start = (xf < kernel_extent_w) ? 0 : (xf - kernel_extent_w) / stride_w + 1;
+    const int sx_end = min(xf / stride_w + 1, psc(w));
+
+    for (int sx = sx_start; sx < sx_end; sx += 1)
+    {
+        int w_k = xf - sx * stride_w;
+
+        if (w_k % dilation_w == 0)
+        {
+            w_k /= dilation_w;
+
+            const int gi = (gz * kernel_w + w_k) * psc(cstep) + sx;
+
+            sum += buffer_ld4(col_blob_data, gi);
+        }
+    }
+
+    sum = activation_afpvec4(sum, activation_type, activation_param_0, activation_param_1);
+
+    buffer_st4(top_blob_data, gz * psc(outw) + gx, sum);
+}

--- a/src/layer/vulkan/shader/deconvolution1d_pack4_col2im.comp
+++ b/src/layer/vulkan/shader/deconvolution1d_pack4_col2im.comp
@@ -1,4 +1,4 @@
-// Copyright 2026 Tencent
+// Copyright 2026 Futz12 <pchar.cn>
 // SPDX-License-Identifier: BSD-3-Clause
 
 #version 450

--- a/tests/test_convolutiondepthwise1d.cpp
+++ b/tests/test_convolutiondepthwise1d.cpp
@@ -14,7 +14,7 @@ static int test_convolutiondepthwise1d(int w, int h, int outh, int kernel, int d
     pd.set(3, stride);   // stride_w
     pd.set(4, pad);      // pad_w
     pd.set(5, bias);     // bias_term
-    pd.set(6, outh / group * h / group * kernel * kernel * group);
+    pd.set(6, outh / group * h / group * kernel * group);
     pd.set(7, group);
 
     int activation_type = RAND() % 7; // 0 1 2 3 4 5 6
@@ -25,7 +25,7 @@ static int test_convolutiondepthwise1d(int w, int h, int outh, int kernel, int d
     pd.set(10, activation_params);
 
     std::vector<ncnn::Mat> weights(2);
-    weights[0] = RandomMat(outh / group * h / group * kernel * kernel * group);
+    weights[0] = RandomMat(outh / group * h / group * kernel * group);
     weights[1] = RandomMat(outh);
 
     int ret = test_layer("ConvolutionDepthWise1D", pd, weights, a);


### PR DESCRIPTION
 This branch adds and accelerates Vulkan implementations for the 1D
  convolution operators used by sequence/audio models.

  1) Convolution1D Vulkan
     - Direct subgroup path (convolution1d_packed_sg.comp): one workgroup
       = one subgroup; lanes cooperatively load input/weight tiles and
       share them via subgroup shuffle. Tile unroll factors are tuned per
       device subgroup size (16/32/64/128), with a guard for fp16 shuffle
       (subgroup extended types).
     - Winograd F(2,3) / F(4,3) for kernel=3, stride=1, dilation=1 and
       in/out channels >= 16: transform input -> GEMM over the winograd
       tiles (4 or 6) -> transform output. F(2,3) is auto-selected for
       short sequences and F(4,3) for longer ones; weights are
       pre-transformed into the winograd domain at create_pipeline.
     - Dedicated 1D winograd GEMM shaders (pack1/pack4/pack1to4/pack4to1)
       replace the generic 2D GEMM path.
     - Precision/correctness fixes: fp32 accumulators with fp16 storage in
       the packed and subgroup shaders, tensor-stride fix, out-of-bounds
       fix in the non-shared-memory GEMM path, and removal of redundant
       bounds checks.

  2) ConvolutionDepthWise1D Vulkan (new operator)
     - Grouped/depthwise 1D convolution with pack1/pack4/pack1to4/pack4to1
       pipelines, mirroring the existing 2D ConvolutionDepthWise operator.

  3) Deconvolution1D Vulkan (new operator)
     - im2col-style GEMM + col2im pipeline (dedicated col2im and packed
       GEMM shaders), with an optional cooperative-matrix path and pack4
       support.

  Files added (highlights):
  - src/layer/vulkan/convolutiondepthwise1d_vulkan.cpp/.h (+7 shaders)
  - src/layer/vulkan/deconvolution1d_vulkan.cpp/.h (+5 shaders)
  - src/layer/vulkan/convolution1d_vulkan.{cpp,h} + winograd/subgroup shaders
  - 8 winograd transform/gemm shaders under src/layer/vulkan/shader/

  Motivation: RVC-style voice conversion graphs are dominated by Conv1d
  (kernel 10/3/2/5/1), depthwise Conv1d and Deconv1d. These operators let
  the whole graph run on Vulkan and give a large speedup over the CPU
  fallbacks / naive paths.