### PR TITLE
initialize softmax layer pointer in YoloDetectionOutput

### DIFF
--- a/src/layer/yolodetectionoutput.cpp
+++ b/src/layer/yolodetectionoutput.cpp
@@ -11,6 +11,7 @@ YoloDetectionOutput::YoloDetectionOutput()
 {
     one_blob_only = false;
     support_inplace = true;
+    softmax = 0;
 }
 
 int YoloDetectionOutput::load_param(const ParamDict& pd)


### PR DESCRIPTION
## Summary

`YoloDetectionOutput::softmax` is a raw `ncnn::Layer*` member that is never
initialized in the constructor. When a `Net` is torn down without
`create_pipeline()` having run (for example, a caller that only loads the param
file and never loads weights), `Net::clear()` reaches
`YoloDetectionOutput::destroy_pipeline()`, which tests `if (softmax)` on an
indeterminate pointer and dereferences garbage — SEGV (CWE-457 uninitialized
pointer / CWE-476 null-pointer-like dereference).

## Changes

- initialize `softmax = 0;` in the constructor

## Why

A 38-byte text `.param` declaring a `YoloDetectionOutput` layer, loaded with the
param-only path (no model weights), drives a deterministic ASan SEGV on master
(stack: `destroy_pipeline <- Net::clear <- ~Net`). Layer subclasses generally
either initialize raw members or set them in `create_pipeline`; this one
declares the member in the header (`yolodetectionoutput.h:30`) but writes it
only in `create_pipeline`, so the load-param-only usage reads uninitialized
memory at teardown.

## Test

| input | before (master) | after |
|---|---|---|
| 38B param, `YoloDetectionOutput x 0 0`, param-only load | ASan SEGV in destroy_pipeline | clean exit, no crash |
| valid model file | loads OK | identical, no false positive |