### PR TITLE
fix(rnn): reject non-positive num_output/hidden_size in load_param

### DIFF
--- a/src/layer/gru.cpp
+++ b/src/layer/gru.cpp
@@ -26,6 +26,12 @@ int GRU::load_param(const ParamDict& pd)
 #endif
     }
 
+    if (num_output <= 0)
+    {
+        // reject invalid num_output (load_model divides by it)
+        return -100;
+    }
+
     return 0;
 }
 

--- a/src/layer/lstm.cpp
+++ b/src/layer/lstm.cpp
@@ -27,6 +27,12 @@ int LSTM::load_param(const ParamDict& pd)
 #endif
     }
 
+    if (num_output <= 0 || hidden_size <= 0)
+    {
+        // reject invalid sizes (load_model divides by hidden_size)
+        return -100;
+    }
+
     return 0;
 }
 

--- a/src/layer/rnn.cpp
+++ b/src/layer/rnn.cpp
@@ -26,6 +26,12 @@ int RNN::load_param(const ParamDict& pd)
 #endif
     }
 
+    if (num_output <= 0)
+    {
+        // reject invalid num_output (load_model divides by it)
+        return -100;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- Reject `num_output <= 0` in `RNN` and `GRU` `load_param` (their `load_model` divides by `num_output`).
- Reject `num_output <= 0 || hidden_size <= 0` in `LSTM` `load_param` (divides by `hidden_size`).

Fixes #6973

## Test plan
- [ ] `RNN` / `GRU` param with `0=0` → `load_param` returns `-100`, no SIGFPE
- [ ] `LSTM` param with `0=0` or `3=0` → `-100`, no SIGFPE
- [ ] Valid positive sizes still load