### PR TITLE
fix(layer): reject non-positive divisors in ShuffleChannel/PixelShuffle/Reorg/GroupNorm

### DIFF
--- a/src/layer/groupnorm.cpp
+++ b/src/layer/groupnorm.cpp
@@ -18,6 +18,12 @@ int GroupNorm::load_param(const ParamDict& pd)
     eps = pd.get(2, 0.001f);
     affine = pd.get(3, 1);
 
+    if (group <= 0)
+    {
+        // reject invalid group (forward divides by group)
+        return -100;
+    }
+
     return 0;
 }
 

--- a/src/layer/pixelshuffle.cpp
+++ b/src/layer/pixelshuffle.cpp
@@ -16,6 +16,12 @@ int PixelShuffle::load_param(const ParamDict& pd)
     upscale_factor = pd.get(0, 1);
     mode = pd.get(1, 0);
 
+    if (upscale_factor <= 0)
+    {
+        // reject invalid upscale_factor (forward divides by upscale_factor^2)
+        return -100;
+    }
+
     return 0;
 }
 

--- a/src/layer/reorg.cpp
+++ b/src/layer/reorg.cpp
@@ -16,6 +16,12 @@ int Reorg::load_param(const ParamDict& pd)
     stride = pd.get(0, 1);
     mode = pd.get(1, 0);
 
+    if (stride <= 0)
+    {
+        // reject invalid stride (forward divides by stride)
+        return -100;
+    }
+
     return 0;
 }
 

--- a/src/layer/shufflechannel.cpp
+++ b/src/layer/shufflechannel.cpp
@@ -16,6 +16,12 @@ int ShuffleChannel::load_param(const ParamDict& pd)
     group = pd.get(0, 1);
     reverse = pd.get(1, 0);
 
+    if (group <= 0)
+    {
+        // reject invalid group (forward divides by group)
+        return -100;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- `ShuffleChannel` / `GroupNorm`: reject `group <= 0` in `load_param`
- `PixelShuffle`: reject `upscale_factor <= 0`
- `Reorg`: reject `stride <= 0`

Prevents SIGFPE in forward when a param explicitly sets these to 0.

Fixes #6976

## Test plan
- [ ] Param with `ShuffleChannel ... 0=0` → `load_param` returns `-100`
- [ ] Same for `PixelShuffle` / `Reorg` / `GroupNorm`
- [ ] Valid positive values still load and forward