### PR TITLE
fix(spectrogram): validate n_fft/winlen in load_param

### DIFF
--- a/src/layer/spectrogram.cpp
+++ b/src/layer/spectrogram.cpp
@@ -23,7 +23,13 @@ int Spectrogram::load_param(const ParamDict& pd)
     normalized = pd.get(7, 0);
     onesided = pd.get(8, 1);
 
-    // assert winlen <= n_fft
+    // Reject invalid params before writing into window_data (ASan #6939).
+    if (n_fft <= 0 || winlen <= 0 || winlen > n_fft)
+    {
+        NCNN_LOGE("Spectrogram load_param invalid n_fft=%d winlen=%d", n_fft, winlen);
+        return -1;
+    }
+
     // generate window
     window_data.create(normalized == 2 ? n_fft + 1 : n_fft);
     {


### PR DESCRIPTION
## Summary
- Reject `n_fft <= 0`, `winlen <= 0`, or `winlen > n_fft` before writing `window_data`, returning `-1` instead of overflowing.

Fixes #6939

## Test plan
- [ ] Load a param with `winlen > n_fft` / `n_fft = 0` and confirm `load_param` returns `-1` without ASan write OOB
- [ ] Valid spectrogram params still load and forward