### PR TITLE
fix(pnnx): widen bool MemoryData attributes to fp32 in .bin (#6855)

### DIFF
--- a/tools/pnnx/src/save_ncnn.cpp
+++ b/tools/pnnx/src/save_ncnn.cpp
@@ -272,6 +272,20 @@ int save_ncnn(const Graph& g, const std::string& parampath, const std::string& b
                 continue;
             }
 
+            if (attr.type == 9) // bool --> fp32
+            {
+                const unsigned char* p = (const unsigned char*)attr.data.data();
+                int len = (int)attr.data.size();
+
+                std::vector<float> data_fp32(len);
+                for (int i = 0; i < len; i++)
+                {
+                    data_fp32[i] = p[i] ? 1.f : 0.f;
+                }
+
+                fwrite(data_fp32.data(), data_fp32.size() * sizeof(float), 1, binfp);
+                continue;
+            }
             if (attr.type == 5) // i64 --> i32
             {
                 const int64_t* p = (const int64_t*)attr.data.data();


### PR DESCRIPTION
## Summary
- `pnnx` wrote bool constants as **1 byte/element** in `model.ncnn.bin`.
- `MemoryData::load_model()` always reads **float32**, so the bin cursor drifts and every later weight loads shifted data.
- Widen bool attributes to `0.f` / `1.f` on write, mirroring the existing int64→int32 path in `save_ncnn.cpp`.

## Test plan
- [ ] Re-run the reporter's minimal repro (Conv2d + `register_buffer(..., dtype=torch.bool)`)
- [ ] Confirm `load_param`/`load_model` succeed and output matches torch reference
- [ ] Spot-check a real model that folds bool masks (e.g. YOLOE seg path from the issue)

Fixes #6855