### PR TITLE
arm: fix fp16 tanh_ps_f16 saturating at 1.044, which broke fast GELU for large negative inputs

### DIFF
--- a/src/layer/arm/neon_mathfun_fp16s.h
+++ b/src/layer/arm/neon_mathfun_fp16s.h
@@ -441,54 +441,58 @@ static inline float16x8_t cos_ps_f16(float16x8_t x)
     return ycos;
 }
 
-#define c_tanh_tiny 1e-4f
-#define c_tanh_hi   9.0f
+#define c_tanh_f16_tiny 1e-4f
+// tanh(4.5) = 0.99975 already rounds to 1.0 in half precision,
+// so anything outside [-4.5, 4.5] is -/+1.0f
+#define c_tanh_f16_hi 4.5f
+// tanh(x) ~= x * P(x^2) / Q(x^2), rational approximation fitted on [0, 4.5] for half precision.
+// The single precision coefficients used by tanh_ps cannot be represented in fp16:
+// alpha_9 alpha_11 alpha_13 underflow to zero and alpha_7 becomes subnormal,
+// which makes the approximation saturate at ~1.044 instead of 1.0 and
+// fast gelu return +0.022*|x| for large negative x.
+// All coefficients below are exactly representable in fp16 and stay in the normal range.
 // The monomial coefficients of the numerator polynomial (odd).
-#define c_tanh_alpha_1  4.89352455891786e-3f
-#define c_tanh_alpha_3  6.37261928875436e-4f
-#define c_tanh_alpha_5  1.48572235717979e-5f
-#define c_tanh_alpha_7  5.12229709037114e-8f
-#define c_tanh_alpha_9  -8.60467152213735e-11f
-#define c_tanh_alpha_11 2.00018790482477e-13f
-#define c_tanh_alpha_13 -2.76076847742355e-16f
+#define c_tanh_f16_alpha_1 1.f
+#define c_tanh_f16_alpha_3 0.1038818359375f
+#define c_tanh_f16_alpha_5 0.0007195472717285156f
 // The monomial coefficients of the denominator polynomial (even).
-#define c_tanh_beta_0 4.89352518554385e-3f
-#define c_tanh_beta_2 2.26843463243900e-3f
-#define c_tanh_beta_4 1.18534705686654e-4f
-#define c_tanh_beta_6 1.19825839466702e-6f
+#define c_tanh_f16_beta_0 1.f
+#define c_tanh_f16_beta_2 0.43701171875f
+#define c_tanh_f16_beta_4 0.0132904052734375f
 
-/* Single precision hyperbolic tangent computed for 4 simultaneous float */
+/* Half precision hyperbolic tangent computed for 4 simultaneous float16 */
 static inline float16x4_t tanh_ps_f16(float16x4_t x)
 {
     float16x4_t x2 = vabs_f16(x);
 
-    uint16x4_t tiny_mask = vcge_f16(x2, vdup_n_f16(c_tanh_tiny));
+    uint16x4_t tiny_mask = vcge_f16(x2, vdup_n_f16(c_tanh_f16_tiny));
 
-    // clamp the inputs to the range [-9, 9] since anything outside
-    // this range is -/+1.0f in single-precision.
-    x2 = (float16x4_t)(vbsl_u16(vcge_f16(vdup_n_f16(c_tanh_hi), x2), (uint16x4_t)(x2), (uint16x4_t)(vdup_n_f16(c_tanh_hi))));
+    // anything outside the range [-4.5, 4.5] is -/+1.0f in half precision.
+    uint16x4_t sat_mask = vcge_f16(x2, vdup_n_f16(c_tanh_f16_hi));
+
+    // clamp the inputs so that x**2 does not overflow.
+    x2 = vmin_f16(x2, vdup_n_f16(c_tanh_f16_hi));
 
     // since the polynomials are odd/even, we need x**2.
     float16x4_t z = vmul_f16(x2, x2);
 
     // evaluate the numerator polynomial y.
-    float16x4_t y = vdup_n_f16(c_tanh_alpha_13);
-    y = vfma_f16(vdup_n_f16(c_tanh_alpha_11), y, z);
-    y = vfma_f16(vdup_n_f16(c_tanh_alpha_9), y, z);
-    y = vfma_f16(vdup_n_f16(c_tanh_alpha_7), y, z);
-    y = vfma_f16(vdup_n_f16(c_tanh_alpha_5), y, z);
-    y = vfma_f16(vdup_n_f16(c_tanh_alpha_3), y, z);
-    y = vfma_f16(vdup_n_f16(c_tanh_alpha_1), y, z);
+    float16x4_t y = vdup_n_f16(c_tanh_f16_alpha_5);
+    y = vfma_f16(vdup_n_f16(c_tanh_f16_alpha_3), y, z);
+    y = vfma_f16(vdup_n_f16(c_tanh_f16_alpha_1), y, z);
     y = vmul_f16(y, x2);
 
     // evaluate the denominator polynomial w.
-    float16x4_t w = vdup_n_f16(c_tanh_beta_6);
-    w = vfma_f16(vdup_n_f16(c_tanh_beta_4), w, z);
-    w = vfma_f16(vdup_n_f16(c_tanh_beta_2), w, z);
-    w = vfma_f16(vdup_n_f16(c_tanh_beta_0), w, z);
+    float16x4_t w = vdup_n_f16(c_tanh_f16_beta_4);
+    w = vfma_f16(vdup_n_f16(c_tanh_f16_beta_2), w, z);
+    w = vfma_f16(vdup_n_f16(c_tanh_f16_beta_0), w, z);
 
     // divide the numerator by the denominator.
     y = vdiv_f16(y, w);
+
+    // the approximation must never exceed 1.0f, and saturate beyond the fitted range.
+    y = vmin_f16(y, vdup_n_f16(1.f));
+    y = (float16x4_t)(vbsl_u16(sat_mask, (uint16x4_t)(vdup_n_f16(1.f)), (uint16x4_t)(y)));
 
     // reinstate the sign.
     y = (float16x4_t)(vbsl_u16(vdup_n_u16(1u << 15), (uint16x4_t)(x), (uint16x4_t)(y)));
@@ -499,37 +503,39 @@ static inline float16x4_t tanh_ps_f16(float16x4_t x)
     return y;
 }
 
+/* Half precision hyperbolic tangent computed for 8 simultaneous float16 */
 static inline float16x8_t tanh_ps_f16(float16x8_t x)
 {
     float16x8_t x2 = vabsq_f16(x);
 
-    uint16x8_t tiny_mask = vcgeq_f16(x2, vdupq_n_f16(c_tanh_tiny));
+    uint16x8_t tiny_mask = vcgeq_f16(x2, vdupq_n_f16(c_tanh_f16_tiny));
 
-    // clamp the inputs to the range [-9, 9] since anything outside
-    // this range is -/+1.0f in single-precision.
-    x2 = vreinterpretq_f16_u16(vbslq_u16(vcgeq_f16(vdupq_n_f16(c_tanh_hi), x2), vreinterpretq_u16_f16(x2), vreinterpretq_u16_f16(vdupq_n_f16(c_tanh_hi))));
+    // anything outside the range [-4.5, 4.5] is -/+1.0f in half precision.
+    uint16x8_t sat_mask = vcgeq_f16(x2, vdupq_n_f16(c_tanh_f16_hi));
+
+    // clamp the inputs so that x**2 does not overflow.
+    x2 = vminq_f16(x2, vdupq_n_f16(c_tanh_f16_hi));
 
     // since the polynomials are odd/even, we need x**2.
     float16x8_t z = vmulq_f16(x2, x2);
 
     // evaluate the numerator polynomial y.
-    float16x8_t y = vdupq_n_f16(c_tanh_alpha_13);
-    y = vfmaq_f16(vdupq_n_f16(c_tanh_alpha_11), y, z);
-    y = vfmaq_f16(vdupq_n_f16(c_tanh_alpha_9), y, z);
-    y = vfmaq_f16(vdupq_n_f16(c_tanh_alpha_7), y, z);
-    y = vfmaq_f16(vdupq_n_f16(c_tanh_alpha_5), y, z);
-    y = vfmaq_f16(vdupq_n_f16(c_tanh_alpha_3), y, z);
-    y = vfmaq_f16(vdupq_n_f16(c_tanh_alpha_1), y, z);
+    float16x8_t y = vdupq_n_f16(c_tanh_f16_alpha_5);
+    y = vfmaq_f16(vdupq_n_f16(c_tanh_f16_alpha_3), y, z);
+    y = vfmaq_f16(vdupq_n_f16(c_tanh_f16_alpha_1), y, z);
     y = vmulq_f16(y, x2);
 
     // evaluate the denominator polynomial w.
-    float16x8_t w = vdupq_n_f16(c_tanh_beta_6);
-    w = vfmaq_f16(vdupq_n_f16(c_tanh_beta_4), w, z);
-    w = vfmaq_f16(vdupq_n_f16(c_tanh_beta_2), w, z);
-    w = vfmaq_f16(vdupq_n_f16(c_tanh_beta_0), w, z);
+    float16x8_t w = vdupq_n_f16(c_tanh_f16_beta_4);
+    w = vfmaq_f16(vdupq_n_f16(c_tanh_f16_beta_2), w, z);
+    w = vfmaq_f16(vdupq_n_f16(c_tanh_f16_beta_0), w, z);
 
     // divide the numerator by the denominator.
     y = vdivq_f16(y, w);
+
+    // the approximation must never exceed 1.0f, and saturate beyond the fitted range.
+    y = vminq_f16(y, vdupq_n_f16(1.f));
+    y = vreinterpretq_f16_u16(vbslq_u16(sat_mask, vreinterpretq_u16_f16(vdupq_n_f16(1.f)), vreinterpretq_u16_f16(y)));
 
     // reinstate the sign.
     y = vreinterpretq_f16_u16(vbslq_u16(vdupq_n_u16(1u << 15), vreinterpretq_u16_f16(x), vreinterpretq_u16_f16(y)));

--- a/tests/test_gelu.cpp
+++ b/tests/test_gelu.cpp
@@ -71,6 +71,22 @@ static int test_gelu_3()
            || test_gelu(RandomMat(120), true);
 }
 
+static int test_gelu_4()
+{
+    // large magnitude inputs, gelu(x) must be 0 for x << 0 and x for x >> 0
+    // fp16 arithmetic used to leak +0.022*|x| on the negative side (tanh_ps_f16 saturated at 1.044)
+    return 0
+           || test_gelu(RandomMat(6, 7, 9, 32, -100.f, 100.f), false)
+           || test_gelu(RandomMat(6, 7, 9, 32, -100.f, 100.f), true)
+           || test_gelu(RandomMat(9, 7, 32, -100.f, 100.f), false)
+           || test_gelu(RandomMat(9, 7, 32, -100.f, 100.f), true)
+           || test_gelu(RandomMat(13, 32, -100.f, 100.f), false)
+           || test_gelu(RandomMat(13, 32, -100.f, 100.f), true)
+           || test_gelu(RandomMat(128, -100.f, 100.f), false)
+           || test_gelu(RandomMat(128, -100.f, 100.f), true)
+           || test_gelu(RandomMat(128, -2000.f, 2000.f), true);
+}
+
 int main()
 {
     SRAND(7767517);
@@ -79,5 +95,6 @@ int main()
            || test_gelu_0()
            || test_gelu_1()
            || test_gelu_2()
-           || test_gelu_3();
+           || test_gelu_3()
+           || test_gelu_4();
 }

--- a/tests/test_tanh.cpp
+++ b/tests/test_tanh.cpp
@@ -50,6 +50,17 @@ static int test_tanh_3()
            || test_tanh(RandomMat(127));
 }
 
+static int test_tanh_4()
+{
+    // inputs beyond the saturation range, tanh(x) must be exactly -/+1
+    return 0
+           || test_tanh(RandomMat(5, 6, 7, 24, -10.f, 10.f))
+           || test_tanh(RandomMat(5, 7, 24, -10.f, 10.f))
+           || test_tanh(RandomMat(15, 24, -10.f, 10.f))
+           || test_tanh(RandomMat(128, -10.f, 10.f))
+           || test_tanh(RandomMat(128, -1000.f, 1000.f));
+}
+
 int main()
 {
     SRAND(7767517);
@@ -58,5 +69,6 @@ int main()
            || test_tanh_0()
            || test_tanh_1()
            || test_tanh_2()
-           || test_tanh_3();
+           || test_tanh_3()
+           || test_tanh_4();
 }


### PR DESCRIPTION
修复 #6978

### 问题

`src/layer/arm/neon_mathfun_fp16s.h` 里的 `tanh_ps_f16` 直接沿用了 fp32 版 `tanh_ps` 的有理分式系数。
其中 `alpha_9`(−8.6e-11)、`alpha_11`(2.0e-13)、`alpha_13`(−2.8e-16)在 fp16 里全部下溢成 0,`alpha_7`(5.1e-8)变成次正规数;
这几项正是 z = x² 较大时把分式压回 1 的,丢掉之后近似值在 |x| ≥ 9 处饱和在 **1.044** 而不是 1.0,|x| ≈ 4 时就已高出 2‰。
另外 `alpha_1 = beta_0 ≈ 4.9e-3`,x 很小时分子 `alpha_1·x` 落入 fp16 次正规区,|x| < 0.1 时误差达 43 ulp。

`fast_gelu_ps_f16` 算的是 `0.5·x·(1 + tanh(…))`,负半轴本应 `(1 − 1) = 0`,现在变成 `(1 − 1.044)·0.5·x = +0.022·|x|`:
GELU(−100) = +2.2,GELU(−1500) = +33。对 ViT 这类 MLP 里有成千上万负激活、且存在数百到上千量级"大激活"通道的模型,
`use_fp16_arithmetic=true` 时整网对任何输入都输出几乎相同的特征(实测 SigLIP2 ViT-B/16,不同图片两两余弦 0.99),完全不可用。

### 修改

`tanh_ps_f16`(`float16x4_t` 与 `float16x8_t` 两个版本)改为按 fp16 精度重新拟合的实现,仍是纯 fp16 运算:

- 截断点 9.0 → 4.5:tanh(4.5) = 0.99975 在 fp16 里已舍成 1.0,|x| ≥ 4.5 直接返回 ±1(select,不再靠有理式饱和)。
- 在 [0, 4.5] 上重新拟合 P3/Q3 有理式,系数全部 fp16 可精确表示且在正规数范围(最小 7.2e-4),`alpha_1 = beta_0 = 1` 消掉小 x 的次正规问题。
- 结果钳到 ≤ 1,防止区间内过冲。
- 宏改名为 `c_tanh_f16_*`,避免与 `neon_mathfun_tanh.h` 里同名的 fp32 宏冲突(9 个 `*_asimdhp.cpp` 同时包含两个头)。
- 分子 2 次 fma + 分母 2 次 fma,比原来的 6 + 3 少 5 条指令。

### 精度(逐算子 fp16 舍入仿真,单位:输出值处的 fp16 ulp)

| tanh 输入区间 | <0.1 | 0.1~1 | 1~2 | 2~3 | 3~3.5 | 3.5~4.5 | ≥4.5 |
|---|---|---|---|---|---|---|---|
| 修改前 | 42.7 | 2.6 | 2.7 | 4.3 | 5.1 | 8.9 | 90(绝对误差 0.044) |
| 修改后 | 2.2 | 3.0 | 2.5 | 3.3 | 3.4 | 3.3 | 0.5 |

fast GELU 逐点(fp16 运算):

| x | 精确值 | 修改前 | 修改后 |
|---|---|---|---|
| −1500 | 0 | +32.97 | 0 |
| −100 | 0 | +2.20 | 0 |
| −10 | 0 | +0.22 | 0 |
| −3 | −0.0036 | −0.0030 | −0.0044 |
| 1 | 0.8412 | 0.8412 | 0.8408 |
| 100 | 100 | 102.1 | 100 |

修改后 |x| ≤ 8 上 GELU 最大绝对误差 0.0035;x³ 在 fp16 里溢出成 inf 的情况由 select 覆盖,输出仍正确。

### 测试

- `tests/test_gelu.cpp` 新增 `test_gelu_4`:输入范围 ±100 与 ±2000。修改前在 Pixel 7(Cortex-A78/A55)上失败:
  `value not match at n:0 c:0 d:0 h:1 w:2 expect 0.000000 but got 1.612305 … fp16s=1 fp16a=1`;修改后通过。
- `tests/test_tanh.cpp` 新增 `test_tanh_4`:输入范围 ±10 与 ±1000,覆盖饱和分支。
- `test_gelu` `test_tanh` `test_unaryop` `test_mish` 四个用例修改后在 Pixel 7 全部通过(arm64-v8a,NDK 28,`-DNCNN_VULKAN=OFF`)。
- 其他架构(x86 / riscv / loongarch / mips)的 GELU 都在 fp32 里算 tanh,新用例不会误伤;fp16 运算的容差是 1.0,`test_tanh` 的新用例在修改前也能过,它只用来覆盖分支。

### 模型级验证

SigLIP2 ViT-B/16 视觉塔(137 层,13 个 `GELU 0=1`),Pixel 7,2 线程,`use_fp16_storage + use_fp16_arithmetic`:

| 配置 | 视觉塔耗时/张 | 输出 |
|---|---|---|
| 修改前,fp16 运算 | 417 ms | 错误:40 张图特征几乎相同,全部判成同一类 |
| 修改前,13 个 GELU 用 featmask `31=1` 退回 fp32 | 482 ms | 正确 |
| **修改后,全网 fp16 运算** | **403 ms** | 正确:与全 fp32 相比 22 列 sigmoid 概率偏差中位 0.012、最大 0.11,40 张 top1 一致 39/40,场景计数完全一致 |
| 全 fp32 运算(参考) | 1276 ms | 参考基线 |

修改后剩余的偏差与 featmask 方案一致(中位 0.012 / 0.012,最大 0.11 / 0.10),来自其余层 fp16 激活的正常舍入,不再有 GELU 引入的系统性错误。