### PR TITLE
pnnx: preserve batch semantics across reshape and flatten

### DIFF
--- a/tools/pnnx/src/pass_ncnn/Tensor_reshape.cpp
+++ b/tools/pnnx/src/pass_ncnn/Tensor_reshape.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "pass_ncnn.h"
+#include "batch_reshape.h"
 
 namespace pnnx {
 
@@ -61,7 +62,7 @@ pnnx.Output             output      1 0 out
             new_shape.push_back(-1);
         }
 
-        const bool batch_reshape = input_ncnn_batch_axis != output_ncnn_batch_axis;
+        const bool batch_reshape = is_batch_reshape(op->inputs[0], op->outputs[0]);
         if (!batch_reshape && output_ncnn_batch_axis != 233 && output_ncnn_batch_axis >= 0 && output_ncnn_batch_axis < (int)new_shape.size())
         {
             new_shape.erase(new_shape.begin() + output_ncnn_batch_axis);

--- a/tools/pnnx/src/pass_ncnn/Tensor_reshape_as.cpp
+++ b/tools/pnnx/src/pass_ncnn/Tensor_reshape_as.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "pass_ncnn.h"
+#include "batch_reshape.h"
 
 namespace pnnx {
 
@@ -36,7 +37,7 @@ pnnx.Output             output      1 0 out
         const int input_ncnn_batch_axis = op->inputs[0]->params["__ncnn_batch_axis"].i;
         const int other_ncnn_batch_axis = op->inputs[1]->params["__ncnn_batch_axis"].i;
         const int output_ncnn_batch_axis = op->outputs[0]->params["__ncnn_batch_axis"].i;
-        const bool batch_reshape = input_ncnn_batch_axis != output_ncnn_batch_axis;
+        const bool batch_reshape = is_batch_reshape(op->inputs[0], op->outputs[0]);
 
         std::vector<int> shape = op->outputs[0]->shape;
         int shape_ncnn_batch_axis = output_ncnn_batch_axis;

--- a/tools/pnnx/src/pass_ncnn/Tensor_unflatten.cpp
+++ b/tools/pnnx/src/pass_ncnn/Tensor_unflatten.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "pass_ncnn.h"
+#include "batch_reshape.h"
 
 namespace pnnx {
 
@@ -59,7 +60,7 @@ pnnx.Output             output      1 0 out
 
         const int input_ncnn_batch_axis = op->inputs[0]->params["__ncnn_batch_axis"].i;
         const int output_ncnn_batch_axis = op->outputs[0]->params["__ncnn_batch_axis"].i;
-        const bool batch_reshape = input_ncnn_batch_axis != output_ncnn_batch_axis;
+        const bool batch_reshape = is_batch_reshape(op->inputs[0], op->outputs[0]);
 
         std::vector<int> new_shape = shape;
 

--- a/tools/pnnx/src/pass_ncnn/batch_reshape.h
+++ b/tools/pnnx/src/pass_ncnn/batch_reshape.h
@@ -1,4 +1,4 @@
-// Copyright 2026 Tencent
+// Copyright 2026 futz12
 // SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef PNNX_NCNN_BATCH_RESHAPE_H

--- a/tools/pnnx/src/pass_ncnn/batch_reshape.h
+++ b/tools/pnnx/src/pass_ncnn/batch_reshape.h
@@ -34,8 +34,8 @@ static inline bool is_batch_reshape(const Operand* input, const Operand* output)
         output_axis += (int)output->shape.size();
 
     if (input_axis < 0 || output_axis < 0
-        || input_axis >= (int)input->shape.size()
-        || output_axis >= (int)output->shape.size())
+            || input_axis >= (int)input->shape.size()
+            || output_axis >= (int)output->shape.size())
         return false;
 
     const int input_batch_size = input->shape[input_axis];

--- a/tools/pnnx/src/pass_ncnn/batch_reshape.h
+++ b/tools/pnnx/src/pass_ncnn/batch_reshape.h
@@ -1,0 +1,54 @@
+// Copyright 2026 Tencent
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef PNNX_NCNN_BATCH_RESHAPE_H
+#define PNNX_NCNN_BATCH_RESHAPE_H
+
+#include "pass_ncnn.h"
+
+namespace pnnx {
+
+namespace ncnn {
+
+// A reshape needs NCNN's batch-aware path when the logical batch axis moves,
+// or when it stays at the same logical axis but its extent changes.  The
+// latter is the important case for flatten(0, 1): solve_batch_index may
+// correctly mark both operands as axis 0 after the Conv1d consumer is seen,
+// while the operation still changes n from B to B*F.
+static inline bool is_batch_reshape(const Operand* input, const Operand* output)
+{
+    const int input_batch_axis = input->params.at("__ncnn_batch_axis").i;
+    const int output_batch_axis = output->params.at("__ncnn_batch_axis").i;
+
+    if (input_batch_axis != output_batch_axis)
+        return true;
+
+    if (input_batch_axis == 233)
+        return false;
+
+    int input_axis = input_batch_axis;
+    int output_axis = output_batch_axis;
+    if (input_axis < 0 && !input->shape.empty())
+        input_axis += (int)input->shape.size();
+    if (output_axis < 0 && !output->shape.empty())
+        output_axis += (int)output->shape.size();
+
+    if (input_axis < 0 || output_axis < 0
+        || input_axis >= (int)input->shape.size()
+        || output_axis >= (int)output->shape.size())
+        return false;
+
+    const int input_batch_size = input->shape[input_axis];
+    const int output_batch_size = output->shape[output_axis];
+
+    // -1 denotes an unresolved extent.  Without two concrete extents there
+    // is no safe way to infer that the operation changes the batch size.
+    return input_batch_size >= 0 && output_batch_size >= 0
+           && input_batch_size != output_batch_size;
+}
+
+} // namespace ncnn
+
+} // namespace pnnx
+
+#endif // PNNX_NCNN_BATCH_RESHAPE_H

--- a/tools/pnnx/src/pass_ncnn/convert_reshape_interp_expression.cpp
+++ b/tools/pnnx/src/pass_ncnn/convert_reshape_interp_expression.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "convert_reshape_interp_expression.h"
+#include "batch_reshape.h"
 
 #include <algorithm>
 #include <stack>
@@ -194,7 +195,7 @@ void convert_reshape_interp_expression(Graph& graph)
                 input_ncnn_batch_axis = op->inputs[0]->params["__ncnn_batch_axis"].i;
                 output_ncnn_batch_axis = op->outputs[0]->params["__ncnn_batch_axis"].i;
             }
-            const bool batch_reshape = input_ncnn_batch_axis != output_ncnn_batch_axis;
+            const bool batch_reshape = is_tensor_reshape && is_batch_reshape(op->inputs[0], op->outputs[0]);
             bool shape_expr_reference_batch = false;
 
             // change nchw annotation to w,h,c / w,h,d,c with batch index dropped

--- a/tools/pnnx/src/pass_ncnn/solve_batch_index.cpp
+++ b/tools/pnnx/src/pass_ncnn/solve_batch_index.cpp
@@ -584,7 +584,14 @@ static void solve_batch_index_forward(Operand* operand)
 
             int batch_index_unflattened = batch_index;
             if (dim == batch_index)
-                batch_index_unflattened = 233;
+            {
+                // Splitting the batch axis is ambiguous until a consumer
+                // tells us which of the new axes NCNN should carry as n.
+                // Leave the output unresolved so a known batch consumer can
+                // propagate its requirement backwards.  If no such consumer
+                // exists, the final fallback below keeps the result ordinary.
+                continue;
+            }
             else if (dim < batch_index)
                 batch_index_unflattened = batch_index + sizes_rank - 1;
 

--- a/tools/pnnx/src/pass_ncnn/torch_flatten.cpp
+++ b/tools/pnnx/src/pass_ncnn/torch_flatten.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "pass_ncnn.h"
+#include "batch_reshape.h"
 
 namespace pnnx {
 
@@ -97,7 +98,7 @@ pnnx.Output             output      1 0 out
 
         const int input_ncnn_batch_axis = op->inputs[0]->params["__ncnn_batch_axis"].i;
         const int output_ncnn_batch_axis = op->outputs[0]->params["__ncnn_batch_axis"].i;
-        const bool batch_reshape = input_ncnn_batch_axis != output_ncnn_batch_axis;
+        const bool batch_reshape = is_batch_reshape(op->inputs[0], op->outputs[0]);
 
         std::vector<int> new_shape = op->outputs[0]->shape;
 

--- a/tools/pnnx/tests/ncnn/test_ncnn_batch_layout.py
+++ b/tools/pnnx/tests/ncnn/test_ncnn_batch_layout.py
@@ -703,13 +703,14 @@ def test():
     if not no_batch_reshape_param(name):
         return False
 
-    torch.manual_seed(0)
-    x = torch.rand(2, 4, 8, 16)
-    name = "test_ncnn_batch_layout_unflatten_after_conv1d"
-    if not run_model(name, ModelBatchUnflattenAfterConv1d(), x):
-        return False
-    if not has_batch_reshape_param(name):
-        return False
+    if version.parse(torch.__version__) >= version.parse('1.13'):
+        torch.manual_seed(0)
+        x = torch.rand(2, 4, 8, 16)
+        name = "test_ncnn_batch_layout_unflatten_after_conv1d"
+        if not run_model(name, ModelBatchUnflattenAfterConv1d(), x):
+            return False
+        if not has_batch_reshape_param(name):
+            return False
 
     return True
 

--- a/tools/pnnx/tests/ncnn/test_ncnn_batch_layout.py
+++ b/tools/pnnx/tests/ncnn/test_ncnn_batch_layout.py
@@ -451,8 +451,7 @@ def run_model(name, net, inputs, inputs2=None):
     mod.save(name + ".pt")
 
     inputshape = ",".join([str(list(x.shape)).replace(" ", "") for x in inputs])
-    pnnxexe = os.environ.get("PNNX_EXE", "../../src/pnnx")
-    pnnxcmd = '"' + pnnxexe + '" ' + name + ".pt inputshape=" + inputshape
+    pnnxcmd = "../../src/pnnx " + name + ".pt inputshape=" + inputshape
     if inputs2 is not None:
         inputshape2 = ",".join([str(list(x.shape)).replace(" ", "") for x in inputs2])
         pnnxcmd += " inputshape2=" + inputshape2
@@ -475,8 +474,7 @@ def run_convert_only(name, net, inputs):
     mod.save(name + ".pt")
 
     inputshape = ",".join([str(list(x.shape)).replace(" ", "") for x in inputs])
-    pnnxexe = os.environ.get("PNNX_EXE", "../../src/pnnx")
-    if os.system('"' + pnnxexe + '" ' + name + ".pt inputshape=" + inputshape) != 0:
+    if os.system("../../src/pnnx " + name + ".pt inputshape=" + inputshape) != 0:
         return False
 
     return True

--- a/tools/pnnx/tests/ncnn/test_ncnn_batch_layout.py
+++ b/tools/pnnx/tests/ncnn/test_ncnn_batch_layout.py
@@ -357,6 +357,55 @@ class ModelSameBatchAxisUnflattenCompat(nn.Module):
         return x
 
 
+class ModelBatchFoldToConv1d(nn.Module):
+    def __init__(self, mode):
+        super(ModelBatchFoldToConv1d, self).__init__()
+        self.pre = nn.Conv2d(4, 4, 1)
+        self.conv = nn.Conv1d(4, 6, 3, padding=1)
+        self.mode = mode
+
+    def forward(self, x):
+        x = self.pre(x)
+        batch, channels, frequencies, frames = x.shape
+        x = x.permute(0, 2, 1, 3)
+        if self.mode == "flatten":
+            x = torch.flatten(x, 0, 1)
+        else:
+            x = x.reshape(batch * frequencies, channels, frames)
+        return self.conv(x)
+
+
+class ModelChannelFoldToConv1d(nn.Module):
+    def __init__(self):
+        super(ModelChannelFoldToConv1d, self).__init__()
+        self.pre = nn.Conv2d(4, 4, 1)
+        self.conv = nn.Conv1d(32, 6, 3, padding=1)
+
+    def forward(self, x):
+        x = self.pre(x)
+        batch, channels, frequencies, frames = x.shape
+        x = x.reshape(batch, channels * frequencies, frames)
+        return self.conv(x)
+
+
+class ModelBatchUnflattenAfterConv1d(nn.Module):
+    def __init__(self):
+        super(ModelBatchUnflattenAfterConv1d, self).__init__()
+        self.pre = nn.Conv2d(4, 4, 1)
+        self.conv = nn.Conv1d(4, 6, 3, padding=1)
+        self.post = nn.Conv2d(6, 6, 1)
+
+    def forward(self, x):
+        x = self.pre(x)
+        batch, _, frequencies, _ = x.shape
+        x = x.permute(0, 2, 1, 3)
+        x = torch.flatten(x, 0, 1)
+        x = self.conv(x)
+        x = x.unflatten(0, (batch, frequencies))
+        x = x.permute(0, 2, 1, 3)
+        return self.post(x)
+
+
 def compare(a, b):
     if isinstance(a, tuple):
         if not isinstance(b, tuple) or len(a) != len(b):
@@ -378,6 +427,16 @@ def no_batch_reshape_param(name):
     return True
 
 
+def has_batch_reshape_param(name, input_axis=0, output_axis=0):
+    expected = "12=" + str(input_axis) + " 13=" + str(output_axis)
+    with open(name + ".ncnn.param") as f:
+        for line in f:
+            if line.startswith("Reshape ") and expected in line:
+                return True
+
+    return False
+
+
 def run_model(name, net, inputs, inputs2=None):
     net.eval()
 
@@ -392,7 +451,8 @@ def run_model(name, net, inputs, inputs2=None):
     mod.save(name + ".pt")
 
     inputshape = ",".join([str(list(x.shape)).replace(" ", "") for x in inputs])
-    pnnxcmd = "../../src/pnnx " + name + ".pt inputshape=" + inputshape
+    pnnxexe = os.environ.get("PNNX_EXE", "../../src/pnnx")
+    pnnxcmd = '"' + pnnxexe + '" ' + name + ".pt inputshape=" + inputshape
     if inputs2 is not None:
         inputshape2 = ",".join([str(list(x.shape)).replace(" ", "") for x in inputs2])
         pnnxcmd += " inputshape2=" + inputshape2
@@ -415,7 +475,8 @@ def run_convert_only(name, net, inputs):
     mod.save(name + ".pt")
 
     inputshape = ",".join([str(list(x.shape)).replace(" ", "") for x in inputs])
-    if os.system("../../src/pnnx " + name + ".pt inputshape=" + inputshape) != 0:
+    pnnxexe = os.environ.get("PNNX_EXE", "../../src/pnnx")
+    if os.system('"' + pnnxexe + '" ' + name + ".pt inputshape=" + inputshape) != 0:
         return False
 
     return True
@@ -592,6 +653,46 @@ def test():
             return False
         if not no_batch_reshape_param(name):
             return False
+
+    torch.manual_seed(0)
+    x = torch.rand(1, 4, 8, 16)
+    name = "test_ncnn_batch_layout_flatten_to_conv1d_batch1"
+    if not run_model(name, ModelBatchFoldToConv1d("flatten"), x):
+        return False
+    if not has_batch_reshape_param(name):
+        return False
+
+    torch.manual_seed(0)
+    x = torch.rand(2, 4, 8, 16)
+    name = "test_ncnn_batch_layout_flatten_to_conv1d_batch2"
+    if not run_model(name, ModelBatchFoldToConv1d("flatten"), x):
+        return False
+    if not has_batch_reshape_param(name):
+        return False
+
+    torch.manual_seed(0)
+    x = torch.rand(2, 4, 8, 16)
+    name = "test_ncnn_batch_layout_reshape_to_conv1d"
+    if not run_model(name, ModelBatchFoldToConv1d("reshape"), x):
+        return False
+    if not has_batch_reshape_param(name):
+        return False
+
+    torch.manual_seed(0)
+    x = torch.rand(2, 4, 8, 16)
+    name = "test_ncnn_batch_layout_channel_fold_to_conv1d"
+    if not run_model(name, ModelChannelFoldToConv1d(), x):
+        return False
+    if not no_batch_reshape_param(name):
+        return False
+
+    torch.manual_seed(0)
+    x = torch.rand(2, 4, 8, 16)
+    name = "test_ncnn_batch_layout_unflatten_after_conv1d"
+    if not run_model(name, ModelBatchUnflattenAfterConv1d(), x):
+        return False
+    if not has_batch_reshape_param(name):
+        return False
 
     return True
 

--- a/tools/pnnx/tests/ncnn/test_ncnn_batch_layout.py
+++ b/tools/pnnx/tests/ncnn/test_ncnn_batch_layout.py
@@ -375,6 +375,17 @@ class ModelBatchFoldToConv1d(nn.Module):
         return self.conv(x)
 
 
+class ModelBatchFoldToUnbatchedPool2d(nn.Module):
+    def __init__(self):
+        super(ModelBatchFoldToUnbatchedPool2d, self).__init__()
+        self.pre = nn.Conv2d(4, 4, 1)
+
+    def forward(self, x):
+        x = self.pre(x)
+        x = torch.flatten(x, 0, 1)
+        return F.max_pool2d(x, 1)
+
+
 class ModelChannelFoldToConv1d(nn.Module):
     def __init__(self):
         super(ModelChannelFoldToConv1d, self).__init__()
@@ -658,6 +669,14 @@ def test():
     if not run_model(name, ModelBatchFoldToConv1d("flatten"), x):
         return False
     if not has_batch_reshape_param(name):
+        return False
+
+    torch.manual_seed(0)
+    x = torch.rand(2, 4, 5, 7)
+    name = "test_ncnn_batch_layout_flatten_to_unbatched_pool2d"
+    if not run_model(name, ModelBatchFoldToUnbatchedPool2d(), x):
+        return False
+    if not has_batch_reshape_param(name, input_axis=0, output_axis=233):
         return False
 
     torch.manual_seed(0)


### PR DESCRIPTION
## Motivation

  PNNX must distinguish between reshape operations where a merged dimension
  represents NCNN batch `n` and operations where the batch dimension is folded
  into an ordinary tensor dimension.

  For example:

  [B, F, C, T] -> [B*F, C, T] -> Conv1d

  requires `[B*F]` to remain NCNN batch `n`.

  However:

  [B, C, H, W] -> [B*C, H, W] -> unbatched MaxPool2d

  is an unbatched operation, so `B` is folded into the ordinary channel
  dimension.

  The previous implementation only compared the batch-axis positions. It could
  therefore emit an ordinary reshape when the batch axis position stayed the
  same but its size changed.

  ## Batch reshape decision

  The batch layout pass first infers the logical batch axis from the surrounding
  graph and stores the NCNN batch axis in `__ncnn_batch_axis`.

  The value `233` means that the tensor has no NCNN batch axis.

  A reshape is considered batch-aware when:

  1. The input and output batch-axis positions are different.

     This includes transitions such as:

     ```text
     0 -> 233
     233 -> 0
     0 -> 1

  2. The input and output batch-axis positions are the same, but the concrete
     batch extents are different.

     For example:

     [B, F, C, T] -> [B*F, C, T]

  3. If both tensors have no batch axis (233 -> 233), the reshape remains an
     ordinary reshape.

  4. If the batch axis and its concrete extent are unchanged, the reshape
     remains an ordinary reshape.

  5. An unresolved extent (-1) is not treated as a batch-size change unless
     the batch-axis positions themselves differ.

  Batch-aware reshapes emit NCNN parameters:

  12=<input_batch_axis> 13=<output_batch_axis>

  For example:

  12=0 13=0
  12=0 13=233

  Ordinary reshapes do not emit parameters 12 or 13.

  ## Implementation

  - Add shared batch-aware reshape detection.
  - Apply the logic to:
      - Tensor.reshape
      - Tensor.reshape_as
      - Tensor.unflatten
      - torch.flatten
      - reshape interpolation expressions

  - Defer unflatten decisions when it splits the current batch axis, allowing
    downstream consumers to determine which resulting axis should represent
    NCNN batch.

  - Preserve ordinary channel/spatial reshapes.
  - Do not modify the NCNN runtime implementation.
  - Do not manually post-process generated .param files.

  ## Tests

  Add regression tests for:

  - flatten(0, 1) followed by Conv1d with B=1.
  - flatten(0, 1) followed by Conv1d with B=2.
  - Explicit reshape(B*F, C, T) followed by Conv1d.
  - Channel/frequency folding into C*F, which must remain an ordinary
    reshape.

  - unflatten(0, (B, F)) after Conv1d.
  - Folding B into an ordinary dimension before an unbatched MaxPool2d,
    which must generate 12=0 13=233.

  The tests verify both:

  - PyTorch and NCNN numerical equivalence.
  - The generated NCNN .param layout attributes.