### PR TITLE
vulkan: fix fp16 arithmetic types in erf and celu shaders

### DIFF
--- a/src/layer/vulkan/shader/celu.comp
+++ b/src/layer/vulkan/shader/celu.comp
@@ -24,7 +24,7 @@ void main()
 
     afpvec4 v = buffer_ld4(bottom_top_blob_data, gi);
 
-    v = max(v, afpvec4(0.0f)) + min(alpha * (exp(v / afpvec4(alpha)) - afpvec4(1.0f)), afpvec4(0.0f));
+    v = max(v, afpvec4(0.0f)) + min(afpvec4(alpha) * (exp(v / afpvec4(alpha)) - afpvec4(1.0f)), afpvec4(0.0f));
 
     buffer_st4(bottom_top_blob_data, gi, v);
 }

--- a/src/layer/vulkan/shader/erf.comp
+++ b/src/layer/vulkan/shader/erf.comp
@@ -22,8 +22,8 @@ afpvec4 erf(afpvec4 x)
     afpvec4 p = afpvec4(0.3275911f);
     afpvec4 s = sign(x);
     afpvec4 x_abs = abs(x);
-    afpvec4 t = 1.0f / (1.0f + p * x_abs);
-    afpvec4 y = 1.0f - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * exp(-x_abs * x_abs);
+    afpvec4 t = afpvec4(1.0f) / (afpvec4(1.0f) + p * x_abs);
+    afpvec4 y = afpvec4(1.0f) - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * exp(-x_abs * x_abs);
     return s * y;
 }
 


### PR DESCRIPTION
  ## Summary

  Fix type mismatches in the Vulkan `erf` and `celu` shaders when
  `NCNN_fp16_arithmetic` is enabled.

  ## Changes

  - Explicitly construct `afpvec4` constants in `erf.comp`.
  - Convert the `alpha` specialization constant to `afpvec4` in
  `celu.comp`.
  - Keep vector operands consistently typed for FP16 arithmetic.
  - No changes to the FP32 or BF16 arithmetic behavior.

  ## Validation

  Validated with a temporary Vulkan shader compilation probe on:

  - Intel Raptor Lake integrated GPU
  - NVIDIA GeForce RTX 4060 Laptop GPU

  Tested modes:

  - FP32
  - FP16 storage and arithmetic
  - FP16 packed arithmetic
  - BF16 storage
  - BF16 packed

  All shader compilation tests completed successfully.

  This PR only modifies `erf.comp` and `celu.comp`.