### PR TITLE
fix(depthwise): reject group==0 in DeconvDW and ConvDW3D load_param

### DIFF
--- a/src/layer/convolutiondepthwise3d.cpp
+++ b/src/layer/convolutiondepthwise3d.cpp
@@ -38,7 +38,7 @@ int ConvolutionDepthWise3D::load_param(const ParamDict& pd)
     activation_type = pd.get(9, 0);
     activation_params = pd.get(10, Mat());
 
-    if (group == 0 || num_output % group != 0)
+    if (group <= 0 || num_output % group != 0)
     {
         // reject invalid group
         return -100;

--- a/src/layer/convolutiondepthwise3d.cpp
+++ b/src/layer/convolutiondepthwise3d.cpp
@@ -38,6 +38,12 @@ int ConvolutionDepthWise3D::load_param(const ParamDict& pd)
     activation_type = pd.get(9, 0);
     activation_params = pd.get(10, Mat());
 
+    if (group == 0 || num_output % group != 0)
+    {
+        // reject invalid group
+        return -100;
+    }
+
     return 0;
 }
 

--- a/src/layer/deconvolutiondepthwise.cpp
+++ b/src/layer/deconvolutiondepthwise.cpp
@@ -43,7 +43,7 @@ int DeconvolutionDepthWise::load_param(const ParamDict& pd)
         one_blob_only = false;
     }
 
-    if (group == 0 || num_output % group != 0)
+    if (group <= 0 || num_output % group != 0)
     {
         // reject invalid group
         return -100;

--- a/src/layer/deconvolutiondepthwise.cpp
+++ b/src/layer/deconvolutiondepthwise.cpp
@@ -43,6 +43,12 @@ int DeconvolutionDepthWise::load_param(const ParamDict& pd)
         one_blob_only = false;
     }
 
+    if (group == 0 || num_output % group != 0)
+    {
+        // reject invalid group
+        return -100;
+    }
+
     return 0;
 }
 

--- a/src/layer/deconvolutiondepthwise1d.cpp
+++ b/src/layer/deconvolutiondepthwise1d.cpp
@@ -36,7 +36,7 @@ int DeconvolutionDepthWise1D::load_param(const ParamDict& pd)
         one_blob_only = false;
     }
 
-    if (group == 0 || num_output % group != 0)
+    if (group <= 0 || num_output % group != 0)
     {
         // reject invalid group
         return -100;

--- a/src/layer/deconvolutiondepthwise1d.cpp
+++ b/src/layer/deconvolutiondepthwise1d.cpp
@@ -36,6 +36,12 @@ int DeconvolutionDepthWise1D::load_param(const ParamDict& pd)
         one_blob_only = false;
     }
 
+    if (group == 0 || num_output % group != 0)
+    {
+        // reject invalid group
+        return -100;
+    }
+
     return 0;
 }
 

--- a/src/layer/deconvolutiondepthwise3d.cpp
+++ b/src/layer/deconvolutiondepthwise3d.cpp
@@ -43,6 +43,12 @@ int DeconvolutionDepthWise3D::load_param(const ParamDict& pd)
     activation_type = pd.get(9, 0);
     activation_params = pd.get(10, Mat());
 
+    if (group == 0 || num_output % group != 0)
+    {
+        // reject invalid group
+        return -100;
+    }
+
     return 0;
 }
 

--- a/src/layer/deconvolutiondepthwise3d.cpp
+++ b/src/layer/deconvolutiondepthwise3d.cpp
@@ -43,7 +43,7 @@ int DeconvolutionDepthWise3D::load_param(const ParamDict& pd)
     activation_type = pd.get(9, 0);
     activation_params = pd.get(10, Mat());
 
-    if (group == 0 || num_output % group != 0)
+    if (group <= 0 || num_output % group != 0)
     {
         // reject invalid group
         return -100;


### PR DESCRIPTION
## Summary
- Add `group == 0 || num_output % group != 0` rejection in `DeconvolutionDepthWise`, `DeconvolutionDepthWise1D`, and `DeconvolutionDepthWise3D` `load_param` (they previously had no group check).
- Add the same guard to `ConvolutionDepthWise3D` (2d/1d already check; #6912 covers `group == 0` there).

Fixes #6970

## Test plan
- [ ] Load a param with `DeconvolutionDepthWise ... 7=0` and confirm `load_param` returns `-100` without SIGFPE
- [ ] Same for `DeconvolutionDepthWise1D` / `3D` and `ConvolutionDepthWise3D`
- [ ] Valid `group >= 1` with `num_output % group == 0` still loads