### PR TITLE
initialize softmax member in YoloDetectionOutput constructor

### DIFF
--- a/src/layer/yolodetectionoutput.cpp
+++ b/src/layer/yolodetectionoutput.cpp
@@ -11,6 +11,7 @@ YoloDetectionOutput::YoloDetectionOutput()
 {
     one_blob_only = false;
     support_inplace = true;
+    softmax = 0;
 }
 
 int YoloDetectionOutput::load_param(const ParamDict& pd)


### PR DESCRIPTION
the raw Layer* softmax member is never initialized. when a Net is torn down without create_pipeline having run (param-only load), the destructor calls destroy_pipeline which tests if(softmax) on an indeterminate pointer and dereferences garbage -> SEGV. initialize to 0.