### PR TITLE
harden paramdict parsing and typed access

### DIFF
--- a/docs/developer-guide/param-and-model-file-structure.md
+++ b/docs/developer-guide/param-and-model-file-structure.md
@@ -21,6 +21,8 @@ Softmax       softmax  1 1 fc prob 0=0
 
 each layer must occupy exactly one physical line, including all blob names and parameters; do not split a layer across lines or put multiple layers on the same line
 
+Custom `DataReader::scan()` implementations and C API `ncnn_datareader_t::scan` callbacks must follow scanf conversion and input consumption rules, including field widths and scansets. Parameter parsing uses `%1023[^\r\n]` to read up to 1023 characters without skipping leading whitespace or consuming CR/LF, repeating the scan for longer lines. A successful scanset conversion must append a null terminator and return 1. Returning 0 for an unsupported format can be interpreted as an empty parameter list and silently select default parameter values.
+
 ```
 [layer type] [layer name] [input count] [output count] [input blobs] [output blobs] [layer specific params]
 ```

--- a/docs/developer-guide/param-and-model-file-structure.md
+++ b/docs/developer-guide/param-and-model-file-structure.md
@@ -41,10 +41,10 @@ key index should be unique in each layer line, pair can be omitted if the defaul
 
 the meaning of existing param key index can be looked up at [operation-param-weight-table](operation-param-weight-table)
 
-* integer or float key : index 0 ~ 19
+* integer or float key : index 0 ~ 31
 * integer value : int
 * float value : float
-* integer array or float array key : -23300 minus index 0 ~ 19
+* integer array or float array key : -23300 minus index 0 ~ 31
 * integer array value : [array size],int,int,...,int
 * float array value : [array size],float,float,...,float
 

--- a/docs/developer-guide/param-and-model-file-structure.md
+++ b/docs/developer-guide/param-and-model-file-structure.md
@@ -46,7 +46,9 @@ the meaning of existing param key index can be looked up at [operation-param-wei
 * integer array value : [array size],int,int,...,int
 * float array value : [array size],float,float,...,float
 
-Use a decimal point or exponent for floating-point scalar values, including integral values, for example `1=6.0`, `1=6e0`, or `1=0.0`. Integer spellings such as `1=6` denote integer parameters and must not be used for floating-point attributes.
+Use a decimal point or exponent when generating floating-point scalar values, including integral values, for example `1=6.0`, `1=6e0`, or `1=0.0`. When loading text parameters, the float getter also converts integer spellings such as `1=6` and `1=0` to `6.0f` and `0.0f`. The int getter does not convert floating-point parameters to integers.
+
+Keep floating-point spellings when converting models with `ncnn2mem`: binary scalar parameters do not retain integer/float type tags, and the converter writes integer spellings as integer bit patterns without this numeric conversion.
 
 Use a decimal point or exponent for every element of a floating-point array, including integral values, for example `-23303=2,1.0,2.0`. Mixed integer and float element spellings within an array are not defined by the format.
 

--- a/docs/developer-guide/param-and-model-file-structure.md
+++ b/docs/developer-guide/param-and-model-file-structure.md
@@ -18,6 +18,9 @@ Softmax       softmax  1 1 fc prob 0=0
 * layer count : count of the layer line follows, should be exactly the count of all layer names
 * blob count : count of all blobs, usually greater than or equals to the layer count
 ### layer line
+
+each layer must occupy exactly one physical line, including all blob names and parameters; do not split a layer across lines or put multiple layers on the same line
+
 ```
 [layer type] [layer name] [input count] [output count] [input blobs] [output blobs] [layer specific params]
 ```

--- a/docs/developer-guide/param-and-model-file-structure.md
+++ b/docs/developer-guide/param-and-model-file-structure.md
@@ -43,6 +43,8 @@ the meaning of existing param key index can be looked up at [operation-param-wei
 * integer array value : [array size],int,int,...,int
 * float array value : [array size],float,float,...,float
 
+Use a decimal point or exponent for every element of a floating-point array, including integral values, for example `-23303=2,1.0,2.0`. Mixed integer and float element spellings within an array are not defined by the format.
+
 In modern ncnn param file
 
 * array could be represented as `3=2.0,3.0` that is much more human friendly

--- a/docs/developer-guide/param-and-model-file-structure.md
+++ b/docs/developer-guide/param-and-model-file-structure.md
@@ -43,7 +43,11 @@ the meaning of existing param key index can be looked up at [operation-param-wei
 * integer array value : [array size],int,int,...,int
 * float array value : [array size],float,float,...,float
 
+Use a decimal point or exponent for floating-point scalar values, including integral values, for example `1=6.0`, `1=6e0`, or `1=0.0`. Integer spellings such as `1=6` denote integer parameters and must not be used for floating-point attributes.
+
 Use a decimal point or exponent for every element of a floating-point array, including integral values, for example `-23303=2,1.0,2.0`. Mixed integer and float element spellings within an array are not defined by the format.
+
+A zero-length array such as `-23300=0` explicitly supplies an empty array. Array getters return that empty array even when a nonempty default is supplied; omitting the parameter returns the default.
 
 In modern ncnn param file
 

--- a/src/c_api.h
+++ b/src/c_api.h
@@ -224,6 +224,9 @@ struct NCNN_EXPORT __ncnn_datareader_t
     void* pthis;
 
 #if NCNN_STRING
+    /* follow scanf conversion and input consumption rules, including field widths and scansets */
+    /* %1023[^\r\n] must preserve leading whitespace and leave CR/LF unread */
+    /* append a null terminator on a successful scanset conversion and return 1 */
     int (*scan)(ncnn_datareader_t dr, const char* format, void* p);
 #endif /* NCNN_STRING */
     size_t (*read)(ncnn_datareader_t dr, void* buf, size_t size);

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -3,6 +3,7 @@
 
 #include "datareader.h"
 
+#include <ctype.h>
 #include <string.h>
 
 namespace ncnn {
@@ -187,23 +188,12 @@ int DataReaderFromAndroidAsset::scan(const char* format, void* p) const
     std::string line;
     {
         off64_t remain_length = AAsset_getRemainingLength64(d->asset);
-        const char* newline_pos;
-        if (remain_length > 1 && ((const char*)d->mem)[0] == '\n')
-        {
-            // skip the leading newline
-            // keep the leading newline for sscanf, which skips it only if the format allows whitespace
-            newline_pos = (const char*)memchr((const char*)d->mem + 1, '\n', remain_length - 1);
-        }
-        else if (remain_length > 2 && ((const char*)d->mem)[0] == '\r' && ((const char*)d->mem)[1] == '\n')
-        {
-            // skip the leading newline
-            // keep the leading newline for sscanf, which skips it only if the format allows whitespace
-            newline_pos = (const char*)memchr((const char*)d->mem + 2, '\n', remain_length - 2);
-        }
-        else
-        {
-            newline_pos = (const char*)memchr((const char*)d->mem, '\n', remain_length);
-        }
+        // include all leading whitespace and the following line in the buffer
+        // sscanf decides whether the conversion consumes that whitespace
+        size_t offset = 0;
+        while (offset < (size_t)remain_length && isspace(d->mem[offset]))
+            offset++;
+        const char* newline_pos = (const char*)memchr(d->mem + offset, '\n', (size_t)remain_length - offset);
 
         size_t line_length = newline_pos ? newline_pos - (const char*)d->mem : (size_t)remain_length;
         line = std::string((const char*)d->mem, line_length);

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -191,13 +191,13 @@ int DataReaderFromAndroidAsset::scan(const char* format, void* p) const
         if (remain_length > 1 && ((const char*)d->mem)[0] == '\n')
         {
             // skip the leading newline
-            // however, it is fine to create "\nXYZ 123 abc" as sscanf will skip the leading newline silently
+            // keep the leading newline for sscanf, which skips it only if the format allows whitespace
             newline_pos = (const char*)memchr((const char*)d->mem + 1, '\n', remain_length - 1);
         }
         else if (remain_length > 2 && ((const char*)d->mem)[0] == '\r' && ((const char*)d->mem)[1] == '\n')
         {
             // skip the leading newline
-            // however, it is fine to create "\r\nXYZ 123 abc" as sscanf will skip the leading newline silently
+            // keep the leading newline for sscanf, which skips it only if the format allows whitespace
             newline_pos = (const char*)memchr((const char*)d->mem + 2, '\n', remain_length - 2);
         }
         else

--- a/src/datareader.h
+++ b/src/datareader.h
@@ -26,6 +26,9 @@ public:
 
 #if NCNN_STRING
     // parse plain param text
+    // follow scanf conversion and input consumption rules, including field widths and scansets
+    // %1023[^\r\n] reads at most 1023 characters without skipping whitespace or consuming CR/LF
+    // append a null terminator on a successful scanset conversion
     // return 1 if scan success
     virtual int scan(const char* format, void* p) const;
 #endif // NCNN_STRING

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -117,6 +117,8 @@ int ParamDict::get(int id, int def) const
 float ParamDict::get(int id, float def) const
 {
     const int t = type(id);
+    if (t == 2)
+        return (float)d->params[id].i;
     return t == 1 || t == 3 ? d->params[id].f : def;
 }
 
@@ -178,6 +180,7 @@ void ParamDict::clear()
     }
 }
 
+// keep array length checks in sync with tools/ncnn2mem.cpp
 static size_t max_array_length()
 {
     // leave room for Mat alignment, the reference count and fastMalloc overhead
@@ -403,7 +406,7 @@ int ParamDict::load_param(const DataReader& dr)
     }
     if (!long_line.empty())
         long_line.push_back('\0');
-    const char* p = long_line.empty() ? line : long_line.data();
+    const char* p = long_line.empty() ? line : &long_line[0];
 
     while (1)
     {

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -369,6 +369,7 @@ static bool param_space(char c)
 
 static int scan_numeric_value(const char*& p, char vstr[128], bool comma = false)
 {
+    vstr[0] = '\0';
     if (comma)
     {
         if (*p != ',')
@@ -380,7 +381,10 @@ static int scan_numeric_value(const char*& p, char vstr[128], bool comma = false
     while (*p && *p != ',' && !param_space(*p))
     {
         if (len == 127)
+        {
+            vstr[len] = '\0';
             return -1;
+        }
         vstr[len++] = *p++;
     }
     vstr[len] = '\0';

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -180,7 +180,6 @@ void ParamDict::clear()
     }
 }
 
-// keep array length checks in sync with tools/ncnn2mem.cpp
 static size_t max_array_length()
 {
     // leave room for Mat alignment, the reference count and fastMalloc overhead
@@ -194,7 +193,6 @@ static bool valid_array_length(size_t len)
 }
 
 #if NCNN_STRING
-// keep numeric parsing in sync with tools/ncnn2mem.cpp
 static bool vstr_is_float(const char* vstr)
 {
     return strchr(vstr, '.') || strchr(vstr, 'e') || strchr(vstr, 'E');

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -294,13 +294,16 @@ static bool vstr_to_float(const char* p, float& value)
     if (*p == '.')
     {
         p++;
-        double scale = 0.1;
+        // accumulate the fraction before adding it to the integer part
+        double fraction = 0.0;
+        double scale = 1.0;
         while (*p >= '0' && *p <= '9')
         {
             has_digit = true;
-            v += (*p++ - '0') * scale;
-            scale *= 0.1;
+            fraction = fraction * 10.0 + (*p++ - '0');
+            scale *= 10.0;
         }
+        v += fraction / scale;
     }
     if (!has_digit)
         return false;
@@ -356,9 +359,9 @@ static bool vstr_to_float(const char* p, float& value)
     return true;
 }
 
-static int scan_numeric_value(const DataReader& dr, char vstr[128])
+static int scan_numeric_value(const DataReader& dr, char vstr[128], bool comma = false)
 {
-    if (dr.scan("%127[^, \t\r\n\v\f]", vstr) != 1)
+    if (dr.scan(comma ? ",%127[^, \t\r\n\v\f]" : "%127[^, \t\r\n\v\f]", vstr) != 1)
         return 0;
 
     // a field-width limit must not silently split a numeric token
@@ -415,7 +418,7 @@ int ParamDict::load_param(const DataReader& dr)
             bool is_float = false;
             for (int j = 0; j < len; j++)
             {
-                if (dr.scan("%1[,]", delimiter) != 1 || scan_numeric_value(dr, vstr) != 1)
+                if (scan_numeric_value(dr, vstr, true) != 1)
                 {
                     NCNN_LOGE("ParamDict read array element failed");
                     return -1;

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -181,7 +181,7 @@ void ParamDict::clear()
 static size_t max_array_length()
 {
     // leave room for Mat alignment, the reference count and fastMalloc overhead
-    const size_t max_len = ((size_t) -1 - 15 - sizeof(int) - sizeof(void*) - NCNN_MALLOC_ALIGN - NCNN_MALLOC_OVERREAD) / sizeof(float);
+    const size_t max_len = ((size_t)-1 - 15 - sizeof(int) - sizeof(void*) - NCNN_MALLOC_ALIGN - NCNN_MALLOC_OVERREAD) / sizeof(float);
     return std::min((size_t)INT_MAX, max_len);
 }
 

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -378,7 +378,7 @@ int ParamDict::load_param(const DataReader& dr)
 
     // stop before the next layer name, leaving it for Net to parse
     char idstr[16];
-    while (dr.scan(" %15[+-0123456789]", idstr) == 1)
+    while (dr.scan(" %15[-+0123456789]", idstr) == 1)
     {
         int id;
         char delimiter[2];

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -181,7 +181,7 @@ void ParamDict::clear()
 static size_t max_array_length()
 {
     // leave room for Mat alignment, the reference count and fastMalloc overhead
-    const size_t max_len = ((size_t)-1 - 15 - sizeof(int) - sizeof(void*) - NCNN_MALLOC_ALIGN - NCNN_MALLOC_OVERREAD) / sizeof(float);
+    const size_t max_len = ((size_t) -1 - 15 - sizeof(int) - sizeof(void*) - NCNN_MALLOC_ALIGN - NCNN_MALLOC_OVERREAD) / sizeof(float);
     return std::min((size_t)INT_MAX, max_len);
 }
 
@@ -191,6 +191,7 @@ static bool valid_array_length(size_t len)
 }
 
 #if NCNN_STRING
+// keep numeric parsing in sync with tools/ncnn2mem.cpp
 static bool vstr_is_float(const char* vstr)
 {
     return strchr(vstr, '.') || strchr(vstr, 'e') || strchr(vstr, 'E');
@@ -221,12 +222,68 @@ static bool vstr_to_int(const char* p, int& v)
     return true;
 }
 
+// the input is a validated unsigned decimal token of at most 127 characters
+static bool vstr_fits_float(const char* p)
+{
+    char digits[128];
+    int len = 0;
+    int point = -1;
+    while (*p && *p != 'e' && *p != 'E')
+    {
+        if (*p == '.')
+            point = len;
+        else
+            digits[len++] = *p;
+        p++;
+    }
+    if (point < 0)
+        point = len;
+
+    int exponent = 0;
+    if (*p)
+    {
+        p++;
+        const bool negative = *p == '-';
+        if (*p == '+' || *p == '-')
+            p++;
+        while (*p)
+        {
+            if (exponent < 1024)
+                exponent = exponent * 10 + (*p - '0');
+            p++;
+        }
+        if (negative)
+            exponent = -exponent;
+    }
+
+    int first = 0;
+    while (first < len && digits[first] == '0')
+        first++;
+    if (first == len)
+        return true;
+
+    const int decimal_digits = point - first + exponent;
+    if (decimal_digits != 39)
+        return decimal_digits < 39;
+
+    // 2^128 - 2^103 is the exact midpoint between FLT_MAX and float overflow
+    const char midpoint[] = "340282356779733661637539395458142568448";
+    for (int i = 0; i < 39; i++)
+    {
+        const char digit = first + i < len ? digits[first + i] : '0';
+        if (digit != midpoint[i])
+            return digit < midpoint[i];
+    }
+    return false;
+}
+
 static bool vstr_to_float(const char* p, float& value)
 {
     const bool negative = *p == '-';
     if (*p == '+' || *p == '-')
         p++;
 
+    const char* digits = p;
     double v = 0.0;
     bool has_digit = false;
     while (*p >= '0' && *p <= '9')
@@ -262,7 +319,11 @@ static bool vstr_to_float(const char* p, float& value)
         while (*p >= '0' && *p <= '9')
         {
             if (exponent < 1024)
-                exponent = std::min(1024u, exponent * 10 + (*p - '0'));
+            {
+                exponent = exponent * 10 + (*p - '0');
+                if (exponent > 1024)
+                    exponent = 1024;
+            }
             p++;
         }
         if (v != 0.0)
@@ -281,13 +342,16 @@ static bool vstr_to_float(const char* p, float& value)
             v = negative_exponent ? v / scale : v * scale;
         }
     }
-    // allow rounding to FLT_MAX, but reject the midpoint that rounds to infinity
-    const double half_ulp = (double)FLT_MAX / ((1u << FLT_MANT_DIG) - 1) * 0.5;
-    if (*p != '\0' || v >= (double)FLT_MAX + half_ulp)
+    if (*p != '\0')
         return false;
 
-    // keep the conversion within the finite float range
-    v = std::min(v, (double)FLT_MAX);
+    // compare the original decimal near overflow, where double rounding can cross the midpoint
+    if (v >= (double)FLT_MAX)
+    {
+        if (!vstr_fits_float(digits))
+            return false;
+        v = (double)FLT_MAX;
+    }
     value = negative ? (float)-v : (float)v;
     return true;
 }
@@ -356,8 +420,7 @@ int ParamDict::load_param(const DataReader& dr)
                     NCNN_LOGE("ParamDict read array element failed");
                     return -1;
                 }
-                if (j == 0)
-                    is_float = vstr_is_float(vstr);
+                is_float = vstr_is_float(vstr);
 
                 const bool ok = is_float ? vstr_to_float(vstr, ((float*)v)[j]) : vstr_to_int(vstr, ((int*)v)[j]);
                 if (!ok)

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -3,11 +3,13 @@
 
 #include "paramdict.h"
 
+#include "allocator.h"
 #include "datareader.h"
 #include "mat.h"
 #include "platform.h"
 
-#include <ctype.h>
+#include <float.h>
+#include <limits.h>
 
 #if NCNN_STDIO
 #include <stdio.h>
@@ -100,50 +102,67 @@ ParamDict& ParamDict::operator=(const ParamDict& rhs)
 
 int ParamDict::type(int id) const
 {
+    if (id < 0 || id >= NCNN_MAX_PARAM_COUNT)
+        return 0;
+
     return d->params[id].type;
 }
 
-// TODO strict type check
 int ParamDict::get(int id, int def) const
 {
-    return d->params[id].type ? d->params[id].i : def;
+    const int t = type(id);
+    return t == 1 || t == 2 ? d->params[id].i : def;
 }
 
 float ParamDict::get(int id, float def) const
 {
-    return d->params[id].type ? d->params[id].f : def;
+    const int t = type(id);
+    return t == 1 || t == 3 ? d->params[id].f : def;
 }
 
 Mat ParamDict::get(int id, const Mat& def) const
 {
-    return d->params[id].type ? d->params[id].v : def;
+    const int t = type(id);
+    return t == 4 || t == 5 || t == 6 ? d->params[id].v : def;
 }
 
 std::string ParamDict::get(int id, const std::string& def) const
 {
-    return d->params[id].type ? d->params[id].s : def;
+    return type(id) == 7 ? d->params[id].s : def;
 }
 
 void ParamDict::set(int id, int i)
 {
+    if (id < 0 || id >= NCNN_MAX_PARAM_COUNT)
+        return;
+
     d->params[id].type = 2;
     d->params[id].i = i;
 }
 
 void ParamDict::set(int id, float f)
 {
+    if (id < 0 || id >= NCNN_MAX_PARAM_COUNT)
+        return;
+
     d->params[id].type = 3;
     d->params[id].f = f;
 }
 
 void ParamDict::set(int id, const Mat& v)
 {
+    if (id < 0 || id >= NCNN_MAX_PARAM_COUNT)
+        return;
+
     d->params[id].type = 4;
     d->params[id].v = v;
 }
 
 void ParamDict::set(int id, const std::string& s)
 {
+    if (id < 0 || id >= NCNN_MAX_PARAM_COUNT)
+        return;
+
     d->params[id].type = 7;
     d->params[id].s = s;
 }
@@ -159,123 +178,142 @@ void ParamDict::clear()
     }
 }
 
+static bool valid_array_length(size_t len)
+{
+    // leave room for Mat alignment, the reference count and fastMalloc overhead
+    const size_t max_len = ((size_t)-1 - 15 - sizeof(int) - sizeof(void*) - NCNN_MALLOC_ALIGN - NCNN_MALLOC_OVERREAD) / sizeof(float);
+    return len <= INT_MAX && len <= max_len;
+}
+
 #if NCNN_STRING
-static bool vstr_is_float(const char vstr[16])
+static bool vstr_is_float(const char* vstr)
 {
-    // look ahead for determine isfloat
-    for (int j = 0; j < 16; j++)
-    {
-        if (vstr[j] == '\0')
-            break;
-
-        if (vstr[j] == '.' || tolower(vstr[j]) == 'e')
-            return true;
-    }
-
-    return false;
+    return strchr(vstr, '.') || strchr(vstr, 'e') || strchr(vstr, 'E');
 }
 
-static bool vstr_is_string(const char vstr[16])
+static bool vstr_to_int(const char* p, int& v)
 {
-    return isalpha(vstr[0]) || vstr[0] == '\"';
-}
-
-static float vstr_to_float(const char vstr[16])
-{
-    double v = 0.0;
-
-    const char* p = vstr;
-
-    // sign
-    bool sign = *p != '-';
+    const bool negative = *p == '-';
     if (*p == '+' || *p == '-')
-    {
         p++;
-    }
 
-    // digits before decimal point or exponent
-    unsigned int v1 = 0;
-    while (isdigit(*p))
+    if (*p < '0' || *p > '9')
+        return false;
+
+    const unsigned int limit = negative ? (unsigned int)INT_MAX + 1u : (unsigned int)INT_MAX;
+    unsigned int magnitude = 0;
+    while (*p >= '0' && *p <= '9')
     {
-        v1 = v1 * 10 + (*p - '0');
-        p++;
+        const unsigned int digit = *p++ - '0';
+        if (magnitude > (limit - digit) / 10)
+            return false;
+        magnitude = magnitude * 10 + digit;
     }
+    if (*p != '\0')
+        return false;
 
-    v = (double)v1;
+    v = negative ? (magnitude == (unsigned int)INT_MAX + 1u ? INT_MIN : -(int)magnitude) : (int)magnitude;
+    return true;
+}
 
-    // digits after decimal point
+static bool vstr_to_float(const char* p, float& value)
+{
+    const bool negative = *p == '-';
+    if (*p == '+' || *p == '-')
+        p++;
+
+    double v = 0.0;
+    bool has_digit = false;
+    while (*p >= '0' && *p <= '9')
+    {
+        has_digit = true;
+        v = v * 10.0 + (*p++ - '0');
+    }
     if (*p == '.')
     {
         p++;
-
-        unsigned int pow10 = 1;
-        unsigned int v2 = 0;
-
-        while (isdigit(*p))
+        double scale = 0.1;
+        while (*p >= '0' && *p <= '9')
         {
-            v2 = v2 * 10 + (*p - '0');
-            pow10 *= 10;
-            p++;
+            has_digit = true;
+            v += (*p++ - '0') * scale;
+            scale *= 0.1;
         }
-
-        v += v2 / (double)pow10;
     }
+    if (!has_digit)
+        return false;
 
-    // exponent
     if (*p == 'e' || *p == 'E')
     {
         p++;
-
-        // sign of exponent
-        bool fact = *p != '-';
+        const bool negative_exponent = *p == '-';
         if (*p == '+' || *p == '-')
+            p++;
+        if (*p < '0' || *p > '9')
+            return false;
+
+        // saturate the exponent instead of overflowing or looping over its value
+        unsigned int exponent = 0;
+        while (*p >= '0' && *p <= '9')
         {
+            if (exponent < 1024)
+                exponent = std::min(1024u, exponent * 10 + (*p - '0'));
             p++;
         }
-
-        // digits of exponent
-        unsigned int expon = 0;
-        while (isdigit(*p))
+        if (v != 0.0)
         {
-            expon = expon * 10 + (*p - '0');
-            p++;
+            double scale = 1.0;
+            double base = 10.0;
+            while (exponent)
+            {
+                if (exponent & 1)
+                    scale *= base;
+                exponent >>= 1;
+                if (exponent)
+                    base *= base;
+            }
+            v = negative_exponent ? v / scale : v * scale;
         }
-
-        double scale = 1.0;
-        while (expon >= 8)
-        {
-            scale *= 1e8;
-            expon -= 8;
-        }
-        while (expon > 0)
-        {
-            scale *= 10.0;
-            expon -= 1;
-        }
-
-        v = fact ? v * scale : v / scale;
     }
+    if (*p != '\0' || v > FLT_MAX)
+        return false;
 
-    //     fprintf(stderr, "v = %f\n", v);
-    return sign ? (float)v : (float)-v;
+    value = negative ? (float)-v : (float)v;
+    return true;
+}
+
+static int scan_numeric_value(const DataReader& dr, char vstr[128])
+{
+    if (dr.scan("%127[^, \t\r\n\v\f]", vstr) != 1)
+        return 0;
+
+    // a field-width limit must not silently split a numeric token
+    char extra[2];
+    if (strlen(vstr) == 127 && dr.scan("%1[^, \t\r\n\v\f]", extra) == 1)
+        return -1;
+
+    return 1;
 }
 
 int ParamDict::load_param(const DataReader& dr)
 {
     clear();
 
-    // 0=100 1=1.250000 -23303=5,0.1,0.2,0.4,0.8,1.0
-    // 3=0.1,0.2,0.4,0.8,1.0
-
-    // parse each key=value pair
-    int id = 0;
-    while (dr.scan("%d=", &id) == 1)
+    // stop before the next layer name, leaving it for Net to parse
+    char idstr[16];
+    while (dr.scan(" %15[+-0123456789]", idstr) == 1)
     {
-        bool is_array = id <= -23300;
-        if (is_array)
+        int id;
+        char delimiter[2];
+        if (!vstr_to_int(idstr, id) || dr.scan("%1[=]", delimiter) != 1)
         {
-            id = -id - 23300;
+            NCNN_LOGE("ParamDict invalid parameter id or missing equals sign");
+            return -1;
         }
+
+        const bool old_array = id <= -23300;
+        if (old_array)
+            id = -(id + 23300);
 
         if (id < 0 || id >= NCNN_MAX_PARAM_COUNT)
         {
@@ -283,203 +321,168 @@ int ParamDict::load_param(const DataReader& dr)
             return -1;
         }
 
-        if (is_array)
+        if (old_array)
         {
-            // old style array
-            int len = 0;
-            int nscan = dr.scan("%d", &len);
-            if (nscan != 1)
+            char vstr[128];
+            int len;
+            if (scan_numeric_value(dr, vstr) != 1 || !vstr_to_int(vstr, len) || !valid_array_length((size_t)len))
             {
-                NCNN_LOGE("ParamDict read array length failed");
+                NCNN_LOGE("ParamDict invalid array length (id=%d)", id);
                 return -1;
             }
 
-            d->params[id].v.create(len);
+            Mat v(len);
+            if (len > 0 && v.empty())
+            {
+                NCNN_LOGE("ParamDict array allocation failed (id=%d, len=%d)", id, len);
+                return -1;
+            }
 
+            bool is_float = false;
             for (int j = 0; j < len; j++)
             {
-                char vstr[16];
-                nscan = dr.scan(",%15[^,\n ]", vstr);
-                if (nscan != 1)
+                if (dr.scan("%1[,]", delimiter) != 1 || scan_numeric_value(dr, vstr) != 1)
                 {
                     NCNN_LOGE("ParamDict read array element failed");
                     return -1;
                 }
+                if (j == 0)
+                    is_float = vstr_is_float(vstr);
 
-                bool is_float = vstr_is_float(vstr);
-
-                if (is_float)
+                const bool ok = is_float ? vstr_to_float(vstr, ((float*)v)[j]) : vstr_to_int(vstr, ((int*)v)[j]);
+                if (!ok)
                 {
-                    float* ptr = d->params[id].v;
-                    ptr[j] = vstr_to_float(vstr);
+                    NCNN_LOGE("ParamDict invalid array element (id=%d, index=%d)", id, j);
+                    return -1;
                 }
-                else
-                {
-                    int* ptr = d->params[id].v;
-                    nscan = sscanf(vstr, "%d", &ptr[j]);
-                    if (nscan != 1)
-                    {
-                        NCNN_LOGE("ParamDict parse array element failed");
-                        return -1;
-                    }
-                }
-
-                d->params[id].type = is_float ? 6 : 5;
+            }
+            // extra elements are not a new parameter or the next layer
+            if (dr.scan("%1[,]", delimiter) == 1)
+            {
+                NCNN_LOGE("ParamDict array length mismatch (id=%d)", id);
+                return -1;
             }
 
+            d->params[id].v = v;
+            d->params[id].type = len == 0 ? 4 : is_float ? 6 : 5;
             continue;
         }
 
-        char vstr[16];
-        char comma[4];
-        int nscan = dr.scan("%15[^,\n ]", vstr);
-        if (nscan != 1)
+        char first[2];
+        if (dr.scan("%1[\"a-zA-Z]", first) == 1)
+        {
+            char text[256] = {0};
+            const bool quoted = first[0] == '\"';
+            if (quoted)
+            {
+                dr.scan("%255[^\"\r\n]", text);
+                if (dr.scan("%1[\"]", delimiter) != 1)
+                {
+                    NCNN_LOGE("ParamDict unterminated or too long string (id=%d)", id);
+                    return -1;
+                }
+            }
+            else
+            {
+                text[0] = first[0];
+                dr.scan("%254[^ \t\r\n\v\f]", text + 1);
+            }
+            if (dr.scan("%1[^ \t\r\n\v\f]", delimiter) == 1)
+            {
+                NCNN_LOGE("ParamDict invalid string suffix or string too long (id=%d)", id);
+                return -1;
+            }
+
+            d->params[id].s = text;
+            d->params[id].type = 7;
+            continue;
+        }
+
+        char vstr[128];
+        if (scan_numeric_value(dr, vstr) != 1)
         {
             NCNN_LOGE("ParamDict read value failed");
             return -1;
         }
 
-        bool is_string = vstr_is_string(vstr);
-        if (is_string)
+        const bool is_float = vstr_is_float(vstr);
+        float f = 0.f;
+        int i = 0;
+        if (!(is_float ? vstr_to_float(vstr, f) : vstr_to_int(vstr, i)))
         {
-            // scan the remaining string
-            char vstr2[256];
-            vstr2[241] = '\0'; // max 255 = 15 + 240
-
-            if (vstr[0] == '\"')
-            {
-                int len = 0;
-                while (vstr[len] != '\0')
-                    len++;
-                char end = vstr[len - 1];
-                if (end != '\"')
-                {
-                    nscan = dr.scan("%255[^\"\n]\"", vstr2);
-                }
-                else
-                    nscan = 0; // already ended with a quote, no need to scan more
-            }
-            else
-            {
-                nscan = dr.scan("%255[^\n ]", vstr2);
-            }
-            if (nscan == 1)
-            {
-                if (vstr2[241] != '\0')
-                {
-                    NCNN_LOGE("string too long (id=%d)", id);
-                    return -1;
-                }
-
-                if (vstr[0] == '\"')
-                    d->params[id].s = std::string(&vstr[1]) + vstr2;
-                else
-                    d->params[id].s = std::string(vstr) + vstr2;
-            }
-            else
-            {
-                if (vstr[0] == '\"')
-                    d->params[id].s = std::string(&vstr[1]);
-                else
-                    d->params[id].s = std::string(vstr);
-            }
-
-            if (d->params[id].s[d->params[id].s.size() - 1] == '\"')
-                d->params[id].s.resize(d->params[id].s.size() - 1);
-
-            d->params[id].type = 7;
-
-            continue;
+            NCNN_LOGE("ParamDict invalid numeric value (id=%d)", id);
+            return -1;
         }
 
-        bool is_float = vstr_is_float(vstr);
-
-        nscan = dr.scan("%1[,]", comma);
-        is_array = nscan == 1;
-
-        if (is_array)
+        if (dr.scan("%1[,]", delimiter) == 1)
         {
-            std::vector<float> af;
-            std::vector<int> ai;
-
+            Mat values(16);
+            if (values.empty())
+            {
+                NCNN_LOGE("ParamDict array allocation failed (id=%d)", id);
+                return -1;
+            }
+            int len = 1;
             if (is_float)
-            {
-                af.push_back(vstr_to_float(vstr));
-            }
+                ((float*)values)[0] = f;
             else
-            {
-                int v = 0;
-                nscan = sscanf(vstr, "%d", &v);
-                if (nscan != 1)
-                {
-                    NCNN_LOGE("ParamDict parse value failed");
-                    return -1;
-                }
-
-                ai.push_back(v);
-            }
+                ((int*)values)[0] = i;
 
             while (1)
             {
-                nscan = dr.scan("%15[^,\n ]", vstr);
-                if (nscan != 1)
+                const int nscan = scan_numeric_value(dr, vstr);
+                // a trailing comma is the established syntax for a one-element array
+                if (nscan == 0)
                 {
+                    if (dr.scan("%1[,]", delimiter) == 1)
+                        return -1;
                     break;
                 }
-
-                if (is_float)
+                if (nscan < 0 || !valid_array_length((size_t)len + 1) || !(is_float ? vstr_to_float(vstr, f) : vstr_to_int(vstr, i)))
                 {
-                    af.push_back(vstr_to_float(vstr));
+                    NCNN_LOGE("ParamDict invalid array element (id=%d)", id);
+                    return -1;
                 }
-                else
+                if (len == values.w)
                 {
-                    int v = 0;
-                    nscan = sscanf(vstr, "%d", &v);
-                    if (nscan != 1)
+                    size_t capacity = (size_t)values.w * 2;
+                    if (!valid_array_length(capacity))
+                        capacity = (size_t)len + 1;
+                    Mat grown((int)capacity);
+                    if (grown.empty())
                     {
-                        NCNN_LOGE("ParamDict parse value failed");
+                        NCNN_LOGE("ParamDict array allocation failed (id=%d)", id);
                         return -1;
                     }
-
-                    ai.push_back(v);
+                    memcpy(grown.data, values.data, (size_t)len * sizeof(float));
+                    values = grown;
                 }
+                if (is_float)
+                    ((float*)values)[len] = f;
+                else
+                    ((int*)values)[len] = i;
+                len++;
 
-                nscan = dr.scan("%1[,]", comma);
-                if (nscan != 1)
-                {
+                if (dr.scan("%1[,]", delimiter) != 1)
                     break;
-                }
             }
 
-            if (is_float)
+            Mat v(len);
+            if (v.empty())
             {
-                d->params[id].v.create((int)af.size());
-                memcpy(d->params[id].v.data, af.data(), af.size() * 4);
+                NCNN_LOGE("ParamDict array allocation failed (id=%d)", id);
+                return -1;
             }
-            else
-            {
-                d->params[id].v.create((int)ai.size());
-                memcpy(d->params[id].v.data, ai.data(), ai.size() * 4);
-            }
-
+            memcpy(v.data, values.data, (size_t)len * sizeof(float));
+            d->params[id].v = v;
             d->params[id].type = is_float ? 6 : 5;
         }
         else
         {
             if (is_float)
-            {
-                d->params[id].f = vstr_to_float(vstr);
-            }
+                d->params[id].f = f;
             else
-            {
-                nscan = sscanf(vstr, "%d", &d->params[id].i);
-                if (nscan != 1)
-                {
-                    NCNN_LOGE("ParamDict parse value failed");
-                    return -1;
-                }
-            }
-
+                d->params[id].i = i;
             d->params[id].type = is_float ? 3 : 2;
         }
     }
@@ -524,11 +527,11 @@ int ParamDict::load_param_bin(const DataReader& dr)
         bool is_string = id <= -23400;
         if (is_string)
         {
-            id = -id - 23400;
+            id = -(id + 23400);
         }
         else if (is_array)
         {
-            id = -id - 23300;
+            id = -(id + 23300);
         }
 
         if (id < 0 || id >= NCNN_MAX_PARAM_COUNT)
@@ -551,16 +554,15 @@ int ParamDict::load_param_bin(const DataReader& dr)
             swap_endianness_32(&len);
 #endif
 
-            if (len > 255)
+            if (len < 0 || len > 255)
             {
-                NCNN_LOGE("string too long (id=%d)", id);
+                NCNN_LOGE("invalid string length %d (id=%d)", len, id);
                 return -1;
             }
 
             size_t len_padded = (len + 3) / 4 * 4;
-            std::vector<char> tmpstr(len_padded + 1);
-
-            char* ptr = (char*)tmpstr.data();
+            char tmpstr[256];
+            char* ptr = tmpstr;
             nread = dr.read(ptr, len_padded);
             if (nread != len_padded)
             {
@@ -568,9 +570,9 @@ int ParamDict::load_param_bin(const DataReader& dr)
                 return -1;
             }
 
-            tmpstr[len_padded] = '\0';
-
-            d->params[id].s = tmpstr.data();
+            d->params[id].s.resize(len);
+            if (len > 0)
+                memcpy(&d->params[id].s[0], tmpstr, len);
 
             d->params[id].type = 7;
         }
@@ -588,10 +590,21 @@ int ParamDict::load_param_bin(const DataReader& dr)
             swap_endianness_32(&len);
 #endif
 
-            d->params[id].v.create(len);
+            if (!valid_array_length((size_t)len))
+            {
+                NCNN_LOGE("ParamDict invalid array length %d (id=%d)", len, id);
+                return -1;
+            }
 
-            float* ptr = d->params[id].v;
-            nread = dr.read(ptr, sizeof(float) * len);
+            Mat v(len);
+            if (len > 0 && v.empty())
+            {
+                NCNN_LOGE("ParamDict array allocation failed (id=%d, len=%d)", id, len);
+                return -1;
+            }
+
+            float* ptr = v;
+            nread = len == 0 ? 0 : dr.read(ptr, sizeof(float) * len);
             if (nread != sizeof(float) * len)
             {
                 NCNN_LOGE("ParamDict read array element failed %zd", nread);
@@ -605,6 +618,7 @@ int ParamDict::load_param_bin(const DataReader& dr)
             }
 #endif
 
+            d->params[id].v = v;
             d->params[id].type = 4;
         }
         else

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -178,11 +178,16 @@ void ParamDict::clear()
     }
 }
 
-static bool valid_array_length(size_t len)
+static size_t max_array_length()
 {
     // leave room for Mat alignment, the reference count and fastMalloc overhead
     const size_t max_len = ((size_t)-1 - 15 - sizeof(int) - sizeof(void*) - NCNN_MALLOC_ALIGN - NCNN_MALLOC_OVERREAD) / sizeof(float);
-    return len <= INT_MAX && len <= max_len;
+    return std::min((size_t)INT_MAX, max_len);
+}
+
+static bool valid_array_length(size_t len)
+{
+    return len <= max_array_length();
 }
 
 #if NCNN_STRING
@@ -262,6 +267,7 @@ static bool vstr_to_float(const char* p, float& value)
         }
         if (v != 0.0)
         {
+            // tokens are limited to 127 characters, so an infinite scale implies float overflow or underflow
             double scale = 1.0;
             double base = 10.0;
             while (exponent)
@@ -439,19 +445,20 @@ int ParamDict::load_param(const DataReader& dr)
                 if (nscan == 0)
                 {
                     if (dr.scan("%1[,]", delimiter) == 1)
+                    {
+                        NCNN_LOGE("ParamDict missing array element (id=%d, index=%d)", id, len);
                         return -1;
+                    }
                     break;
                 }
                 if (nscan < 0 || !valid_array_length((size_t)len + 1) || !(is_float ? vstr_to_float(vstr, f) : vstr_to_int(vstr, i)))
                 {
-                    NCNN_LOGE("ParamDict invalid array element (id=%d)", id);
+                    NCNN_LOGE("ParamDict invalid array element (id=%d, index=%d)", id, len);
                     return -1;
                 }
                 if (len == values.w)
                 {
-                    size_t capacity = (size_t)values.w * 2;
-                    if (!valid_array_length(capacity))
-                        capacity = (size_t)len + 1;
+                    const size_t capacity = std::min((size_t)values.w * 2, max_array_length());
                     Mat grown((int)capacity);
                     if (grown.empty())
                     {
@@ -471,14 +478,21 @@ int ParamDict::load_param(const DataReader& dr)
                     break;
             }
 
-            Mat v(len);
-            if (v.empty())
+            if (len == values.w)
             {
-                NCNN_LOGE("ParamDict array allocation failed (id=%d)", id);
-                return -1;
+                d->params[id].v = values;
             }
-            memcpy(v.data, values.data, (size_t)len * sizeof(float));
-            d->params[id].v = v;
+            else
+            {
+                Mat v(len);
+                if (v.empty())
+                {
+                    NCNN_LOGE("ParamDict array allocation failed (id=%d)", id);
+                    return -1;
+                }
+                memcpy(v.data, values.data, (size_t)len * sizeof(float));
+                d->params[id].v = v;
+            }
             d->params[id].type = is_float ? 6 : 5;
         }
         else
@@ -517,7 +531,7 @@ int ParamDict::load_param_bin(const DataReader& dr)
     nread = dr.read(&id, sizeof(int));
     if (nread != sizeof(int))
     {
-        NCNN_LOGE("ParamDict read id failed %zd", nread);
+        NCNN_LOGE("ParamDict read id failed %zu", nread);
         return -1;
     }
 
@@ -550,7 +564,7 @@ int ParamDict::load_param_bin(const DataReader& dr)
             nread = dr.read(&len, sizeof(int));
             if (nread != sizeof(int))
             {
-                NCNN_LOGE("ParamDict read array length failed %zd", nread);
+                NCNN_LOGE("ParamDict read string length failed %zu", nread);
                 return -1;
             }
 
@@ -570,13 +584,13 @@ int ParamDict::load_param_bin(const DataReader& dr)
             nread = dr.read(ptr, len_padded);
             if (nread != len_padded)
             {
-                NCNN_LOGE("ParamDict read string failed %zd", nread);
+                NCNN_LOGE("ParamDict read string failed %zu", nread);
                 return -1;
             }
 
-            d->params[id].s.resize(len);
-            if (len > 0)
-                memcpy(&d->params[id].s[0], tmpstr, len);
+            // preserve text string semantics without including alignment padding
+            tmpstr[len] = '\0';
+            d->params[id].s = tmpstr;
 
             d->params[id].type = 7;
         }
@@ -586,7 +600,7 @@ int ParamDict::load_param_bin(const DataReader& dr)
             nread = dr.read(&len, sizeof(int));
             if (nread != sizeof(int))
             {
-                NCNN_LOGE("ParamDict read array length failed %zd", nread);
+                NCNN_LOGE("ParamDict read array length failed %zu", nread);
                 return -1;
             }
 
@@ -611,7 +625,7 @@ int ParamDict::load_param_bin(const DataReader& dr)
             nread = len == 0 ? 0 : dr.read(ptr, sizeof(float) * len);
             if (nread != sizeof(float) * len)
             {
-                NCNN_LOGE("ParamDict read array element failed %zd", nread);
+                NCNN_LOGE("ParamDict read array element failed %zu", nread);
                 return -1;
             }
 
@@ -630,7 +644,7 @@ int ParamDict::load_param_bin(const DataReader& dr)
             nread = dr.read(&d->params[id].f, sizeof(float));
             if (nread != sizeof(float))
             {
-                NCNN_LOGE("ParamDict read value failed %zd", nread);
+                NCNN_LOGE("ParamDict read value failed %zu", nread);
                 return -1;
             }
 
@@ -644,7 +658,7 @@ int ParamDict::load_param_bin(const DataReader& dr)
         nread = dr.read(&id, sizeof(int));
         if (nread != sizeof(int))
         {
-            NCNN_LOGE("ParamDict read EOP failed %zd", nread);
+            NCNN_LOGE("ParamDict read EOP failed %zu", nread);
             return -1;
         }
 

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -359,34 +359,71 @@ static bool vstr_to_float(const char* p, float& value)
     return true;
 }
 
-static int scan_numeric_value(const DataReader& dr, char vstr[128], bool comma = false)
+static bool param_space(char c)
 {
-    if (dr.scan(comma ? ",%127[^, \t\r\n\v\f]" : "%127[^, \t\r\n\v\f]", vstr) != 1)
-        return 0;
+    return c == ' ' || c == '\t' || c == '\v' || c == '\f';
+}
 
-    // a field-width limit must not silently split a numeric token
-    char extra[2];
-    if (strlen(vstr) == 127 && dr.scan("%1[^, \t\r\n\v\f]", extra) == 1)
-        return -1;
+static int scan_numeric_value(const char*& p, char vstr[128], bool comma = false)
+{
+    if (comma)
+    {
+        if (*p != ',')
+            return 0;
+        p++;
+    }
 
-    return 1;
+    int len = 0;
+    while (*p && *p != ',' && !param_space(*p))
+    {
+        if (len == 127)
+            return -1;
+        vstr[len++] = *p++;
+    }
+    vstr[len] = '\0';
+    return len > 0 ? 1 : 0;
 }
 
 int ParamDict::load_param(const DataReader& dr)
 {
     clear();
 
-    // require '=' separately: a successful numeric conversion alone does not validate "id="
-    char idstr[16];
-    while (dr.scan(" %15[-+0123456789]", idstr) == 1)
+    // each layer occupies one line
+    // leave the newline for the next layer header scan
+    char line[1024] = {0};
+    std::vector<char> long_line;
+    while (dr.scan("%1023[^\r\n]", line) == 1)
     {
+        const size_t len = strlen(line);
+        if (long_line.empty() && len < sizeof(line) - 1)
+            break;
+        long_line.insert(long_line.end(), line, line + len);
+        if (len < sizeof(line) - 1)
+            break;
+    }
+    if (!long_line.empty())
+        long_line.push_back('\0');
+    const char* p = long_line.empty() ? line : long_line.data();
+
+    while (1)
+    {
+        while (param_space(*p))
+            p++;
+        if (!*p)
+            break;
+
+        char idstr[16];
+        int idlen = 0;
+        while ((*p == '-' || *p == '+' || (*p >= '0' && *p <= '9')) && idlen < 15)
+            idstr[idlen++] = *p++;
+        idstr[idlen] = '\0';
         int id;
-        char delimiter[2];
-        if (!vstr_to_int(idstr, id) || dr.scan("%1[=]", delimiter) != 1)
+        if (!vstr_to_int(idstr, id) || *p != '=')
         {
             NCNN_LOGE("ParamDict invalid parameter id or missing equals sign");
             return -1;
         }
+        p++;
 
         const bool old_array = id <= -23300;
         if (old_array)
@@ -402,7 +439,7 @@ int ParamDict::load_param(const DataReader& dr)
         {
             char vstr[128];
             int len;
-            if (scan_numeric_value(dr, vstr) != 1 || !vstr_to_int(vstr, len) || !valid_array_length((size_t)len))
+            if (scan_numeric_value(p, vstr) != 1 || !vstr_to_int(vstr, len) || !valid_array_length((size_t)len))
             {
                 NCNN_LOGE("ParamDict invalid array length (id=%d)", id);
                 return -1;
@@ -418,7 +455,7 @@ int ParamDict::load_param(const DataReader& dr)
             bool is_float = false;
             for (int j = 0; j < len; j++)
             {
-                if (scan_numeric_value(dr, vstr, true) != 1)
+                if (scan_numeric_value(p, vstr, true) != 1)
                 {
                     NCNN_LOGE("ParamDict read array element failed");
                     return -1;
@@ -433,7 +470,7 @@ int ParamDict::load_param(const DataReader& dr)
                 }
             }
             // extra elements are not a new parameter or the next layer
-            if (dr.scan("%1[,]", delimiter) == 1)
+            if (*p == ',')
             {
                 NCNN_LOGE("ParamDict array length mismatch (id=%d)", id);
                 return -1;
@@ -444,26 +481,25 @@ int ParamDict::load_param(const DataReader& dr)
             continue;
         }
 
-        char first[2];
-        if (dr.scan("%1[\"a-zA-Z]", first) == 1)
+        if (*p == '\"' || (*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z'))
         {
             char text[256] = {0};
-            const bool quoted = first[0] == '\"';
+            const bool quoted = *p == '\"';
+            if (quoted)
+                p++;
+            int len = 0;
+            while (*p && (quoted ? *p != '\"' : !param_space(*p)) && len < 255)
+                text[len++] = *p++;
             if (quoted)
             {
-                dr.scan("%255[^\"\r\n]", text);
-                if (dr.scan("%1[\"]", delimiter) != 1)
+                if (*p != '\"')
                 {
                     NCNN_LOGE("ParamDict unterminated or too long string (id=%d)", id);
                     return -1;
                 }
+                p++;
             }
-            else
-            {
-                text[0] = first[0];
-                dr.scan("%254[^ \t\r\n\v\f]", text + 1);
-            }
-            if (dr.scan("%1[^ \t\r\n\v\f]", delimiter) == 1)
+            if (*p && !param_space(*p))
             {
                 NCNN_LOGE("ParamDict invalid string suffix or string too long (id=%d)", id);
                 return -1;
@@ -475,7 +511,7 @@ int ParamDict::load_param(const DataReader& dr)
         }
 
         char vstr[128];
-        if (scan_numeric_value(dr, vstr) != 1)
+        if (scan_numeric_value(p, vstr) != 1)
         {
             NCNN_LOGE("ParamDict read value failed");
             return -1;
@@ -490,27 +526,27 @@ int ParamDict::load_param(const DataReader& dr)
             return -1;
         }
 
-        if (dr.scan("%1[,]", delimiter) == 1)
+        if (*p == ',')
         {
-            Mat values(16);
-            if (values.empty())
-            {
-                NCNN_LOGE("ParamDict array allocation failed (id=%d)", id);
-                return -1;
-            }
+            p++;
+            // keep short arrays on the stack until their final Mat allocation
+            unsigned char local_values[16 * sizeof(float)];
+            Mat values;
+            unsigned char* data = local_values;
+            int capacity = 16;
             int len = 1;
             if (is_float)
-                ((float*)values)[0] = f;
+                memcpy(data, &f, sizeof(float));
             else
-                ((int*)values)[0] = i;
+                memcpy(data, &i, sizeof(int));
 
             while (1)
             {
-                const int nscan = scan_numeric_value(dr, vstr);
+                const int nscan = scan_numeric_value(p, vstr);
                 // a trailing comma is the established syntax for a one-element array
                 if (nscan == 0)
                 {
-                    if (dr.scan("%1[,]", delimiter) == 1)
+                    if (*p == ',')
                     {
                         NCNN_LOGE("ParamDict missing array element (id=%d, index=%d)", id, len);
                         return -1;
@@ -522,26 +558,29 @@ int ParamDict::load_param(const DataReader& dr)
                     NCNN_LOGE("ParamDict invalid array element (id=%d, index=%d)", id, len);
                     return -1;
                 }
-                if (len == values.w)
+                if (len == capacity)
                 {
-                    const size_t capacity = std::min((size_t)values.w * 2, max_array_length());
-                    Mat grown((int)capacity);
+                    const size_t next_capacity = std::min((size_t)capacity * 2, max_array_length());
+                    Mat grown((int)next_capacity);
                     if (grown.empty())
                     {
                         NCNN_LOGE("ParamDict array allocation failed (id=%d)", id);
                         return -1;
                     }
-                    memcpy(grown.data, values.data, (size_t)len * sizeof(float));
+                    memcpy(grown.data, data, (size_t)len * sizeof(float));
                     values = grown;
+                    data = (unsigned char*)values.data;
+                    capacity = (int)next_capacity;
                 }
                 if (is_float)
-                    ((float*)values)[len] = f;
+                    memcpy(data + (size_t)len * sizeof(float), &f, sizeof(float));
                 else
-                    ((int*)values)[len] = i;
+                    memcpy(data + (size_t)len * sizeof(int), &i, sizeof(int));
                 len++;
 
-                if (dr.scan("%1[,]", delimiter) != 1)
+                if (*p != ',')
                     break;
+                p++;
             }
 
             if (len == values.w)
@@ -556,7 +595,7 @@ int ParamDict::load_param(const DataReader& dr)
                     NCNN_LOGE("ParamDict array allocation failed (id=%d)", id);
                     return -1;
                 }
-                memcpy(v.data, values.data, (size_t)len * sizeof(float));
+                memcpy(v.data, data, (size_t)len * sizeof(float));
                 d->params[id].v = v;
             }
             d->params[id].type = is_float ? 6 : 5;

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -690,8 +690,7 @@ int ParamDict::load_param_bin(const DataReader& dr)
 
             size_t len_padded = (len + 3) / 4 * 4;
             char tmpstr[256];
-            char* ptr = tmpstr;
-            nread = dr.read(ptr, len_padded);
+            nread = dr.read(tmpstr, len_padded);
             if (nread != len_padded)
             {
                 NCNN_LOGE("ParamDict read string failed %zu", nread);

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -275,9 +275,13 @@ static bool vstr_to_float(const char* p, float& value)
             v = negative_exponent ? v / scale : v * scale;
         }
     }
-    if (*p != '\0' || v > FLT_MAX)
+    // allow rounding to FLT_MAX, but reject the midpoint that rounds to infinity
+    const double half_ulp = (double)FLT_MAX / ((1u << FLT_MANT_DIG) - 1) * 0.5;
+    if (*p != '\0' || v >= (double)FLT_MAX + half_ulp)
         return false;
 
+    // keep the conversion within the finite float range
+    v = std::min(v, (double)FLT_MAX);
     value = negative ? (float)-v : (float)v;
     return true;
 }

--- a/src/paramdict.cpp
+++ b/src/paramdict.cpp
@@ -376,7 +376,7 @@ int ParamDict::load_param(const DataReader& dr)
 {
     clear();
 
-    // stop before the next layer name, leaving it for Net to parse
+    // require '=' separately: a successful numeric conversion alone does not validate "id="
     char idstr[16];
     while (dr.scan(" %15[-+0123456789]", idstr) == 1)
     {

--- a/src/paramdict.h
+++ b/src/paramdict.h
@@ -58,6 +58,7 @@ protected:
 
     void clear();
 
+    // failed loads may leave partially parsed parameters; discard them or load again
     int load_param(const DataReader& dr);
     int load_param_bin(const DataReader& dr);
 

--- a/src/paramdict.h
+++ b/src/paramdict.h
@@ -36,7 +36,7 @@ public:
     // get int
     int get(int id, int def) const;
     // get float
-    // integer 0 is a type mismatch; use set(id, 0.f) or text id=0.0 for floating-point zero
+    // integer parameters are converted to float
     float get(int id, float def) const;
     // get array
     Mat get(int id, const Mat& def) const;

--- a/src/paramdict.h
+++ b/src/paramdict.h
@@ -28,9 +28,11 @@ public:
     // assign
     ParamDict& operator=(const ParamDict&);
 
-    // get type
+    // get type, or 0 for an invalid id
     int type(int id) const;
 
+    // getters return the default for an invalid id or mismatched type
+    // binary scalar and array types remain untyped int/float data
     // get int
     int get(int id, int def) const;
     // get float
@@ -40,6 +42,7 @@ public:
     // get string
     std::string get(int id, const std::string& def) const;
 
+    // setters ignore invalid ids
     // set int
     void set(int id, int i);
     // set float

--- a/src/paramdict.h
+++ b/src/paramdict.h
@@ -36,6 +36,7 @@ public:
     // get int
     int get(int id, int def) const;
     // get float
+    // integer 0 is a type mismatch; use set(id, 0.f) or text id=0.0 for floating-point zero
     float get(int id, float def) const;
     // get array
     Mat get(int id, const Mat& def) const;

--- a/tests/test_clip.cpp
+++ b/tests/test_clip.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "testutil.h"
+#include "datareader.h"
 
 static int test_clip(const ncnn::Mat& a, float min, float max)
 {
@@ -55,6 +56,67 @@ static int test_clip_3()
            || test_clip(RandomMat(127), -1.f, 1.f);
 }
 
+class ClipParamDict : public ncnn::ParamDict
+{
+public:
+    using ncnn::ParamDict::load_param;
+};
+
+static int test_clip_zero_type()
+{
+    for (int mode = 0; mode < 4; mode++)
+    {
+        const bool floating = mode % 2 == 1;
+        ClipParamDict pd;
+        if (mode < 2)
+        {
+            if (floating)
+                pd.set(0, 0.f);
+            else
+                pd.set(0, 0);
+            pd.set(1, 6.f);
+        }
+        else
+        {
+#if NCNN_STRING
+            const unsigned char* text = (const unsigned char*)(floating ? "0=0.0 1=6.000000e+00" : "0=0 1=6.000000e+00");
+            ncnn::DataReaderFromMemory reader(text);
+            if (pd.load_param(reader))
+                return -1;
+#else
+            continue;
+#endif
+        }
+
+        ncnn::Option opt;
+        opt.num_threads = 1;
+        ncnn::Layer* op = ncnn::create_layer_cpu("Clip");
+        if (!op)
+            return -1;
+        int ret = op->load_param(pd);
+        if (ret == 0)
+            ret = op->create_pipeline(opt);
+
+        ncnn::Mat values(3);
+        values[0] = -1.f;
+        values[1] = 0.f;
+        values[2] = 7.f;
+        if (ret == 0)
+            ret = op->forward_inplace(values, opt);
+        op->destroy_pipeline(opt);
+        delete op;
+
+        // integer zero selects the nonzero default lower bound of -FLT_MAX
+        const float lower = floating ? 0.f : -1.f;
+        if (ret != 0 || values[0] != lower || values[1] != 0.f || values[2] != 6.f)
+        {
+            fprintf(stderr, "test_clip_zero_type failed mode=%d ret=%d\n", mode, ret);
+            return -1;
+        }
+    }
+    return 0;
+}
+
 int main()
 {
     SRAND(7767517);
@@ -63,5 +125,6 @@ int main()
            || test_clip_0()
            || test_clip_1()
            || test_clip_2()
-           || test_clip_3();
+           || test_clip_3()
+           || test_clip_zero_type();
 }

--- a/tests/test_clip.cpp
+++ b/tests/test_clip.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "testutil.h"
-#include "datareader.h"
 
 static int test_clip(const ncnn::Mat& a, float min, float max)
 {
@@ -56,67 +55,6 @@ static int test_clip_3()
            || test_clip(RandomMat(127), -1.f, 1.f);
 }
 
-class ClipParamDict : public ncnn::ParamDict
-{
-public:
-    using ncnn::ParamDict::load_param;
-};
-
-static int test_clip_zero_type()
-{
-    for (int mode = 0; mode < 4; mode++)
-    {
-        const bool floating = mode % 2 == 1;
-        ClipParamDict pd;
-        if (mode < 2)
-        {
-            if (floating)
-                pd.set(0, 0.f);
-            else
-                pd.set(0, 0);
-            pd.set(1, 6.f);
-        }
-        else
-        {
-#if NCNN_STRING
-            const unsigned char* text = (const unsigned char*)(floating ? "0=0.0 1=6.000000e+00" : "0=0 1=6.000000e+00");
-            ncnn::DataReaderFromMemory reader(text);
-            if (pd.load_param(reader))
-                return -1;
-#else
-            continue;
-#endif
-        }
-
-        ncnn::Option opt;
-        opt.num_threads = 1;
-        ncnn::Layer* op = ncnn::create_layer_cpu("Clip");
-        if (!op)
-            return -1;
-        int ret = op->load_param(pd);
-        if (ret == 0)
-            ret = op->create_pipeline(opt);
-
-        ncnn::Mat values(3);
-        values[0] = -1.f;
-        values[1] = 0.f;
-        values[2] = 7.f;
-        if (ret == 0)
-            ret = op->forward_inplace(values, opt);
-        op->destroy_pipeline(opt);
-        delete op;
-
-        // integer zero selects the nonzero default lower bound of -FLT_MAX
-        const float lower = floating ? 0.f : -1.f;
-        if (ret != 0 || values[0] != lower || values[1] != 0.f || values[2] != 6.f)
-        {
-            fprintf(stderr, "test_clip_zero_type failed mode=%d ret=%d\n", mode, ret);
-            return -1;
-        }
-    }
-    return 0;
-}
-
 int main()
 {
     SRAND(7767517);
@@ -125,6 +63,5 @@ int main()
            || test_clip_0()
            || test_clip_1()
            || test_clip_2()
-           || test_clip_3()
-           || test_clip_zero_type();
+           || test_clip_3();
 }

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -544,10 +544,13 @@ static int compare_paramdict(const ncnn::ParamDict& pd, const ncnn::ParamDict& p
     for (int id = 0; id < NCNN_MAX_PARAM_COUNT; id++)
     {
         const int type0 = pd0.type(id);
+        if (pd.type(id) != type0)
+        {
+            fprintf(stderr, "compare_paramdict type failed id=%d: %d != %d\n", id, pd.type(id), type0);
+            return -1;
+        }
         if (type0 == 0)
         {
-            if (pd.type(id) != 0)
-                return -1;
             continue;
         }
         else if (type0 == 2)

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -9,6 +9,10 @@
 #include "datareader.h"
 #include "paramdict.h"
 
+#if NCNN_STDIO && defined(_WIN32)
+#include <windows.h>
+#endif
+
 class ParamDictTest : public ncnn::ParamDict
 {
 public:
@@ -34,10 +38,26 @@ int ParamDictTest::load_param_bin(const unsigned char* mem)
 #if NCNN_STDIO
 static FILE* make_param_file(const void* data, size_t size)
 {
+#if defined(_WIN32)
+    // Microsoft CRT tmpfile() uses the drive root, which may not be writable
+    wchar_t directory[MAX_PATH];
+    wchar_t filename[MAX_PATH];
+    const DWORD len = GetTempPathW(MAX_PATH, directory);
+    if (len == 0 || len >= MAX_PATH || !GetTempFileNameW(directory, L"ncn", 0, filename))
+    {
+        fprintf(stderr, "ParamDict temporary file creation failed\n");
+        return 0;
+    }
+    // D deletes the file on fclose, including the write-failure path below
+    FILE* fp = _wfopen(filename, L"w+bD");
+    if (!fp)
+        DeleteFileW(filename);
+#else
     FILE* fp = tmpfile();
+#endif
     if (!fp)
     {
-        perror("ParamDict tmpfile failed");
+        perror("ParamDict temporary file open failed");
         return 0;
     }
     if (fwrite(data, 1, size, fp) != size)
@@ -853,6 +873,7 @@ static int test_paramdict_invalid_text()
         "0=.", "0=-", "0=--1", "0=1e", "0=1e+", "0=1.2.3", "0=1e4294967295", "0=1e39",
         "0=\"", "0=\"unterminated", "0=\"abc\n", "0=\"abc\"suffix", "0=\"abc\"1=2",
         "-23300=1", "-23300=2,1", "-23300=1,1,2", "-23300=0,1", "-23300=1x,2",
+        "-23300=1 1", "-23300=1,,1", "-23300=1, 1",
         "0=1,,2", "0=1,2x", "0=1.0,2e", "-23300=1,1e+"
     };
     for (size_t i = 0; i < sizeof(malformed) / sizeof(malformed[0]); i++)
@@ -1005,7 +1026,19 @@ static int check_float_boundary(const char* text, float expected, int count, boo
 
 static int test_paramdict_float_boundaries()
 {
+    // combining the comma scan must retain the full numeric token limit
+    for (int len = 127; len <= 128; len++)
+    {
+        std::string text = "-23300=1,0.";
+        text += make_param_string(len - 2, '0');
+        text += " 1=42\nReLU next 1 1 in out\n";
+        if (check_float_boundary(text.c_str(), 0.f, 1, len == 127))
+            return -1;
+    }
+
     const char* numbers[] = {
+        // exact float midpoints and their decimal neighbors in the old token-length range
+        "32768.017578124", "32768.017578125", "32768.017578126", "32768.021484374", "32768.021484375", "32768.021484376",
         "3.40282347e+38", "3.4028235e38", "3.40282356e38", "3.402823e38", "3.40282357e38", "1e39",
         "3.402823567797336e38", "3.402823567797337e38",
         "340282356779733661637539395458142568447.0", "340282356779733661637539395458142568448.0",
@@ -1013,8 +1046,11 @@ static int test_paramdict_float_boundaries()
         "0.000340282356779733661637539395458142568447e42",
         "000340282356779733661637539395458142568448e0"
     };
-    const float expected[] = {FLT_MAX, FLT_MAX, FLT_MAX, 3.402823e38f, 0.f, 0.f, FLT_MAX, 0.f, FLT_MAX, 0.f, 0.f, FLT_MAX, 0.f};
-    const bool valid[] = {true, true, true, true, false, false, true, false, true, false, false, true, false};
+    const float expected[] = {
+        32768.015625f, 32768.015625f, 32768.01953125f, 32768.01953125f, 32768.0234375f, 32768.0234375f,
+        FLT_MAX, FLT_MAX, FLT_MAX, 3.402823e38f, 0.f, 0.f, FLT_MAX, 0.f, FLT_MAX, 0.f, 0.f, FLT_MAX, 0.f
+    };
+    const bool valid[] = {true, true, true, true, true, true, true, true, true, true, false, false, true, false, true, false, false, true, false};
     for (size_t i = 0; i < sizeof(numbers) / sizeof(numbers[0]); i++)
         for (int negative = 0; negative < 2; negative++)
         {
@@ -1146,6 +1182,7 @@ static int check_paramdict_reload(const ncnn::DataReader& dr, bool binary)
 static int test_paramdict_reload()
 {
     const char* text = "0=42 1=1.5 2=3,4 3=hello 31=31\r\nReLU next 1 1 in out\r\n4=7\r\nClip last 1 1 out final\r\n";
+    const char* old_array_text = "0=42 1=1.5 -23302=2,3,4 3=hello 31=31\r\nReLU next 1 1 in out\r\n4=7\r\nClip last 1 1 out final\r\n";
 
     // three consecutive parameter blocks, with no parameters in the last block
     const int words[] = {0, 42, 1, 0x3fc00000, -23302, 2, 3, 4, -23403, 5, 0x6c6c6568, 0x6f, 31, 31, -233, 4, 7, -233, -233};
@@ -1153,10 +1190,11 @@ static int test_paramdict_reload()
     for (size_t i = 0; i < sizeof(words) / sizeof(words[0]); i++)
         append_param_word(data, words[i]);
 
-    for (int mode = 0; mode < 4; mode++)
+    for (int mode = 0; mode < 6; mode++)
     {
-        const bool binary = mode >= 2;
-        const unsigned char* ptr = binary ? data.data() : (const unsigned char*)text;
+        const bool binary = mode >= 4;
+        const char* input = mode < 2 ? text : old_array_text;
+        const unsigned char* ptr = binary ? data.data() : (const unsigned char*)input;
         int ret;
         if (mode % 2 == 0)
         {
@@ -1166,7 +1204,7 @@ static int test_paramdict_reload()
         else
         {
 #if NCNN_STDIO
-            FILE* fp = make_param_file(ptr, binary ? data.size() : strlen(text));
+            FILE* fp = make_param_file(ptr, binary ? data.size() : strlen(input));
             if (!fp)
                 return -1;
             ncnn::DataReaderFromStdio dr(fp);

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -745,6 +745,14 @@ static int test_paramdict_access()
         fprintf(stderr, "ParamDict retagged copy access failed\n");
         return -1;
     }
+
+    pd.set(4, ncnn::Mat());
+    if (pd.type(4) != 4 || !pd.get(4, array).empty()
+            || pd.type(5) != 0 || pd.get(5, array).data != array.data)
+    {
+        fprintf(stderr, "ParamDict empty array setter default failed\n");
+        return -1;
+    }
     return 0;
 }
 
@@ -847,6 +855,11 @@ static int test_paramdict_text_boundaries()
             || b.w != 1 || ((const int*)b)[0] != 7 || c.w != 2 || c[0] != 1.f || c[1] != 2.f)
     {
         fprintf(stderr, "ParamDict text array values failed\n");
+        return -1;
+    }
+    if (!pd.get(7, a).empty() || pd.type(31) != 0 || pd.get(31, a).data != a.data)
+    {
+        fprintf(stderr, "ParamDict empty text array default failed\n");
         return -1;
     }
 
@@ -1091,6 +1104,35 @@ static int check_paramdict_reload(const ncnn::DataReader& dr, bool binary)
 
 static int test_paramdict_reload()
 {
+    // a literal '-' in the id scanset must not consume punctuation in layer types
+    const char* headers[] = {".Custom next 1 1 in out", "/Custom next 1 1 in out", ",Custom next 1 1 in out"};
+    for (size_t i = 0; i < sizeof(headers) / sizeof(headers[0]); i++)
+        for (int empty = 0; empty < 2; empty++)
+        {
+            char input[128];
+            snprintf(input, sizeof(input), "%s\n%s\n", empty ? "" : "+0=42 -23301=2,3,4", headers[i]);
+            const unsigned char* ptr = (const unsigned char*)input;
+            ncnn::DataReaderFromMemory dr(ptr);
+            ParamDictTest pd;
+            if (pd.load_param(dr))
+                return -1;
+            if (!empty)
+            {
+                const ncnn::Mat values = pd.get(1, ncnn::Mat());
+                if (pd.get(0, 0) != 42 || values.w != 2 || ((const int*)values)[0] != 3 || ((const int*)values)[1] != 4)
+                {
+                    fprintf(stderr, "ParamDict signed parameter id failed\n");
+                    return -1;
+                }
+            }
+            char header[64];
+            if (dr.scan(" %63[^\r\n]", header) != 1 || strcmp(header, headers[i]))
+            {
+                fprintf(stderr, "ParamDict custom layer header changed: %s\n", headers[i]);
+                return -1;
+            }
+        }
+
     const char* text = "0=42 1=1.5 2=3,4 3=hello 31=31\r\nReLU next 1 1 in out\r\n4=7\r\nClip last 1 1 out final\r\n";
     const char* old_array_text = "0=42 1=1.5 -23302=2,3,4 3=hello 31=31\r\nReLU next 1 1 in out\r\n4=7\r\nClip last 1 1 out final\r\n";
 
@@ -1222,6 +1264,12 @@ static int test_paramdict_binary_bounds()
             || pd.get(8, std::string()) != "1" || pd.get(9, 0) != 99)
     {
         fprintf(stderr, "ParamDict binary boundary values failed\n");
+        return -1;
+    }
+    const ncnn::Mat fallback = pd.get(1, ncnn::Mat());
+    if (!pd.get(2, fallback).empty() || pd.type(31) != 0 || pd.get(31, fallback).data != fallback.data)
+    {
+        fprintf(stderr, "ParamDict empty binary array default failed\n");
         return -1;
     }
 

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -768,6 +768,47 @@ static int test_paramdict_access()
     return 0;
 }
 
+static int test_paramdict_zero_type()
+{
+    const char* text = "0=0 1=0.0";
+    for (int mode = 0; mode < 3; mode++)
+    {
+        ParamDictTest pd;
+        if (mode == 0)
+        {
+            pd.set(0, 0);
+            pd.set(1, 0.f);
+        }
+        else if (mode == 1)
+        {
+            if (pd.load_param(text))
+                return -1;
+        }
+        else
+        {
+#if NCNN_STDIO
+            FILE* fp = make_param_file(text, strlen(text));
+            if (!fp)
+                return -1;
+            ncnn::DataReaderFromStdio dr(fp);
+            const int ret = pd.load_param(dr);
+            fclose(fp);
+            if (ret)
+                return -1;
+#else
+            continue;
+#endif
+        }
+        if (pd.type(0) != 2 || pd.get(0, 7) != 0 || pd.get(0, 7.f) != 7.f
+                || pd.type(1) != 3 || pd.get(1, 7.f) != 0.f || pd.get(1, 7) != 7)
+        {
+            fprintf(stderr, "ParamDict zero type access failed mode=%d\n", mode);
+            return -1;
+        }
+    }
+    return 0;
+}
+
 static int check_text_result(const char* text, bool valid)
 {
     ParamDictTest memory;
@@ -812,7 +853,7 @@ static int test_paramdict_invalid_text()
         "0=.", "0=-", "0=--1", "0=1e", "0=1e+", "0=1.2.3", "0=1e4294967295", "0=1e39",
         "0=\"", "0=\"unterminated", "0=\"abc\n", "0=\"abc\"suffix", "0=\"abc\"1=2",
         "-23300=1", "-23300=2,1", "-23300=1,1,2", "-23300=0,1", "-23300=1x,2",
-        "0=1,,2", "0=1,2x", "0=1,2.5", "-23300=2,1,2.5", "0=1.0,2e", "-23300=1,1e+"
+        "0=1,,2", "0=1,2x", "0=1.0,2e", "-23300=1,1e+"
     };
     for (size_t i = 0; i < sizeof(malformed) / sizeof(malformed[0]); i++)
         if (check_text_result(malformed[i], false))
@@ -836,7 +877,7 @@ static int test_paramdict_invalid_text()
 static int test_paramdict_text_boundaries()
 {
     ParamDictTest pd;
-    const char* text = "0=-2147483648\t1=2147483647\r\n2=\"\" 3=\" \" 4=1.0,2,-3 5=7, -23306=2,1.0,2 -23307=0 8=0e9999999999 9=1e-9999999999 10=.5 11=4294967296.0";
+    const char* text = "0=-2147483648\t1=2147483647\r\n2=\"\" 3=\" \" 4=1.0,2.0,-3.0 5=7, -23306=2,1.0,2.0 -23307=0 8=0e9999999999 9=1e-9999999999 10=.5 11=4294967296.0";
     if (check_text_result(text, true) || pd.load_param(text))
         return -1;
     if (pd.get(0, 0) != INT_MIN || pd.get(1, 0) != INT_MAX
@@ -964,9 +1005,16 @@ static int check_float_boundary(const char* text, float expected, int count, boo
 
 static int test_paramdict_float_boundaries()
 {
-    const char* numbers[] = {"3.40282347e+38", "3.4028235e38", "3.40282356e38", "3.402823e38", "3.40282357e38", "1e39"};
-    const float expected[] = {FLT_MAX, FLT_MAX, FLT_MAX, 3.402823e38f, 0.f, 0.f};
-    const bool valid[] = {true, true, true, true, false, false};
+    const char* numbers[] = {
+        "3.40282347e+38", "3.4028235e38", "3.40282356e38", "3.402823e38", "3.40282357e38", "1e39",
+        "3.402823567797336e38", "3.402823567797337e38",
+        "340282356779733661637539395458142568447.0", "340282356779733661637539395458142568448.0",
+        "340282356779733661637539395458142568449.0",
+        "0.000340282356779733661637539395458142568447e42",
+        "000340282356779733661637539395458142568448e0"
+    };
+    const float expected[] = {FLT_MAX, FLT_MAX, FLT_MAX, 3.402823e38f, 0.f, 0.f, FLT_MAX, 0.f, FLT_MAX, 0.f, 0.f, FLT_MAX, 0.f};
+    const bool valid[] = {true, true, true, true, false, false, true, false, true, false, false, true, false};
     for (size_t i = 0; i < sizeof(numbers) / sizeof(numbers[0]); i++)
         for (int negative = 0; negative < 2; negative++)
         {
@@ -1271,6 +1319,7 @@ int main()
            || test_paramdict_5()
            || test_paramdict_6()
            || test_paramdict_access()
+           || test_paramdict_zero_type()
            || test_paramdict_invalid_text()
            || test_paramdict_text_boundaries()
            || test_paramdict_float_boundaries()

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -9,10 +9,6 @@
 #include "datareader.h"
 #include "paramdict.h"
 
-#if NCNN_STDIO && defined(_WIN32)
-#include <windows.h>
-#endif
-
 class ParamDictTest : public ncnn::ParamDict
 {
 public:
@@ -34,42 +30,6 @@ int ParamDictTest::load_param_bin(const unsigned char* mem)
     ncnn::DataReaderFromMemory dr(mem);
     return ncnn::ParamDict::load_param_bin(dr);
 }
-
-#if NCNN_STDIO
-static FILE* make_param_file(const void* data, size_t size)
-{
-#if defined(_WIN32)
-    // Microsoft CRT tmpfile() uses the drive root, which may not be writable
-    wchar_t directory[MAX_PATH];
-    wchar_t filename[MAX_PATH];
-    const DWORD len = GetTempPathW(MAX_PATH, directory);
-    if (len == 0 || len >= MAX_PATH || !GetTempFileNameW(directory, L"ncn", 0, filename))
-    {
-        fprintf(stderr, "ParamDict temporary file creation failed\n");
-        return 0;
-    }
-    // D deletes the file on fclose, including the write-failure path below
-    FILE* fp = _wfopen(filename, L"w+bD");
-    if (!fp)
-        DeleteFileW(filename);
-#else
-    FILE* fp = tmpfile();
-#endif
-    if (!fp)
-    {
-        perror("ParamDict temporary file open failed");
-        return 0;
-    }
-    if (fwrite(data, 1, size, fp) != size)
-    {
-        perror("ParamDict temporary file write failed");
-        fclose(fp);
-        return 0;
-    }
-    rewind(fp);
-    return fp;
-}
-#endif
 
 static int test_paramdict_0()
 {
@@ -791,7 +751,7 @@ static int test_paramdict_access()
 static int test_paramdict_zero_type()
 {
     const char* text = "0=0 1=0.0";
-    for (int mode = 0; mode < 3; mode++)
+    for (int mode = 0; mode < 2; mode++)
     {
         ParamDictTest pd;
         if (mode == 0)
@@ -799,25 +759,10 @@ static int test_paramdict_zero_type()
             pd.set(0, 0);
             pd.set(1, 0.f);
         }
-        else if (mode == 1)
+        else
         {
             if (pd.load_param(text))
                 return -1;
-        }
-        else
-        {
-#if NCNN_STDIO
-            FILE* fp = make_param_file(text, strlen(text));
-            if (!fp)
-                return -1;
-            ncnn::DataReaderFromStdio dr(fp);
-            const int ret = pd.load_param(dr);
-            fclose(fp);
-            if (ret)
-                return -1;
-#else
-            continue;
-#endif
         }
         if (pd.type(0) != 2 || pd.get(0, 7) != 0 || pd.get(0, 7.f) != 7.f
                 || pd.type(1) != 3 || pd.get(1, 7.f) != 0.f || pd.get(1, 7) != 7)
@@ -837,21 +782,6 @@ static int check_text_result(const char* text, bool valid)
         fprintf(stderr, "ParamDict memory parse result failed: %s\n", text);
         return -1;
     }
-#if NCNN_STDIO
-    // fscanf and sscanf have different consumption behavior on failed matches
-    FILE* fp = make_param_file(text, strlen(text));
-    if (!fp)
-        return -1;
-    ncnn::DataReaderFromStdio dr(fp);
-    ParamDictTest stdio;
-    const int ret = stdio.load_param(dr);
-    fclose(fp);
-    if ((ret == 0) != valid)
-    {
-        fprintf(stderr, "ParamDict stdio parse result failed: %s\n", text);
-        return -1;
-    }
-#endif
     return 0;
 }
 
@@ -974,52 +904,32 @@ static int test_paramdict_text_boundaries()
 
 static int check_float_boundary(const char* text, float expected, int count, bool valid)
 {
-    for (int backend = 0; backend < 2; backend++)
+    ParamDictTest pd;
+    const int ret = pd.load_param(text);
+    if ((ret == 0) != valid)
     {
-        ParamDictTest pd;
-        int ret;
-        if (backend == 0)
-        {
-            ret = pd.load_param(text);
-        }
-        else
-        {
-#if NCNN_STDIO
-            FILE* fp = make_param_file(text, strlen(text));
-            if (!fp)
-                return -1;
-            ncnn::DataReaderFromStdio dr(fp);
-            ret = pd.load_param(dr);
-            fclose(fp);
-#else
-            continue;
-#endif
-        }
-        if ((ret == 0) != valid)
-        {
-            fprintf(stderr, "ParamDict float boundary parse failed backend=%d: %s\n", backend, text);
-            return -1;
-        }
-        if (!valid)
-            continue;
+        fprintf(stderr, "ParamDict float boundary parse failed: %s\n", text);
+        return -1;
+    }
+    if (!valid)
+        return 0;
 
-        bool matches;
-        if (count == 0)
-        {
-            matches = pd.type(0) == 3 && pd.get(0, 0.f) == expected;
-        }
-        else
-        {
-            const ncnn::Mat values = pd.get(0, ncnn::Mat());
-            matches = pd.type(0) == 6 && values.w == count && values[0] == expected;
-            if (matches && count == 2)
-                matches = values[1] == 1.f;
-        }
-        if (!matches)
-        {
-            fprintf(stderr, "ParamDict float boundary value failed backend=%d: %s\n", backend, text);
-            return -1;
-        }
+    bool matches;
+    if (count == 0)
+    {
+        matches = pd.type(0) == 3 && pd.get(0, 0.f) == expected;
+    }
+    else
+    {
+        const ncnn::Mat values = pd.get(0, ncnn::Mat());
+        matches = pd.type(0) == 6 && values.w == count && values[0] == expected;
+        if (matches && count == 2)
+            matches = values[1] == 1.f;
+    }
+    if (!matches)
+    {
+        fprintf(stderr, "ParamDict float boundary value failed: %s\n", text);
+        return -1;
     }
     return 0;
 }
@@ -1190,30 +1100,13 @@ static int test_paramdict_reload()
     for (size_t i = 0; i < sizeof(words) / sizeof(words[0]); i++)
         append_param_word(data, words[i]);
 
-    for (int mode = 0; mode < 6; mode++)
+    for (int mode = 0; mode < 3; mode++)
     {
-        const bool binary = mode >= 4;
-        const char* input = mode < 2 ? text : old_array_text;
+        const bool binary = mode == 2;
+        const char* input = mode == 0 ? text : old_array_text;
         const unsigned char* ptr = binary ? data.data() : (const unsigned char*)input;
-        int ret;
-        if (mode % 2 == 0)
-        {
-            ncnn::DataReaderFromMemory dr(ptr);
-            ret = check_paramdict_reload(dr, binary);
-        }
-        else
-        {
-#if NCNN_STDIO
-            FILE* fp = make_param_file(ptr, binary ? data.size() : strlen(input));
-            if (!fp)
-                return -1;
-            ncnn::DataReaderFromStdio dr(fp);
-            ret = check_paramdict_reload(dr, binary);
-            fclose(fp);
-#else
-            continue;
-#endif
-        }
+        ncnn::DataReaderFromMemory dr(ptr);
+        const int ret = check_paramdict_reload(dr, binary);
         if (ret != 0)
         {
             fprintf(stderr, "ParamDict reload failed mode=%d\n", mode);

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -1166,6 +1166,42 @@ static int check_paramdict_reload(const ncnn::DataReader& dr, bool binary)
     return 0;
 }
 
+static int test_paramdict_reload_after_failure()
+{
+    for (int binary = 0; binary < 2; binary++)
+    {
+        ParamDictTest pd;
+        pd.set(9, 99);
+
+        // the first scalar is valid, but the second value is invalid or missing
+        std::vector<unsigned char> data;
+        append_param_word(data, 0);
+        append_param_word(data, 1);
+        append_param_word(data, 1);
+        BoundedParamReader truncated(&data[0], data.size());
+        const int ret = binary ? pd.load_param_bin(truncated) : pd.load_param("0=1 1=1e+");
+        if (ret == 0 || pd.get(0, 0) != 1 || pd.type(1) != 0 || pd.type(9) != 0)
+        {
+            fprintf(stderr, "ParamDict failed load state failed binary=%d\n", binary);
+            return -1;
+        }
+
+        // reloading must discard the partial result of the failed load
+        data.clear();
+        append_param_word(data, 4);
+        append_param_word(data, 7);
+        append_param_word(data, -233);
+        BoundedParamReader valid(&data[0], data.size());
+        const int reload_ret = binary ? pd.load_param_bin(valid) : pd.load_param("4=7");
+        if (reload_ret != 0 || check_reloaded_params(pd, 4, 7))
+        {
+            fprintf(stderr, "ParamDict reload after failure failed binary=%d\n", binary);
+            return -1;
+        }
+    }
+    return 0;
+}
+
 static int test_paramdict_reload()
 {
     // the next layer name is independent of parameter syntax, even with no parameters
@@ -1367,5 +1403,6 @@ int main()
            || test_paramdict_text_boundaries()
            || test_paramdict_float_boundaries()
            || test_paramdict_reload()
+           || test_paramdict_reload_after_failure()
            || test_paramdict_binary_bounds();
 }

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -782,7 +782,9 @@ static int test_paramdict_numeric_conversion()
                 if (pd.load_param(text))
                     return -1;
             }
-            if (pd.get(0, 7.f) != expected[j] || pd.type(0) != 2 || pd.get(0, 7) != integers[j]
+            // round to float storage precision before comparing an x87 return value
+            volatile float value = pd.get(0, 7.f);
+            if (value != expected[j] || pd.type(0) != 2 || pd.get(0, 7) != integers[j]
                     || pd.type(1) != 3 || pd.get(1, 7.f) != 0.f || pd.get(1, 7) != 7
                     || pd.get(2, 7.f) != 7.f)
             {

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -31,6 +31,26 @@ int ParamDictTest::load_param_bin(const unsigned char* mem)
     return ncnn::ParamDict::load_param_bin(dr);
 }
 
+#if NCNN_STDIO
+static FILE* make_param_file(const void* data, size_t size)
+{
+    FILE* fp = tmpfile();
+    if (!fp)
+    {
+        perror("ParamDict tmpfile failed");
+        return 0;
+    }
+    if (fwrite(data, 1, size, fp) != size)
+    {
+        perror("ParamDict temporary file write failed");
+        fclose(fp);
+        return 0;
+    }
+    rewind(fp);
+    return fp;
+}
+#endif
+
 static int test_paramdict_0()
 {
     ParamDictTest pdt;
@@ -713,7 +733,10 @@ static int test_paramdict_access()
         }
     }
     if (pd.get(0, 0) != 10 || pd.get(31, 0) != 31)
+    {
+        fprintf(stderr, "ParamDict valid id access failed\n");
         return -1;
+    }
 
     if (pd.get(0, 7.f) != 7.f || pd.get(1, 7) != 7
             || pd.get(2, 7) != 7 || pd.get(2, 7.f) != 7.f
@@ -733,7 +756,8 @@ static int test_paramdict_access()
     assigned.set(2, array);
     assigned.set(3, text);
     assigned = pd;
-    assigned = assigned;
+    const ncnn::ParamDict& alias = assigned;
+    assigned = alias;
     if (!copied.get(2, ncnn::Mat()).empty() || copied.get(3, std::string()) != ""
             || !assigned.get(2, ncnn::Mat()).empty() || assigned.get(3, std::string()) != ""
             || copied.get(2, 0) != 22 || assigned.get(3, 0) != 33)
@@ -754,11 +778,9 @@ static int check_text_result(const char* text, bool valid)
     }
 #if NCNN_STDIO
     // fscanf and sscanf have different consumption behavior on failed matches
-    FILE* fp = tmpfile();
+    FILE* fp = make_param_file(text, strlen(text));
     if (!fp)
         return -1;
-    fwrite(text, 1, strlen(text), fp);
-    rewind(fp);
     ncnn::DataReaderFromStdio dr(fp);
     ParamDictTest stdio;
     const int ret = stdio.load_param(dr);
@@ -817,13 +839,19 @@ static int test_paramdict_text_boundaries()
             || pd.type(7) != 4 || !pd.get(7, ncnn::Mat()).empty()
             || pd.get(8, 1.f) != 0.f || pd.get(9, 1.f) != 0.f || pd.get(10, 0.f) != 0.5f
             || pd.get(11, 0.f) != 4294967296.f)
+    {
+        fprintf(stderr, "ParamDict text boundary values failed\n");
         return -1;
+    }
     ncnn::Mat a = pd.get(4, ncnn::Mat());
     ncnn::Mat b = pd.get(5, ncnn::Mat());
     ncnn::Mat c = pd.get(6, ncnn::Mat());
     if (a.w != 3 || a[0] != 1.f || a[1] != 2.f || a[2] != -3.f
             || b.w != 1 || ((const int*)b)[0] != 7 || c.w != 2 || c[0] != 1.f || c[1] != 2.f)
+    {
+        fprintf(stderr, "ParamDict text array values failed\n");
         return -1;
+    }
 
     const int lengths[] = {1, 14, 15, 16, 240, 241, 254, 255};
     for (size_t i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++)
@@ -841,13 +869,6 @@ static int test_paramdict_text_boundaries()
         }
     }
 
-    // leave the next layer header untouched for the caller
-    const unsigned char* ptr = (const unsigned char*)"0=42\nReLU next 1 1 in out\n";
-    ncnn::DataReaderFromMemory reader(ptr);
-    char layer_type[5];
-    if (pd.load_param(reader) || pd.get(0, 0) != 42 || reader.scan("%4s", layer_type) != 1 || strcmp(layer_type, "ReLU"))
-        return -1;
-
     // exercise array growth and the final copy for both element types
     const int array_lengths[] = {16, 17, 32, 33, 257};
     for (size_t j = 0; j < sizeof(array_lengths) / sizeof(array_lengths[0]); j++)
@@ -862,13 +883,22 @@ static int test_paramdict_text_boundaries()
             }
             input += " 1=42";
             if (check_text_result(input.c_str(), true) || pd.load_param(input.c_str()) || pd.get(1, 0) != 42)
+            {
+                fprintf(stderr, "ParamDict array growth parse failed len=%d floating=%d\n", array_lengths[j], floating);
                 return -1;
+            }
             const ncnn::Mat values = pd.get(0, ncnn::Mat());
             if (values.w != array_lengths[j])
+            {
+                fprintf(stderr, "ParamDict array growth length failed %d != %d\n", values.w, array_lengths[j]);
                 return -1;
+            }
             for (int i = 0; i < values.w; i++)
                 if (floating ? values[i] != (float)i : ((const int*)values)[i] != i)
+                {
+                    fprintf(stderr, "ParamDict array growth value failed len=%d index=%d floating=%d\n", values.w, i, floating);
                     return -1;
+                }
         }
     return 0;
 }
@@ -886,11 +916,9 @@ static int check_float_boundary(const char* text, float expected, int count, boo
         else
         {
 #if NCNN_STDIO
-            FILE* fp = tmpfile();
+            FILE* fp = make_param_file(text, strlen(text));
             if (!fp)
                 return -1;
-            fwrite(text, 1, strlen(text), fp);
-            rewind(fp);
             ncnn::DataReaderFromStdio dr(fp);
             ret = pd.load_param(dr);
             fclose(fp);
@@ -993,6 +1021,115 @@ static void append_param_word(std::vector<unsigned char>& bytes, int value)
         bytes.push_back((v >> (i * 8)) & 255);
 }
 
+static int check_reloaded_params(const ParamDictTest& pd, int present_id, int value)
+{
+    for (int id = 0; id < NCNN_MAX_PARAM_COUNT; id++)
+    {
+        if (id == present_id)
+        {
+            if (pd.get(id, 0) != value)
+            {
+                fprintf(stderr, "ParamDict reloaded value failed id=%d\n", id);
+                return -1;
+            }
+        }
+        else if (pd.type(id) != 0)
+        {
+            fprintf(stderr, "ParamDict stale parameter after reload id=%d type=%d\n", id, pd.type(id));
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int check_paramdict_reload(const ncnn::DataReader& dr, bool binary)
+{
+    ParamDictTest pd;
+    int ret = binary ? pd.load_param_bin(dr) : pd.load_param(dr);
+    const ncnn::Mat values = pd.get(2, ncnn::Mat());
+    if (ret != 0 || pd.get(0, 0) != 42 || pd.get(1, 0.f) != 1.5f
+            || values.w != 2 || ((const int*)values)[0] != 3 || ((const int*)values)[1] != 4
+            || pd.get(3, std::string()) != "hello" || pd.get(31, 0) != 31)
+    {
+        fprintf(stderr, "ParamDict initial reload state failed\n");
+        return -1;
+    }
+
+    // leave each following layer header for the caller, including after a failed scan
+    char header[64];
+    if (!binary && (dr.scan(" %63[^\r\n]", header) != 1 || strcmp(header, "ReLU next 1 1 in out")))
+    {
+        fprintf(stderr, "ParamDict next layer header failed\n");
+        return -1;
+    }
+    ret = binary ? pd.load_param_bin(dr) : pd.load_param(dr);
+    if (ret != 0 || check_reloaded_params(pd, 4, 7))
+    {
+        fprintf(stderr, "ParamDict second load failed\n");
+        return -1;
+    }
+
+    if (!binary && (dr.scan(" %63[^\r\n]", header) != 1 || strcmp(header, "Clip last 1 1 out final")))
+    {
+        fprintf(stderr, "ParamDict last layer header failed\n");
+        return -1;
+    }
+    ret = binary ? pd.load_param_bin(dr) : pd.load_param(dr);
+    if (ret != 0 || check_reloaded_params(pd, -1, 0))
+    {
+        fprintf(stderr, "ParamDict empty load failed\n");
+        return -1;
+    }
+    if (((const int*)values)[0] != 3 || ((const int*)values)[1] != 4)
+    {
+        fprintf(stderr, "ParamDict array reference after reload failed\n");
+        return -1;
+    }
+    return 0;
+}
+
+static int test_paramdict_reload()
+{
+    const char* text = "0=42 1=1.5 2=3,4 3=hello 31=31\r\nReLU next 1 1 in out\r\n4=7\r\nClip last 1 1 out final\r\n";
+
+    // three consecutive parameter blocks, with no parameters in the last block
+    const int words[] = {0, 42, 1, 0x3fc00000, -23302, 2, 3, 4, -23403, 5, 0x6c6c6568, 0x6f, 31, 31, -233, 4, 7, -233, -233};
+    std::vector<unsigned char> data;
+    for (size_t i = 0; i < sizeof(words) / sizeof(words[0]); i++)
+        append_param_word(data, words[i]);
+
+    for (int mode = 0; mode < 4; mode++)
+    {
+        const bool binary = mode >= 2;
+        const unsigned char* ptr = binary ? data.data() : (const unsigned char*)text;
+        int ret;
+        if (mode % 2 == 0)
+        {
+            ncnn::DataReaderFromMemory dr(ptr);
+            ret = check_paramdict_reload(dr, binary);
+        }
+        else
+        {
+#if NCNN_STDIO
+            FILE* fp = make_param_file(ptr, binary ? data.size() : strlen(text));
+            if (!fp)
+                return -1;
+            ncnn::DataReaderFromStdio dr(fp);
+            ret = check_paramdict_reload(dr, binary);
+            fclose(fp);
+#else
+            continue;
+#endif
+        }
+        if (ret != 0)
+        {
+            fprintf(stderr, "ParamDict reload failed mode=%d\n", mode);
+            return -1;
+        }
+    }
+    return 0;
+}
+
 static int test_paramdict_binary_bounds()
 {
     const int ids[] = {-23304, -23404};
@@ -1022,7 +1159,10 @@ static int test_paramdict_binary_bounds()
         BoundedParamReader reader(data.data(), data.size());
         ParamDictTest pd;
         if (pd.load_param_bin(reader) == 0)
+        {
+            fprintf(stderr, "ParamDict invalid binary id accepted %d\n", invalid_ids[i]);
             return -1;
+        }
     }
 
     const int invalid_string_lengths[] = {256, INT_MAX};
@@ -1034,7 +1174,10 @@ static int test_paramdict_binary_bounds()
         BoundedParamReader reader(data.data(), data.size());
         ParamDictTest pd;
         if (pd.load_param_bin(reader) == 0)
+        {
+            fprintf(stderr, "ParamDict oversized binary string accepted len=%d\n", invalid_string_lengths[i]);
             return -1;
+        }
     }
 
     if (sizeof(size_t) == 4)
@@ -1045,7 +1188,10 @@ static int test_paramdict_binary_bounds()
         BoundedParamReader reader(data.data(), data.size());
         ParamDictTest pd;
         if (pd.load_param_bin(reader) == 0 || check_text_result("-23300=1073741824", false))
+        {
+            fprintf(stderr, "ParamDict overflowing array byte count accepted\n");
             return -1;
+        }
     }
 
     // untyped binary scalars/arrays remain readable as both int and float
@@ -1064,11 +1210,19 @@ static int test_paramdict_binary_bounds()
     append_param_word(data, 0x64636261); // only 'a' belongs to the string; padding is nonzero
     append_param_word(data, -23405);
     append_param_word(data, 3);
-    append_param_word(data, 0x7f620061); // embedded NUL is part of the declared length
+    append_param_word(data, 0x7f620061); // an embedded NUL terminates the text string
     append_param_word(data, -23406);
     append_param_word(data, 255);
     for (int i = 0; i < 256; i++)
         data.push_back('q');
+    append_param_word(data, -23407);
+    append_param_word(data, 4);
+    append_param_word(data, 0x63626100); // a leading NUL produces an empty string
+    append_param_word(data, -23408);
+    append_param_word(data, 4);
+    append_param_word(data, 0x322c0031); // the expression suffix after NUL must not become visible
+    append_param_word(data, 9);
+    append_param_word(data, 99);
     append_param_word(data, -233);
     ParamDictTest pd;
     BoundedParamReader reader(data.data(), data.size());
@@ -1076,10 +1230,14 @@ static int test_paramdict_binary_bounds()
             || pd.get(1, ncnn::Mat()).w != 1 || pd.get(1, ncnn::Mat())[0] != 1.f
             || pd.type(2) != 4 || !pd.get(2, ncnn::Mat()).empty()
             || pd.type(3) != 7 || pd.get(3, std::string("default")) != ""
-            || pd.get(4, std::string()) != "a" || pd.get(5, std::string()).size() != 3
-            || pd.get(5, std::string())[0] != 'a' || pd.get(5, std::string())[1] != '\0' || pd.get(5, std::string())[2] != 'b'
-            || pd.get(6, std::string()) != make_param_string(255, 'q'))
+            || pd.get(4, std::string()) != "a" || pd.get(5, std::string()) != "a"
+            || pd.get(6, std::string()) != make_param_string(255, 'q')
+            || pd.type(7) != 7 || pd.get(7, std::string("default")) != ""
+            || pd.get(8, std::string()) != "1" || pd.get(9, 0) != 99)
+    {
+        fprintf(stderr, "ParamDict binary boundary values failed\n");
         return -1;
+    }
 
     // every truncation, including missing EOP and short scalar/array/string data, fails
     for (size_t size = 0; size < data.size(); size++)
@@ -1109,5 +1267,6 @@ int main()
            || test_paramdict_invalid_text()
            || test_paramdict_text_boundaries()
            || test_paramdict_float_boundaries()
+           || test_paramdict_reload()
            || test_paramdict_binary_bounds();
 }

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -818,11 +818,16 @@ static int test_paramdict_invalid_text()
         if (check_text_result(malformed[i], false))
             return -1;
 
-    const std::string long_number = "0=0." + make_param_string(128, '0') + "1";
+    std::string long_number = "0=0.";
+    long_number += make_param_string(128, '0');
+    long_number += "1";
     if (check_text_result(long_number.c_str(), false))
         return -1;
-    const std::string long_string = "0=" + make_param_string(256, 'a');
-    const std::string long_quoted = "0=\"" + make_param_string(256, 'a') + "\"";
+    std::string long_string = "0=";
+    long_string += make_param_string(256, 'a');
+    std::string long_quoted = "0=\"";
+    long_quoted += make_param_string(256, 'a');
+    long_quoted += "\"";
     if (check_text_result(long_string.c_str(), false) || check_text_result(long_quoted.c_str(), false))
         return -1;
     return 0;
@@ -859,7 +864,9 @@ static int test_paramdict_text_boundaries()
         const std::string value = make_param_string(lengths[i], 'x');
         for (int quoted = 0; quoted < 2; quoted++)
         {
-            const std::string input = quoted ? "0=\"" + value + "\" 1=19" : "0=" + value + " 1=19";
+            std::string input = quoted ? "0=\"" : "0=";
+            input += value;
+            input += quoted ? "\" 1=19" : " 1=19";
             if (check_text_result(input.c_str(), true) || pd.load_param(input.c_str())
                     || pd.get(0, std::string()) != value || pd.get(1, 0) != 19)
             {

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -715,13 +715,13 @@ static int test_paramdict_access()
             return -1;
         }
     }
-    if (pd.get(0, 0) != 10 || pd.get(31, 0) != 31)
+    if (pd.get(0, 0) != 10 || pd.get(0, 7.f) != 10.f || pd.get(31, 0) != 31)
     {
         fprintf(stderr, "ParamDict valid id access failed\n");
         return -1;
     }
 
-    if (pd.get(0, 7.f) != 7.f || pd.get(1, 7) != 7
+    if (pd.get(1, 7) != 7
             || pd.get(2, 7) != 7 || pd.get(2, 7.f) != 7.f
             || pd.get(3, 7) != 7 || pd.get(3, 7.f) != 7.f
             || pd.get(0, array).data != array.data || pd.get(0, text) != text
@@ -741,8 +741,11 @@ static int test_paramdict_access()
     assigned = pd;
     const ncnn::ParamDict& alias = assigned;
     assigned = alias;
-    if (!copied.get(2, ncnn::Mat()).empty() || copied.get(3, std::string()) != ""
-            || !assigned.get(2, ncnn::Mat()).empty() || assigned.get(3, std::string()) != ""
+    ncnn::Mat fallback_array(1);
+    ((int*)fallback_array)[0] = 99;
+    const std::string fallback_text = "fallback";
+    if (copied.get(2, fallback_array).data != fallback_array.data || copied.get(3, fallback_text) != fallback_text
+            || assigned.get(2, fallback_array).data != fallback_array.data || assigned.get(3, fallback_text) != fallback_text
             || copied.get(2, 0) != 22 || assigned.get(3, 0) != 33)
     {
         fprintf(stderr, "ParamDict retagged copy access failed\n");
@@ -759,29 +762,34 @@ static int test_paramdict_access()
     return 0;
 }
 
-static int test_paramdict_zero_type()
+static int test_paramdict_numeric_conversion()
 {
-    const char* text = "0=0 1=0.0";
-    for (int mode = 0; mode < 2; mode++)
-    {
-        ParamDictTest pd;
-        if (mode == 0)
+    const int integers[] = {0, 6, -6, 16777217, INT_MIN, INT_MAX};
+    const float expected[] = {0.f, 6.f, -6.f, 16777216.f, -2147483648.f, 2147483648.f};
+    for (size_t j = 0; j < sizeof(integers) / sizeof(integers[0]); j++)
+        for (int mode = 0; mode < 2; mode++)
         {
-            pd.set(0, 0);
-            pd.set(1, 0.f);
-        }
-        else
-        {
-            if (pd.load_param(text))
+            ParamDictTest pd;
+            if (mode == 0)
+            {
+                pd.set(0, integers[j]);
+                pd.set(1, 0.f);
+            }
+            else
+            {
+                char text[64];
+                snprintf(text, sizeof(text), "0=%d 1=0.0", integers[j]);
+                if (pd.load_param(text))
+                    return -1;
+            }
+            if (pd.get(0, 7.f) != expected[j] || pd.type(0) != 2 || pd.get(0, 7) != integers[j]
+                    || pd.type(1) != 3 || pd.get(1, 7.f) != 0.f || pd.get(1, 7) != 7
+                    || pd.get(2, 7.f) != 7.f)
+            {
+                fprintf(stderr, "ParamDict numeric conversion failed value=%d mode=%d\n", integers[j], mode);
                 return -1;
+            }
         }
-        if (pd.type(0) != 2 || pd.get(0, 7) != 0 || pd.get(0, 7.f) != 7.f
-                || pd.type(1) != 3 || pd.get(1, 7.f) != 0.f || pd.get(1, 7) != 7)
-        {
-            fprintf(stderr, "ParamDict zero type access failed mode=%d\n", mode);
-            return -1;
-        }
-    }
     return 0;
 }
 
@@ -884,6 +892,22 @@ static int test_paramdict_text_boundaries()
         }
     }
 
+    // accept signs, leading zeroes and trailing commas without changing element types
+    if (pd.load_param("0=+7 1=0007 -23302=1,+2 3=1,2, 4=+1.5 5=1.0,2.0,"))
+        return -1;
+    a = pd.get(2, ncnn::Mat());
+    b = pd.get(3, ncnn::Mat());
+    c = pd.get(5, ncnn::Mat());
+    if (pd.type(0) != 2 || pd.get(0, 0) != 7 || pd.type(1) != 2 || pd.get(1, 0) != 7
+            || pd.type(2) != 5 || a.w != 1 || ((const int*)a)[0] != 2
+            || pd.type(3) != 5 || b.w != 2 || ((const int*)b)[0] != 1 || ((const int*)b)[1] != 2
+            || pd.type(4) != 3 || pd.get(4, 0.f) != 1.5f
+            || pd.type(5) != 6 || c.w != 2 || c[0] != 1.f || c[1] != 2.f)
+    {
+        fprintf(stderr, "ParamDict numeric spelling failed\n");
+        return -1;
+    }
+
     // lines may end at a read-buffer boundary or split a quoted/numeric token across it
     const int line_lengths[] = {1022, 1023, 1024, 1035, 1048, 2046, 2047};
     for (size_t j = 0; j < sizeof(line_lengths) / sizeof(line_lengths[0]); j++)
@@ -981,13 +1005,19 @@ static int check_float_boundary(const char* text, float expected, int count, boo
 
 static int test_paramdict_float_boundaries()
 {
-    // old array elements retain the full numeric token limit
+    // old and modern array elements retain the full numeric token limit
     for (int len = 127; len <= 128; len++)
     {
         std::string text = "-23300=1,0.";
         text += make_param_string(len - 2, '0');
         text += " 1=42\nReLU next 1 1 in out\n";
         if (check_float_boundary(text.c_str(), 0.f, 1, len == 127))
+            return -1;
+
+        text = "0=0.0,1.";
+        text += make_param_string(len - 2, '0');
+        text += " 1=42\nReLU next 1 1 in out\n";
+        if (check_float_boundary(text.c_str(), 0.f, 2, len == 127))
             return -1;
     }
 
@@ -999,13 +1029,13 @@ static int test_paramdict_float_boundaries()
         "340282356779733661637539395458142568447.0", "340282356779733661637539395458142568448.0",
         "340282356779733661637539395458142568449.0",
         "0.000340282356779733661637539395458142568447e42",
-        "000340282356779733661637539395458142568448e0"
+        "000340282356779733661637539395458142568448e0", "1e-46"
     };
     const float expected[] = {
         32768.015625f, 32768.015625f, 32768.01953125f, 32768.01953125f, 32768.0234375f, 32768.0234375f,
-        FLT_MAX, FLT_MAX, FLT_MAX, 3.402823e38f, 0.f, 0.f, FLT_MAX, 0.f, FLT_MAX, 0.f, 0.f, FLT_MAX, 0.f
+        FLT_MAX, FLT_MAX, FLT_MAX, 3.402823e38f, 0.f, 0.f, FLT_MAX, 0.f, FLT_MAX, 0.f, 0.f, FLT_MAX, 0.f, 0.f
     };
-    const bool valid[] = {true, true, true, true, true, true, true, true, true, true, false, false, true, false, true, false, false, true, false};
+    const bool valid[] = {true, true, true, true, true, true, true, true, true, true, false, false, true, false, true, false, false, true, false, true};
     for (size_t i = 0; i < sizeof(numbers) / sizeof(numbers[0]); i++)
         for (int negative = 0; negative < 2; negative++)
         {
@@ -1178,7 +1208,7 @@ static int test_paramdict_reload()
     {
         const bool binary = mode == 2;
         const char* input = mode == 0 ? text : old_array_text;
-        const unsigned char* ptr = binary ? data.data() : (const unsigned char*)input;
+        const unsigned char* ptr = binary ? &data[0] : (const unsigned char*)input;
         ncnn::DataReaderFromMemory dr(ptr);
         const int ret = check_paramdict_reload(dr, binary);
         if (ret != 0)
@@ -1201,7 +1231,7 @@ static int test_paramdict_binary_bounds()
             append_param_word(data, ids[i]);
             append_param_word(data, lengths[j]);
             append_param_word(data, -233);
-            BoundedParamReader reader(data.data(), data.size());
+            BoundedParamReader reader(&data[0], data.size());
             ParamDictTest pd;
             if (pd.load_param_bin(reader) == 0)
             {
@@ -1216,7 +1246,7 @@ static int test_paramdict_binary_bounds()
         std::vector<unsigned char> data;
         append_param_word(data, invalid_ids[i]);
         append_param_word(data, -233);
-        BoundedParamReader reader(data.data(), data.size());
+        BoundedParamReader reader(&data[0], data.size());
         ParamDictTest pd;
         if (pd.load_param_bin(reader) == 0)
         {
@@ -1231,7 +1261,7 @@ static int test_paramdict_binary_bounds()
         std::vector<unsigned char> data;
         append_param_word(data, -23400);
         append_param_word(data, invalid_string_lengths[i]);
-        BoundedParamReader reader(data.data(), data.size());
+        BoundedParamReader reader(&data[0], data.size());
         ParamDictTest pd;
         if (pd.load_param_bin(reader) == 0)
         {
@@ -1245,7 +1275,7 @@ static int test_paramdict_binary_bounds()
         std::vector<unsigned char> data;
         append_param_word(data, -23300);
         append_param_word(data, 0x40000000); // byte count wraps on 32-bit targets
-        BoundedParamReader reader(data.data(), data.size());
+        BoundedParamReader reader(&data[0], data.size());
         ParamDictTest pd;
         if (pd.load_param_bin(reader) == 0 || check_text_result("-23300=1073741824", false))
         {
@@ -1285,7 +1315,7 @@ static int test_paramdict_binary_bounds()
     append_param_word(data, 99);
     append_param_word(data, -233);
     ParamDictTest pd;
-    BoundedParamReader reader(data.data(), data.size());
+    BoundedParamReader reader(&data[0], data.size());
     if (pd.load_param_bin(reader) || pd.get(0, 0) != 0x3f800000 || pd.get(0, 0.f) != 1.f
             || pd.get(1, ncnn::Mat()).w != 1 || pd.get(1, ncnn::Mat())[0] != 1.f
             || pd.type(2) != 4 || !pd.get(2, ncnn::Mat()).empty()
@@ -1308,7 +1338,7 @@ static int test_paramdict_binary_bounds()
     // every truncation, including missing EOP and short scalar/array/string data, fails
     for (size_t size = 0; size < data.size(); size++)
     {
-        BoundedParamReader truncated(data.data(), size);
+        BoundedParamReader truncated(&data[0], size);
         ParamDictTest partial;
         if (partial.load_param_bin(truncated) == 0)
         {
@@ -1330,7 +1360,7 @@ int main()
            || test_paramdict_5()
            || test_paramdict_6()
            || test_paramdict_access()
-           || test_paramdict_zero_type()
+           || test_paramdict_numeric_conversion()
            || test_paramdict_invalid_text()
            || test_paramdict_text_boundaries()
            || test_paramdict_float_boundaries()

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <limits.h>
+#include <float.h>
 #include <string.h>
 
 #include "datareader.h"
@@ -872,6 +873,95 @@ static int test_paramdict_text_boundaries()
     return 0;
 }
 
+static int check_float_boundary(const char* text, float expected, int count, bool valid)
+{
+    for (int backend = 0; backend < 2; backend++)
+    {
+        ParamDictTest pd;
+        int ret;
+        if (backend == 0)
+        {
+            ret = pd.load_param(text);
+        }
+        else
+        {
+#if NCNN_STDIO
+            FILE* fp = tmpfile();
+            if (!fp)
+                return -1;
+            fwrite(text, 1, strlen(text), fp);
+            rewind(fp);
+            ncnn::DataReaderFromStdio dr(fp);
+            ret = pd.load_param(dr);
+            fclose(fp);
+#else
+            continue;
+#endif
+        }
+        if ((ret == 0) != valid)
+        {
+            fprintf(stderr, "ParamDict float boundary parse failed backend=%d: %s\n", backend, text);
+            return -1;
+        }
+        if (!valid)
+            continue;
+
+        bool matches;
+        if (count == 0)
+        {
+            matches = pd.type(0) == 3 && pd.get(0, 0.f) == expected;
+        }
+        else
+        {
+            const ncnn::Mat values = pd.get(0, ncnn::Mat());
+            matches = pd.type(0) == 6 && values.w == count && values[0] == expected;
+            if (matches && count == 2)
+                matches = values[1] == 1.f;
+        }
+        if (!matches)
+        {
+            fprintf(stderr, "ParamDict float boundary value failed backend=%d: %s\n", backend, text);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int test_paramdict_float_boundaries()
+{
+    const char* numbers[] = {"3.40282347e+38", "3.4028235e38", "3.40282356e38", "3.402823e38", "3.40282357e38", "1e39"};
+    const float expected[] = {FLT_MAX, FLT_MAX, FLT_MAX, 3.402823e38f, 0.f, 0.f};
+    const bool valid[] = {true, true, true, true, false, false};
+    for (size_t i = 0; i < sizeof(numbers) / sizeof(numbers[0]); i++)
+        for (int negative = 0; negative < 2; negative++)
+        {
+            char text[128];
+            const char* sign = negative ? "-" : "";
+            const float value = negative ? -expected[i] : expected[i];
+            snprintf(text, sizeof(text), "0=%s%s", sign, numbers[i]);
+            if (check_float_boundary(text, value, 0, valid[i]))
+                return -1;
+            snprintf(text, sizeof(text), "0=%s%s,1.0", sign, numbers[i]);
+            if (check_float_boundary(text, value, 2, valid[i]))
+                return -1;
+            snprintf(text, sizeof(text), "-23300=1,%s%s", sign, numbers[i]);
+            if (check_float_boundary(text, value, 1, valid[i]))
+                return -1;
+        }
+
+    // nine significant digits must round trip the largest finite float
+    const float values[] = {FLT_MAX, -FLT_MAX};
+    for (size_t i = 0; i < sizeof(values) / sizeof(values[0]); i++)
+    {
+        char text[64];
+        snprintf(text, sizeof(text), "0=%.9g", values[i]);
+        if (check_float_boundary(text, values[i], 0, true))
+            return -1;
+    }
+    return 0;
+}
+
+// short-read coverage requires a reader that knows the input size
 class BoundedParamReader : public ncnn::DataReader
 {
 public:
@@ -1018,5 +1108,6 @@ int main()
            || test_paramdict_access()
            || test_paramdict_invalid_text()
            || test_paramdict_text_boundaries()
+           || test_paramdict_float_boundaries()
            || test_paramdict_binary_bounds();
 }

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <stdio.h>
+#include <limits.h>
+#include <string.h>
 
 #include "datareader.h"
 #include "paramdict.h"
@@ -9,6 +11,8 @@
 class ParamDictTest : public ncnn::ParamDict
 {
 public:
+    using ncnn::ParamDict::load_param;
+    using ncnn::ParamDict::load_param_bin;
     int load_param(const char* str);
     int load_param_bin(const unsigned char* mem);
 };
@@ -536,12 +540,14 @@ static int test_paramdict_5()
 
 static int compare_paramdict(const ncnn::ParamDict& pd, const ncnn::ParamDict& pd0)
 {
-    for (int id = 0;; id++)
+    for (int id = 0; id < NCNN_MAX_PARAM_COUNT; id++)
     {
         const int type0 = pd0.type(id);
         if (type0 == 0)
         {
-            break;
+            if (pd.type(id) != 0)
+                return -1;
+            continue;
         }
         else if (type0 == 2)
         {
@@ -556,14 +562,14 @@ static int compare_paramdict(const ncnn::ParamDict& pd, const ncnn::ParamDict& p
         else if (type0 == 3)
         {
             const float f0 = pd0.get(id, 0.f);
-            int f = pd.get(id, 0.f);
+            float f = pd.get(id, 0.f);
             if (f != f0)
             {
                 fprintf(stderr, "compare_paramdict float failed %f != %f\n", f, f0);
                 return -1;
             }
         }
-        else if (type0 == 5)
+        else if (type0 == 4 || type0 == 5)
         {
             const ncnn::Mat ai0 = pd0.get(id, ncnn::Mat());
             ncnn::Mat ai = pd.get(id, ncnn::Mat());
@@ -678,6 +684,326 @@ static int test_paramdict_6()
     return 0;
 }
 
+static int test_paramdict_access()
+{
+    ncnn::ParamDict pd;
+    ncnn::Mat array(1);
+    ((int*)array)[0] = 17;
+    const std::string text = "text";
+    pd.set(0, 10);
+    pd.set(1, 2.5f);
+    pd.set(2, array);
+    pd.set(3, text);
+    pd.set(31, 31);
+
+    const int invalid_ids[] = {INT_MIN, -1, NCNN_MAX_PARAM_COUNT, INT_MAX};
+    for (size_t j = 0; j < sizeof(invalid_ids) / sizeof(invalid_ids[0]); j++)
+    {
+        const int id = invalid_ids[j];
+        pd.set(id, 1);
+        pd.set(id, 1.f);
+        pd.set(id, array);
+        pd.set(id, text);
+        if (pd.type(id) != 0 || pd.get(id, 7) != 7 || pd.get(id, 7.f) != 7.f
+            || pd.get(id, array).data != array.data || pd.get(id, text) != text)
+        {
+            fprintf(stderr, "ParamDict invalid id access failed %d\n", id);
+            return -1;
+        }
+    }
+    if (pd.get(0, 0) != 10 || pd.get(31, 0) != 31)
+        return -1;
+
+    if (pd.get(0, 7.f) != 7.f || pd.get(1, 7) != 7
+        || pd.get(2, 7) != 7 || pd.get(2, 7.f) != 7.f
+        || pd.get(3, 7) != 7 || pd.get(3, 7.f) != 7.f
+        || pd.get(0, array).data != array.data || pd.get(0, text) != text
+        || pd.get(3, array).data != array.data || pd.get(2, text) != text)
+    {
+        fprintf(stderr, "ParamDict mismatched type access failed\n");
+        return -1;
+    }
+
+    // retagging and copying must not expose an earlier array or string value
+    pd.set(2, 22);
+    pd.set(3, 33);
+    ncnn::ParamDict copied(pd);
+    ncnn::ParamDict assigned;
+    assigned.set(2, array);
+    assigned.set(3, text);
+    assigned = pd;
+    assigned = assigned;
+    if (!copied.get(2, ncnn::Mat()).empty() || copied.get(3, std::string()) != ""
+        || !assigned.get(2, ncnn::Mat()).empty() || assigned.get(3, std::string()) != ""
+        || copied.get(2, 0) != 22 || assigned.get(3, 0) != 33)
+    {
+        fprintf(stderr, "ParamDict retagged copy access failed\n");
+        return -1;
+    }
+    return 0;
+}
+
+static int check_text_result(const char* text, bool valid)
+{
+    ParamDictTest memory;
+    if ((memory.load_param(text) == 0) != valid)
+    {
+        fprintf(stderr, "ParamDict memory parse result failed: %s\n", text);
+        return -1;
+    }
+#if NCNN_STDIO
+    // fscanf and sscanf have different consumption behavior on failed matches
+    FILE* fp = tmpfile();
+    if (!fp)
+        return -1;
+    fwrite(text, 1, strlen(text), fp);
+    rewind(fp);
+    ncnn::DataReaderFromStdio dr(fp);
+    ParamDictTest stdio;
+    const int ret = stdio.load_param(dr);
+    fclose(fp);
+    if ((ret == 0) != valid)
+    {
+        fprintf(stderr, "ParamDict stdio parse result failed: %s\n", text);
+        return -1;
+    }
+#endif
+    return 0;
+}
+
+static std::string make_param_string(size_t len, char c)
+{
+    std::string s;
+    s.resize(len);
+    for (size_t i = 0; i < len; i++)
+        s[i] = c;
+    return s;
+}
+
+static int test_paramdict_invalid_text()
+{
+    const char* malformed[] = {
+        "-23304=-4", "-23304=-1", "-23304=-2147483648", "-23304=2147483648",
+        "-2147483648=0", "2147483648=0", "999999999999999999999=0", "32=0", "-1=0", "-23332=0",
+        "0", "0 1", "0=", "+=1", "0=2147483648", "0=-2147483649", "0=1junk", "0=1.0junk",
+        "0=.", "0=-", "0=--1", "0=1e", "0=1e+", "0=1.2.3", "0=1e4294967295", "0=1e39",
+        "0=\"", "0=\"unterminated", "0=\"abc\n", "0=\"abc\"suffix", "0=\"abc\"1=2",
+        "-23300=1", "-23300=2,1", "-23300=1,1,2", "-23300=0,1", "-23300=1x,2",
+        "0=1,,2", "0=1,2x", "0=1,2.5", "-23300=2,1,2.5", "0=1.0,2e", "-23300=1,1e+"
+    };
+    for (size_t i = 0; i < sizeof(malformed) / sizeof(malformed[0]); i++)
+        if (check_text_result(malformed[i], false))
+            return -1;
+
+    const std::string long_number = "0=0." + make_param_string(128, '0') + "1";
+    if (check_text_result(long_number.c_str(), false))
+        return -1;
+    const std::string long_string = "0=" + make_param_string(256, 'a');
+    const std::string long_quoted = "0=\"" + make_param_string(256, 'a') + "\"";
+    if (check_text_result(long_string.c_str(), false) || check_text_result(long_quoted.c_str(), false))
+        return -1;
+    return 0;
+}
+
+static int test_paramdict_text_boundaries()
+{
+    ParamDictTest pd;
+    const char* text = "0=-2147483648\t1=2147483647\r\n2=\"\" 3=\" \" 4=1.0,2,-3 5=7, -23306=2,1.0,2 -23307=0 8=0e9999999999 9=1e-9999999999 10=.5 11=4294967296.0";
+    if (check_text_result(text, true) || pd.load_param(text))
+        return -1;
+    if (pd.get(0, 0) != INT_MIN || pd.get(1, 0) != INT_MAX
+        || pd.type(2) != 7 || pd.get(2, std::string("default")) != "" || pd.get(3, std::string()) != " "
+        || pd.type(7) != 4 || !pd.get(7, ncnn::Mat()).empty()
+        || pd.get(8, 1.f) != 0.f || pd.get(9, 1.f) != 0.f || pd.get(10, 0.f) != 0.5f
+        || pd.get(11, 0.f) != 4294967296.f)
+        return -1;
+    ncnn::Mat a = pd.get(4, ncnn::Mat());
+    ncnn::Mat b = pd.get(5, ncnn::Mat());
+    ncnn::Mat c = pd.get(6, ncnn::Mat());
+    if (a.w != 3 || a[0] != 1.f || a[1] != 2.f || a[2] != -3.f
+        || b.w != 1 || ((const int*)b)[0] != 7 || c.w != 2 || c[0] != 1.f || c[1] != 2.f)
+        return -1;
+
+    const int lengths[] = {1, 14, 15, 16, 240, 241, 254, 255};
+    for (size_t i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++)
+    {
+        const std::string value = make_param_string(lengths[i], 'x');
+        for (int quoted = 0; quoted < 2; quoted++)
+        {
+            const std::string input = quoted ? "0=\"" + value + "\" 1=19" : "0=" + value + " 1=19";
+            if (check_text_result(input.c_str(), true) || pd.load_param(input.c_str())
+                || pd.get(0, std::string()) != value || pd.get(1, 0) != 19)
+            {
+                fprintf(stderr, "ParamDict string boundary failed len=%d quoted=%d\n", lengths[i], quoted);
+                return -1;
+            }
+        }
+    }
+
+    // leave the next layer header untouched for the caller
+    const unsigned char* ptr = (const unsigned char*)"0=42\nReLU next 1 1 in out\n";
+    ncnn::DataReaderFromMemory reader(ptr);
+    char layer_type[5];
+    if (pd.load_param(reader) || pd.get(0, 0) != 42 || reader.scan("%4s", layer_type) != 1 || strcmp(layer_type, "ReLU"))
+        return -1;
+
+    // exercise array growth and the final copy for both element types
+    const int array_lengths[] = {16, 17, 32, 33, 257};
+    for (size_t j = 0; j < sizeof(array_lengths) / sizeof(array_lengths[0]); j++)
+        for (int floating = 0; floating < 2; floating++)
+        {
+            std::string input = "0=";
+            for (int i = 0; i < array_lengths[j]; i++)
+            {
+                char value[32];
+                snprintf(value, sizeof(value), "%s%d%s", i ? "," : "", i, floating ? ".0" : "");
+                input += value;
+            }
+            input += " 1=42";
+            if (check_text_result(input.c_str(), true) || pd.load_param(input.c_str()) || pd.get(1, 0) != 42)
+                return -1;
+            const ncnn::Mat values = pd.get(0, ncnn::Mat());
+            if (values.w != array_lengths[j])
+                return -1;
+            for (int i = 0; i < values.w; i++)
+                if (floating ? values[i] != (float)i : ((const int*)values)[i] != i)
+                    return -1;
+        }
+    return 0;
+}
+
+class BoundedParamReader : public ncnn::DataReader
+{
+public:
+    BoundedParamReader(const unsigned char* data, size_t size)
+        : ptr(data), remaining(size)
+    {
+    }
+    virtual size_t read(void* buf, size_t size) const
+    {
+        const size_t n = std::min(size, remaining);
+        if (n != 0)
+        {
+            memcpy(buf, ptr, n);
+            ptr += n;
+            remaining -= n;
+        }
+        return n;
+    }
+private:
+    mutable const unsigned char* ptr;
+    mutable size_t remaining;
+};
+
+static void append_param_word(std::vector<unsigned char>& bytes, int value)
+{
+    const unsigned int v = (unsigned int)value;
+    for (int i = 0; i < 4; i++)
+        bytes.push_back((v >> (i * 8)) & 255);
+}
+
+static int test_paramdict_binary_bounds()
+{
+    const int ids[] = {-23304, -23404};
+    const int lengths[] = {-1, -4, -8, INT_MIN};
+    for (size_t i = 0; i < sizeof(ids) / sizeof(ids[0]); i++)
+        for (size_t j = 0; j < sizeof(lengths) / sizeof(lengths[0]); j++)
+        {
+            std::vector<unsigned char> data;
+            append_param_word(data, ids[i]);
+            append_param_word(data, lengths[j]);
+            append_param_word(data, -233);
+            BoundedParamReader reader(data.data(), data.size());
+            ParamDictTest pd;
+            if (pd.load_param_bin(reader) == 0)
+            {
+                fprintf(stderr, "ParamDict negative binary length accepted id=%d len=%d\n", ids[i], lengths[j]);
+                return -1;
+            }
+        }
+
+    const int invalid_ids[] = {INT_MIN, -1, 32, INT_MAX, -23332, -23432};
+    for (size_t i = 0; i < sizeof(invalid_ids) / sizeof(invalid_ids[0]); i++)
+    {
+        std::vector<unsigned char> data;
+        append_param_word(data, invalid_ids[i]);
+        append_param_word(data, -233);
+        BoundedParamReader reader(data.data(), data.size());
+        ParamDictTest pd;
+        if (pd.load_param_bin(reader) == 0)
+            return -1;
+    }
+
+    const int invalid_string_lengths[] = {256, INT_MAX};
+    for (size_t i = 0; i < sizeof(invalid_string_lengths) / sizeof(invalid_string_lengths[0]); i++)
+    {
+        std::vector<unsigned char> data;
+        append_param_word(data, -23400);
+        append_param_word(data, invalid_string_lengths[i]);
+        BoundedParamReader reader(data.data(), data.size());
+        ParamDictTest pd;
+        if (pd.load_param_bin(reader) == 0)
+            return -1;
+    }
+
+    if (sizeof(size_t) == 4)
+    {
+        std::vector<unsigned char> data;
+        append_param_word(data, -23300);
+        append_param_word(data, 0x40000000); // byte count wraps on 32-bit targets
+        BoundedParamReader reader(data.data(), data.size());
+        ParamDictTest pd;
+        if (pd.load_param_bin(reader) == 0 || check_text_result("-23300=1073741824", false))
+            return -1;
+    }
+
+    // untyped binary scalars/arrays remain readable as both int and float
+    std::vector<unsigned char> data;
+    append_param_word(data, 0);
+    append_param_word(data, 0x3f800000);
+    append_param_word(data, -23301);
+    append_param_word(data, 1);
+    append_param_word(data, 0x3f800000);
+    append_param_word(data, -23302);
+    append_param_word(data, 0);
+    append_param_word(data, -23403);
+    append_param_word(data, 0);
+    append_param_word(data, -23404);
+    append_param_word(data, 1);
+    append_param_word(data, 0x64636261); // only 'a' belongs to the string; padding is nonzero
+    append_param_word(data, -23405);
+    append_param_word(data, 3);
+    append_param_word(data, 0x7f620061); // embedded NUL is part of the declared length
+    append_param_word(data, -23406);
+    append_param_word(data, 255);
+    for (int i = 0; i < 256; i++)
+        data.push_back('q');
+    append_param_word(data, -233);
+    ParamDictTest pd;
+    BoundedParamReader reader(data.data(), data.size());
+    if (pd.load_param_bin(reader) || pd.get(0, 0) != 0x3f800000 || pd.get(0, 0.f) != 1.f
+        || pd.get(1, ncnn::Mat()).w != 1 || pd.get(1, ncnn::Mat())[0] != 1.f
+        || pd.type(2) != 4 || !pd.get(2, ncnn::Mat()).empty()
+        || pd.type(3) != 7 || pd.get(3, std::string("default")) != ""
+        || pd.get(4, std::string()) != "a" || pd.get(5, std::string()).size() != 3
+        || pd.get(5, std::string())[0] != 'a' || pd.get(5, std::string())[1] != '\0' || pd.get(5, std::string())[2] != 'b'
+        || pd.get(6, std::string()) != make_param_string(255, 'q'))
+        return -1;
+
+    // every truncation, including missing EOP and short scalar/array/string data, fails
+    for (size_t size = 0; size < data.size(); size++)
+    {
+        BoundedParamReader truncated(data.data(), size);
+        ParamDictTest partial;
+        if (partial.load_param_bin(truncated) == 0)
+        {
+            fprintf(stderr, "ParamDict truncated binary accepted at %zu\n", size);
+            return -1;
+        }
+    }
+    return 0;
+}
+
 int main()
 {
     return 0
@@ -687,5 +1013,9 @@ int main()
            || test_paramdict_3()
            || test_paramdict_4()
            || test_paramdict_5()
-           || test_paramdict_6();
+           || test_paramdict_6()
+           || test_paramdict_access()
+           || test_paramdict_invalid_text()
+           || test_paramdict_text_boundaries()
+           || test_paramdict_binary_bounds();
 }

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -839,7 +839,7 @@ static int test_paramdict_invalid_text()
 static int test_paramdict_text_boundaries()
 {
     ParamDictTest pd;
-    const char* text = "0=-2147483648\t1=2147483647\r\n2=\"\" 3=\" \" 4=1.0,2.0,-3.0 5=7, -23306=2,1.0,2.0 -23307=0 8=0e9999999999 9=1e-9999999999 10=.5 11=4294967296.0";
+    const char* text = "0=-2147483648\t1=2147483647 2=\"\" 3=\" \" 4=1.0,2.0,-3.0 5=7, -23306=2,1.0,2.0 -23307=0 8=0e9999999999 9=1e-9999999999 10=.5 11=4294967296.0";
     if (check_text_result(text, true) || pd.load_param(text))
         return -1;
     if (pd.get(0, 0) != INT_MIN || pd.get(1, 0) != INT_MAX
@@ -884,8 +884,35 @@ static int test_paramdict_text_boundaries()
         }
     }
 
-    // exercise array growth and the final copy for both element types
-    const int array_lengths[] = {16, 17, 32, 33, 257};
+    // lines may end at a read-buffer boundary or split a quoted/numeric token across it
+    const int line_lengths[] = {1022, 1023, 1024, 1035, 1048, 2046, 2047};
+    for (size_t j = 0; j < sizeof(line_lengths) / sizeof(line_lengths[0]); j++)
+        for (int leading = 0; leading < 2; leading++)
+        {
+            const char* params = "0=\"hello world\" 1=1.25,2.5 2=42";
+            const std::string padding = make_param_string(line_lengths[j] - strlen(params), ' ');
+            std::string input = leading ? padding : std::string(params);
+            input += leading ? std::string(params) : padding;
+            input += "\r\n+Probe next 1 1 in out\n";
+            const unsigned char* ptr = (const unsigned char*)input.c_str();
+            ncnn::DataReaderFromMemory dr(ptr);
+            if (pd.load_param(dr) || pd.get(0, std::string()) != "hello world" || pd.get(2, 0) != 42)
+            {
+                fprintf(stderr, "ParamDict long line failed len=%d leading=%d\n", line_lengths[j], leading);
+                return -1;
+            }
+            const ncnn::Mat values = pd.get(1, ncnn::Mat());
+            char header[64];
+            if (values.w != 2 || values[0] != 1.25f || values[1] != 2.5f
+                    || dr.scan(" %63[^\r\n]", header) != 1 || strcmp(header, "+Probe next 1 1 in out"))
+            {
+                fprintf(stderr, "ParamDict long line array or next header failed\n");
+                return -1;
+            }
+        }
+
+    // exercise stack storage, array growth and the final copy for both element types
+    const int array_lengths[] = {1, 15, 16, 17, 31, 32, 33, 257, 1024};
     for (size_t j = 0; j < sizeof(array_lengths) / sizeof(array_lengths[0]); j++)
         for (int floating = 0; floating < 2; floating++)
         {
@@ -896,6 +923,8 @@ static int test_paramdict_text_boundaries()
                 snprintf(value, sizeof(value), "%s%d%s", i ? "," : "", i, floating ? ".0" : "");
                 input += value;
             }
+            if (array_lengths[j] == 1)
+                input += ",";
             input += " 1=42";
             if (check_text_result(input.c_str(), true) || pd.load_param(input.c_str()) || pd.get(1, 0) != 42)
             {
@@ -952,7 +981,7 @@ static int check_float_boundary(const char* text, float expected, int count, boo
 
 static int test_paramdict_float_boundaries()
 {
-    // combining the comma scan must retain the full numeric token limit
+    // old array elements retain the full numeric token limit
     for (int len = 127; len <= 128; len++)
     {
         std::string text = "-23300=1,0.";
@@ -1072,9 +1101,9 @@ static int check_paramdict_reload(const ncnn::DataReader& dr, bool binary)
         return -1;
     }
 
-    // leave each following layer header for the caller, including after a failed scan
-    char header[64];
-    if (!binary && (dr.scan(" %63[^\r\n]", header) != 1 || strcmp(header, "ReLU next 1 1 in out")))
+    // read each following header without consuming its parameters on the same line
+    char header[64] = {0};
+    if (!binary && (dr.scan(" %20c", header) != 1 || strcmp(header, "ReLU next 1 1 in out")))
     {
         fprintf(stderr, "ParamDict next layer header failed\n");
         return -1;
@@ -1086,7 +1115,7 @@ static int check_paramdict_reload(const ncnn::DataReader& dr, bool binary)
         return -1;
     }
 
-    if (!binary && (dr.scan(" %63[^\r\n]", header) != 1 || strcmp(header, "Clip last 1 1 out final")))
+    if (!binary && (dr.scan(" %23c", header) != 1 || strcmp(header, "Clip last 1 1 out final")))
     {
         fprintf(stderr, "ParamDict last layer header failed\n");
         return -1;
@@ -1107,8 +1136,8 @@ static int check_paramdict_reload(const ncnn::DataReader& dr, bool binary)
 
 static int test_paramdict_reload()
 {
-    // a literal '-' in the id scanset must not consume punctuation in layer types
-    const char* headers[] = {".Custom next 1 1 in out", "/Custom next 1 1 in out", ",Custom next 1 1 in out"};
+    // the next layer name is independent of parameter syntax, even with no parameters
+    const char* headers[] = {".Custom next 1 1 in out", "/Custom next 1 1 in out", ",Custom next 1 1 in out", "+Probe next 1 1 in out", "-Probe next 1 1 in out", "123Probe next 1 1 in out"};
     for (size_t i = 0; i < sizeof(headers) / sizeof(headers[0]); i++)
         for (int empty = 0; empty < 2; empty++)
         {
@@ -1136,8 +1165,8 @@ static int test_paramdict_reload()
             }
         }
 
-    const char* text = "0=42 1=1.5 2=3,4 3=hello 31=31\r\nReLU next 1 1 in out\r\n4=7\r\nClip last 1 1 out final\r\n";
-    const char* old_array_text = "0=42 1=1.5 -23302=2,3,4 3=hello 31=31\r\nReLU next 1 1 in out\r\n4=7\r\nClip last 1 1 out final\r\n";
+    const char* text = "0=42 1=1.5 2=3,4 3=hello 31=31\r\nReLU next 1 1 in out 4=7\r\nClip last 1 1 out final\r\n";
+    const char* old_array_text = "0=42 1=1.5 -23302=2,3,4 3=hello 31=31\r\nReLU next 1 1 in out 4=7\r\nClip last 1 1 out final\r\n";
 
     // three consecutive parameter blocks, with no parameters in the last block
     const int words[] = {0, 42, 1, 0x3fc00000, -23302, 2, 3, 4, -23403, 5, 0x6c6c6568, 0x6f, 31, 31, -233, 4, 7, -233, -233};

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -705,7 +705,7 @@ static int test_paramdict_access()
         pd.set(id, array);
         pd.set(id, text);
         if (pd.type(id) != 0 || pd.get(id, 7) != 7 || pd.get(id, 7.f) != 7.f
-            || pd.get(id, array).data != array.data || pd.get(id, text) != text)
+                || pd.get(id, array).data != array.data || pd.get(id, text) != text)
         {
             fprintf(stderr, "ParamDict invalid id access failed %d\n", id);
             return -1;
@@ -715,10 +715,10 @@ static int test_paramdict_access()
         return -1;
 
     if (pd.get(0, 7.f) != 7.f || pd.get(1, 7) != 7
-        || pd.get(2, 7) != 7 || pd.get(2, 7.f) != 7.f
-        || pd.get(3, 7) != 7 || pd.get(3, 7.f) != 7.f
-        || pd.get(0, array).data != array.data || pd.get(0, text) != text
-        || pd.get(3, array).data != array.data || pd.get(2, text) != text)
+            || pd.get(2, 7) != 7 || pd.get(2, 7.f) != 7.f
+            || pd.get(3, 7) != 7 || pd.get(3, 7.f) != 7.f
+            || pd.get(0, array).data != array.data || pd.get(0, text) != text
+            || pd.get(3, array).data != array.data || pd.get(2, text) != text)
     {
         fprintf(stderr, "ParamDict mismatched type access failed\n");
         return -1;
@@ -734,8 +734,8 @@ static int test_paramdict_access()
     assigned = pd;
     assigned = assigned;
     if (!copied.get(2, ncnn::Mat()).empty() || copied.get(3, std::string()) != ""
-        || !assigned.get(2, ncnn::Mat()).empty() || assigned.get(3, std::string()) != ""
-        || copied.get(2, 0) != 22 || assigned.get(3, 0) != 33)
+            || !assigned.get(2, ncnn::Mat()).empty() || assigned.get(3, std::string()) != ""
+            || copied.get(2, 0) != 22 || assigned.get(3, 0) != 33)
     {
         fprintf(stderr, "ParamDict retagged copy access failed\n");
         return -1;
@@ -812,16 +812,16 @@ static int test_paramdict_text_boundaries()
     if (check_text_result(text, true) || pd.load_param(text))
         return -1;
     if (pd.get(0, 0) != INT_MIN || pd.get(1, 0) != INT_MAX
-        || pd.type(2) != 7 || pd.get(2, std::string("default")) != "" || pd.get(3, std::string()) != " "
-        || pd.type(7) != 4 || !pd.get(7, ncnn::Mat()).empty()
-        || pd.get(8, 1.f) != 0.f || pd.get(9, 1.f) != 0.f || pd.get(10, 0.f) != 0.5f
-        || pd.get(11, 0.f) != 4294967296.f)
+            || pd.type(2) != 7 || pd.get(2, std::string("default")) != "" || pd.get(3, std::string()) != " "
+            || pd.type(7) != 4 || !pd.get(7, ncnn::Mat()).empty()
+            || pd.get(8, 1.f) != 0.f || pd.get(9, 1.f) != 0.f || pd.get(10, 0.f) != 0.5f
+            || pd.get(11, 0.f) != 4294967296.f)
         return -1;
     ncnn::Mat a = pd.get(4, ncnn::Mat());
     ncnn::Mat b = pd.get(5, ncnn::Mat());
     ncnn::Mat c = pd.get(6, ncnn::Mat());
     if (a.w != 3 || a[0] != 1.f || a[1] != 2.f || a[2] != -3.f
-        || b.w != 1 || ((const int*)b)[0] != 7 || c.w != 2 || c[0] != 1.f || c[1] != 2.f)
+            || b.w != 1 || ((const int*)b)[0] != 7 || c.w != 2 || c[0] != 1.f || c[1] != 2.f)
         return -1;
 
     const int lengths[] = {1, 14, 15, 16, 240, 241, 254, 255};
@@ -832,7 +832,7 @@ static int test_paramdict_text_boundaries()
         {
             const std::string input = quoted ? "0=\"" + value + "\" 1=19" : "0=" + value + " 1=19";
             if (check_text_result(input.c_str(), true) || pd.load_param(input.c_str())
-                || pd.get(0, std::string()) != value || pd.get(1, 0) != 19)
+                    || pd.get(0, std::string()) != value || pd.get(1, 0) != 19)
             {
                 fprintf(stderr, "ParamDict string boundary failed len=%d quoted=%d\n", lengths[i], quoted);
                 return -1;
@@ -890,6 +890,7 @@ public:
         }
         return n;
     }
+
 private:
     mutable const unsigned char* ptr;
     mutable size_t remaining;
@@ -982,12 +983,12 @@ static int test_paramdict_binary_bounds()
     ParamDictTest pd;
     BoundedParamReader reader(data.data(), data.size());
     if (pd.load_param_bin(reader) || pd.get(0, 0) != 0x3f800000 || pd.get(0, 0.f) != 1.f
-        || pd.get(1, ncnn::Mat()).w != 1 || pd.get(1, ncnn::Mat())[0] != 1.f
-        || pd.type(2) != 4 || !pd.get(2, ncnn::Mat()).empty()
-        || pd.type(3) != 7 || pd.get(3, std::string("default")) != ""
-        || pd.get(4, std::string()) != "a" || pd.get(5, std::string()).size() != 3
-        || pd.get(5, std::string())[0] != 'a' || pd.get(5, std::string())[1] != '\0' || pd.get(5, std::string())[2] != 'b'
-        || pd.get(6, std::string()) != make_param_string(255, 'q'))
+            || pd.get(1, ncnn::Mat()).w != 1 || pd.get(1, ncnn::Mat())[0] != 1.f
+            || pd.type(2) != 4 || !pd.get(2, ncnn::Mat()).empty()
+            || pd.type(3) != 7 || pd.get(3, std::string("default")) != ""
+            || pd.get(4, std::string()) != "a" || pd.get(5, std::string()).size() != 3
+            || pd.get(5, std::string())[0] != 'a' || pd.get(5, std::string())[1] != '\0' || pd.get(5, std::string())[2] != 'b'
+            || pd.get(6, std::string()) != make_param_string(255, 'q'))
         return -1;
 
     // every truncation, including missing EOP and short scalar/array/string data, fails

--- a/tests/test_paramdict.cpp
+++ b/tests/test_paramdict.cpp
@@ -850,7 +850,7 @@ static int test_paramdict_text_boundaries()
 {
     ParamDictTest pd;
     const char* text = "0=-2147483648\t1=2147483647 2=\"\" 3=\" \" 4=1.0,2.0,-3.0 5=7, -23306=2,1.0,2.0 -23307=0 8=0e9999999999 9=1e-9999999999 10=.5 11=4294967296.0";
-    if (check_text_result(text, true) || pd.load_param(text))
+    if (pd.load_param(text))
         return -1;
     if (pd.get(0, 0) != INT_MIN || pd.get(1, 0) != INT_MAX
             || pd.type(2) != 7 || pd.get(2, std::string("default")) != "" || pd.get(3, std::string()) != " "
@@ -885,7 +885,7 @@ static int test_paramdict_text_boundaries()
             std::string input = quoted ? "0=\"" : "0=";
             input += value;
             input += quoted ? "\" 1=19" : " 1=19";
-            if (check_text_result(input.c_str(), true) || pd.load_param(input.c_str())
+            if (pd.load_param(input.c_str())
                     || pd.get(0, std::string()) != value || pd.get(1, 0) != 19)
             {
                 fprintf(stderr, "ParamDict string boundary failed len=%d quoted=%d\n", lengths[i], quoted);
@@ -952,7 +952,7 @@ static int test_paramdict_text_boundaries()
             if (array_lengths[j] == 1)
                 input += ",";
             input += " 1=42";
-            if (check_text_result(input.c_str(), true) || pd.load_param(input.c_str()) || pd.get(1, 0) != 42)
+            if (pd.load_param(input.c_str()) || pd.get(1, 0) != 42)
             {
                 fprintf(stderr, "ParamDict array growth parse failed len=%d floating=%d\n", array_lengths[j], floating);
                 return -1;
@@ -1023,35 +1023,48 @@ static int test_paramdict_float_boundaries()
             return -1;
     }
 
-    const char* numbers[] = {
+    const struct
+    {
+        const char* text;
+        float expected;
+        bool valid;
+    } cases[] = {
         // exact float midpoints and their decimal neighbors in the old token-length range
-        "32768.017578124", "32768.017578125", "32768.017578126", "32768.021484374", "32768.021484375", "32768.021484376",
-        "3.40282347e+38", "3.4028235e38", "3.40282356e38", "3.402823e38", "3.40282357e38", "1e39",
-        "3.402823567797336e38", "3.402823567797337e38",
-        "340282356779733661637539395458142568447.0", "340282356779733661637539395458142568448.0",
-        "340282356779733661637539395458142568449.0",
-        "0.000340282356779733661637539395458142568447e42",
-        "000340282356779733661637539395458142568448e0", "1e-46"
+        {"32768.017578124", 32768.015625f, true},
+        {"32768.017578125", 32768.015625f, true},
+        {"32768.017578126", 32768.01953125f, true},
+        {"32768.021484374", 32768.01953125f, true},
+        {"32768.021484375", 32768.0234375f, true},
+        {"32768.021484376", 32768.0234375f, true},
+        {"3.40282347e+38", FLT_MAX, true},
+        {"3.4028235e38", FLT_MAX, true},
+        {"3.40282356e38", FLT_MAX, true},
+        {"3.402823e38", 3.402823e38f, true},
+        {"3.40282357e38", 0.f, false},
+        {"1e39", 0.f, false},
+        {"3.402823567797336e38", FLT_MAX, true},
+        {"3.402823567797337e38", 0.f, false},
+        {"340282356779733661637539395458142568447.0", FLT_MAX, true},
+        {"340282356779733661637539395458142568448.0", 0.f, false},
+        {"340282356779733661637539395458142568449.0", 0.f, false},
+        {"0.000340282356779733661637539395458142568447e42", FLT_MAX, true},
+        {"000340282356779733661637539395458142568448e0", 0.f, false},
+        {"1e-46", 0.f, true},
     };
-    const float expected[] = {
-        32768.015625f, 32768.015625f, 32768.01953125f, 32768.01953125f, 32768.0234375f, 32768.0234375f,
-        FLT_MAX, FLT_MAX, FLT_MAX, 3.402823e38f, 0.f, 0.f, FLT_MAX, 0.f, FLT_MAX, 0.f, 0.f, FLT_MAX, 0.f, 0.f
-    };
-    const bool valid[] = {true, true, true, true, true, true, true, true, true, true, false, false, true, false, true, false, false, true, false, true};
-    for (size_t i = 0; i < sizeof(numbers) / sizeof(numbers[0]); i++)
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
         for (int negative = 0; negative < 2; negative++)
         {
             char text[128];
             const char* sign = negative ? "-" : "";
-            const float value = negative ? -expected[i] : expected[i];
-            snprintf(text, sizeof(text), "0=%s%s", sign, numbers[i]);
-            if (check_float_boundary(text, value, 0, valid[i]))
+            const float value = negative ? -cases[i].expected : cases[i].expected;
+            snprintf(text, sizeof(text), "0=%s%s", sign, cases[i].text);
+            if (check_float_boundary(text, value, 0, cases[i].valid))
                 return -1;
-            snprintf(text, sizeof(text), "0=%s%s,1.0", sign, numbers[i]);
-            if (check_float_boundary(text, value, 2, valid[i]))
+            snprintf(text, sizeof(text), "0=%s%s,1.0", sign, cases[i].text);
+            if (check_float_boundary(text, value, 2, cases[i].valid))
                 return -1;
-            snprintf(text, sizeof(text), "-23300=1,%s%s", sign, numbers[i]);
-            if (check_float_boundary(text, value, 1, valid[i]))
+            snprintf(text, sizeof(text), "-23300=1,%s%s", sign, cases[i].text);
+            if (check_float_boundary(text, value, 1, cases[i].valid))
                 return -1;
         }
 

--- a/tools/modelwriter.h
+++ b/tools/modelwriter.h
@@ -192,6 +192,10 @@ public:
             {
                 fprintf(pp, " %d=%e", i, mpd.get(i, 0.f));
             }
+            if (type == 4 && mpd.get(i, ncnn::Mat()).empty())
+            {
+                fprintf(pp, " %d=0", -i - 23300);
+            }
             if (type == 5)
             {
                 ncnn::Mat v = mpd.get(i, ncnn::Mat());
@@ -213,6 +217,15 @@ public:
                 {
                     fprintf(pp, ",%e", p[j]);
                 }
+            }
+            if (type == 7)
+            {
+                const std::string v = mpd.get(i, std::string());
+                // unquoted text strings may contain double quotes
+                if (v.find('"') != std::string::npos)
+                    fprintf(pp, " %d=%s", i, v.c_str());
+                else
+                    fprintf(pp, " %d=\"%s\"", i, v.c_str());
             }
         }
     }

--- a/tools/ncnn2mem.cpp
+++ b/tools/ncnn2mem.cpp
@@ -248,7 +248,7 @@ static bool parse_numeric_value(const char* vstr, bool is_float, int& value)
 static int dump_param_values(FILE* fp, FILE* mp)
 {
     char idstr[16];
-    while (fscanf(fp, " %15[+-0123456789]", idstr) == 1)
+    while (fscanf(fp, " %15[-+0123456789]", idstr) == 1)
     {
         int id;
         char delimiter[2];

--- a/tools/ncnn2mem.cpp
+++ b/tools/ncnn2mem.cpp
@@ -14,7 +14,6 @@
 #include <string>
 #include <vector>
 
-static std::vector<std::string> layer_names;
 static std::vector<std::string> blob_names;
 
 static int find_blob_index_by_name(const char* name)
@@ -33,11 +32,11 @@ static int find_blob_index_by_name(const char* name)
 
 static void sanitize_name(char* name)
 {
-    for (std::size_t i = 0; i < strlen(name); i++)
+    for (char* p = name; *p; p++)
     {
-        if (!isalnum(name[i]))
+        if (!isalnum((unsigned char)*p))
         {
-            name[i] = '_';
+            *p = '_';
         }
     }
 }
@@ -48,7 +47,13 @@ static std::string path_to_varname(const char* path)
     const char* name = lastslash == NULL ? path : lastslash + 1;
 
     std::string varname = name;
-    sanitize_name((char*)varname.c_str());
+    for (std::size_t i = 0; i < varname.size(); i++)
+    {
+        if (!isalnum((unsigned char)varname[i]))
+        {
+            varname[i] = '_';
+        }
+    }
 
     return varname;
 }
@@ -241,6 +246,7 @@ static bool param_space(char c)
 
 static int scan_numeric_value(const char*& p, char vstr[128], bool comma = false)
 {
+    vstr[0] = '\0';
     if (comma)
     {
         if (*p != ',')
@@ -252,7 +258,10 @@ static int scan_numeric_value(const char*& p, char vstr[128], bool comma = false
     while (*p && *p != ',' && !param_space(*p))
     {
         if (len == 127)
+        {
+            vstr[len] = '\0';
             return -1;
+        }
         vstr[len++] = *p++;
     }
     vstr[len] = '\0';
@@ -501,7 +510,6 @@ static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, 
     if (!write_param(mp, &layer_count, sizeof(int)) || !write_param(mp, &blob_count, sizeof(int)))
         return -1;
 
-    layer_names.resize(layer_count);
     blob_names.resize(blob_count);
 
     std::vector<std::string> custom_layer_index;
@@ -598,8 +606,6 @@ static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, 
             fprintf(stderr, "write %s failed\n", idcpppath);
             return -1;
         }
-
-        layer_names[i] = std::string(layer_name);
     }
 
     // dump custom layer index

--- a/tools/ncnn2mem.cpp
+++ b/tools/ncnn2mem.cpp
@@ -302,8 +302,8 @@ static int dump_param_values(FILE* fp, FILE* mp)
             char text[256] = {0};
             if (first[0] == '\"')
             {
-                if (fscanf(fp, "%255[^\"\r\n]", text) != 1)
-                    text[0] = '\0';
+                const int nscan = fscanf(fp, "%255[^\"\r\n]", text);
+                (void)nscan;
                 if (fscanf(fp, "%1[\"]", delimiter) != 1)
                 {
                     fprintf(stderr, "unterminated or too long string (id=%d)\n", id);
@@ -313,8 +313,8 @@ static int dump_param_values(FILE* fp, FILE* mp)
             else
             {
                 text[0] = first[0];
-                if (fscanf(fp, "%254[^ \t\r\n\v\f]", text + 1) != 1)
-                    text[1] = '\0';
+                const int nscan = fscanf(fp, "%254[^ \t\r\n\v\f]", text + 1);
+                (void)nscan;
             }
             if (fscanf(fp, "%1[^ \t\r\n\v\f]", delimiter) == 1)
             {

--- a/tools/ncnn2mem.cpp
+++ b/tools/ncnn2mem.cpp
@@ -67,6 +67,29 @@ static bool write_param(FILE* fp, const void* data, size_t size)
     return true;
 }
 
+// numeric fields in binary params use little-endian 32-bit words
+static bool write_param_32(FILE* fp, const void* data, size_t size)
+{
+#if __BIG_ENDIAN__
+    const unsigned char* ptr = (const unsigned char*)data;
+    while (size > 0)
+    {
+        unsigned char buffer[1024];
+        const size_t n = size < sizeof(buffer) ? size : sizeof(buffer);
+        memcpy(buffer, ptr, n);
+        for (size_t i = 0; i < n; i += 4)
+            ncnn::swap_endianness_32(buffer + i);
+        if (!write_param(fp, buffer, n))
+            return false;
+        ptr += n;
+        size -= n;
+    }
+    return true;
+#else
+    return write_param(fp, data, size);
+#endif
+}
+
 static int close_file(FILE* fp, const char* path)
 {
     // fclose may report a buffered write failure even when earlier writes succeeded
@@ -106,13 +129,13 @@ static int dump_param_values(FILE* fp, FILE* mp)
         if (type == 2)
         {
             const int value = pd.get(id, 0);
-            if (!write_param(mp, &id, sizeof(int)) || !write_param(mp, &value, sizeof(int)))
+            if (!write_param_32(mp, &id, sizeof(int)) || !write_param_32(mp, &value, sizeof(int)))
                 return -1;
         }
         else if (type == 3)
         {
             const float value = pd.get(id, 0.f);
-            if (!write_param(mp, &id, sizeof(int)) || !write_param(mp, &value, sizeof(float)))
+            if (!write_param_32(mp, &id, sizeof(int)) || !write_param_32(mp, &value, sizeof(float)))
                 return -1;
         }
         else if (type == 4 || type == 5 || type == 6)
@@ -120,9 +143,9 @@ static int dump_param_values(FILE* fp, FILE* mp)
             const ncnn::Mat value = pd.get(id, ncnn::Mat());
             const int encoded_id = -id - 23300;
             const int len = value.w;
-            if (!write_param(mp, &encoded_id, sizeof(int)) || !write_param(mp, &len, sizeof(int)))
+            if (!write_param_32(mp, &encoded_id, sizeof(int)) || !write_param_32(mp, &len, sizeof(int)))
                 return -1;
-            if (len > 0 && !write_param(mp, value.data, (size_t)len * sizeof(float)))
+            if (len > 0 && !write_param_32(mp, value.data, (size_t)len * sizeof(float)))
                 return -1;
         }
         else if (type == 7)
@@ -132,7 +155,7 @@ static int dump_param_values(FILE* fp, FILE* mp)
             const int len = (int)value.size();
             const char padding[3] = {0};
             const int padding_size = (4 - len % 4) % 4;
-            if (!write_param(mp, &encoded_id, sizeof(int)) || !write_param(mp, &len, sizeof(int))
+            if (!write_param_32(mp, &encoded_id, sizeof(int)) || !write_param_32(mp, &len, sizeof(int))
                     || !write_param(mp, value.data(), len) || !write_param(mp, padding, padding_size))
                 return -1;
         }
@@ -144,7 +167,7 @@ static int dump_param_values(FILE* fp, FILE* mp)
     }
 
     const int eop = -233;
-    return write_param(mp, &eop, sizeof(int)) ? 0 : -1;
+    return write_param_32(mp, &eop, sizeof(int)) ? 0 : -1;
 }
 
 static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, const char* idcpppath)
@@ -170,7 +193,7 @@ static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, 
         fprintf(stderr, "param is too old, please regenerate\n");
         return -1;
     }
-    if (!write_param(mp, &magic, sizeof(int)))
+    if (!write_param_32(mp, &magic, sizeof(int)))
         return -1;
 
     int layer_count = 0;
@@ -186,7 +209,7 @@ static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, 
         fprintf(stderr, "invalid layer_count or blob_count\n");
         return -1;
     }
-    if (!write_param(mp, &layer_count, sizeof(int)) || !write_param(mp, &blob_count, sizeof(int)))
+    if (!write_param_32(mp, &layer_count, sizeof(int)) || !write_param_32(mp, &blob_count, sizeof(int)))
         return -1;
 
     blob_names.resize(blob_count);
@@ -235,8 +258,8 @@ static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, 
                 typeindex = ncnn::LayerType::CustomBit | j;
             }
         }
-        if (!write_param(mp, &typeindex, sizeof(int))
-                || !write_param(mp, &bottom_count, sizeof(int)) || !write_param(mp, &top_count, sizeof(int)))
+        if (!write_param_32(mp, &typeindex, sizeof(int))
+                || !write_param_32(mp, &bottom_count, sizeof(int)) || !write_param_32(mp, &top_count, sizeof(int)))
             return -1;
 
         fprintf(ip, "const int LAYER_%s = %d;\n", layer_name, i);
@@ -258,7 +281,7 @@ static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, 
             if (bottom_blob_index < 0)
                 return -1;
 
-            if (!write_param(mp, &bottom_blob_index, sizeof(int)))
+            if (!write_param_32(mp, &bottom_blob_index, sizeof(int)))
                 return -1;
         }
 
@@ -279,7 +302,7 @@ static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, 
 
             fprintf(ip, "const int BLOB_%s = %d;\n", blob_name, blob_index);
 
-            if (!write_param(mp, &blob_index, sizeof(int)))
+            if (!write_param_32(mp, &blob_index, sizeof(int)))
                 return -1;
 
             blob_index++;

--- a/tools/ncnn2mem.cpp
+++ b/tools/ncnn2mem.cpp
@@ -220,16 +220,29 @@ static bool vstr_to_float(const char* p, float& value)
     return true;
 }
 
-static int scan_numeric_value(FILE* fp, char vstr[128], bool comma = false)
+static bool param_space(char c)
 {
-    if (fscanf(fp, comma ? ",%127[^, \t\r\n\v\f]" : "%127[^, \t\r\n\v\f]", vstr) != 1)
-        return 0;
+    return c == ' ' || c == '\t' || c == '\v' || c == '\f';
+}
 
-    char extra[2];
-    if (strlen(vstr) == 127 && fscanf(fp, "%1[^, \t\r\n\v\f]", extra) == 1)
-        return -1;
+static int scan_numeric_value(const char*& p, char vstr[128], bool comma = false)
+{
+    if (comma)
+    {
+        if (*p != ',')
+            return 0;
+        p++;
+    }
 
-    return 1;
+    int len = 0;
+    while (*p && *p != ',' && !param_space(*p))
+    {
+        if (len == 127)
+            return -1;
+        vstr[len++] = *p++;
+    }
+    vstr[len] = '\0';
+    return len > 0 ? 1 : 0;
 }
 
 static bool parse_numeric_value(const char* vstr, bool is_float, int& value)
@@ -247,16 +260,42 @@ static bool parse_numeric_value(const char* vstr, bool is_float, int& value)
 
 static int dump_param_values(FILE* fp, FILE* mp)
 {
-    char idstr[16];
-    while (fscanf(fp, " %15[-+0123456789]", idstr) == 1)
+    // each layer occupies one line
+    // leave the newline for the next layer header scan
+    char line[1024] = {0};
+    std::vector<char> long_line;
+    while (fscanf(fp, "%1023[^\r\n]", line) == 1)
     {
+        const size_t len = strlen(line);
+        if (long_line.empty() && len < sizeof(line) - 1)
+            break;
+        long_line.insert(long_line.end(), line, line + len);
+        if (len < sizeof(line) - 1)
+            break;
+    }
+    if (!long_line.empty())
+        long_line.push_back('\0');
+    const char* p = long_line.empty() ? line : long_line.data();
+
+    while (1)
+    {
+        while (param_space(*p))
+            p++;
+        if (!*p)
+            break;
+
+        char idstr[16];
+        int idlen = 0;
+        while ((*p == '-' || *p == '+' || (*p >= '0' && *p <= '9')) && idlen < 15)
+            idstr[idlen++] = *p++;
+        idstr[idlen] = '\0';
         int id;
-        char delimiter[2];
-        if (!vstr_to_int(idstr, id) || fscanf(fp, "%1[=]", delimiter) != 1)
+        if (!vstr_to_int(idstr, id) || *p != '=')
         {
             fprintf(stderr, "invalid parameter id or missing equals sign\n");
             return -1;
         }
+        p++;
 
         const bool old_array = id <= -23300;
         const int param_id = old_array ? -(id + 23300) : id;
@@ -270,7 +309,7 @@ static int dump_param_values(FILE* fp, FILE* mp)
         {
             char vstr[128];
             int len;
-            if (scan_numeric_value(fp, vstr) != 1 || !vstr_to_int(vstr, len) || len < 0)
+            if (scan_numeric_value(p, vstr) != 1 || !vstr_to_int(vstr, len) || len < 0)
             {
                 fprintf(stderr, "invalid array length (id=%d)\n", id);
                 return -1;
@@ -280,7 +319,7 @@ static int dump_param_values(FILE* fp, FILE* mp)
             for (int j = 0; j < len; j++)
             {
                 int value;
-                if (scan_numeric_value(fp, vstr, true) != 1
+                if (scan_numeric_value(p, vstr, true) != 1
                         || !parse_numeric_value(vstr, vstr_is_float(vstr), value))
                 {
                     fprintf(stderr, "invalid array element (id=%d, index=%d)\n", id, j);
@@ -288,7 +327,7 @@ static int dump_param_values(FILE* fp, FILE* mp)
                 }
                 fwrite(&value, sizeof(int), 1, mp);
             }
-            if (fscanf(fp, "%1[,]", delimiter) == 1)
+            if (*p == ',')
             {
                 fprintf(stderr, "array length mismatch (id=%d)\n", id);
                 return -1;
@@ -296,34 +335,31 @@ static int dump_param_values(FILE* fp, FILE* mp)
             continue;
         }
 
-        char first[2];
-        if (fscanf(fp, "%1[\"a-zA-Z]", first) == 1)
+        if (*p == '\"' || (*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z'))
         {
             char text[256] = {0};
-            if (first[0] == '\"')
+            const bool quoted = *p == '\"';
+            if (quoted)
+                p++;
+            int len = 0;
+            while (*p && (quoted ? *p != '\"' : !param_space(*p)) && len < 255)
+                text[len++] = *p++;
+            if (quoted)
             {
-                const int nscan = fscanf(fp, "%255[^\"\r\n]", text);
-                (void)nscan;
-                if (fscanf(fp, "%1[\"]", delimiter) != 1)
+                if (*p != '\"')
                 {
                     fprintf(stderr, "unterminated or too long string (id=%d)\n", id);
                     return -1;
                 }
+                p++;
             }
-            else
-            {
-                text[0] = first[0];
-                const int nscan = fscanf(fp, "%254[^ \t\r\n\v\f]", text + 1);
-                (void)nscan;
-            }
-            if (fscanf(fp, "%1[^ \t\r\n\v\f]", delimiter) == 1)
+            if (*p && !param_space(*p))
             {
                 fprintf(stderr, "invalid string suffix or string too long (id=%d)\n", id);
                 return -1;
             }
 
             id = -id - 23400;
-            int len = (int)strlen(text);
             fwrite(&id, sizeof(int), 1, mp);
             fwrite(&len, sizeof(int), 1, mp);
             fwrite(text, 1, (len + 3) / 4 * 4, mp);
@@ -331,7 +367,7 @@ static int dump_param_values(FILE* fp, FILE* mp)
         }
 
         char vstr[128];
-        if (scan_numeric_value(fp, vstr) != 1)
+        if (scan_numeric_value(p, vstr) != 1)
         {
             fprintf(stderr, "read value failed (id=%d)\n", id);
             return -1;
@@ -344,16 +380,17 @@ static int dump_param_values(FILE* fp, FILE* mp)
             return -1;
         }
 
-        if (fscanf(fp, "%1[,]", delimiter) == 1)
+        if (*p == ',')
         {
+            p++;
             std::vector<int> values;
             values.push_back(value);
             while (1)
             {
-                const int nscan = scan_numeric_value(fp, vstr);
+                const int nscan = scan_numeric_value(p, vstr);
                 if (nscan == 0)
                 {
-                    if (fscanf(fp, "%1[,]", delimiter) == 1)
+                    if (*p == ',')
                     {
                         fprintf(stderr, "missing array element (id=%d)\n", id);
                         return -1;
@@ -366,8 +403,9 @@ static int dump_param_values(FILE* fp, FILE* mp)
                     return -1;
                 }
                 values.push_back(value);
-                if (fscanf(fp, "%1[,]", delimiter) != 1)
+                if (*p != ',')
                     break;
+                p++;
             }
             id = -id - 23300;
             int len = (int)values.size();

--- a/tools/ncnn2mem.cpp
+++ b/tools/ncnn2mem.cpp
@@ -155,13 +155,16 @@ static bool vstr_to_float(const char* p, float& value)
     if (*p == '.')
     {
         p++;
-        double scale = 0.1;
+        // accumulate the fraction before adding it to the integer part
+        double fraction = 0.0;
+        double scale = 1.0;
         while (*p >= '0' && *p <= '9')
         {
             has_digit = true;
-            v += (*p++ - '0') * scale;
-            scale *= 0.1;
+            fraction = fraction * 10.0 + (*p++ - '0');
+            scale *= 10.0;
         }
+        v += fraction / scale;
     }
     if (!has_digit)
         return false;
@@ -217,9 +220,9 @@ static bool vstr_to_float(const char* p, float& value)
     return true;
 }
 
-static int scan_numeric_value(FILE* fp, char vstr[128])
+static int scan_numeric_value(FILE* fp, char vstr[128], bool comma = false)
 {
-    if (fscanf(fp, "%127[^, \t\r\n\v\f]", vstr) != 1)
+    if (fscanf(fp, comma ? ",%127[^, \t\r\n\v\f]" : "%127[^, \t\r\n\v\f]", vstr) != 1)
         return 0;
 
     char extra[2];
@@ -277,7 +280,7 @@ static int dump_param_values(FILE* fp, FILE* mp)
             for (int j = 0; j < len; j++)
             {
                 int value;
-                if (fscanf(fp, "%1[,]", delimiter) != 1 || scan_numeric_value(fp, vstr) != 1
+                if (scan_numeric_value(fp, vstr, true) != 1
                         || !parse_numeric_value(vstr, vstr_is_float(vstr), value))
                 {
                     fprintf(stderr, "invalid array element (id=%d, index=%d)\n", id, j);

--- a/tools/ncnn2mem.cpp
+++ b/tools/ncnn2mem.cpp
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <ctype.h>
+#include <float.h>
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <string>
@@ -50,104 +52,336 @@ static std::string path_to_varname(const char* path)
     return varname;
 }
 
-static bool vstr_is_float(const char vstr[16])
+// keep numeric parsing in sync with src/paramdict.cpp
+static bool vstr_is_float(const char* vstr)
 {
-    // look ahead for determine isfloat
-    for (int j = 0; j < 16; j++)
-    {
-        if (vstr[j] == '\0')
-            break;
+    return strchr(vstr, '.') || strchr(vstr, 'e') || strchr(vstr, 'E');
+}
 
-        if (vstr[j] == '.' || tolower(vstr[j]) == 'e')
-            return true;
+static bool vstr_to_int(const char* p, int& v)
+{
+    const bool negative = *p == '-';
+    if (*p == '+' || *p == '-')
+        p++;
+
+    if (*p < '0' || *p > '9')
+        return false;
+
+    const unsigned int limit = negative ? (unsigned int)INT_MAX + 1u : (unsigned int)INT_MAX;
+    unsigned int magnitude = 0;
+    while (*p >= '0' && *p <= '9')
+    {
+        const unsigned int digit = *p++ - '0';
+        if (magnitude > (limit - digit) / 10)
+            return false;
+        magnitude = magnitude * 10 + digit;
+    }
+    if (*p != '\0')
+        return false;
+
+    v = negative ? (magnitude == (unsigned int)INT_MAX + 1u ? INT_MIN : -(int)magnitude) : (int)magnitude;
+    return true;
+}
+
+// the input is a validated unsigned decimal token of at most 127 characters
+static bool vstr_fits_float(const char* p)
+{
+    char digits[128];
+    int len = 0;
+    int point = -1;
+    while (*p && *p != 'e' && *p != 'E')
+    {
+        if (*p == '.')
+            point = len;
+        else
+            digits[len++] = *p;
+        p++;
+    }
+    if (point < 0)
+        point = len;
+
+    int exponent = 0;
+    if (*p)
+    {
+        p++;
+        const bool negative = *p == '-';
+        if (*p == '+' || *p == '-')
+            p++;
+        while (*p)
+        {
+            if (exponent < 1024)
+                exponent = exponent * 10 + (*p - '0');
+            p++;
+        }
+        if (negative)
+            exponent = -exponent;
     }
 
+    int first = 0;
+    while (first < len && digits[first] == '0')
+        first++;
+    if (first == len)
+        return true;
+
+    const int decimal_digits = point - first + exponent;
+    if (decimal_digits != 39)
+        return decimal_digits < 39;
+
+    // 2^128 - 2^103 is the exact midpoint between FLT_MAX and float overflow
+    const char midpoint[] = "340282356779733661637539395458142568448";
+    for (int i = 0; i < 39; i++)
+    {
+        const char digit = first + i < len ? digits[first + i] : '0';
+        if (digit != midpoint[i])
+            return digit < midpoint[i];
+    }
     return false;
 }
 
-static bool vstr_is_string(const char vstr[16])
+static bool vstr_to_float(const char* p, float& value)
 {
-    return isalpha(vstr[0]) || vstr[0] == '\"';
-}
-
-static float vstr_to_float(const char vstr[16])
-{
-    double v = 0.0;
-
-    const char* p = vstr;
-
-    // sign
-    bool sign = *p != '-';
+    const bool negative = *p == '-';
     if (*p == '+' || *p == '-')
-    {
         p++;
-    }
 
-    // digits before decimal point or exponent
-    unsigned int v1 = 0;
-    while (isdigit(*p))
+    const char* digits = p;
+    double v = 0.0;
+    bool has_digit = false;
+    while (*p >= '0' && *p <= '9')
     {
-        v1 = v1 * 10 + (*p - '0');
-        p++;
+        has_digit = true;
+        v = v * 10.0 + (*p++ - '0');
     }
-
-    v = (double)v1;
-
-    // digits after decimal point
     if (*p == '.')
     {
         p++;
-
-        unsigned int pow10 = 1;
-        unsigned int v2 = 0;
-
-        while (isdigit(*p))
+        double scale = 0.1;
+        while (*p >= '0' && *p <= '9')
         {
-            v2 = v2 * 10 + (*p - '0');
-            pow10 *= 10;
-            p++;
+            has_digit = true;
+            v += (*p++ - '0') * scale;
+            scale *= 0.1;
         }
-
-        v += v2 / (double)pow10;
     }
+    if (!has_digit)
+        return false;
 
-    // exponent
     if (*p == 'e' || *p == 'E')
     {
         p++;
-
-        // sign of exponent
-        bool fact = *p != '-';
+        const bool negative_exponent = *p == '-';
         if (*p == '+' || *p == '-')
+            p++;
+        if (*p < '0' || *p > '9')
+            return false;
+
+        // saturate the exponent instead of overflowing or looping over its value
+        unsigned int exponent = 0;
+        while (*p >= '0' && *p <= '9')
         {
+            if (exponent < 1024)
+            {
+                exponent = exponent * 10 + (*p - '0');
+                if (exponent > 1024)
+                    exponent = 1024;
+            }
             p++;
         }
-
-        // digits of exponent
-        unsigned int expon = 0;
-        while (isdigit(*p))
+        if (v != 0.0)
         {
-            expon = expon * 10 + (*p - '0');
-            p++;
+            // tokens are limited to 127 characters, so an infinite scale implies float overflow or underflow
+            double scale = 1.0;
+            double base = 10.0;
+            while (exponent)
+            {
+                if (exponent & 1)
+                    scale *= base;
+                exponent >>= 1;
+                if (exponent)
+                    base *= base;
+            }
+            v = negative_exponent ? v / scale : v * scale;
+        }
+    }
+    if (*p != '\0')
+        return false;
+
+    // compare the original decimal near overflow, where double rounding can cross the midpoint
+    if (v >= (double)FLT_MAX)
+    {
+        if (!vstr_fits_float(digits))
+            return false;
+        v = (double)FLT_MAX;
+    }
+    value = negative ? (float)-v : (float)v;
+    return true;
+}
+
+static int scan_numeric_value(FILE* fp, char vstr[128])
+{
+    if (fscanf(fp, "%127[^, \t\r\n\v\f]", vstr) != 1)
+        return 0;
+
+    char extra[2];
+    if (strlen(vstr) == 127 && fscanf(fp, "%1[^, \t\r\n\v\f]", extra) == 1)
+        return -1;
+
+    return 1;
+}
+
+static bool parse_numeric_value(const char* vstr, bool is_float, int& value)
+{
+    if (is_float)
+    {
+        float f;
+        if (!vstr_to_float(vstr, f))
+            return false;
+        memcpy(&value, &f, sizeof(float));
+        return true;
+    }
+    return vstr_to_int(vstr, value);
+}
+
+static int dump_param_values(FILE* fp, FILE* mp)
+{
+    char idstr[16];
+    while (fscanf(fp, " %15[+-0123456789]", idstr) == 1)
+    {
+        int id;
+        char delimiter[2];
+        if (!vstr_to_int(idstr, id) || fscanf(fp, "%1[=]", delimiter) != 1)
+        {
+            fprintf(stderr, "invalid parameter id or missing equals sign\n");
+            return -1;
         }
 
-        double scale = 1.0;
-        while (expon >= 8)
+        const bool old_array = id <= -23300;
+        const int param_id = old_array ? -(id + 23300) : id;
+        if (param_id < 0 || param_id >= NCNN_MAX_PARAM_COUNT)
         {
-            scale *= 1e8;
-            expon -= 8;
-        }
-        while (expon > 0)
-        {
-            scale *= 10.0;
-            expon -= 1;
+            fprintf(stderr, "invalid parameter id %d\n", id);
+            return -1;
         }
 
-        v = fact ? v * scale : v / scale;
+        if (old_array)
+        {
+            char vstr[128];
+            int len;
+            if (scan_numeric_value(fp, vstr) != 1 || !vstr_to_int(vstr, len) || len < 0)
+            {
+                fprintf(stderr, "invalid array length (id=%d)\n", id);
+                return -1;
+            }
+            fwrite(&id, sizeof(int), 1, mp);
+            fwrite(&len, sizeof(int), 1, mp);
+            for (int j = 0; j < len; j++)
+            {
+                int value;
+                if (fscanf(fp, "%1[,]", delimiter) != 1 || scan_numeric_value(fp, vstr) != 1
+                        || !parse_numeric_value(vstr, vstr_is_float(vstr), value))
+                {
+                    fprintf(stderr, "invalid array element (id=%d, index=%d)\n", id, j);
+                    return -1;
+                }
+                fwrite(&value, sizeof(int), 1, mp);
+            }
+            if (fscanf(fp, "%1[,]", delimiter) == 1)
+            {
+                fprintf(stderr, "array length mismatch (id=%d)\n", id);
+                return -1;
+            }
+            continue;
+        }
+
+        char first[2];
+        if (fscanf(fp, "%1[\"a-zA-Z]", first) == 1)
+        {
+            char text[256] = {0};
+            if (first[0] == '\"')
+            {
+                if (fscanf(fp, "%255[^\"\r\n]", text) != 1)
+                    text[0] = '\0';
+                if (fscanf(fp, "%1[\"]", delimiter) != 1)
+                {
+                    fprintf(stderr, "unterminated or too long string (id=%d)\n", id);
+                    return -1;
+                }
+            }
+            else
+            {
+                text[0] = first[0];
+                if (fscanf(fp, "%254[^ \t\r\n\v\f]", text + 1) != 1)
+                    text[1] = '\0';
+            }
+            if (fscanf(fp, "%1[^ \t\r\n\v\f]", delimiter) == 1)
+            {
+                fprintf(stderr, "invalid string suffix or string too long (id=%d)\n", id);
+                return -1;
+            }
+
+            id = -id - 23400;
+            int len = (int)strlen(text);
+            fwrite(&id, sizeof(int), 1, mp);
+            fwrite(&len, sizeof(int), 1, mp);
+            fwrite(text, 1, (len + 3) / 4 * 4, mp);
+            continue;
+        }
+
+        char vstr[128];
+        if (scan_numeric_value(fp, vstr) != 1)
+        {
+            fprintf(stderr, "read value failed (id=%d)\n", id);
+            return -1;
+        }
+        const bool is_float = vstr_is_float(vstr);
+        int value;
+        if (!parse_numeric_value(vstr, is_float, value))
+        {
+            fprintf(stderr, "invalid numeric value (id=%d)\n", id);
+            return -1;
+        }
+
+        if (fscanf(fp, "%1[,]", delimiter) == 1)
+        {
+            std::vector<int> values;
+            values.push_back(value);
+            while (1)
+            {
+                const int nscan = scan_numeric_value(fp, vstr);
+                if (nscan == 0)
+                {
+                    if (fscanf(fp, "%1[,]", delimiter) == 1)
+                    {
+                        fprintf(stderr, "missing array element (id=%d)\n", id);
+                        return -1;
+                    }
+                    break;
+                }
+                if (nscan < 0 || values.size() >= (size_t)INT_MAX || !parse_numeric_value(vstr, is_float, value))
+                {
+                    fprintf(stderr, "invalid array element (id=%d)\n", id);
+                    return -1;
+                }
+                values.push_back(value);
+                if (fscanf(fp, "%1[,]", delimiter) != 1)
+                    break;
+            }
+            id = -id - 23300;
+            int len = (int)values.size();
+            fwrite(&id, sizeof(int), 1, mp);
+            fwrite(&len, sizeof(int), 1, mp);
+            fwrite(values.data(), sizeof(int), len, mp);
+        }
+        else
+        {
+            fwrite(&id, sizeof(int), 1, mp);
+            fwrite(&value, sizeof(int), 1, mp);
+        }
     }
 
-    //     fprintf(stderr, "v = %f\n", v);
-    return sign ? (float)v : (float)-v;
+    int EOP = -233;
+    fwrite(&EOP, sizeof(int), 1, mp);
+    return 0;
 }
 
 static int dump_param(const char* parampath, const char* parambinpath, const char* idcpppath)
@@ -281,223 +515,13 @@ static int dump_param(const char* parampath, const char* parambinpath, const cha
             blob_index++;
         }
 
-        // dump layer specific params
-        // parse each key=value pair
-        int id = 0;
-        while (fscanf(fp, "%d=", &id) == 1)
+        if (dump_param_values(fp, mp) != 0)
         {
-            bool is_array = id <= -23300;
-
-            if (is_array)
-            {
-                fwrite(&id, sizeof(int), 1, mp);
-
-                // old style array
-                int len = 0;
-                nscan = fscanf(fp, "%d", &len);
-                if (nscan != 1)
-                {
-                    fprintf(stderr, "read array length failed %d\n", nscan);
-                    return -1;
-                }
-                fwrite(&len, sizeof(int), 1, mp);
-
-                for (int j = 0; j < len; j++)
-                {
-                    char vstr[16];
-                    nscan = fscanf(fp, ",%15[^,\n ]", vstr);
-                    if (nscan != 1)
-                    {
-                        fprintf(stderr, "read array element failed %d\n", nscan);
-                        return -1;
-                    }
-
-                    bool is_float = vstr_is_float(vstr);
-
-                    if (is_float)
-                    {
-                        float vf = vstr_to_float(vstr);
-                        fwrite(&vf, sizeof(float), 1, mp);
-                    }
-                    else
-                    {
-                        int v;
-                        sscanf(vstr, "%d", &v);
-                        fwrite(&v, sizeof(int), 1, mp);
-                    }
-                }
-
-                continue;
-            }
-
-            char vstr[16];
-            char comma[4];
-            nscan = fscanf(fp, "%15[^,\n ]", vstr);
-            if (nscan != 1)
-            {
-                fprintf(stderr, "read value failed %d\n", nscan);
-                return -1;
-            }
-
-            bool is_string = vstr_is_string(vstr);
-            if (is_string)
-            {
-                id = -id - 23400;
-                fwrite(&id, sizeof(int), 1, mp);
-
-                // scan the remaining string
-                char vstr2[256];
-                vstr2[241] = '\0'; // max 255 = 15 + 240
-
-                if (vstr[0] == '\"')
-                {
-                    int len = 0;
-                    while (vstr[len] != '\0')
-                        len++;
-                    char end = vstr[len - 1];
-                    if (end != '\"')
-                    {
-                        nscan = fscanf(fp, "%255[^\"\n]\"", vstr2);
-                    }
-                    else
-                        nscan = 0; // already ended with a quote, no need to scan more
-                }
-                else
-                {
-                    nscan = fscanf(fp, "%255[^\n ]", vstr2);
-                }
-
-                std::string str;
-                if (nscan == 1)
-                {
-                    if (vstr2[241] != '\0')
-                    {
-                        fprintf(stderr, "string too long (id=%d)\n", id);
-                        return -1;
-                    }
-
-                    if (vstr[0] == '\"')
-                        str = std::string(&vstr[1]) + vstr2;
-                    else
-                        str = std::string(vstr) + vstr2;
-                }
-                else
-                {
-                    if (vstr[0] == '\"')
-                        str = std::string(&vstr[1]);
-                    else
-                        str = std::string(vstr);
-                }
-
-                if (str[str.size() - 1] == '\"')
-                    str.resize(str.size() - 1);
-
-                int len = (int)str.length();
-
-                // pad to 4 bytes
-                str.resize((str.size() + 3) / 4 * 4, 0);
-
-                fwrite(&len, sizeof(int), 1, mp);
-                fwrite(str.data(), sizeof(char), str.size(), mp);
-
-                continue;
-            }
-
-            bool is_float = vstr_is_float(vstr);
-
-            nscan = fscanf(fp, "%1[,]", comma);
-            is_array = nscan == 1;
-
-            if (is_array)
-            {
-                id = -id - 23300;
-                fwrite(&id, sizeof(int), 1, mp);
-
-                std::vector<float> af;
-                std::vector<int> ai;
-
-                if (is_float)
-                {
-                    af.push_back(vstr_to_float(vstr));
-                }
-                else
-                {
-                    int v = 0;
-                    nscan = sscanf(vstr, "%d", &v);
-                    if (nscan != 1)
-                    {
-                        fprintf(stderr, "parse value failed %d\n", nscan);
-                        return -1;
-                    }
-
-                    ai.push_back(v);
-                }
-
-                while (1)
-                {
-                    nscan = fscanf(fp, "%15[^,\n ]", vstr);
-                    if (nscan != 1)
-                    {
-                        break;
-                    }
-
-                    if (is_float)
-                    {
-                        af.push_back(vstr_to_float(vstr));
-                    }
-                    else
-                    {
-                        int v = 0;
-                        nscan = sscanf(vstr, "%d", &v);
-                        if (nscan != 1)
-                        {
-                            fprintf(stderr, "parse value failed %d\n", nscan);
-                            return -1;
-                        }
-
-                        ai.push_back(v);
-                    }
-
-                    nscan = fscanf(fp, "%1[,]", comma);
-                    if (nscan != 1)
-                    {
-                        break;
-                    }
-                }
-
-                if (is_float)
-                {
-                    int len = (int)af.size();
-                    fwrite(&len, sizeof(int), 1, mp);
-                    fwrite(af.data(), sizeof(float), len, mp);
-                }
-                else
-                {
-                    int len = (int)ai.size();
-                    fwrite(&len, sizeof(int), 1, mp);
-                    fwrite(ai.data(), sizeof(int), len, mp);
-                }
-            }
-            else
-            {
-                fwrite(&id, sizeof(int), 1, mp);
-
-                if (is_float)
-                {
-                    float vf = vstr_to_float(vstr);
-                    fwrite(&vf, sizeof(float), 1, mp);
-                }
-                else
-                {
-                    int v;
-                    sscanf(vstr, "%d", &v);
-                    fwrite(&v, sizeof(int), 1, mp);
-                }
-            }
+            fclose(fp);
+            fclose(mp);
+            fclose(ip);
+            return -1;
         }
-
-        int EOP = -233;
-        fwrite(&EOP, sizeof(int), 1, mp);
 
         layer_names[i] = std::string(layer_name);
     }
@@ -621,9 +645,8 @@ int main(int argc, char** argv)
 
     std::string parambinpath = std::string(parampath) + ".bin";
 
-    dump_param(parampath, parambinpath.c_str(), idcpppath);
+    if (dump_param(parampath, parambinpath.c_str(), idcpppath) != 0)
+        return -1;
 
-    write_memcpp(parambinpath.c_str(), modelpath, memcpppath);
-
-    return 0;
+    return write_memcpp(parambinpath.c_str(), modelpath, memcpppath);
 }

--- a/tools/ncnn2mem.cpp
+++ b/tools/ncnn2mem.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "allocator.h"
 #include "layer.h"
 #include "layer_type.h"
 
@@ -50,6 +51,19 @@ static std::string path_to_varname(const char* path)
     sanitize_name((char*)varname.c_str());
 
     return varname;
+}
+
+// keep array length checks in sync with src/paramdict.cpp
+static size_t max_array_length()
+{
+    // leave room for Mat alignment, the reference count and fastMalloc overhead
+    const size_t max_len = ((size_t)-1 - 15 - sizeof(int) - sizeof(void*) - NCNN_MALLOC_ALIGN - NCNN_MALLOC_OVERREAD) / sizeof(float);
+    return std::min((size_t)INT_MAX, max_len);
+}
+
+static bool valid_array_length(size_t len)
+{
+    return len <= max_array_length();
 }
 
 // keep numeric parsing in sync with src/paramdict.cpp
@@ -258,6 +272,29 @@ static bool parse_numeric_value(const char* vstr, bool is_float, int& value)
     return vstr_to_int(vstr, value);
 }
 
+static bool write_param(FILE* fp, const void* data, size_t size)
+{
+    if (fwrite(data, 1, size, fp) != size)
+    {
+        fprintf(stderr, "write param failed\n");
+        return false;
+    }
+    return true;
+}
+
+static int close_file(FILE* fp, const char* path)
+{
+    // fclose may report a buffered write failure even when earlier writes succeeded
+    const int io_error = ferror(fp);
+    const int close_error = fclose(fp);
+    if (io_error || close_error != 0)
+    {
+        fprintf(stderr, "file io failed %s\n", path);
+        return -1;
+    }
+    return 0;
+}
+
 static int dump_param_values(FILE* fp, FILE* mp)
 {
     // each layer occupies one line
@@ -273,9 +310,14 @@ static int dump_param_values(FILE* fp, FILE* mp)
         if (len < sizeof(line) - 1)
             break;
     }
+    if (ferror(fp))
+    {
+        fprintf(stderr, "read param failed\n");
+        return -1;
+    }
     if (!long_line.empty())
         long_line.push_back('\0');
-    const char* p = long_line.empty() ? line : long_line.data();
+    const char* p = long_line.empty() ? line : &long_line[0];
 
     while (1)
     {
@@ -309,13 +351,13 @@ static int dump_param_values(FILE* fp, FILE* mp)
         {
             char vstr[128];
             int len;
-            if (scan_numeric_value(p, vstr) != 1 || !vstr_to_int(vstr, len) || len < 0)
+            if (scan_numeric_value(p, vstr) != 1 || !vstr_to_int(vstr, len) || !valid_array_length((size_t)len))
             {
                 fprintf(stderr, "invalid array length (id=%d)\n", id);
                 return -1;
             }
-            fwrite(&id, sizeof(int), 1, mp);
-            fwrite(&len, sizeof(int), 1, mp);
+            if (!write_param(mp, &id, sizeof(int)) || !write_param(mp, &len, sizeof(int)))
+                return -1;
             for (int j = 0; j < len; j++)
             {
                 int value;
@@ -325,7 +367,8 @@ static int dump_param_values(FILE* fp, FILE* mp)
                     fprintf(stderr, "invalid array element (id=%d, index=%d)\n", id, j);
                     return -1;
                 }
-                fwrite(&value, sizeof(int), 1, mp);
+                if (!write_param(mp, &value, sizeof(int)))
+                    return -1;
             }
             if (*p == ',')
             {
@@ -360,9 +403,10 @@ static int dump_param_values(FILE* fp, FILE* mp)
             }
 
             id = -id - 23400;
-            fwrite(&id, sizeof(int), 1, mp);
-            fwrite(&len, sizeof(int), 1, mp);
-            fwrite(text, 1, (len + 3) / 4 * 4, mp);
+            if (!write_param(mp, &id, sizeof(int)) || !write_param(mp, &len, sizeof(int)))
+                return -1;
+            if (!write_param(mp, text, (len + 3) / 4 * 4))
+                return -1;
             continue;
         }
 
@@ -397,7 +441,7 @@ static int dump_param_values(FILE* fp, FILE* mp)
                     }
                     break;
                 }
-                if (nscan < 0 || values.size() >= (size_t)INT_MAX || !parse_numeric_value(vstr, is_float, value))
+                if (nscan < 0 || !valid_array_length(values.size() + 1) || !parse_numeric_value(vstr, is_float, value))
                 {
                     fprintf(stderr, "invalid array element (id=%d)\n", id);
                     return -1;
@@ -409,35 +453,24 @@ static int dump_param_values(FILE* fp, FILE* mp)
             }
             id = -id - 23300;
             int len = (int)values.size();
-            fwrite(&id, sizeof(int), 1, mp);
-            fwrite(&len, sizeof(int), 1, mp);
-            fwrite(values.data(), sizeof(int), len, mp);
+            if (!write_param(mp, &id, sizeof(int)) || !write_param(mp, &len, sizeof(int)))
+                return -1;
+            if (!write_param(mp, &values[0], (size_t)len * sizeof(int)))
+                return -1;
         }
         else
         {
-            fwrite(&id, sizeof(int), 1, mp);
-            fwrite(&value, sizeof(int), 1, mp);
+            if (!write_param(mp, &id, sizeof(int)) || !write_param(mp, &value, sizeof(int)))
+                return -1;
         }
     }
 
     int EOP = -233;
-    fwrite(&EOP, sizeof(int), 1, mp);
-    return 0;
+    return write_param(mp, &EOP, sizeof(int)) ? 0 : -1;
 }
 
-static int dump_param(const char* parampath, const char* parambinpath, const char* idcpppath)
+static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, const char* idcpppath)
 {
-    FILE* fp = fopen(parampath, "rb");
-
-    if (!fp)
-    {
-        fprintf(stderr, "fopen %s failed\n", parampath);
-        return -1;
-    }
-
-    FILE* mp = fopen(parambinpath, "wb");
-    FILE* ip = fopen(idcpppath, "wb");
-
     std::string param_var = path_to_varname(parampath);
 
     std::string include_guard_var = path_to_varname(idcpppath);
@@ -454,7 +487,8 @@ static int dump_param(const char* parampath, const char* parambinpath, const cha
         fprintf(stderr, "read magic failed %d\n", nscan);
         return -1;
     }
-    fwrite(&magic, sizeof(int), 1, mp);
+    if (!write_param(mp, &magic, sizeof(int)))
+        return -1;
 
     int layer_count = 0;
     int blob_count = 0;
@@ -464,8 +498,8 @@ static int dump_param(const char* parampath, const char* parambinpath, const cha
         fprintf(stderr, "read layer_count and blob_count failed %d\n", nscan);
         return -1;
     }
-    fwrite(&layer_count, sizeof(int), 1, mp);
-    fwrite(&blob_count, sizeof(int), 1, mp);
+    if (!write_param(mp, &layer_count, sizeof(int)) || !write_param(mp, &blob_count, sizeof(int)))
+        return -1;
 
     layer_names.resize(layer_count);
     blob_names.resize(blob_count);
@@ -509,10 +543,9 @@ static int dump_param(const char* parampath, const char* parambinpath, const cha
                 typeindex = ncnn::LayerType::CustomBit | j;
             }
         }
-        fwrite(&typeindex, sizeof(int), 1, mp);
-
-        fwrite(&bottom_count, sizeof(int), 1, mp);
-        fwrite(&top_count, sizeof(int), 1, mp);
+        if (!write_param(mp, &typeindex, sizeof(int))
+                || !write_param(mp, &bottom_count, sizeof(int)) || !write_param(mp, &top_count, sizeof(int)))
+            return -1;
 
         fprintf(ip, "const int LAYER_%s = %d;\n", layer_name, i);
 
@@ -531,7 +564,8 @@ static int dump_param(const char* parampath, const char* parambinpath, const cha
 
             int bottom_blob_index = find_blob_index_by_name(bottom_name);
 
-            fwrite(&bottom_blob_index, sizeof(int), 1, mp);
+            if (!write_param(mp, &bottom_blob_index, sizeof(int)))
+                return -1;
         }
 
         //         layer->tops.resize(top_count);
@@ -551,16 +585,17 @@ static int dump_param(const char* parampath, const char* parambinpath, const cha
 
             fprintf(ip, "const int BLOB_%s = %d;\n", blob_name, blob_index);
 
-            fwrite(&blob_index, sizeof(int), 1, mp);
+            if (!write_param(mp, &blob_index, sizeof(int)))
+                return -1;
 
             blob_index++;
         }
 
         if (dump_param_values(fp, mp) != 0)
+            return -1;
+        if (ferror(ip))
         {
-            fclose(fp);
-            fclose(mp);
-            fclose(ip);
+            fprintf(stderr, "write %s failed\n", idcpppath);
             return -1;
         }
 
@@ -581,30 +616,51 @@ static int dump_param(const char* parampath, const char* parambinpath, const cha
     fprintf(ip, "} // namespace %s_id\n", param_var.c_str());
     fprintf(ip, "#endif // NCNN_INCLUDE_GUARD_%s\n", include_guard_var.c_str());
 
-    fclose(fp);
-
-    fclose(mp);
-    fclose(ip);
-
     return 0;
 }
 
-static int write_memcpp(const char* parambinpath, const char* modelpath, const char* memcpppath)
+static int dump_param(const char* parampath, const char* parambinpath, const char* idcpppath)
 {
-    FILE* cppfp = fopen(memcpppath, "wb");
+    FILE* fp = fopen(parampath, "rb");
+    if (!fp)
+    {
+        fprintf(stderr, "fopen %s failed\n", parampath);
+        return -1;
+    }
 
+    FILE* mp = fopen(parambinpath, "wb");
+    if (!mp)
+    {
+        fprintf(stderr, "fopen %s failed\n", parambinpath);
+        close_file(fp, parampath);
+        return -1;
+    }
+
+    FILE* ip = fopen(idcpppath, "wb");
+    if (!ip)
+    {
+        fprintf(stderr, "fopen %s failed\n", idcpppath);
+        close_file(fp, parampath);
+        close_file(mp, parambinpath);
+        return -1;
+    }
+
+    int ret = dump_param_impl(fp, mp, ip, parampath, idcpppath);
+    if (close_file(fp, parampath) != 0)
+        ret = -1;
+    if (close_file(mp, parambinpath) != 0)
+        ret = -1;
+    if (close_file(ip, idcpppath) != 0)
+        ret = -1;
+    return ret;
+}
+
+static int write_memcpp_impl(FILE* mp, FILE* bp, FILE* cppfp, const char* parambinpath, const char* modelpath, const char* memcpppath)
+{
     // dump param
     std::string param_var = path_to_varname(parambinpath);
 
     std::string include_guard_var = path_to_varname(memcpppath);
-
-    FILE* mp = fopen(parambinpath, "rb");
-
-    if (!mp)
-    {
-        fprintf(stderr, "fopen %s failed\n", parambinpath);
-        return -1;
-    }
 
     fprintf(cppfp, "#ifndef NCNN_INCLUDE_GUARD_%s\n", include_guard_var.c_str());
     fprintf(cppfp, "#define NCNN_INCLUDE_GUARD_%s\n", include_guard_var.c_str());
@@ -618,7 +674,11 @@ static int write_memcpp(const char* parambinpath, const char* modelpath, const c
         int c = fgetc(mp);
         if (c == EOF)
             break;
-        fprintf(cppfp, "0x%02x,", c);
+        if (fprintf(cppfp, "0x%02x,", c) < 0)
+        {
+            fprintf(stderr, "write %s failed\n", memcpppath);
+            return -1;
+        }
 
         i++;
         if (i % 16 == 0)
@@ -629,18 +689,14 @@ static int write_memcpp(const char* parambinpath, const char* modelpath, const c
 
     fprintf(cppfp, "};\n");
 
-    fclose(mp);
+    if (ferror(mp))
+    {
+        fprintf(stderr, "read %s failed\n", parambinpath);
+        return -1;
+    }
 
     // dump model
     std::string model_var = path_to_varname(modelpath);
-
-    FILE* bp = fopen(modelpath, "rb");
-
-    if (!bp)
-    {
-        fprintf(stderr, "fopen %s failed\n", modelpath);
-        return -1;
-    }
 
     fprintf(cppfp, "\n#ifdef _MSC_VER\n__declspec(align(4))\n#else\n__attribute__((aligned(4)))\n#endif\n");
     fprintf(cppfp, "static const unsigned char %s[] = {\n", model_var.c_str());
@@ -651,7 +707,11 @@ static int write_memcpp(const char* parambinpath, const char* modelpath, const c
         int c = fgetc(bp);
         if (c == EOF)
             break;
-        fprintf(cppfp, "0x%02x,", c);
+        if (fprintf(cppfp, "0x%02x,", c) < 0)
+        {
+            fprintf(stderr, "write %s failed\n", memcpppath);
+            return -1;
+        }
 
         i++;
         if (i % 16 == 0)
@@ -664,11 +724,43 @@ static int write_memcpp(const char* parambinpath, const char* modelpath, const c
 
     fprintf(cppfp, "#endif // NCNN_INCLUDE_GUARD_%s\n", include_guard_var.c_str());
 
-    fclose(bp);
-
-    fclose(cppfp);
-
     return 0;
+}
+
+static int write_memcpp(const char* parambinpath, const char* modelpath, const char* memcpppath)
+{
+    FILE* mp = fopen(parambinpath, "rb");
+    if (!mp)
+    {
+        fprintf(stderr, "fopen %s failed\n", parambinpath);
+        return -1;
+    }
+
+    FILE* bp = fopen(modelpath, "rb");
+    if (!bp)
+    {
+        fprintf(stderr, "fopen %s failed\n", modelpath);
+        close_file(mp, parambinpath);
+        return -1;
+    }
+
+    FILE* cppfp = fopen(memcpppath, "wb");
+    if (!cppfp)
+    {
+        fprintf(stderr, "fopen %s failed\n", memcpppath);
+        close_file(mp, parambinpath);
+        close_file(bp, modelpath);
+        return -1;
+    }
+
+    int ret = write_memcpp_impl(mp, bp, cppfp, parambinpath, modelpath, memcpppath);
+    if (close_file(mp, parambinpath) != 0)
+        ret = -1;
+    if (close_file(bp, modelpath) != 0)
+        ret = -1;
+    if (close_file(cppfp, memcpppath) != 0)
+        ret = -1;
+    return ret;
 }
 
 int main(int argc, char** argv)

--- a/tools/ncnn2mem.cpp
+++ b/tools/ncnn2mem.cpp
@@ -1,14 +1,13 @@
 // Copyright 2017 Tencent
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "allocator.h"
+#include "datareader.h"
 #include "layer.h"
 #include "layer_type.h"
+#include "paramdict.h"
 
 #include <cstddef>
 #include <ctype.h>
-#include <float.h>
-#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <string>
@@ -58,229 +57,6 @@ static std::string path_to_varname(const char* path)
     return varname;
 }
 
-// keep array length checks in sync with src/paramdict.cpp
-static size_t max_array_length()
-{
-    // leave room for Mat alignment, the reference count and fastMalloc overhead
-    const size_t max_len = ((size_t)-1 - 15 - sizeof(int) - sizeof(void*) - NCNN_MALLOC_ALIGN - NCNN_MALLOC_OVERREAD) / sizeof(float);
-    return std::min((size_t)INT_MAX, max_len);
-}
-
-static bool valid_array_length(size_t len)
-{
-    return len <= max_array_length();
-}
-
-// keep numeric parsing in sync with src/paramdict.cpp
-static bool vstr_is_float(const char* vstr)
-{
-    return strchr(vstr, '.') || strchr(vstr, 'e') || strchr(vstr, 'E');
-}
-
-static bool vstr_to_int(const char* p, int& v)
-{
-    const bool negative = *p == '-';
-    if (*p == '+' || *p == '-')
-        p++;
-
-    if (*p < '0' || *p > '9')
-        return false;
-
-    const unsigned int limit = negative ? (unsigned int)INT_MAX + 1u : (unsigned int)INT_MAX;
-    unsigned int magnitude = 0;
-    while (*p >= '0' && *p <= '9')
-    {
-        const unsigned int digit = *p++ - '0';
-        if (magnitude > (limit - digit) / 10)
-            return false;
-        magnitude = magnitude * 10 + digit;
-    }
-    if (*p != '\0')
-        return false;
-
-    v = negative ? (magnitude == (unsigned int)INT_MAX + 1u ? INT_MIN : -(int)magnitude) : (int)magnitude;
-    return true;
-}
-
-// the input is a validated unsigned decimal token of at most 127 characters
-static bool vstr_fits_float(const char* p)
-{
-    char digits[128];
-    int len = 0;
-    int point = -1;
-    while (*p && *p != 'e' && *p != 'E')
-    {
-        if (*p == '.')
-            point = len;
-        else
-            digits[len++] = *p;
-        p++;
-    }
-    if (point < 0)
-        point = len;
-
-    int exponent = 0;
-    if (*p)
-    {
-        p++;
-        const bool negative = *p == '-';
-        if (*p == '+' || *p == '-')
-            p++;
-        while (*p)
-        {
-            if (exponent < 1024)
-                exponent = exponent * 10 + (*p - '0');
-            p++;
-        }
-        if (negative)
-            exponent = -exponent;
-    }
-
-    int first = 0;
-    while (first < len && digits[first] == '0')
-        first++;
-    if (first == len)
-        return true;
-
-    const int decimal_digits = point - first + exponent;
-    if (decimal_digits != 39)
-        return decimal_digits < 39;
-
-    // 2^128 - 2^103 is the exact midpoint between FLT_MAX and float overflow
-    const char midpoint[] = "340282356779733661637539395458142568448";
-    for (int i = 0; i < 39; i++)
-    {
-        const char digit = first + i < len ? digits[first + i] : '0';
-        if (digit != midpoint[i])
-            return digit < midpoint[i];
-    }
-    return false;
-}
-
-static bool vstr_to_float(const char* p, float& value)
-{
-    const bool negative = *p == '-';
-    if (*p == '+' || *p == '-')
-        p++;
-
-    const char* digits = p;
-    double v = 0.0;
-    bool has_digit = false;
-    while (*p >= '0' && *p <= '9')
-    {
-        has_digit = true;
-        v = v * 10.0 + (*p++ - '0');
-    }
-    if (*p == '.')
-    {
-        p++;
-        // accumulate the fraction before adding it to the integer part
-        double fraction = 0.0;
-        double scale = 1.0;
-        while (*p >= '0' && *p <= '9')
-        {
-            has_digit = true;
-            fraction = fraction * 10.0 + (*p++ - '0');
-            scale *= 10.0;
-        }
-        v += fraction / scale;
-    }
-    if (!has_digit)
-        return false;
-
-    if (*p == 'e' || *p == 'E')
-    {
-        p++;
-        const bool negative_exponent = *p == '-';
-        if (*p == '+' || *p == '-')
-            p++;
-        if (*p < '0' || *p > '9')
-            return false;
-
-        // saturate the exponent instead of overflowing or looping over its value
-        unsigned int exponent = 0;
-        while (*p >= '0' && *p <= '9')
-        {
-            if (exponent < 1024)
-            {
-                exponent = exponent * 10 + (*p - '0');
-                if (exponent > 1024)
-                    exponent = 1024;
-            }
-            p++;
-        }
-        if (v != 0.0)
-        {
-            // tokens are limited to 127 characters, so an infinite scale implies float overflow or underflow
-            double scale = 1.0;
-            double base = 10.0;
-            while (exponent)
-            {
-                if (exponent & 1)
-                    scale *= base;
-                exponent >>= 1;
-                if (exponent)
-                    base *= base;
-            }
-            v = negative_exponent ? v / scale : v * scale;
-        }
-    }
-    if (*p != '\0')
-        return false;
-
-    // compare the original decimal near overflow, where double rounding can cross the midpoint
-    if (v >= (double)FLT_MAX)
-    {
-        if (!vstr_fits_float(digits))
-            return false;
-        v = (double)FLT_MAX;
-    }
-    value = negative ? (float)-v : (float)v;
-    return true;
-}
-
-static bool param_space(char c)
-{
-    return c == ' ' || c == '\t' || c == '\v' || c == '\f';
-}
-
-static int scan_numeric_value(const char*& p, char vstr[128], bool comma = false)
-{
-    vstr[0] = '\0';
-    if (comma)
-    {
-        if (*p != ',')
-            return 0;
-        p++;
-    }
-
-    int len = 0;
-    while (*p && *p != ',' && !param_space(*p))
-    {
-        if (len == 127)
-        {
-            vstr[len] = '\0';
-            return -1;
-        }
-        vstr[len++] = *p++;
-    }
-    vstr[len] = '\0';
-    return len > 0 ? 1 : 0;
-}
-
-static bool parse_numeric_value(const char* vstr, bool is_float, int& value)
-{
-    if (is_float)
-    {
-        float f;
-        if (!vstr_to_float(vstr, f))
-            return false;
-        memcpy(&value, &f, sizeof(float));
-        return true;
-    }
-    return vstr_to_int(vstr, value);
-}
-
 static bool write_param(FILE* fp, const void* data, size_t size)
 {
     if (fwrite(data, 1, size, fp) != size)
@@ -304,178 +80,71 @@ static int close_file(FILE* fp, const char* path)
     return 0;
 }
 
+class ParamDictText : public ncnn::ParamDict
+{
+public:
+    using ncnn::ParamDict::load_param;
+};
+
 static int dump_param_values(FILE* fp, FILE* mp)
 {
-    // each layer occupies one line
-    // leave the newline for the next layer header scan
-    char line[1024] = {0};
-    std::vector<char> long_line;
-    while (fscanf(fp, "%1023[^\r\n]", line) == 1)
-    {
-        const size_t len = strlen(line);
-        if (long_line.empty() && len < sizeof(line) - 1)
-            break;
-        long_line.insert(long_line.end(), line, line + len);
-        if (len < sizeof(line) - 1)
-            break;
-    }
+    ncnn::DataReaderFromStdio dr(fp);
+    ParamDictText pd;
+    if (pd.load_param(dr) != 0)
+        return -1;
     if (ferror(fp))
     {
         fprintf(stderr, "read param failed\n");
         return -1;
     }
-    if (!long_line.empty())
-        long_line.push_back('\0');
-    const char* p = long_line.empty() ? line : &long_line[0];
 
-    while (1)
+    for (int id = 0; id < NCNN_MAX_PARAM_COUNT; id++)
     {
-        while (param_space(*p))
-            p++;
-        if (!*p)
-            break;
-
-        char idstr[16];
-        int idlen = 0;
-        while ((*p == '-' || *p == '+' || (*p >= '0' && *p <= '9')) && idlen < 15)
-            idstr[idlen++] = *p++;
-        idstr[idlen] = '\0';
-        int id;
-        if (!vstr_to_int(idstr, id) || *p != '=')
-        {
-            fprintf(stderr, "invalid parameter id or missing equals sign\n");
-            return -1;
-        }
-        p++;
-
-        const bool old_array = id <= -23300;
-        const int param_id = old_array ? -(id + 23300) : id;
-        if (param_id < 0 || param_id >= NCNN_MAX_PARAM_COUNT)
-        {
-            fprintf(stderr, "invalid parameter id %d\n", id);
-            return -1;
-        }
-
-        if (old_array)
-        {
-            char vstr[128];
-            int len;
-            if (scan_numeric_value(p, vstr) != 1 || !vstr_to_int(vstr, len) || !valid_array_length((size_t)len))
-            {
-                fprintf(stderr, "invalid array length (id=%d)\n", id);
-                return -1;
-            }
-            if (!write_param(mp, &id, sizeof(int)) || !write_param(mp, &len, sizeof(int)))
-                return -1;
-            for (int j = 0; j < len; j++)
-            {
-                int value;
-                if (scan_numeric_value(p, vstr, true) != 1
-                        || !parse_numeric_value(vstr, vstr_is_float(vstr), value))
-                {
-                    fprintf(stderr, "invalid array element (id=%d, index=%d)\n", id, j);
-                    return -1;
-                }
-                if (!write_param(mp, &value, sizeof(int)))
-                    return -1;
-            }
-            if (*p == ',')
-            {
-                fprintf(stderr, "array length mismatch (id=%d)\n", id);
-                return -1;
-            }
+        const int type = pd.type(id);
+        if (type == 0)
             continue;
-        }
-
-        if (*p == '\"' || (*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z'))
+        if (type == 2)
         {
-            char text[256] = {0};
-            const bool quoted = *p == '\"';
-            if (quoted)
-                p++;
-            int len = 0;
-            while (*p && (quoted ? *p != '\"' : !param_space(*p)) && len < 255)
-                text[len++] = *p++;
-            if (quoted)
-            {
-                if (*p != '\"')
-                {
-                    fprintf(stderr, "unterminated or too long string (id=%d)\n", id);
-                    return -1;
-                }
-                p++;
-            }
-            if (*p && !param_space(*p))
-            {
-                fprintf(stderr, "invalid string suffix or string too long (id=%d)\n", id);
+            const int value = pd.get(id, 0);
+            if (!write_param(mp, &id, sizeof(int)) || !write_param(mp, &value, sizeof(int)))
                 return -1;
-            }
-
-            id = -id - 23400;
-            if (!write_param(mp, &id, sizeof(int)) || !write_param(mp, &len, sizeof(int)))
-                return -1;
-            if (!write_param(mp, text, (len + 3) / 4 * 4))
-                return -1;
-            continue;
         }
-
-        char vstr[128];
-        if (scan_numeric_value(p, vstr) != 1)
+        else if (type == 3)
         {
-            fprintf(stderr, "read value failed (id=%d)\n", id);
-            return -1;
-        }
-        const bool is_float = vstr_is_float(vstr);
-        int value;
-        if (!parse_numeric_value(vstr, is_float, value))
-        {
-            fprintf(stderr, "invalid numeric value (id=%d)\n", id);
-            return -1;
-        }
-
-        if (*p == ',')
-        {
-            p++;
-            std::vector<int> values;
-            values.push_back(value);
-            while (1)
-            {
-                const int nscan = scan_numeric_value(p, vstr);
-                if (nscan == 0)
-                {
-                    if (*p == ',')
-                    {
-                        fprintf(stderr, "missing array element (id=%d)\n", id);
-                        return -1;
-                    }
-                    break;
-                }
-                if (nscan < 0 || !valid_array_length(values.size() + 1) || !parse_numeric_value(vstr, is_float, value))
-                {
-                    fprintf(stderr, "invalid array element (id=%d)\n", id);
-                    return -1;
-                }
-                values.push_back(value);
-                if (*p != ',')
-                    break;
-                p++;
-            }
-            id = -id - 23300;
-            int len = (int)values.size();
-            if (!write_param(mp, &id, sizeof(int)) || !write_param(mp, &len, sizeof(int)))
+            const float value = pd.get(id, 0.f);
+            if (!write_param(mp, &id, sizeof(int)) || !write_param(mp, &value, sizeof(float)))
                 return -1;
-            if (!write_param(mp, &values[0], (size_t)len * sizeof(int)))
+        }
+        else if (type == 4 || type == 5 || type == 6)
+        {
+            const ncnn::Mat value = pd.get(id, ncnn::Mat());
+            const int encoded_id = -id - 23300;
+            const int len = value.w;
+            if (!write_param(mp, &encoded_id, sizeof(int)) || !write_param(mp, &len, sizeof(int)))
+                return -1;
+            if (len > 0 && !write_param(mp, value.data, (size_t)len * sizeof(float)))
+                return -1;
+        }
+        else if (type == 7)
+        {
+            const std::string value = pd.get(id, std::string());
+            const int encoded_id = -id - 23400;
+            const int len = (int)value.size();
+            const char padding[3] = {0};
+            const int padding_size = (4 - len % 4) % 4;
+            if (!write_param(mp, &encoded_id, sizeof(int)) || !write_param(mp, &len, sizeof(int))
+                    || !write_param(mp, value.data(), len) || !write_param(mp, padding, padding_size))
                 return -1;
         }
         else
         {
-            if (!write_param(mp, &id, sizeof(int)) || !write_param(mp, &value, sizeof(int)))
-                return -1;
+            fprintf(stderr, "unsupported parameter type %d (id=%d)\n", type, id);
+            return -1;
         }
     }
 
-    int EOP = -233;
-    return write_param(mp, &EOP, sizeof(int)) ? 0 : -1;
+    const int eop = -233;
+    return write_param(mp, &eop, sizeof(int)) ? 0 : -1;
 }
 
 static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, const char* idcpppath)
@@ -496,6 +165,11 @@ static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, 
         fprintf(stderr, "read magic failed %d\n", nscan);
         return -1;
     }
+    if (magic != 7767517)
+    {
+        fprintf(stderr, "param is too old, please regenerate\n");
+        return -1;
+    }
     if (!write_param(mp, &magic, sizeof(int)))
         return -1;
 
@@ -505,6 +179,11 @@ static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, 
     if (nscan != 2)
     {
         fprintf(stderr, "read layer_count and blob_count failed %d\n", nscan);
+        return -1;
+    }
+    if (layer_count <= 0 || blob_count <= 0)
+    {
+        fprintf(stderr, "invalid layer_count or blob_count\n");
         return -1;
     }
     if (!write_param(mp, &layer_count, sizeof(int)) || !write_param(mp, &blob_count, sizeof(int)))
@@ -525,6 +204,11 @@ static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, 
         if (nscan != 4)
         {
             fprintf(stderr, "read layer params failed %d\n", nscan);
+            return -1;
+        }
+        if (bottom_count < 0 || top_count < 0 || top_count > blob_count - blob_index)
+        {
+            fprintf(stderr, "invalid bottom_count or top_count (layer=%d)\n", i);
             return -1;
         }
 
@@ -571,6 +255,8 @@ static int dump_param_impl(FILE* fp, FILE* mp, FILE* ip, const char* parampath, 
             sanitize_name(bottom_name);
 
             int bottom_blob_index = find_blob_index_by_name(bottom_name);
+            if (bottom_blob_index < 0)
+                return -1;
 
             if (!write_param(mp, &bottom_blob_index, sizeof(int)))
                 return -1;


### PR DESCRIPTION
Reject negative and overflowing array lengths and check allocations before reading or copying parameter data. Bound strings by their declared length and reject unterminated quotes, malformed numbers and overflowing integers. Parse exponents with bounded work and decode encoded IDs without signed overflow.

Validate IDs and stored types in public accessors while preserving untyped binary int/float values. Keep legacy arrays, trailing-comma singleton arrays and empty strings, and add regression coverage for memory-backed text parsing, bounded binary reads and truncation, type mismatches, reload isolation and allocation-size boundaries. Repair the copy test so sparse entries and float values are actually checked.

Additional local checks cover stdio-based conversion, Android asset scanning with a mock asset interface, and little-endian output from a PowerPC build under QEMU. These checks are not included in the repository test suite.

Incorporates the fixes reported in:
https://github.com/Tencent/ncnn/pull/6874
https://github.com/Tencent/ncnn/pull/6917
https://github.com/Tencent/ncnn/pull/6918