### PR TITLE
remove woa linux ci

### DIFF
--- a/.github/workflows/windows-arm.yml
+++ b/.github/workflows/windows-arm.yml
@@ -88,7 +88,7 @@ jobs:
     - name: build
       run: |
         mkdir build; cd build
-        cmake -G "Visual Studio 18 2026" -A arm64 -T v145 -DNCNN_BUILD_TESTS=ON -DNCNN_BUILD_TOOLS=OFF -DNCNN_BUILD_EXAMPLES=OFF -DNCNN_VULKAN=OFF -DNCNN_ARM82=OFF ..
+        cmake -G "Visual Studio 18 2026" -A arm64 -T v145 -DNCNN_BUILD_TESTS=ON -DNCNN_BUILD_TOOLS=OFF -DNCNN_BUILD_EXAMPLES=OFF -DNCNN_VULKAN=OFF ..
         cmake --build . --config Release -j 4
     - name: test
       run: cd build; ctest -C Release --output-on-failure -j 4

--- a/.github/workflows/windows-arm.yml
+++ b/.github/workflows/windows-arm.yml
@@ -75,38 +75,6 @@ jobs:
         cmake -T ${{ matrix.toolset-version }},host=x64 -A arm64,version=10.0.${{ matrix.windows-sdk-version }}.0 ${{ env.NCNN_CMAKE_OPTIONS }} -DNCNN_SHARED_LIB=ON ..
         cmake --build . --config Release -j 4
 
-  woa-linux:
-    name: woa-linux
-    runs-on: ubuntu-latest
-    container: linaro/wine-arm64
-    steps:
-    - uses: actions/checkout@v7
-    - name: msvc-wine
-      env:
-        WINEPREFIX: /tmp/wine-x64-prefix/
-      run: |
-        apt-get update
-        apt-get install -y wine64 python3 msitools python3-simplejson python3-six ca-certificates winbind cmake ninja-build meson
-        ln -s /usr/bin/wine /usr/bin/wine64
-        xvfb-run winecfg &
-        git clone --depth 1 https://github.com/mstorsjo/msvc-wine
-        msvc-wine/vsdownload.py --accept-license --dest /msvc
-        msvc-wine/install.sh /msvc
-    - name: build
-      env:
-        WINEPREFIX: /tmp/wine-x64-prefix/
-        CC: cl
-        CXX: cl
-      run: |
-        export PATH=/msvc/bin/arm64:$PATH
-        mkdir build && cd build
-        cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Windows -DNCNN_BUILD_TESTS=ON ..
-        cmake --build . --config Release -j $(nproc)
-    - name: test
-      run: |
-        cd build
-        TESTS_EXECUTABLE_LOADER=wine-arm64 TESTS_EXECUTABLE_LOADER_ARGUMENTS="" ctest --output-on-failure -j $(nproc)
-
   windows-arm:
     name: vs2026-arm64-native
     runs-on: windows-11-vs2026-arm


### PR DESCRIPTION
Remove the `woa-linux` job that builds and runs Windows ARM64 tests under Wine on Linux. Remove the `NCNN_ARM82=OFF` override from the native Windows ARM64 test job so it uses ncnn's default ARM feature detection and retains runtime coverage of supported ARM82 paths.

Validation: [native Windows ARM64 run](https://github.com/mingshi2333/ncnn/actions/runs/34409391334) using the same build and CTest commands passed all 179 tests. The validation also confirmed `NCNN_ARM82=ON` and Windows FP16/DOTPROD support. YAML parsing and `git diff --check` pass.
