### PR TITLE
fix: guard group<=0 in ConvolutionDepthWise(::1D)::load_param to avoid FPE divide-by-zero (#6911)

### DIFF
--- a/src/layer/convolutiondepthwise.cpp
+++ b/src/layer/convolutiondepthwise.cpp
@@ -43,7 +43,7 @@ int ConvolutionDepthWise::load_param(const ParamDict& pd)
         one_blob_only = false;
     }
 
-    if (num_output % group != 0)
+    if (group <= 0 || num_output % group != 0)
     {
         // reject invalid group
         return -100;

--- a/src/layer/convolutiondepthwise1d.cpp
+++ b/src/layer/convolutiondepthwise1d.cpp
@@ -37,7 +37,7 @@ int ConvolutionDepthWise1D::load_param(const ParamDict& pd)
         one_blob_only = false;
     }
 
-    if (num_output % group != 0)
+    if (group <= 0 || num_output % group != 0)
     {
         // reject invalid group
         return -100;

--- a/tests/test_convolutiondepthwise1d_invalid.cpp
+++ b/tests/test_convolutiondepthwise1d_invalid.cpp
@@ -1,0 +1,50 @@
+// Copyright 2025 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "testutil.h"
+
+#include "layer.h"
+
+static int test_convolutiondepthwise1d_invalid_group(int group)
+{
+    ncnn::ParamDict pd;
+    pd.set(0, 8);     // num_output
+    pd.set(1, 3);     // kernel_w
+    pd.set(2, 1);     // dilation_w
+    pd.set(3, 1);     // stride_w
+    pd.set(4, 0);     // pad_left
+    pd.set(5, 0);     // bias_term
+    pd.set(6, 8);     // weight_data_size
+    pd.set(7, group); // group
+
+    int typeindex = ncnn::layer_to_index("ConvolutionDepthWise1D");
+    if (typeindex == -1)
+        return -1;
+
+    ncnn::Layer* op = ncnn::create_layer_cpu(typeindex);
+
+    int ret = op->load_param(pd);
+
+    delete op;
+
+    if (ret != -100)
+    {
+        fprintf(stderr, "test_convolutiondepthwise1d_invalid_group failed group=%d ret=%d (expected -100)\n", group, ret);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int test_convolutiondepthwise1d_invalid_0()
+{
+    return 0
+           || test_convolutiondepthwise1d_invalid_group(0)
+           || test_convolutiondepthwise1d_invalid_group(-1)
+           || test_convolutiondepthwise1d_invalid_group(-8);
+}
+
+int main()
+{
+    return test_convolutiondepthwise1d_invalid_0();
+}

--- a/tests/test_convolutiondepthwise_invalid.cpp
+++ b/tests/test_convolutiondepthwise_invalid.cpp
@@ -1,0 +1,50 @@
+// Copyright 2025 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "testutil.h"
+
+#include "layer.h"
+
+static int test_convolutiondepthwise_invalid_group(int group)
+{
+    ncnn::ParamDict pd;
+    pd.set(0, 8);     // num_output
+    pd.set(1, 3);     // kernel_w
+    pd.set(2, 1);     // dilation_w
+    pd.set(3, 1);     // stride_w
+    pd.set(4, 0);     // pad_left
+    pd.set(5, 0);     // bias_term
+    pd.set(6, 8);     // weight_data_size
+    pd.set(7, group); // group
+
+    int typeindex = ncnn::layer_to_index("ConvolutionDepthWise");
+    if (typeindex == -1)
+        return -1;
+
+    ncnn::Layer* op = ncnn::create_layer_cpu(typeindex);
+
+    int ret = op->load_param(pd);
+
+    delete op;
+
+    if (ret != -100)
+    {
+        fprintf(stderr, "test_convolutiondepthwise_invalid_group failed group=%d ret=%d (expected -100)\n", group, ret);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int test_convolutiondepthwise_invalid_0()
+{
+    return 0
+           || test_convolutiondepthwise_invalid_group(0)
+           || test_convolutiondepthwise_invalid_group(-1)
+           || test_convolutiondepthwise_invalid_group(-8);
+}
+
+int main()
+{
+    return test_convolutiondepthwise_invalid_0();
+}


### PR DESCRIPTION
## Summary

Fixes #6911 — FPE divide-by-zero in `ConvolutionDepthWise::load_param` when a malformed param file provides `group == 0`.

## Problem

When `group == 0`, the existing guard `num_output % group != 0` itself performs an integer division by zero, triggering SIGFPE (FPE divide-by-zero) before the rejection path is reached. The CPU and 1D variants of `ConvolutionDepthWise::load_param` were missing the `group <= 0` check that the Vulkan int8 path already had (`convolutiondepthwise_vulkan.cpp:597`).

## Fix

Add a `group <= 0` short-circuit guard before the modulo in both affected `load_param` implementations, returning `-100` (the existing "reject invalid group" code) without performing the division:

```cpp
if (group <= 0 || num_output % group != 0)
{
    // reject invalid group
    return -100;
}
```

- `src/layer/convolutiondepthwise.cpp` — CPU `ConvolutionDepthWise::load_param`
- `src/layer/convolutiondepthwise1d.cpp` — `ConvolutionDepthWise1D::load_param`

The Vulkan variant calls the CPU `load_param`, so it is covered transitively. `group < 0` is rejected too (defensive), matching the spirit of the existing guard. Normal-path behavior is unchanged: valid `group > 0` with `num_output % group == 0` still returns 0.

## Regression tests

- `tests/test_convolutiondepthwise_invalid.cpp` — asserts `load_param` returns `-100` for `group` = 0, -1, -8.
- `tests/test_convolutiondepthwise1d_invalid.cpp` — same for the 1D variant.

### Verification

- Before fix: `test_convolutiondepthwise_invalid` aborts with `Floating point exception (core dumped)` (exit 136 / SIGFPE), reproducing #6911.
- After fix: both new tests exit 0.
- Existing `test_convolutiondepthwise`, `test_convolutiondepthwise_1`, `test_convolutiondepthwise_oom`, `test_convolutiondepthwise1d` all still pass — no regression on the normal path.

## Checklist

- [x] one clear bug -> one local fix -> one regression test
- [x] no change to normal-path behavior
- [x] no architecture / API change
