### PR TITLE
fix(net): add blob_index bounds check in load_param

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1436,6 +1436,13 @@ int Net::load_param(const DataReader& dr)
             int bottom_blob_index = find_blob_index_by_name(bottom_name);
             if (bottom_blob_index == -1)
             {
+                if (blob_index >= (int)d->blobs.size())
+                {
+                    NCNN_LOGE("blob_index %d out of range, blob_count=%d", blob_index, blob_count);
+                    delete layer;
+                    clear();
+                    return -1;
+                }
                 Blob& blob = d->blobs[blob_index];
 
                 bottom_blob_index = blob_index;
@@ -1456,6 +1463,13 @@ int Net::load_param(const DataReader& dr)
         layer->tops.resize(top_count);
         for (int j = 0; j < top_count; j++)
         {
+            if (blob_index >= (int)d->blobs.size())
+            {
+                NCNN_LOGE("blob_index %d out of range, blob_count=%d", blob_index, blob_count);
+                delete layer;
+                clear();
+                return -1;
+            }
             Blob& blob = d->blobs[blob_index];
 
             char blob_name[256];


### PR DESCRIPTION
## Summary

A malformed `.param` file with an under-reported `blob_count` can cause `blob_index` to grow beyond `d->blobs.size()`, leading to out-of-bounds read/write via `Blob& blob = d->blobs[blob_index]`.

## Changes

- Add `blob_index >= d->blobs.size()` bounds check before bottom-blob assignment
- Add `blob_index >= d->blobs.size()` bounds check before top-blob assignment
- Return `-1` and clean up partial net state on out-of-range detection

## Verification

- Built with AddressSanitizer (`-fsanitize=address`)
- Reproduced crash with AFL++ generated PoC (heap-buffer-overflow at `net.cpp:1464`)
- After patch: `./ncnn_param poc6` exits cleanly with `EXIT=0`, no ASAN errors

Fixes #6913
