### PR TITLE
fix(multiheadattention): add num_heads and embed_dim validation to prevent FPE

### DIFF
--- a/src/layer/multiheadattention.cpp
+++ b/src/layer/multiheadattention.cpp
@@ -52,6 +52,19 @@ int MultiHeadAttention::load_param(const ParamDict& pd)
 {
     embed_dim = pd.get(0, 0);
     num_heads = pd.get(1, 1);
+
+    if (num_heads <= 0)
+    {
+        NCNN_LOGE("MultiHeadAttention invalid num_heads %d", num_heads);
+        return -1;
+    }
+
+    if (embed_dim <= 0)
+    {
+        NCNN_LOGE("MultiHeadAttention invalid embed_dim %d", embed_dim);
+        return -1;
+    }
+
     weight_data_size = pd.get(2, 0);
     kdim = pd.get(3, embed_dim);
     vdim = pd.get(4, embed_dim);


### PR DESCRIPTION
## Description

Fix divide-by-zero (SIGFPE) in `MultiHeadAttention::load_param` when `num_heads` or `embed_dim` is 0.

## Root Cause

```cpp
// src/layer/multiheadattention.cpp:59
scale = pd.get(6, 1.f / sqrtf(embed_dim / num_heads));
```

- `embed_dim / num_heads` is integer division
- When `num_heads = 0`, this causes SIGFPE
- The default value `1` for `num_heads` only applies when the key is absent, not when explicitly set to 0
- Even providing `scale` explicitly doesn't help because the default argument is evaluated unconditionally

## Fix

Add validation checks after reading `num_heads` and `embed_dim` from ParamDict:

```cpp
num_heads = pd.get(1, 1);
if (num_heads <= 0)
{
    NCNN_LOGE("MultiHeadAttention invalid num_heads %d", num_heads);
    return -1;
}

if (embed_dim <= 0)
{
    NCNN_LOGE("MultiHeadAttention invalid embed_dim %d", embed_dim);
    return -1;
}
```

## Testing

Verified with the reproduction case from #6926:
```
7767517
2 2
Input                    in    0 1 in
MultiHeadAttention       mha   1 1 in out 0=64 1=0
```

Before: `Floating point exception (core dumped)`
After: `MultiHeadAttention invalid num_heads 0` (returns -1)

## Related Issues

Fixes #6926
Related: #6911, #6913, #6914, #6915 (similar validation issues)
