### PR TITLE
fix(paramdict): add non-negative check for array length in load_param

### DIFF
--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -294,6 +294,12 @@ int ParamDict::load_param(const DataReader& dr)
                 return -1;
             }
 
+            if (len < 0)
+            {
+                NCNN_LOGE("ParamDict read array length %d failed", len);
+                return -1;
+            }
+
             d->params[id].v.create(len);
 
             for (int j = 0; j < len; j++)


### PR DESCRIPTION
## Summary

When parsing old-style arrays in `ParamDict::load_param`, the array length `len` is read directly from the input stream without validating that it is non-negative. A negative `len` causes `Mat::create(len)` to compute a wrapped-around `totalsize`, leading to a heap-buffer-overflow write before the allocated block.

## Changes

- Add `len < 0` guard in `ParamDict::load_param` old-style array parser
- Return `-1` and log an error when an invalid negative array length is detected

## Verification

- Built with AddressSanitizer (`-fsanitize=address`)
- Reproduced crash with AFL++ generated PoC (heap-buffer-overflow at `mat.cpp:337`)
- After patch: `./ncnn_param poc4` exits cleanly with `EXIT=0`, no ASAN errors

Fixes #6914
