### PR TITLE
vulkan: apply atan2 zero workaround to packed shaders

### DIFF
--- a/src/layer/vulkan/shader/binaryop_broadcast_pack1to4.comp
+++ b/src/layer/vulkan/shader/binaryop_broadcast_pack1to4.comp
@@ -98,8 +98,6 @@ void main()
     if (op_type == 10) res = afpvec4(atan(vec4(v1), vec4(v2)));
     if (op_type == 11) res = afpvec4(atan(vec4(v2), vec4(v1)));
 #else
-#if ncnn_driverID == 13
-    // llvmpipe driver (VK_DRIVER_ID_MESA_LLVMPIPE = 13) workaround for atan(0, 0), match atan2f(0, 0) == 0
     if (op_type == 10)
     {
         bvec4 zero_mask = bvec4(uvec4(equal(v1, afpvec4(0.f))) & uvec4(equal(v2, afpvec4(0.f))));
@@ -112,10 +110,6 @@ void main()
         afpvec4 v1_safe = mix(v1, afpvec4(1.f), zero_mask);
         res = atan(v2, v1_safe);
     }
-#else
-    if (op_type == 10) res = atan(v1, v2);
-    if (op_type == 11) res = atan(v2, v1);
-#endif
 #endif
     if (op_type == 12) res = v1 - trunc(v1 / v2) * v2;
     if (op_type == 13) res = v2 - trunc(v2 / v1) * v1;

--- a/src/layer/vulkan/shader/binaryop_broadcast_pack4.comp
+++ b/src/layer/vulkan/shader/binaryop_broadcast_pack4.comp
@@ -167,8 +167,6 @@ void main()
     if (op_type == 10) res = afpvec4(atan(vec4(v1), vec4(v2)));
     if (op_type == 11) res = afpvec4(atan(vec4(v2), vec4(v1)));
 #else
-#if ncnn_driverID == 13
-    // llvmpipe driver (VK_DRIVER_ID_MESA_LLVMPIPE = 13) workaround for atan(0, 0), match atan2f(0, 0) == 0
     if (op_type == 10)
     {
         bvec4 zero_mask = bvec4(uvec4(equal(v1, afpvec4(0.f))) & uvec4(equal(v2, afpvec4(0.f))));
@@ -181,10 +179,6 @@ void main()
         afpvec4 v1_safe = mix(v1, afpvec4(1.f), zero_mask);
         res = atan(v2, v1_safe);
     }
-#else
-    if (op_type == 10) res = atan(v1, v2);
-    if (op_type == 11) res = atan(v2, v1);
-#endif
 #endif
     if (op_type == 12) res = v1 - trunc(v1 / v2) * v2;
     if (op_type == 13) res = v2 - trunc(v2 / v1) * v1;

--- a/src/layer/vulkan/shader/binaryop_pack4.comp
+++ b/src/layer/vulkan/shader/binaryop_pack4.comp
@@ -93,8 +93,6 @@ void main()
     if (op_type == 10) res = afpvec4(atan(vec4(v1), vec4(v2)));
     if (op_type == 11) res = afpvec4(atan(vec4(v2), vec4(v1)));
 #else
-#if ncnn_driverID == 13
-    // llvmpipe driver (VK_DRIVER_ID_MESA_LLVMPIPE = 13) workaround for atan(0, 0), match atan2f(0, 0) == 0
     if (op_type == 10)
     {
         bvec4 zero_mask = bvec4(uvec4(equal(v1, afpvec4(0.f))) & uvec4(equal(v2, afpvec4(0.f))));
@@ -107,10 +105,6 @@ void main()
         afpvec4 v1_safe = mix(v1, afpvec4(1.f), zero_mask);
         res = atan(v2, v1_safe);
     }
-#else
-    if (op_type == 10) res = atan(v1, v2);
-    if (op_type == 11) res = atan(v2, v1);
-#endif
 #endif
     if (op_type == 12) res = v1 - trunc(v1 / v2) * v2;
     if (op_type == 13) res = v2 - trunc(v2 / v1) * v1;


### PR DESCRIPTION
## Summary

Apply the existing packed-vector `atan(0, 0)` workaround to all non-MoltenVK drivers. Mesa v3dv exhibits the same incorrect vectorized result as llvmpipe, so restricting the workaround to driver ID 13 leaves packed `BinaryOp` atan2/ratan2 broken on v3dv.

The change covers:

- `binaryop_pack4.comp`
- `binaryop_broadcast_pack4.comp`
- `binaryop_broadcast_pack1to4.comp`

## Verification

Built with Vulkan and system glslang on Ubuntu 24.04, then ran `test_binaryop_3` with Mesa llvmpipe 25.2.8:

```
100% tests passed, 0 tests failed out of 1
```

Fixes #6884.