### PR TITLE
fix(convolutiondepthwise): add group == 0 guard to prevent FPE

### DIFF
--- a/src/layer/convolutiondepthwise.cpp
+++ b/src/layer/convolutiondepthwise.cpp
@@ -43,7 +43,7 @@ int ConvolutionDepthWise::load_param(const ParamDict& pd)
         one_blob_only = false;
     }
 
-    if (num_output % group != 0)
+    if (group == 0 || num_output % group != 0)
     {
         // reject invalid group
         return -100;

--- a/src/layer/convolutiondepthwise1d.cpp
+++ b/src/layer/convolutiondepthwise1d.cpp
@@ -37,7 +37,7 @@ int ConvolutionDepthWise1D::load_param(const ParamDict& pd)
         one_blob_only = false;
     }
 
-    if (num_output % group != 0)
+    if (group == 0 || num_output % group != 0)
     {
         // reject invalid group
         return -100;


### PR DESCRIPTION
Summary:
- The Vulkan backend already has the correct `group == 0 || num_output % group != 0` check.
- CPU backend (convolutiondepthwise.cpp:46) and 1D variant (convolutiondepthwise1d.cpp:40) are missing the `group == 0` guard.
- When a malicious param file stores group as an array type, `pd.get(7, 1)` returns 0, triggering integer divide-by-zero.

Verification:
- Built ncnn with AddressSanitizer (`-fsanitize=address`).
- Reproduced FPE with the AFL++ generated crash sample.
- Confirmed the patch gracefully rejects the invalid param with `layer load_param failed` instead of crashing.

Fixes #6911