### PR TITLE
fix(inversespectrogram): validate n_fft/winlen in load_param

### DIFF
--- a/src/layer/inversespectrogram.cpp
+++ b/src/layer/inversespectrogram.cpp
@@ -21,7 +21,13 @@ int InverseSpectrogram::load_param(const ParamDict& pd)
     center = pd.get(5, 1);
     normalized = pd.get(7, 0);
 
-    // assert winlen <= n_fft
+    // Reject invalid params before writing into window_data (same class of ASan as #6939).
+    if (n_fft <= 0 || winlen <= 0 || winlen > n_fft)
+    {
+        NCNN_LOGE("InverseSpectrogram load_param invalid n_fft=%d winlen=%d", n_fft, winlen);
+        return -1;
+    }
+
     // generate window
     window_data.create(normalized == 2 ? n_fft + 1 : n_fft);
     {


### PR DESCRIPTION
## Summary
- Reject `n_fft <= 0`, `winlen <= 0`, or `winlen > n_fft` before writing `window_data` in `InverseSpectrogram::load_param`.
- Same failure class as Spectrogram ASan #6939 (fixed in #6948).

## Test plan
- [ ] Load param with invalid `winlen`/`n_fft` and confirm `-1` without heap overflow
- [ ] Valid InverseSpectrogram params still load and forward