### PR TITLE
fix unvalidated layer counts, out-of-bounds blob index and division by zero in load_param and load_param_bin

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1331,9 +1331,9 @@ int Net::load_param(const DataReader& dr)
     int blob_count = 0;
     SCAN_VALUE("%d", layer_count)
     SCAN_VALUE("%d", blob_count)
-    if (layer_count <= 0 || blob_count <= 0)
+    if (layer_count <= 0 || blob_count <= 0 || layer_count > MAX_LAYER_COUNT || blob_count > MAX_BLOB_COUNT)
     {
-        NCNN_LOGE("invalid layer_count or blob_count");
+        NCNN_LOGE("invalid layer_count or blob_count %d %d", layer_count, blob_count);
         return -1;
     }
 
@@ -1402,6 +1402,13 @@ int Net::load_param(const DataReader& dr)
         SCAN_VALUE("%255s", layer_name)
         SCAN_VALUE("%d", bottom_count)
         SCAN_VALUE("%d", top_count)
+
+        if (bottom_count < 0 || top_count < 0 || bottom_count > MAX_BLOB_COUNT || top_count > MAX_BLOB_COUNT)
+        {
+            NCNN_LOGE("invalid bottom_count or top_count %d %d", bottom_count, top_count);
+            clear();
+            return -1;
+        }
 
         Layer* layer = create_overwrite_builtin_layer(layer_type);
 #if NCNN_VULKAN

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1499,7 +1499,7 @@ int Net::load_param(const DataReader& dr)
 
         // pull out top shape hints
         Mat shape_hints = pd.get(30, Mat());
-        if (!shape_hints.empty())
+        if (!shape_hints.empty() && top_count > 0)
         {
             const int psh_step = shape_hints.w / top_count;
             const int* psh = shape_hints;
@@ -1879,7 +1879,7 @@ int Net::load_param_bin(const DataReader& dr)
 
         // pull out top blob shape hints
         Mat shape_hints = pd.get(30, Mat());
-        if (!shape_hints.empty())
+        if (!shape_hints.empty() && top_count > 0)
         {
             const int psh_step = shape_hints.w / top_count;
             const int* psh = shape_hints;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -24,6 +24,12 @@
 
 namespace ncnn {
 
+// maximum sizes accepted from an untrusted model file header;
+// larger values indicate a corrupt or malicious model and are rejected
+// before any allocation (resize with a huge count would otherwise OOM)
+static const int MAX_LAYER_COUNT = 1000000;
+static const int MAX_BLOB_COUNT = 1000000;
+
 class NetPrivate
 {
 public:
@@ -1699,9 +1705,9 @@ int Net::load_param_bin(const DataReader& dr)
     int blob_count = 0;
     READ_VALUE(layer_count)
     READ_VALUE(blob_count)
-    if (layer_count <= 0 || blob_count <= 0)
+    if (layer_count <= 0 || blob_count <= 0 || layer_count > MAX_LAYER_COUNT || blob_count > MAX_BLOB_COUNT)
     {
-        NCNN_LOGE("invalid layer_count or blob_count");
+        NCNN_LOGE("invalid layer_count or blob_count %d %d", layer_count, blob_count);
         return -1;
     }
 
@@ -1768,6 +1774,13 @@ int Net::load_param_bin(const DataReader& dr)
         READ_VALUE(bottom_count)
         READ_VALUE(top_count)
 
+        if (bottom_count < 0 || top_count < 0 || bottom_count > MAX_BLOB_COUNT || top_count > MAX_BLOB_COUNT)
+        {
+            NCNN_LOGE("invalid bottom_count or top_count %d %d", bottom_count, top_count);
+            clear();
+            return -1;
+        }
+
         Layer* layer = create_overwrite_builtin_layer(typeindex);
 #if NCNN_VULKAN
         if (!layer && opt.use_vulkan_compute && d->vkdev)
@@ -1806,6 +1819,14 @@ int Net::load_param_bin(const DataReader& dr)
             int bottom_blob_index;
             READ_VALUE(bottom_blob_index)
 
+            if (bottom_blob_index < 0 || bottom_blob_index >= blob_count)
+            {
+                NCNN_LOGE("invalid bottom_blob_index %d", bottom_blob_index);
+                d->layers[i] = layer;
+                clear();
+                return -1;
+            }
+
             Blob& blob = d->blobs[bottom_blob_index];
 
             blob.consumer = i;
@@ -1818,6 +1839,14 @@ int Net::load_param_bin(const DataReader& dr)
         {
             int top_blob_index;
             READ_VALUE(top_blob_index)
+
+            if (top_blob_index < 0 || top_blob_index >= blob_count)
+            {
+                NCNN_LOGE("invalid top_blob_index %d", top_blob_index);
+                d->layers[i] = layer;
+                clear();
+                return -1;
+            }
 
             Blob& blob = d->blobs[top_blob_index];
 


### PR DESCRIPTION
## Summary

`ncnn::Net` loads model parameter files from attacker-controlled paths. Both
`load_param()` (text `.param`) and `load_param_bin()` (binary `.parambin`)
read `layer_count` / `blob_count` from the file header and `bottom_count` /
`top_count` from each layer header with **no upper bound and no sign check**,
and the binary path does **not** bound-check blob indices before indexing
`d->blobs`. In addition, when a layer carries a non-empty shape-hint parameter
(id 30) and `top_count == 0`, both loaders divide by `top_count` — integer
division by zero (FPE).

### Binary path (`load_param_bin`)

1. Huge `blob_count` in the header → `d->blobs.resize()` allocates ~137 GB
   and OOMs before the layer loop even starts (ASan: allocator out of memory).
2. Negative or enormous per-layer `bottom_count` / `top_count` →
   `layer->tops.resize()` throws `std::length_error` (uncaught → `terminate`)
   or triggers a multi-gigabyte allocation / `std::bad_alloc`.
3. `bottom_blob_index` / `top_blob_index` out of range → out-of-bounds WRITE
   into `d->blobs` (ASan: heap-buffer-overflow, found by fuzzing).

### Text path (`load_param`)

Same header/count issues as (1)/(2) above. The index-write issue is not
reachable here because the text format names blobs instead of indexing them.

### Fix

Reject the input before any allocation, in both loaders:

- `layer_count` / `blob_count` must be in `[1, 1000000]`
- per-layer `bottom_count` / `top_count` must be in `[0, 1000000]`
- blob indices must be in `[0, blob_count)` (binary path only)
- when `top_count == 0`, skip shape-hint processing (zero-output layers are
  otherwise valid and must not be rejected)

The limits are far above any real network; anything larger is treated as a
corrupt or malicious model.

## Verification

A/B-tested against upstream `master` with AddressSanitizer (same input file on
both builds):

| crafted input | master | patched |
|---|---|---|
| header `blob_count` = 2^30 (bin) | ASan allocator OOM (~137 GB) | `invalid layer_count or blob_count`, ret -1 |
| `top_count` = -1 (bin) | `std::length_error` abort | `invalid bottom_count or top_count`, ret -1 |
| `bottom_count` = INT_MAX (bin) | multi-GB resize / `bad_alloc` | `invalid bottom_count or top_count`, ret -1 |
| blob index 5, 1 blob (bin) | heap-buffer-overflow WRITE | `invalid bottom_blob_index 5`, ret -1 |
| header `blob_count` = 2^30 (text) | ASan allocator OOM (~137 GB) | `invalid layer_count or blob_count`, ret -1 |
| `top_count` = -1 (text) | `std::length_error` abort | `invalid bottom_count or top_count`, ret -1 |
| `top_count` = 0 + shape hint (text) | integer division by zero (FPE) | load OK, ret 0 |
| `top_count` = 0 + shape hint (bin) | integer division by zero (FPE) | load OK, ret 0 |
| valid minimal / squeezenet | load OK | load OK (no false rejection) |

## Related

This PR supersedes #6902, which applied the binary-path guards alone. The two
loaders share the same header/count validation, so they are now fixed together
in one change.
