### PR TITLE
Fix empty string bounds check in ParamDict::load_param

### DIFF
--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -384,7 +384,7 @@ int ParamDict::load_param(const DataReader& dr)
                     d->params[id].s = std::string(vstr);
             }
 
-            if (d->params[id].s[d->params[id].s.size() - 1] == '\"')
+            if (!d->params[id].s.empty() && d->params[id].s[d->params[id].s.size() - 1] == '\"')
                 d->params[id].s.resize(d->params[id].s.size() - 1);
 
             d->params[id].type = 7;


### PR DESCRIPTION
## Summary
This PR fixes a heap-buffer-overflow (READ) in `ParamDict::load_param` when parsing string parameters in `.param` files.

## Changes
- Added an emptiness check (`!d->params[id].s.empty() &&`) before accessing `s[s.size() - 1]` to strip trailing quotes.
- Prevents `size_t` underflow when the parsed string is empty, which previously caused an out-of-bounds heap read.

## Verification
- Reproduced the crash with the attached PoC (poc5) using AddressSanitizer.
- After applying this patch, `./ncnn_param poc5` exits cleanly without ASAN errors.

Fixes #6915
