### PR TITLE
fix(net): bounds-check blob indexes in load_param_bin

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1805,6 +1805,14 @@ int Net::load_param_bin(const DataReader& dr)
             int bottom_blob_index;
             READ_VALUE(bottom_blob_index)
 
+            if (bottom_blob_index < 0 || bottom_blob_index >= (int)d->blobs.size())
+            {
+                NCNN_LOGE("layer %d bottom_blob_index %d out of range", i, bottom_blob_index);
+                delete layer;
+                clear();
+                return -1;
+            }
+
             Blob& blob = d->blobs[bottom_blob_index];
 
             blob.consumer = i;
@@ -1817,6 +1825,14 @@ int Net::load_param_bin(const DataReader& dr)
         {
             int top_blob_index;
             READ_VALUE(top_blob_index)
+
+            if (top_blob_index < 0 || top_blob_index >= (int)d->blobs.size())
+            {
+                NCNN_LOGE("layer %d top_blob_index %d out of range", i, top_blob_index);
+                delete layer;
+                clear();
+                return -1;
+            }
 
             Blob& blob = d->blobs[top_blob_index];
 


### PR DESCRIPTION
## Summary
- Validate `bottom_blob_index` / `top_blob_index` against `blobs.size()` in `Net::load_param_bin` before indexing.

Fixes #6937

## Test plan
- [ ] Load a crafted `param.bin` with out-of-range blob indexes and confirm `-1` + log without ASan OOB
- [ ] Normal models still `load_param_bin` successfully